### PR TITLE
Fixes #592

### DIFF
--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -429,9 +429,13 @@ sub make_bibcite {
               title   => [$doc->trimChildNodes($title || $keytag)],
               attr    => { idref => $id,
                 href => orNull($self->generateURL($doc, $id)),
-                ($title ? (title => orNull($title->textContent)) : ()) } }); } } }
+                ($title ? (title => orNull($title->textContent)) : ()) } }); } }
+      else {
+        $self->note_missing('warn', 'Entry for citation', $key);
+        push(@data, { refnum => [$key], title => [$key], attr => { idref => $key, title => $key, class => "ltx_missing_citation" } }); } }
     else {
-      $self->note_missing('warn', 'Entry for citation', $key); } }
+      $self->note_missing('warn', 'Entry for citation', $key);
+      push(@data, { refnum => [$key], title => [$key], attr => { idref => $key, title => $key, class => "ltx_missing_citation" } }); } }
   my $checkdups = ($show =~ /author/i) && ($show =~ /(year|number)/i);
   my @refs      = ();
   my $saveshow  = $show;


### PR DESCRIPTION
1. There was an else conditional for a missing citation that wasn't being reported as a warning, which I now handled.

2. Instead of returning nothing, I now pass the original citation key to the post-processed XML, with a special ```ltx_missing_citation``` class. 

This is all I need in #592, and I am open to reworking it to a reasonable alternative. I think this PR catches the gist of the request, feel free to merge if you like it.

The XML snippet produced for #592 is now:
```xml
<document xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="Document">
  <resource src="LaTeXML.css" type="text/css"/>
  <resource src="ltx-article.css" type="text/css"/>
  <para xml:id="p1" fragid="p1">
    <p>Request: Preserve content of <cite>[<ref class="ltx_missing_citation" idref="missing:citations" title="missing:citations">missing:citations</ref>]</cite> in post-processing.</p>
  </para>
</document>
```

I am unsure which attributes are worth copying over, since I am not familiar with the uses of each of them. I set all of them to the key value for now, until I understand more.