### PR TITLE
Simple crossref fill-in for missing citations

### DIFF
--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -451,6 +451,12 @@ sub make_bibcite {
     $show = $saveshow;
     if (($show eq 'none') && @preformatted) {
       @stuff = @preformatted; $show = ''; }
+    elsif ($$datum{attr}{class} && ($$datum{attr}{class} eq 'ltx_missing_citation')) {
+      @stuff = (['ltx:ref', $$datum{attr}, $$datum{key} ]);
+      $didref = 1;
+      $show = '';
+    }
+
     while ($show) {
       if ($show =~ s/^authors?//i) {
         push(@stuff, $doc->cloneNodes(@{ $$datum{authors} })); }


### PR DESCRIPTION
For cases such as natbib, the fill-in "show" pattern becomes quite complex (e.g. ```AuthorPhrase1, AuthorPhrase2``` or similar). 

In the case for missing citations, I think we agreed in one of the previous pull requests, that we just want to propagate the citation key back into the XML, as a form of user-facing error report. This behaviour is currently broken under natbib, where you could get ```<cite>``` contents such as ```[]``` or ``` , ```.

So, with this pull request I am doing a simple circumvention of the ```show``` parser in the case of missing citations, which ensures we get the citation key into the final XML output.