### PR TITLE
 deprecating postoverride tests

### DIFF
--- a/t/daemon/api/postoverride.spec
+++ b/t/daemon/api/postoverride.spec
@@ -1,5 +1,0 @@
-whatsin = fragment
-whatsout = math
-source = ../fragment.tex
-noparse =
-pmml = 

--- a/t/daemon/api/postoverride.status
+++ b/t/daemon/api/postoverride.status
@@ -1,2 +1,0 @@
-No obvious problems
-Wrote postoverride.test.xml

--- a/t/daemon/api/postoverride.xml
+++ b/t/daemon/api/postoverride.xml
@@ -1,9 +1,0 @@
-<Math mode="inline" xml:id="p2.m1" tex="1+2=3">
-  <XMath>
-    <XMTok meaning="1" role="NUMBER">1</XMTok>
-    <XMTok meaning="plus" role="ADDOP">+</XMTok>
-    <XMTok meaning="2" role="NUMBER">2</XMTok>
-    <XMTok meaning="equals" role="RELOP">=</XMTok>
-    <XMTok meaning="3" role="NUMBER">3</XMTok>
-  </XMath>
-</Math>


### PR DESCRIPTION
The post override test I had is no longer meaningful, as reworking the implementation for output packaging now implies that post-processing will almost always be triggered (in order to use LaTeXML::Post::Pack). 
