### PR TITLE
 adding Package::Pool headers to two bindings that were missing it

### DIFF
--- a/lib/LaTeXML/Package/amssymb.sty.ltxml
+++ b/lib/LaTeXML/Package/amssymb.sty.ltxml
@@ -14,6 +14,7 @@
 # See amsfndoc
 # Compiled from tables in Section 7
 #
+package LaTeXML::Package::Pool;
 use strict;
 use LaTeXML::Package;
 

--- a/lib/LaTeXML/Package/dcolumn.sty.ltxml
+++ b/lib/LaTeXML/Package/dcolumn.sty.ltxml
@@ -10,6 +10,7 @@
 # | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
 # | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
 # \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
 use LaTeXML::Package;
 use strict;
 


### PR DESCRIPTION
Testing a pull request created via "git cherry-pick", it's my first try to take a commit from a diverging branch (KWARC/LaTeXML) and pass it on to the core LaTeXML.

I followed the instructions at:
http://stackoverflow.com/questions/5256021/send-a-pull-request-on-github-for-only-latest-commit
