### PR TITLE
Preserve cite macro information as class attribute

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2869,7 +2869,7 @@ AssignValue(CITE_SEPARATOR      => T_OTHER(','));
 AssignValue(CITE_YY_SEPARATOR   => T_OTHER(','));
 AssignValue(CITE_NOTE_SEPARATOR => T_OTHER(','));
 
-DefConstructor('\@@cite{}', "<ltx:cite>#1</ltx:cite>",
+DefConstructor('\@@cite []{}', "<ltx:cite ?#1(class='ltx_citemacro_#1')>#2</ltx:cite>",
   mode => 'text');
 
 # \@@bibref{what to show}{bibkeys}{phrase1}{phrase2}
@@ -2890,6 +2890,7 @@ DefMacro('\cite[] Semiverbatim', sub {
       = map { LookupValue($_) } qw(CITE_STYLE CITE_OPEN CITE_CLOSE CITE_NOTE_SEPARATOR);
     $post = undef unless $post && $post->unlist;
     Invocation(T_CS('\@@cite'),
+      Tokens(Explode('cite')),
       Tokens($open,
         Invocation(T_CS('\@@bibref'), Tokens(Explode("Refnum")), $keys, undef, undef),
         ($post ? ($ns, T_SPACE, $post) : ()), $close)); });

--- a/lib/LaTeXML/Package/natbib.sty.ltxml
+++ b/lib/LaTeXML/Package/natbib.sty.ltxml
@@ -134,18 +134,21 @@ DefMacro('\cite[] Semiverbatim', sub {
     $post = undef unless $post && $post->unlist;
     if ($style eq 'numbers') {
       Invocation(T_CS('\@@cite'),
+        Tokens(Explode('cite')),
         Tokens($open,
           Invocation(T_CS('\@@bibref'), Tokens(Explode("Number")), $keys, undef, undef),
           ($post ? ($ns, T_SPACE, $post) : ()),
           $close)); }
     elsif ($style eq 'super') {
       Invocation(T_CS('\@@cite'),
+        Tokens(Explode('cite')),
         Tokens(Invocation(T_CS('\textsuperscript'),
             Invocation(T_CS('\@@bibref'), Tokens(Explode("Number")), $keys,
               undef, undef)),
           ($post ? (T_SPACE, $post) : ()))); }
     else {
       Invocation(T_CS('\@@cite'),
+        Tokens(Explode('cite')),
         Invocation(T_CS('\@@bibref'),
           Tokens(Explode("Authors Phrase1YearPhrase2")),
           $keys,
@@ -164,6 +167,7 @@ DefMacro('\citet OptionalMatch:* [][] Semiverbatim', sub {
     my $author = ($star ? "FullAuthors" : "Authors");
     if ($style eq 'numbers') {
       Invocation(T_CS('\@@cite'),
+        Tokens(Explode('citet')),
         Tokens(($pre ? ($pre, T_SPACE) : ()),
           Invocation(T_CS('\@@bibref'),
             Tokens(Explode("$author Phrase1NumberPhrase2")),
@@ -173,6 +177,7 @@ DefMacro('\citet OptionalMatch:* [][] Semiverbatim', sub {
           ($post ? ($ns->unlist, T_SPACE, $post->unlist) : ()))); }
     elsif ($style eq 'super') {
       Invocation(T_CS('\@@cite'),
+        Tokens(Explode('citet')),
         Tokens(($pre ? ($pre, T_SPACE) : ()),
           Invocation(T_CS('\@@bibref'),
             Tokens(Explode("$author Phrase1SuperPhrase2")),
@@ -180,6 +185,7 @@ DefMacro('\citet OptionalMatch:* [][] Semiverbatim', sub {
           ($post ? ($ns, T_SPACE, $post->unlist) : ()))); }
     else {
       Invocation(T_CS('\@@cite'),
+        Tokens(Explode('citet')),
         Invocation(T_CS('\@@bibref'),
           Tokens(Explode("$author Phrase1YearPhrase2")),
           $keys,
@@ -201,16 +207,19 @@ DefMacro('\citep OptionalMatch:* [][] Semiverbatim', sub {
 
     if ($style eq 'numbers') {
       Invocation(T_CS('\@@cite'),
+        Tokens(Explode('citep')),
         Tokens($open, ($pre ? ($pre, T_SPACE) : ()),
           Invocation(T_CS('\@@bibref'), Tokens(Explode("Number")), $keys, undef, undef),
           ($post ? ($ns, T_SPACE, $post) : ()), $close)); }
     elsif ($style eq 'super') {
       Invocation(T_CS('\@@cite'),
+        Tokens(Explode('citep')),
         Tokens(($pre ? ($pre, T_SPACE) : ()),
           Invocation(T_CS('\@@bibref'), Tokens(Explode("Super")), $keys, undef, undef),
           ($post ? (T_SPACE, $post) : ()))); }
     else {
       Invocation(T_CS('\@@cite'),
+        Tokens(Explode('citep')),
         Tokens($open->unlist, ($pre ? ($pre, T_SPACE) : ()),
           Invocation(T_CS('\@@bibref'),
             Tokens(Explode("${author}Phrase1Year")),
@@ -242,6 +251,7 @@ DefMacro('\citealp OptionalMatch:* [][] Semiverbatim', sub {
 DefMacro('\citenum Semiverbatim', sub {
     my ($gullet, $keys) = @_;
     Invocation(T_CS('\@@cite'),
+      Tokens(Explode('citenum')),
       Invocation(T_CS('\@@bibref'), Tokens(Explode("Number")), $keys, undef, undef)); });
 
 # Sorta right, but would like to avoid the nested <ltx:cite>!
@@ -252,22 +262,26 @@ DefMacro('\citeauthor OptionalMatch:* Semiverbatim', sub {
     my ($gullet, $star, $keys) = @_;
     my $author = ($star ? "FullAuthors" : "Authors");
     Invocation(T_CS('\@@cite'),
+      Tokens(Explode('citeauthor')),
       Invocation(T_CS('\@@bibref'), Tokens(Explode($author)), $keys, undef, undef)); });
 
 DefMacro('\citefullauthor Semiverbatim', sub {
     my ($gullet, $star, $keys) = @_;
     Invocation(T_CS('\@@cite'),
+      Tokens(Explode('citefullauthor')),
       Invocation(T_CS('\@@bibref'), Tokens(Explode("FullAuthors")), $keys, undef, undef)); });
 
 DefMacro('\citeyear Semiverbatim', sub {
     my ($gullet, $keys) = @_;
     Invocation(T_CS('\@@cite'),
+      Tokens(Explode('citeyear')),
       Invocation(T_CS('\@@bibref'), Tokens(Explode("Year")), $keys, undef, undef)); });
 
 DefMacro('\citeyearpar Semiverbatim', sub {
     my ($gullet, $keys) = @_;
     my ($open, $close) = map { LookupValue($_) } qw(CITE_OPEN CITE_CLOSE);
     Invocation(T_CS('\@@cite'),
+      Tokens(Explode('citeyearpar')),
       Tokens($open,
         Invocation(T_CS('\@@bibref'), Tokens(Explode("Year")), $keys, undef, undef),
         $close)); });
@@ -300,6 +314,7 @@ DefMacro('\citetalias Semiverbatim', sub {
     my ($gullet, $key) = @_;
     my ($open, $close) = map { LookupValue($_) } qw(CITE_OPEN CITE_CLOSE);
     Invocation(T_CS('\@@cite'),
+      Tokens(Explode('citealias')),
       Invocation(T_CS('\@@bibref'),
         Tokens(Explode("Phrase1")),
         $key,
@@ -309,6 +324,7 @@ DefMacro('\citepalias Semiverbatim', sub {
     my ($gullet, $key) = @_;
     my ($open, $close) = map { LookupValue($_) } qw(CITE_OPEN CITE_CLOSE);
     Invocation(T_CS('\@@cite'),
+      Tokens(Explode('citepalias')),
       Tokens($open,
         Invocation(T_CS('\@@bibref'),
           Tokens(Explode("Phrase1")),

--- a/t/daemon/formats/citation.xml
+++ b/t/daemon/formats/citation.xml
@@ -12,7 +12,7 @@
 <div class="ltx_page_content">
 <div class="ltx_document">
 <div id="p1" class="ltx_para">
-<p class="ltx_p">A sample citation <cite class="ltx_cite">[<a href="#bib.bib1" title="Handbook of mathematical functions with formulas, graphs, and mathematical tables" class="ltx_ref">AS64</a>]</cite>, then point to bibliography:</p>
+<p class="ltx_p">A sample citation <cite class="ltx_cite ltx_citemacro_cite">[<a href="#bib.bib1" title="Handbook of mathematical functions with formulas, graphs, and mathematical tables" class="ltx_ref">AS64</a>]</cite>, then point to bibliography:</p>
 </div>
 <div id="bib" class="ltx_bibliography">
 <h2 class="ltx_title ltx_title_bibliography">References</h2>

--- a/t/daemon/formats/citationraw.xml
+++ b/t/daemon/formats/citationraw.xml
@@ -12,7 +12,7 @@
 <div class="ltx_page_content">
 <div class="ltx_document">
 <div id="p1" class="ltx_para">
-<p class="ltx_p">A sample citation <cite class="ltx_cite">[<a href="#bib.bib1" title="Handbook of mathematical functions with formulas, graphs, and mathematical tables" class="ltx_ref">AS64</a>]</cite>, then point to bibliography:</p>
+<p class="ltx_p">A sample citation <cite class="ltx_cite ltx_citemacro_cite">[<a href="#bib.bib1" title="Handbook of mathematical functions with formulas, graphs, and mathematical tables" class="ltx_ref">AS64</a>]</cite>, then point to bibliography:</p>
 </div>
 <div id="bib" class="ltx_bibliography">
 <h2 class="ltx_title ltx_title_bibliography">References</h2>

--- a/t/theorem/amstheorem.xml
+++ b/t/theorem/amstheorem.xml
@@ -132,7 +132,7 @@ variant fonts and other differences.</p>
       <p>This is a test of a citing theorem to cite a theorem from some other source.</p>
     </para>
     <theorem class="ltx_theorem_varthm" xml:id="Thmvarthmx1">
-      <title class="ltx_runin" font="bold">Theorem 3.6 in <cite>[<bibref bibrefs="thatone" separator="," show="Refnum" yyseparator=","/>]</cite>.</title>
+      <title class="ltx_runin" font="bold">Theorem 3.6 in <cite class="ltx_citemacro_cite">[<bibref bibrefs="thatone" separator="," show="Refnum" yyseparator=","/>]</cite>.</title>
       <para xml:id="Thmvarthmx1.p1">
         <p>
           <text font="italic">No hyperlinking available here yet … but that’s not a


### PR DESCRIPTION
The goal of this pull request is to preserve more of the information we originally had in the TeX source to the XML output of LaTeXML.

In particular, I have added a hook for preserving the macro name of (natbib and core) citation commands (such as ```\citep``` or ```\citet```) as an optional argument to the internal ```\@@cite``` macro. I am happy to refactor if you find flaws in the approach.

My personal goal here is to apply different CSS styling to the different macros, when dealing with an HTML version of the input. 