### PR TITLE
Acronyms now behave as expected in preambles

### DIFF
--- a/lib/LaTeXML/Package/acronym.sty.ltxml
+++ b/lib/LaTeXML/Package/acronym.sty.ltxml
@@ -175,7 +175,8 @@ Tag('ltx:glossaryentry', afterClose => sub { GenerateID(@_, ''); });
 # Should these be allowed inside ltx:glossarylist, or float outside it?
 DefConstructor('\acrodef{}[]{}',
   "<ltx:glossaryphrase role='acronym' key='#1' show='short'>?#2(#2)(#1)</ltx:glossaryphrase>"
-    . "<ltx:glossaryphrase role='acronym' key='#1' show='long'>#3</ltx:glossaryphrase>");
+    . "<ltx:glossaryphrase role='acronym' key='#1' show='long'>#3</ltx:glossaryphrase>",
+bounded => 1, beforeDigest => sub { AssignValue(inPreamble => 0); });
 
 Let('\newacro', '\acrodef');
 Let('\acro',    '\acrodef');

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -747,4 +747,5 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="ltx:glossaryphrase[@role='acronym']"/>
 </xsl:stylesheet>


### PR DESCRIPTION
Fixes #623

I am not sure this is the "optimal" fix, but the minimal example now behaves as expected:
```tex
\documentclass{article}
\usepackage{acronym}

\newacro{HST}{Hubble Space Telescope}
\newacro{RGB}{Red Giant Branch}

\begin{document}
Testing \ac{HST} and \ac{RGB}, \ac{RGB} and \ac{RGB}.
\end{document}
```