### PR TITLE
 status code getter, useful for quickly reporting back a conversion stat...

### DIFF
--- a/lib/LaTeXML/State.pm
+++ b/lib/LaTeXML/State.pm
@@ -517,6 +517,19 @@ sub getStatusMessage {
     if @miss;
   return join('; ', @report) || 'No obvious problems'; }
 
+sub getStatusCode {
+  my ($self) = @_;
+  my $status = $$self{status};
+  my $code;
+  if ($$status{fatal} && $$status{fatal} > 0) {
+    $code = 3; }
+  elsif ($$status{error} && $$status{error} > 0) {
+    $code = 2; }
+  elsif ($$status{warning} && $$status{warning} > 0) {
+    $code = 1; }
+  else {
+    $code = 0; }
+  return $code; }
 #======================================================================
 1;
 


### PR DESCRIPTION
...us to web services

Moritz is making heavy use of this code for MediaWiki, as it avoids having to parse the log.
