### PR TITLE
grffile.sty.ltxml

### DIFF
--- a/lib/LaTeXML/Package/grffile.sty.ltxml
+++ b/lib/LaTeXML/Package/grffile.sty.ltxml
@@ -1,0 +1,25 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  grffile                                                            | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+# The main use of grffile.sty is to allow for filenames with spaces in \includegraphics
+# LaTeXML can already handle that natively.
+
+# Documentation: http://bay.uchicago.edu/tex-archive/macros/latex/contrib/oberdiek/grffile.pdf
+
+DefMacro('\grffilesetup{}', '');
+# #======================================================================
+1;


### PR DESCRIPTION
It extends the pathname capabilities of graphicx, which (I am almost certain) is already supported by native LaTeXML.

We use this LaTeX style at Authorea, so I am sending over a stub binding to the LaTeXML master.