### PR TITLE
Safe I/O option for latexml.sty

### DIFF
--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -34,6 +34,13 @@ DeclareOption('noids', sub { AssignValue('GENERATE_IDS' => 0, 'global'); });
 DeclareOption('comments',   sub { AssignValue('INCLUDE_COMMENTS' => 1, 'global'); });
 DeclareOption('nocomments', sub { AssignValue('INCLUDE_COMMENTS' => 0, 'global'); });
 
+DeclareOption('safeio',sub{
+  foreach my $macro(qw(input @@input @iinput include InputIfFileExists)) {
+    DefMacroI("\\$macro", undef, '\relax', locked => 1);
+  }
+  return;
+});
+
 ProcessOptions();
 #======================================================================
 # From latexml.sty

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -35,7 +35,7 @@ DeclareOption('comments',   sub { AssignValue('INCLUDE_COMMENTS' => 1, 'global')
 DeclareOption('nocomments', sub { AssignValue('INCLUDE_COMMENTS' => 0, 'global'); });
 
 DeclareOption('safeio',sub{
-  foreach my $macro(qw(input @@input @iinput include InputIfFileExists)) {
+  foreach my $macro(qw(input @@input @iinput include InputIfFileExists openin verbatiminput)) {
     DefMacroI("\\$macro", undef, '\relax', locked => 1);
   }
   return;


### PR DESCRIPTION
This is an important security enhancement for processing third-party TeX code in a web server context.

The PR disables all commands that perform a direct call to ```Package::Input``` or directly create a file Mouth. It may not be complete, but it is an important first step.