### PR TITLE
Search for profiles in LaTeXML's --paths

### DIFF
--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -308,7 +308,7 @@ sub _obey_profile {
   if ($profile ne 'custom') {
     if (defined $$PROFILES_DB{$profile}) {
       %$profile_opts = %{ $$PROFILES_DB{$profile} }
-    } elsif (my $file = pathname_find($profile . '.opt', paths => [],
+    } elsif (my $file = pathname_find($profile . '.opt', paths => $$opts{paths},
         types => [], installation_subdir => 'resources/Profiles')) {
       my $conf_tmp = LaTeXML::Common::Config->new;
       $conf_tmp->read(_read_options_file($file));


### PR DESCRIPTION
Until now, LaTeXML would only look for profile ```.opt``` files in its own resource directory, ignoring user-supplied paths.

However, this hinders using custom profiles, and is also problematic for testing plugin modules. As ```make test``` executes the tests using the built ```blib``` directory, prior to installing LaTeXML, it becomes a necessity to be able to specify the built directories as search paths for LaTeXML, as in this example:
https://github.com/KWARC/LaTeXML-Plugin-MathWebSearch/commit/2b8838b3e5dc6a6105572c27d0dc52075b646c7b#diff-d0d26286eac2af991850ff3ab61960c8R16

My other request is that after merging here we also increment the minor version number of LaTeXML and push a new release to CPAN, so that I can have a successfully building plugin release of ```LaTeXML::Plugin::MathWebSearch```. This is part of our testing process for establishing an effective and convenient plug-in ecosystem.