### PR TITLE
 defensive check whether input path is already absolute

### DIFF
--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -577,7 +577,8 @@ sub getDestinationExtension {
 
 sub checkDestination {
   my ($self, $reldest) = @_;
-  my $dest = pathname_concat($self->getDestinationDirectory, $reldest);
+  my $dest = (pathname_absolute($reldest) && $reldest)
+    || pathname_concat($self->getDestinationDirectory, $reldest);
   if (my $destdir = pathname_directory($dest)) {
     pathname_mkdir($destdir)
       or return Fatal("I/O", $destdir, undef,


### PR DESCRIPTION
In case you agree that checkDestination should be more defensive in the case that the input path is absolute, here is a patch that worked for me. Feel welcome to reject if you think being defensive here would hide relevant errors.
