### PR TITLE
Abbreviate alpha cite labels to the third letter

### DIFF
--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -400,7 +400,9 @@ sub formatBibEntry {
       @rfnames = $keytag->childNodes; }
     my $aa;
     if (scalar(@rfnames) > 1) {
-      $aa = join('', map { substr($_->textContent, 0, 1); } @rfnames); }
+      $aa = join('', map { substr($_->textContent, 0, 1); } @rfnames); 
+      if (length($aa)>3) {
+        $aa = substr($aa, 0, 3)."+"; } }
     else {
       $aa = uc(substr($rfnames[0]->textContent, 0, 3)); }
     my $yrtext = (@year ? join('', map { (ref $_ ? $_->textContent : $_); } @year) : '');


### PR DESCRIPTION
Fixes #583 

In the end it was easy to make a pull request that solves the problem. Here is a screenshot of the result:

![fixed_cite](https://cloud.githubusercontent.com/assets/348975/6331025/c2e32b74-bb4a-11e4-839f-2eecd02b2cc7.png)
