### PR TITLE
Preserve RDFa in MathML

### DIFF
--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -78,9 +78,12 @@ sub outerWrapper {
       'altimg-width'  => $math->getAttribute('imagewidth'),
       'altimg-height' => $math->getAttribute('imageheight'),
       'altimg-valign' => ($depth ? -$depth : undef)); }        # Note the sign!
+  my @rdfa = map {my $val = ($math->getAttribute($_)||$xmath->getAttribute($_)); $val ? ($_ => $val) : ()}
+    qw(about resource property rel rev typeof datatype content);
   my $wrapped = ['m:math', { display => ($mode eq 'display' ? 'block' : 'inline'),
       class   => $math->getAttribute('class'),
       alttext => $math->getAttribute('tex'),
+      @rdfa,
       @img },
     $mml];
   # Associate the generated node with the source XMath node, but don't cross-reference


### PR DESCRIPTION
This is a stop gap measure to preserve all RDFa attributes in top-level math elements, akin to the way LaTeXML has been preserving image-related attributes.

Maybe it helps move the discussion forward, maybe it gets merged. I have tested and it does exactly what I would expect it to - the MathML <math> element can be seen carrying RDFa attributes e.g. in LaTeXML's HTML output.