### PR TITLE
 making pre-commit aware of files with both staged and unstaged changes;...

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -12,12 +12,22 @@ use Term::ANSIColor;
 my $changes = `git status --porcelain`;
 if (my @modified_files =
   map  { $_->[1] }                # select the filename
-  grep { $_->[0] =~ /^[AM]$/ }    # take only Modified or Added
+  grep { $_->[0] =~ /^[AM]/ }    # take only Modified or Added (with possible additional unstaged changes)
   map  { [split(/\s+/, $_)] }     # [status, name]
   split("\n", $changes)) {        # from all files
-  my $status = system(catfile('tools', 'latexmllint'), "--precommit", @modified_files);
-  my $code = $status >> 8;
+  my @dirty_files=();
+  my $exit_code=0;
+  foreach my $modified_file(@modified_files) {
+    my $temp_file = $modified_file;
+    $temp_file =~ s/\.([^.]+)$/.lint.$1/; # add .lint.pm to .pm , etc.
+    system("git show ':$modified_file' > $temp_file");
+    my $status = system(catfile('tools', 'latexmllint'), "--precommit", $temp_file);
+    unlink($temp_file);
+    my $code = $status >> 8;
+    if ($code) {
+      push(@dirty_files,$modified_file);
+      $exit_code = $code; }}
 
-  print STDERR "Some files had issues; To correct these, run:\n   tools/latexmllint <files>."
-    . colored("COMMIT ABORTED", 'red') . "\n" if $code;
-  exit $code; }
+  print STDERR "Some files had issues; To correct these, run:\n tools/latexmllint <files>.\n"
+    . colored("COMMIT ABORTED", 'red') . "\n" if @dirty_files;
+  exit $exit_code; }


### PR DESCRIPTION
... focus only on the staged file

When you first do a:

```
git add foo.pm
git commit -m 'foo'
```

and the commit gets aborted, the follow-up is to run:

```
tools/latexmllint foo.pm
```

Which will reformat and invite you to do local modifications. Once all is done  you get a status report looking like:

```
$ git status
# On branch latexmllint_on_staged_content_only
# Changes to be committed:
#   (use "git reset HEAD <file>..." to unstage)
#
#   modified:   lib/LaTeXML.pm
#
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
#   modified:   lib/LaTeXML.pm
```

and the porcelain status will tell you this is an `MM lib/LaTeXML.pm` state of that Perl class.

The master pre-commit always looked at the file on disk, which is _unstaged_ in this circumstance (it is missing a `git add` to stage it alongside the rest of the changes for the commit). To this end, I have reworked the pre-commit hook to use `git show` in order to obtain only the file as it is _staged_ for committing and lint that version.

The flaw is that since latexmllint doesn't support STDIN input, I need to write a temporary file (which I tentatively call `foo.lint.ext` for any file `foo.ext` which I then run latexmllint on and delete in the end).

That works perfectly and survives my example, never allowing to commit changes that don't comply with latexmllint. Once all changes are _staged_, it succeeds as expected.
