### PR TITLE
Consistent Model Interpretation

### DIFF
--- a/lib/LaTeXML/Common/Model.pm
+++ b/lib/LaTeXML/Common/Model.pm
@@ -297,12 +297,12 @@ sub getXPath {
 
 sub getTags {
   my ($self) = @_;
-  return keys %{ $$self{tagprop} }; }
+  return sort keys %{ $$self{tagprop} }; }
 
 sub getTagContents {
   my ($self, $tag) = @_;
   my $h = $$self{tagprop}{$tag}{model};
-  return $h ? keys %$h : (); }
+  return $h ? sort keys %$h : (); }
 
 sub addTagContent {
   my ($self, $tag, @elements) = @_;
@@ -313,7 +313,7 @@ sub addTagContent {
 sub getTagAttributes {
   my ($self, $tag) = @_;
   my $h = $$self{tagprop}{$tag}{attributes};
-  return $h ? keys %$h : (); }
+  return $h ? sort keys %$h : (); }
 
 sub addTagAttribute {
   my ($self, $tag, @attributes) = @_;

--- a/lib/LaTeXML/Common/Model/RelaxNG.pm
+++ b/lib/LaTeXML/Common/Model/RelaxNG.pm
@@ -69,9 +69,9 @@ sub loadSchema {
 
   # The resulting @schema should contain the "start" of the grammar.
   my ($startcontent) = $self->extractContent('#Document', @schema);
-  $$self{model}->addTagContent('#Document', keys %$startcontent);
+  $$self{model}->addTagContent('#Document', sort keys %$startcontent);
   if ($LaTeXML::Common::Model::RelaxNG::DEBUG) {
-    print STDERR "========================\nStart\n" . join(', ', keys %$startcontent) . "\n"; }
+    print STDERR "========================\nStart\n" . join(', ', sort keys %$startcontent) . "\n"; }
 
   # NOTE: Do something automatic about this too!?!
   # We'll need to generate namespace prefixes for all namespaces found in the doc!
@@ -85,8 +85,8 @@ sub loadSchema {
       next; }
     my @body = @{ $$self{elements}{$tag} };
     my ($content, $attributes) = $self->extractContent($tag, @body);
-    $$self{model}->addTagContent($tag, keys %$content);
-    $$self{model}->addTagAttribute($tag, keys %$attributes); }
+    $$self{model}->addTagContent($tag, sort keys %$content);
+    $$self{model}->addTagAttribute($tag, sort keys %$attributes); }
   # Extract definitions of symbols that define Schema Classes, too
   foreach my $symbol (sort keys %{ $$self{defs} }) {
     if ($symbol =~ /^grammar\d+:(.+?)\.class$/) {
@@ -351,7 +351,7 @@ sub scanNameClass {
     my %names = ();
     foreach my $choice ($node->childNodes) {
       map { $names{$_} = 1 } $self->scanNameClass($choice, $ns); }
-    return ($names{ANY} ? ('ANY') : keys %names); }
+    return ($names{ANY} ? ('ANY') : sort keys %names); }
   else {
     my $op = $node->nodeName;
     Fatal('misdefined', $op, undef,
@@ -533,7 +533,7 @@ sub documentModules {
       "\\begin{schemamodule}{$name}",
       (map { $self->toTeX($_) } @content),
       "\\end{schemamodule}"); }
-  foreach my $name (keys %{ $$self{defined_patterns} }) {
+  foreach my $name (sort keys %{ $$self{defined_patterns} }) {
     if ($$self{defined_patterns}{$name} < 0) {
       $docs =~ s/\\patternadd\{$name\}/\\patterndefadd{$name}/s; } }
   return $docs; }


### PR DESCRIPTION
In sTeX, we are currently seeing inconsistent XML produced on different runs of LaTeXML, as shown here:
https://github.com/KWARC/sTeX/issues/68#issuecomment-93775585

Interestingly, we were getting inconsistent output only when LaTeXML was starting up from scratch. During daemonized runs the output was consistently the same. This lead me to believe there are possible non-deterministic interpretations of the sTeX schema.

We are using an already pre-compiled model, as in:
```
(Loading compiled schema /home/dreamweaver/localmh/ext/sTeX/schema/omdoc+ltxml.model... 0.03 sec)...... 0.14 sec)
```

Which reduced the possible causes.

As it turns out, we need to be extra careful with sorting hash keys in ```LaTeXML::Common::Model``` and ```LaTeXML::Common::Model::RelaxNG```, as the different orders were creating a different interpretation of the sTeX schema. I have tested this PR and can confirm it solves the sTeX inconsistencies.