### PR TITLE
getStatusCode getter for LaTeXML

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -85,6 +85,10 @@ sub getStatusMessage {
   my ($self) = @_;
   return $$self{state}->getStatusMessage; }
 
+sub getStatusCode {
+  my ($self) = @_;
+  return $$self{state}->getStatusCode; }
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Mid-level API.
 


### PR DESCRIPTION
Just a convenience method that allows to access the statusCode getter you already merged in LaTeXML::State
