### PR TITLE
Post finalize hook

### DIFF
--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -217,7 +217,7 @@ sub process {
   $doc; }
 
 # Hook for singleton processors/wrapp-up operations
-sub finalize {();}
+sub finalize { (); }
 
 #======================================================================
 # Some postprocessors will want to create a bunch of "resource"s,
@@ -432,7 +432,7 @@ sub addCrossrefs {
   my $selfs_map  = $$self{convertedIDs};
   my $others_map = $$otherprocessor{convertedIDs};
   foreach my $xid (keys %$selfs_map) {    # For each XMath id that $self converted
-    if (my $other_ids = $$others_map{$xid}) { # Did $other also convert those ids?
+    if (my $other_ids = $$others_map{$xid}) {    # Did $other also convert those ids?
       if (my $xref_id = $other_ids && $$other_ids[0]) {    # get (first) id $other created from $xid.
         foreach my $id (@{ $$selfs_map{$xid} }) {          # look at each node $self created from $xid
           if (my $node = $doc->findNodeByID($id)) {        # If we find a node,


### PR DESCRIPTION
Please disregard the spurious merge commits for now, I am just getting used to using rebase, but there were some merge trials to align the branches. As you can see from the diff, perltidy helped a lot and the diff actually shows only meaningful code differences.

That wasn't the case before, I had a bunch of spurious spacing diffs in Post.pm.

Anyhow, this pull request suggest introducing a new hook for post-processor objects.

I introduced a finalize() hook for post-processors that is useful for things like Manifest and Pack which need to write a file at the very end of post-processing. Currently, both of the former feel very appropriate as terminal post-processors that get executed at the end of post-processing (especially Manifest, which benefits from the order of ->process() invocations to generate a proper table of contents for the split document).

And of course, any post-processor that isn't aware of the finalize method would simply have it as a no-op.
