### PR TITLE
Downcase citation keys only for lookup

### DIFF
--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -386,8 +386,7 @@ sub fill_in_bibrefs {
 sub make_bibcite {
   my ($self, $doc, $bibref) = @_;
 
-  # NOTE: bibkeys are downcased when we look them up!
-  my @keys         = map { lc($_) } grep { $_ } split(/,/, $bibref->getAttribute('bibrefs'));
+  my @keys         = grep { $_ } split(/,/, $bibref->getAttribute('bibrefs'));
   my $show         = $bibref->getAttribute('show');
   my @preformatted = $bibref->childNodes();
   if ($show && ($show eq 'none') && !@preformatted) {
@@ -404,7 +403,8 @@ sub make_bibcite {
   my @data    = ();
   foreach my $key (@keys) {
     my ($bentry, $id, $entry);
-    if (($bentry = $$self{db}->lookup("BIBLABEL:$key"))
+    # NOTE: bibkeys are downcased when we look them up!
+    if (($bentry = $$self{db}->lookup("BIBLABEL:".lc($key)))
       && ($id    = $bentry->getValue('id'))
       && ($entry = $$self{db}->lookup("ID:$id"))) {
       my $authors  = $entry->getValue('authors');


### PR DESCRIPTION
This is a minor change with an important impact for my server-side use of LaTeXML. Key points of understanding:
 * BibTeX keys are case insensitive. LaTeXML uses a lower-cased canonical form to accommodate that, which is great.
 * While lookup should work in a case-insensitive manner, the actual key value shouldn't be changed, in terms of reporting the key back to the log or output.
 * In my use, I need the missing citations to be recorded on output with the exact key written in the source, in order to have some sanity and not worry about special normalizations LaTeXML has a preference towards.

This PR preserves the functional behaviour, while leaving the key intact for output. Feedback welcome!