### PR TITLE
 writing LaTeXML's TeX packages should be optional

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -177,7 +177,8 @@ sub install_TeXStyles {
   $$MORE_MACROS{INST_TEXMFDIR}       = '$(INST_LIB)/LaTeXML/texmf';
   $$MORE_MACROS{INSTALLTEXMFDIR}     = "$TEXMF/tex/latex/latexml";
   $$MORE_MACROS{DESTINSTALLTEXMFDIR} = '$(DESTDIR)$(INSTALLTEXMFDIR)';
-
+  $$MORE_MACROS{INSTALLTEXMFBASEDIR} = "$TEXMF";
+  $$MORE_MACROS{DESTINSTALLTEXMFBASEDIR} = '$(DESTDIR)$(INSTALLTEXMFBASEDIR)';
   # The installation directory of TeX may well have spaces which screws up Make.
   # we need to wrap any pathname that includes TEXMF with quotes in case of embedded spaces
   # The quotes apparently don't hurt, when they completely enclose the path.
@@ -189,24 +190,20 @@ sub install_TeXStyles {
 
 # Install LaTeXML's LaTeX style files into the standard texmf location
 pure_install ::
-	@if [ -w "$(DESTINSTALLTEXMFDIR)" ]; then \
-		$(MKPATH) "$(DESTINSTALLTEXMFDIR)"; \
-		$(MOD_INSTALL) \
-			read "$(INSTALLTEXMFDIR)/.packlist" \
-			write "$(DESTINSTALLTEXMFDIR)/.packlist" \
-			"$(INST_TEXMFDIR)" "$(DESTINSTALLTEXMFDIR)"; \
-		$(PERLRUN) -e "exit(1) unless -w shift;" "$(INSTALLTEXMFDIR)" && mktexlsr; \
-	else \
-		echo "No write permission for TeXMF, skipping installing LaTeXML TeX packages"; \
-	fi
+	$(NOECHO) (($(PERLRUN) -e "exit(1) unless -w shift;" -- "$(DESTINSTALLTEXMFBASEDIR)") && \
+	$(MKPATH) "$(DESTINSTALLTEXMFDIR)" && \
+	$(MOD_INSTALL) \
+		read "$(INSTALLTEXMFDIR)/.packlist" \
+		write "$(DESTINSTALLTEXMFDIR)/.packlist" \
+		"$(INST_TEXMFDIR)" "$(DESTINSTALLTEXMFDIR)" && \
+	($(PERLRUN) -e "exit(1) if -w shift;" -- "$(INSTALLTEXMFDIR)" || mktexlsr)) \
+	|| echo "No write permission for $(DESTINSTALLTEXMFBASEDIR), skipping installing LaTeXML TeX packages"
 
 uninstall ::
-	@if [ -w "$(DESTINSTALLTEXMFDIR)" ]; then \
-		$(UNINSTALL) "$(INSTALLTEXMFDIR)/.packlist"; \
-		$(PERLRUN) -e "exit(1) unless -w shift;" "$(INSTALLTEXMFDIR)" && mktexlsr; \
-	else
-		echo "No write permission for TeXMF, skipping uninstalling LaTeXML TeX packages"; \
-	fi
+	$(NOECHO) (($(PERLRUN) -e "exit(1) unless -w shift;" -- "$(DESTINSTALLTEXMFBASEDIR)") && \
+		$(UNINSTALL) "$(INSTALLTEXMFDIR)/.packlist" && \
+		($(PERLRUN) -e "exit(1) if -w shift;" -- "$(INSTALLTEXMFDIR)" || mktexlsr)) \
+	|| echo "No write permission for $(DESTINSTALLTEXMFBASEDIR), skipping uninstalling LaTeXML TeX packages"
 
 InstallTeXStyles
   return; }


### PR DESCRIPTION
For my distributed LaTeXML processing of arXiv, I want to automate the LaTeXML installation on the various machines we are using via a simple cpanminus invocation:

```
cpanm git://github.com/brucemiller/LaTeXML.git@commitSHA
```

When I tried that, it turned out there was a single failure - LaTeXML always attempts to write its TeX package files when a TeX installation is found, assuming it has the required permissions. I have added a check that throws a warning and skips that part of the installation when the texmf directory isn't writable. If I am not mistaken the TeX files are only needed for the manual generation in the first place?
