### PR TITLE
 memoize cwd; installation subdirs should be first paths to be searched

### DIFF
--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -185,7 +185,8 @@ sub pathname_absolute {
 sub pathname_timestamp {
   -f $_[0] ? (stat($_[0]))[9] : 0; }
 
-sub pathname_cwd { pathname_canonical(cwd()); }
+our $Pathname_CWD = pathname_canonical(cwd());
+sub pathname_cwd { $Pathname_CWD; }
 
 sub pathname_mkdir {
   my($directory)=@_;
@@ -275,7 +276,7 @@ sub candidate_pathnames {
     push(@dirs,pathname_concat($cwd,$pathdir)) unless @dirs; # At least have the current directory!
     # And, if installation dir specified, append it.
     if(my $subdir = $options{installation_subdir}){
-      push(@dirs,map(pathname_concat($_,$subdir),@INSTALLDIRS)); }}
+      unshift(@dirs,map(pathname_concat($_,$subdir),@INSTALLDIRS)); }}
 
   # extract the desired extensions.
   my @exts = ();


### PR DESCRIPTION
Two simple enhancements:
- memoize the calls to cwd() in order to improve performance (LaTeXML doesn't have any invocation of chdir() so it keeps its current directory throughout the runtime)
- make sure the installation directory is the first to be examined, in order to always prefer them.

I am now starting to doubt the second enhancement, as it would mean that an author can never supply a binding of the same name as an existing binding in the installation directory. That seems like a bad idea. I need to recall where it was that I found this change essential... it's probably the wrong solution to whatever problem I had.
