### PR TITLE
nameref.sty.ltxml

### DIFF
--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -16,6 +16,7 @@ use warnings;
 use LaTeXML::Package;
 
 RequirePackage('url');
+RequirePackage('nameref');
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Follow hyperref's manual.pdf
@@ -188,10 +189,9 @@ DefMacroI('\phantomsection', undef, '');
 # This only approximates the "contextual label" that should precede the number,
 # and ignores the user-definable macros.
 # But, we normally defer such bookkeeping until postprocessing....sigh
-DefMacro('\autoref Semiverbatim', '\ref{#1}');
 DefConstructor('\autoref Semiverbatim',
-  "<ltx:ref show='type refnum' labelref='#label'/>",
-  properties => sub { (label => CleanLabel($_[2])); });
+  "<ltx:ref class='ltx_refmacro_autoref' show='type refnum' labelref='#label'/>",
+  properties => sub { (label => CleanLabel($_[1])); });
 
 # Covered in LaTeX.pool, but non-ref character is ignored.
 # \ref*{label}

--- a/lib/LaTeXML/Package/nameref.sty.ltxml
+++ b/lib/LaTeXML/Package/nameref.sty.ltxml
@@ -1,0 +1,24 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  nameref                                                           | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+# We want to display the actual "name" of the labeled structure (e.g. \section),
+#   which is accessible via show="title"
+DefConstructor('\nameref Semiverbatim',
+  "<ltx:ref class='ltx_refmacro_nameref' show='title' labelref='#label'/>",
+  properties => sub { (label => CleanLabel($_[1])); });
+
+1;

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -1250,6 +1250,10 @@ sub trimChildNodes {
   elsif (!ref $node) {
     return ($node); }
   elsif (my @children = $node->childNodes) {
+    if (($self->getQName($node) eq 'ltx:title') && # Trim tags from titles
+      ($children[0]->nodeType == XML_ELEMENT_NODE) && ($self->getQName($children[0]) eq 'ltx:tag')) {
+      shift @children;
+    }
     if ($children[0]->nodeType == XML_TEXT_NODE) {
       my $s = $children[0]->data;
       $s =~ s/^\s+//;

--- a/t/post/hyperref-post.xml
+++ b/t/post/hyperref-post.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="hyperref"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="Document">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <section refnum="1" xml:id="S1" labels="LABEL:sec:intro" fragid="S1">
+    <title><tag close=" ">1</tag>Introduction</title>
+  </section>
+  <section refnum="2" xml:id="S2" labels="LABEL:sec:motivation" fragid="S2">
+    <title><tag close=" ">2</tag>Motivation</title>
+  </section>
+  <section refnum="3" xml:id="S3" labels="LABEL:sec:conclusion" fragid="S3">
+    <title><tag close=" ">3</tag>Conclusion</title>
+    <subsection refnum="3.1" xml:id="S3.SS1" labels="LABEL:subsec:nameref" fragid="S3.SS1">
+      <title><tag close=" ">3.1</tag>nameref</title>
+      <para xml:id="S3.SS1.p1" fragid="S3.SS1.p1">
+        <p>Nameref for sections <ref class="ltx_refmacro_nameref" labelref="LABEL:sec:intro" show="title" href="#S1" title="1 Introduction"><text class="ltx_ref_title">Introduction</text></ref> and <ref class="ltx_refmacro_nameref" labelref="LABEL:sec:motivation" show="title" href="#S2" title="2 Motivation"><text class="ltx_ref_title">Motivation</text></ref>.</p>
+      </para>
+      <para xml:id="S3.SS1.p2" fragid="S3.SS1.p2">
+        <p>And subsections <ref class="ltx_refmacro_nameref" labelref="LABEL:subsec:nameref" show="title" href="#S3.SS1" title="3.1 nameref ‣ 3 Conclusion"><text class="ltx_ref_title">nameref</text></ref> and <ref class="ltx_refmacro_nameref" labelref="LABEL:subsec:autoref" show="title" href="#S3.SS2" title="3.2 autoref ‣ 3 Conclusion"><text class="ltx_ref_title">autoref</text></ref>.</p>
+      </para>
+    </subsection>
+    <subsection refnum="3.2" xml:id="S3.SS2" labels="LABEL:subsec:autoref" fragid="S3.SS2">
+      <title><tag close=" ">3.2</tag>autoref</title>
+      <para xml:id="S3.SS2.p1" fragid="S3.SS2.p1">
+        <p>Autoref for <ref class="ltx_refmacro_autoref" labelref="LABEL:sec:intro" show="type refnum" href="#S1" title="1 Introduction"> <text class="ltx_ref_tag">1</text></ref> and <ref class="ltx_refmacro_autoref" labelref="LABEL:sec:motivation" show="type refnum" href="#S2" title="2 Motivation"> <text class="ltx_ref_tag">2</text></ref>.</p>
+      </para>
+      <para xml:id="S3.SS2.p2" fragid="S3.SS2.p2">
+        <p>And also <ref class="ltx_refmacro_autoref" labelref="LABEL:subsec:nameref" show="type refnum" href="#S3.SS1" title="3.1 nameref ‣ 3 Conclusion"> <text class="ltx_ref_tag">3.1</text></ref> and <ref class="ltx_refmacro_autoref" labelref="LABEL:subsec:autoref" show="type refnum" href="#S3.SS2" title="3.2 autoref ‣ 3 Conclusion"> <text class="ltx_ref_tag">3.2</text></ref>.</p>
+      </para>
+      <para xml:id="S3.SS2.p3" fragid="S3.SS2.p3">
+        <p>These two should fail gracefully: <ref class="ltx_refmacro_nameref ltx_missing_label" labelref="LABEL:sec:fail" show="title" broken="1">LABEL:sec:fail</ref> and <ref class="ltx_refmacro_autoref ltx_missing_label" labelref="LABEL:sec:fail" show="type refnum" broken="1">LABEL:sec:fail</ref>.</p>
+      </para>
+    </subsection>
+  </section>
+</document>

--- a/t/post/hyperref.xml
+++ b/t/post/hyperref.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="hyperref"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <section refnum="1" xml:id="S1" labels="LABEL:sec:intro">
+    <title><tag close=" ">1</tag>Introduction</title>
+  </section>
+  <section refnum="2" xml:id="S2" labels="LABEL:sec:motivation">
+    <title><tag close=" ">2</tag>Motivation</title>
+  </section>
+  <section refnum="3" xml:id="S3" labels="LABEL:sec:conclusion">
+    <title><tag close=" ">3</tag>Conclusion</title>
+    <subsection refnum="3.1" xml:id="S3.SS1" labels="LABEL:subsec:nameref">
+      <title><tag close=" ">3.1</tag>nameref</title>
+      <para xml:id="S3.SS1.p1">
+        <p>Nameref for sections <ref class="ltx_refmacro_nameref" labelref="LABEL:sec:intro" show="title"/> and <ref class="ltx_refmacro_nameref" labelref="LABEL:sec:motivation" show="title"/>.</p>
+      </para>
+      <para xml:id="S3.SS1.p2">
+        <p>And subsections <ref class="ltx_refmacro_nameref" labelref="LABEL:subsec:nameref" show="title"/> and <ref class="ltx_refmacro_nameref" labelref="LABEL:subsec:autoref" show="title"/>.</p>
+      </para>
+    </subsection>
+    <subsection refnum="3.2" xml:id="S3.SS2" labels="LABEL:subsec:autoref">
+      <title><tag close=" ">3.2</tag>autoref</title>
+      <para xml:id="S3.SS2.p1">
+        <p>Autoref for <ref class="ltx_refmacro_autoref" labelref="LABEL:sec:intro" show="type refnum"/> and <ref class="ltx_refmacro_autoref" labelref="LABEL:sec:motivation" show="type refnum"/>.</p>
+      </para>
+      <para xml:id="S3.SS2.p2">
+        <p>And also <ref class="ltx_refmacro_autoref" labelref="LABEL:subsec:nameref" show="type refnum"/> and <ref class="ltx_refmacro_autoref" labelref="LABEL:subsec:autoref" show="type refnum"/>.</p>
+      </para>
+      <para xml:id="S3.SS2.p3">
+        <p>These two should fail gracefully: <ref class="ltx_refmacro_nameref" labelref="LABEL:sec:fail" show="title"/> and <ref class="ltx_refmacro_autoref" labelref="LABEL:sec:fail" show="type refnum"/>.</p>
+      </para>
+    </subsection>
+  </section>
+</document>

--- a/t/structure/hyperref.tex
+++ b/t/structure/hyperref.tex
@@ -1,0 +1,20 @@
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+\section{Introduction}\label{sec:intro}
+\section{Motivation}\label{sec:motivation}
+\section{Conclusion}\label{sec:conclusion}
+
+\subsection{nameref}\label{subsec:nameref}
+Nameref for sections \nameref{sec:intro} and \nameref{sec:motivation}.
+
+And subsections \nameref{subsec:nameref} and \nameref{subsec:autoref}.
+
+\subsection{autoref}\label{subsec:autoref}
+Autoref for \autoref{sec:intro} and \autoref{sec:motivation}.
+
+And also \autoref{subsec:nameref} and \autoref{subsec:autoref}.
+
+These two should fail gracefully: \nameref{sec:fail} and \autoref{sec:fail}.
+
+\end{document}

--- a/t/structure/hyperref.xml
+++ b/t/structure/hyperref.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="hyperref"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <section refnum="1" xml:id="S1" labels="LABEL:sec:intro">
+    <title><tag close=" ">1</tag>Introduction</title>
+  </section>
+  <section refnum="2" xml:id="S2" labels="LABEL:sec:motivation">
+    <title><tag close=" ">2</tag>Motivation</title>
+  </section>
+  <section refnum="3" xml:id="S3" labels="LABEL:sec:conclusion">
+    <title><tag close=" ">3</tag>Conclusion</title>
+    <subsection refnum="3.1" xml:id="S3.SS1" labels="LABEL:subsec:nameref">
+      <title><tag close=" ">3.1</tag>nameref</title>
+      <para xml:id="S3.SS1.p1">
+        <p>Nameref for sections <ref class="ltx_refmacro_nameref" labelref="LABEL:sec:intro" show="title"/> and <ref class="ltx_refmacro_nameref" labelref="LABEL:sec:motivation" show="title"/>.</p>
+      </para>
+      <para xml:id="S3.SS1.p2">
+        <p>And subsections <ref class="ltx_refmacro_nameref" labelref="LABEL:subsec:nameref" show="title"/> and <ref class="ltx_refmacro_nameref" labelref="LABEL:subsec:autoref" show="title"/>.</p>
+      </para>
+    </subsection>
+    <subsection refnum="3.2" xml:id="S3.SS2" labels="LABEL:subsec:autoref">
+      <title><tag close=" ">3.2</tag>autoref</title>
+      <para xml:id="S3.SS2.p1">
+        <p>Autoref for <ref class="ltx_refmacro_autoref" labelref="LABEL:sec:intro" show="type refnum"/> and <ref class="ltx_refmacro_autoref" labelref="LABEL:sec:motivation" show="type refnum"/>.</p>
+      </para>
+      <para xml:id="S3.SS2.p2">
+        <p>And also <ref class="ltx_refmacro_autoref" labelref="LABEL:subsec:nameref" show="type refnum"/> and <ref class="ltx_refmacro_autoref" labelref="LABEL:subsec:autoref" show="type refnum"/>.</p>
+      </para>
+      <para xml:id="S3.SS2.p3">
+        <p>These two should fail gracefully: <ref class="ltx_refmacro_nameref" labelref="LABEL:sec:fail" show="title"/> and <ref class="ltx_refmacro_autoref" labelref="LABEL:sec:fail" show="type refnum"/>.</p>
+      </para>
+    </subsection>
+  </section>
+</document>


### PR DESCRIPTION
 * Added support for nameref.sty.ltxml
 * Fixed an argument counting bug for \autoref, cleaned up double definition
 * Trimmed "tag"s from shown titles in CrossRef
 * Added classes for ref macro names 
  * this bit is openly Authorea-motivated, as we are doing the labels and referencing outside of LaTeXML and would like to know the macro information, so that we created the right label
 * Added tests