### PR TITLE
Legible error messages for timeouts and interrupts

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -209,7 +209,7 @@ sub convert {
   # 2 Beginning Core conversion - digest the source:
   my ($digested, $dom, $serialized) = (undef, undef, undef);
   my $convert_eval_return = eval {
-    local $SIG{'ALRM'} = sub { die "Fatal:conversion:timeout Conversion timed out after " . $$opts{timeout} . " seconds!\n"; };
+    $$latexml{timeout} = $$opts{timeout}; # For reporting purposes
     alarm($$opts{timeout});
     my $mode = ($$opts{type} eq 'auto') ? 'TeX' : $$opts{type};
     $digested = $latexml->digestFile($source, preamble => $current_preamble,

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -227,8 +227,10 @@ sub withState {
   # And, set fancy error handler for ANY die!
   # Could be useful to distill the more common messages so they provide useful build statistics?
   local $SIG{__DIE__} = sub { LaTeXML::Common::Error::perl_die_handler(@_); };
-  local $SIG{INT} = sub { LaTeXML::Common::Error::Fatal('perl', 'interrupt', undef, "LaTeXML was interrupted", @_); };
+  local $SIG{INT} = sub { undef $SIG{__DIE__}; LaTeXML::Common::Error::Fatal('perl', 'interrupt', undef, "LaTeXML was interrupted", @_); };
   local $SIG{__WARN__} = sub { LaTeXML::Common::Error::perl_warn_handler(@_); };
+  local $SIG{ALRM} = sub { undef $SIG{__DIE__}; LaTeXML::Common::Error::Fatal('conversion','timeout', undef, "Conversion timed out after " . $$self{timeout} . " seconds!\n"); };
+
   local $LaTeXML::DUAL_BRANCH = '';
 
   return &$closure($STATE); }

--- a/t/daemon/runtimes/timeout.status
+++ b/t/daemon/runtimes/timeout.status
@@ -1,2 +1,2 @@
-2 fatal errors
+1 fatal error
 Error! Did not write file timeout.test.xml


### PR DESCRIPTION
Fixes #618 .

Not exactly sure if undefing the ```_DIE_``` signal is the optimal way of getting rid of the die Fatal error, but it works exactly as I expect it. With this PR the interrupt and timeout Fatals are cleanly displayed without any extra-wrappers.

An example with ```latexmlc --timeout=2 'literal:\def\foo{\foo\foo}\foo'```:
```
(Digesting TeX Anonymous String...
(Processing content Literal String \def\foo{\...
Fatal:conversion:timeout Conversion timed out after 2 seconds!
	at Literal String \def\foo{\; line 1 col 23
	In \foo from at String; line 1 col 18
	 <= Core::Gullet[@0x3750258] <= Core::Stomach[@0x3750150] <= ...
1 fatal error at /home/dreamweaver/git/my-LaTeXML/blib/script/../lib/LaTeXML/Common/Error.pm line 69.


Conversion complete: 1 fatal error.
Status:conversion:3
```