### PR TITLE
 had forgotten to remove the literal: protocol when unpacking a literal ...

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -28,6 +28,7 @@ sub unpack_source {
   my $zip_handle = Archive::Zip->new();
   if (pathname_is_literaldata($source)) {
     # If literal, just use the data
+    $source =~ s/^literal\://;
     my $content_handle = IO::String->new($source);
     unless ($zip_handle->readFromFileHandle($content_handle) == AZ_OK) {
       print STDERR "Fatal:IO:Archive Can't read in literal archive:\n $source\n"; } }


### PR DESCRIPTION
...archive

Kind of a silly oversight, somewhat amazing that the unpacking still worked. But it was producing spurious error messages, so it allowed me to spot the issue.

Should be an immediate merge (kind of a minor change).
