### PR TITLE
[labels] option for RDFa auto-preservation of TeX labels

### DIFF
--- a/lib/LaTeXML/Package/lxRDFa.sty.ltxml
+++ b/lib/LaTeXML/Package/lxRDFa.sty.ltxml
@@ -16,6 +16,14 @@ use warnings;
 use LaTeXML::Package;
 
 #======================================================================
+# Package Options
+DeclareOption('labels', sub {
+  Let(T_CS('\lxRDF@original@label'),T_CS('\label'));
+  DefMacro('\label Semiverbatim','\lxRDF@original@label{#1}\lxRDFa{property=dcterms:alternative,content=#1}');
+});
+
+ProcessOptions();
+#======================================================================
 # Context
 
 # \lxRDFaPrefix{prefix}{initialurl}

--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -248,9 +248,10 @@ sub get_embeddable {
     foreach ($doc->getDocumentElement->getNamespaces) {
       $embeddable->setNamespace($_->getData, $_->getLocalName, 0);
     }
-    # Also, copy the prefix attribute, for RDFa:
-    my $prefix = $doc->getDocumentElement->getAttribute('prefix');
-    $embeddable->setAttribute('prefix', $prefix) if ($prefix);
+    # Also, copy RDFa attributes:
+    foreach my $rdfa_attr(qw(prefix property content resource about typeof rel rev datatype)) {
+      if (my $rdfa_value = $doc->getDocumentElement->getAttribute($rdfa_attr)) {
+        $embeddable->setAttribute($rdfa_attr, $rdfa_value); } }
   }
   return $embeddable || $doc; }
 

--- a/lib/LaTeXML/texmf/lxRDFa.sty
+++ b/lib/LaTeXML/texmf/lxRDFa.sty
@@ -12,6 +12,8 @@
 
 % This markup is essentially invisible in any sort of regular latex processing.
 % See lxRDFa.sty.ltxml for the intended usages
+\DeclareOption{labels}{}
+\ProcessOptions
 
 % These just disappear
 \DeclareRobustCommand{\lxRDFaPrefix}[2]{}


### PR DESCRIPTION
Adds a [labels] option to lxRDFa.sty, which auto-generates RDFa for LaTeX labels.

Example use:
```
latexmlc --preload=article.cls --preload=[labels]lxRDFa.sty 
  --whatsin=fragment --whatsout=fragment --format=html
  'literal:\section{Foo}\label{bar}test' 
```

Output:
```html
<article class="ltx_document" prefix="dcterms: http://purl.org/dc/terms/">
  <section id="S1" class="ltx_section" property="dcterms:alternative" content="bar">
    <h2 class="ltx_title ltx_title_section"><span class="ltx_tag ltx_tag_section">1 </span>Foo</h2>

    <div id="S1.p1" class="ltx_para">
      <p class="ltx_p">test</p>
    </div>
  </section>
</article>
```