### PR TITLE
 explicit literal protocol is now required

### DIFF
--- a/t/daemon/runtimes/timeout.spec
+++ b/t/daemon/runtimes/timeout.spec
@@ -2,5 +2,5 @@
 timeout = 2
 whatsin = math
 whatsout = math
-source = \def\foo{.\foo}\foo
+source = literal:\def\foo{.\foo}\foo
 noparse =


### PR DESCRIPTION
Updating a test case, as the literal protocol is no longer guessed, but is now mandatory.
