### PR TITLE
Daemon-friendly listings and literal strings

### DIFF
--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -239,6 +239,7 @@ sub initializeState {
   my $gullet  = $stomach->getGullet;
   $stomach->initialize;
   my $paths = $state->lookupValue('SEARCHPATHS');
+  $state->assignValue('InitialPreloads' => 1, 'global');
   foreach my $preload (@files) {
     my ($options, $type);
     $options = $1 if $preload =~ s/^\[([^\]]*)\]//;
@@ -258,6 +259,7 @@ sub initializeState {
     LaTeXML::Package::InputDefinitions($preload, type => $type,
       handleoptions => $handleoptions, options => $options);
   }
+  $state->assignValue('InitialPreloads' => undef, 'global');
   return; }
 
 sub writeDOM {

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -34,7 +34,7 @@ sub create {
     $options{shortsource} = "$name.$ext";
     return $class->new($options{content}, %options); }
   elsif ($source =~ s/^literal://) {    # we've supplied literal data
-    $options{source} = 'Literal String' unless defined $options{source};
+    $options{source} = "Literal String ".substr($source,0,10) unless defined $options{source};
     return $class->new($source, %options); }
   elsif (!defined $source) {
     return $class->new('', %options); }

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -1296,8 +1296,8 @@ sub lstLoadConfiguration {
   AssignValue(LST_LANGUAGE_FILES => [lstSplit(Digest(T_CS('\lstlanguagefiles')))], 'global');
   # Now, if you want to read in all definitions immediately, you could do this (Daemon?)
   # otherwise, they'll be read in whenever missing languages are used.
-##  while(my $file = ShiftValue('LST_LANGUAGE_FILES')){
-##    InputDefinitions($file,noerror=>1); }
+  while(my $file = ShiftValue('LST_LANGUAGE_FILES')){
+    InputDefinitions($file,noerror=>1); }
   return; }
 
 lstLoadConfiguration();

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -1294,10 +1294,12 @@ EoTeX
 sub lstLoadConfiguration {
   InputDefinitions("listings", type => 'cfg');
   AssignValue(LST_LANGUAGE_FILES => [lstSplit(Digest(T_CS('\lstlanguagefiles')))], 'global');
-  # Now, if you want to read in all definitions immediately, you could do this (Daemon?)
+
+  # Now, if you want to read in all definitions immediately, you could do this (on preload)
   # otherwise, they'll be read in whenever missing languages are used.
-  while(my $file = ShiftValue('LST_LANGUAGE_FILES')){
-    InputDefinitions($file,noerror=>1); }
+  if (LookupValue('InitialPreloads')) {
+    while(my $file = ShiftValue('LST_LANGUAGE_FILES')){
+      InputDefinitions($file,noerror=>1); } }
   return; }
 
 lstLoadConfiguration();


### PR DESCRIPTION
It took me a while to realize why the listing language styles were being reloaded on every daemonized conversion job, and then I saw this wonderfully helpful commented out code.

I would like to make a very warm request for including it, as the speedup it grands in daemon mode is in the order of 5+ seconds, while classic mode wouldn't experience much of a hit.

I also included a very helpful 10 character snippet of the mouth content when reporting that a Literal String is being processed, so that the logs are a lot more informative. For example this helped me figure out I had to be looking at \lstset:
```
(Processing content Literal String \subsectio...
(Processing content Literal String \lstset{ %...
(Digesting TeX Anonymous String...
(Processing content Literal String \end{docum...
(Processing content Literal String \section{{...
(Processing content Literal String \lstset{ %...
(Digesting TeX Anonymous String...
(Processing content Literal String \end{docum...
(Processing content Literal String \section{L...
(Processing content Literal String \lstset{ %... 0.24 sec) 0.26 sec) 0.25 sec) 0.49 sec) 0.49 sec) 0.49 sec)
```

Would be super happy to see this merged!