### PR TITLE
Realtime logging for latexmlc

### DIFF
--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -15,7 +15,6 @@ use warnings;
 
 use Cwd qw(cwd abs_path);
 use IO::Socket;
-#use Data::Dumper;
 
 my $RealBin_safe;
 use FindBin;
@@ -107,6 +106,7 @@ if ((!$sock) && $local && ($expire == -1)) {
   # Don't boot a server, single job requested:
   require LaTeXML::Converter;
   $opts->set('local', 1);
+  $opts->push('debug','Converter');
   my $converter = LaTeXML::Converter->get_converter($opts);
   $converter->prepare_session($opts);
   my $response = $converter->convert($source);

--- a/lib/LaTeXML/Converter.pm
+++ b/lib/LaTeXML/Converter.pm
@@ -40,11 +40,13 @@ sub new {
   # The daemon should be setting the identity:
   my $self = bless { opts => $config->options, ready => 0, log => q{}, runtime => {},
     latexml => undef }, $class;
+  # Special check if the debug directive is on, just to neutralize the bind_log
+  my $debug_directives = $self->{opts}->{debug};
+  $LaTeXML::Converter::DEBUG = 1 if (ref $debug_directives eq 'ARRAY') && (grep {/converter/i} @$debug_directives);
   $self->bind_log;
   my $rv = eval { $config->check; };
   $self->{log} .= $self->flush_log;
-  return $self;
-}
+  return $self; }
 
 sub prepare_session {
   my ($self, $config) = @_;


### PR DESCRIPTION
I wanted to keep the default realtime logging behaviour of latexml (printing to STDERR as the conversion goes along) when latexmlc isn't communicating to a server.

I added that feature in latexmlc, also adding a convenience method "push" for LaTeXML::Util::Config options.

That revealed a regression in LaTeXML::Util::Config in actually activating the DEBUG variables in each requested LaTeXML class.

It also revealed a timing issue with the activation in LaTeXML::Converter, which does bind_log pretty early on (and the DEBUG flag disables the binding/flushing of a log variable. That's ALL it does for the moment, and I think all it should ever do). 

With all these in place, latexmlc now behaves exactly like latexml unless instructed otherwise (via an --expire or --address option).
