### PR TITLE
\nonumber is now preserved in the TeX revision

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1529,7 +1529,9 @@ Tag('ltx:Math', afterOpen => sub { GenerateID(@_, 'm'); });
 # not the numbering of the equationgroup itself.
 DefPrimitiveI('\@equationgroup@number', undef, sub { AssignValue(EQUATIONGROUP_NUMBER => '_AUTO_'); });
 DefPrimitiveI('\@equationgroup@nonumber', undef, sub { AssignValue(EQUATIONGROUP_NUMBER => 0); });
-DefPrimitiveI('\nonumber', undef, sub { AssignValue(EQUATIONROW_NUMBER => 0, 'global'); });
+DefPrimitiveI('\nonumber', undef, sub {
+ AssignValue(EQUATIONROW_NUMBER => 0, 'global');
+ Box(undef, undef, undef, T_CS('\nonumber'), alignmentSkippable => 1);});
 
 # Alternate versions of alignment open/close@row that deal with numbering.
 # Depending on how an eqnarray ends, we might end up with an empty equation, which will be deleted.


### PR DESCRIPTION
Huge thanks to @brucemiller who tutored me through this enhancement.

LaTeXML has a brilliant design for dealing with boxes and the intricacies of TeX, as long as one manages to properly get the design in focus.

Now that I did, here is a super simple pull request that preserves ```\nonumber``` in the TeX revision source, so that follow-up applications can benefit from it.