### PR TITLE
Reversion for label

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2649,7 +2649,7 @@ DefConstructor('\label Semiverbatim', sub {
       my %labels = map { ($_ => 1) } $label, split(/\s+/, $node->getAttribute('labels') || '');
       $document->setAttribute($node, labels => join(' ', sort keys %labels));
       $document->setNode($savenode); } },
-  reversion   => '',
+  reversion   => '\label{#1}',
   properties  => { alignmentSkippable => 1 },
   afterDigest => sub {
     my $label = CleanLabel(ToString($_[1]->getArg(1)));

--- a/t/alignment/eqnarray.xml
+++ b/t/alignment/eqnarray.xml
@@ -8,7 +8,7 @@
     <equationgroup class="ltx_eqn_eqnarray" xml:id="S0.EGx1">
       <equation labels="LABEL:e1" xml:id="S0.E1" refnum="1" frefnum="(1)">
         <MathFork>
-          <Math xml:id="S0.E1.m4" tex="\displaystyle x=17y" text="x = 17 * y">
+          <Math xml:id="S0.E1.m4" tex="\displaystyle x=17y\label{e1}" text="x = 17 * y">
             <XMath>
               <XMApp>
                 <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -38,7 +38,7 @@
                 </Math>
               </td>
               <td align="left">
-                <Math mode="inline" xml:id="S0.E1.m3" tex="\displaystyle 17y" text="17 * y">
+                <Math mode="inline" xml:id="S0.E1.m3" tex="\displaystyle 17y\label{e1}" text="17 * y">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
@@ -54,7 +54,7 @@
       </equation>
       <equation labels="LABEL:e2" xml:id="S0.E2" refnum="2" frefnum="(2)">
         <MathFork>
-          <Math xml:id="S0.E2.m4" tex="\displaystyle y&gt;a+b+c+d+e+f+g+h+i+j+\nonumber k+l+m+n+o+p" text="y &gt; a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p">
+          <Math xml:id="S0.E2.m4" tex="\displaystyle y&gt;a+b+c+d+e+f+g+h+i+j+\nonumber k+l+m+n+o+p\label{e2}" text="y &gt; a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p">
             <XMath>
               <XMApp>
                 <XMTok meaning="greater-than" role="RELOP">&gt;</XMTok>

--- a/t/alignment/eqnarray.xml
+++ b/t/alignment/eqnarray.xml
@@ -125,7 +125,7 @@
               <td align="right"/>
               <td align="center"/>
               <td align="left">
-                <Math mode="inline" xml:id="S0.E2.m3" tex="\displaystyle k+l+m+n+o+p" text="k + l + m + n + o + p">
+                <Math mode="inline" xml:id="S0.E2.m3" tex="\displaystyle k+l+m+n+o+p\label{e2}" text="k + l + m + n + o + p">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="plus" role="ADDOP">+</XMTok>
@@ -149,7 +149,7 @@
     <equationgroup class="ltx_eqn_eqnarray" xml:id="S0.EGx2">
       <equation labels="LABEL:e3" xml:id="S0.E4" refnum="4" frefnum="(4)">
         <MathFork>
-          <Math xml:id="S0.E4.m4" tex="\displaystyle x=17y" text="x = 17 * y">
+          <Math xml:id="S0.E4.m4" tex="\displaystyle x=17y\label{e3}" text="x = 17 * y">
             <XMath>
               <XMApp>
                 <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -179,7 +179,7 @@
                 </Math>
               </td>
               <td align="left">
-                <Math mode="inline" xml:id="S0.E4.m3" tex="\displaystyle 17y" text="17 * y">
+                <Math mode="inline" xml:id="S0.E4.m3" tex="\displaystyle 17y\label{e3}" text="17 * y">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
@@ -195,7 +195,7 @@
       </equation>
       <equation labels="LABEL:e4" xml:id="S0.E5" refnum="5" frefnum="(5)">
         <MathFork>
-          <Math xml:id="S0.E5.m4" tex="\displaystyle y&gt;a+b+c+d+e+f+g+h+i+j+\nonumber k+l+m+n+o+p" text="y &gt; a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p">
+          <Math xml:id="S0.E5.m4" tex="\displaystyle y&gt;a+b+c+d+e+f+g+h+i+j+\nonumber k+l+m+n+o+p\label{e4}" text="y &gt; a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p">
             <XMath>
               <XMApp>
                 <XMTok meaning="greater-than" role="RELOP">&gt;</XMTok>
@@ -266,7 +266,7 @@
               <td align="right"/>
               <td align="center"/>
               <td align="left">
-                <Math mode="inline" xml:id="S0.E5.m3" tex="\displaystyle k+l+m+n+o+p" text="k + l + m + n + o + p">
+                <Math mode="inline" xml:id="S0.E5.m3" tex="\displaystyle k+l+m+n+o+p\label{e4}" text="k + l + m + n + o + p">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="plus" role="ADDOP">+</XMTok>

--- a/t/ams/amsdisplay.xml
+++ b/t/ams/amsdisplay.xml
@@ -29,7 +29,7 @@
       </Math>
     </equation>
     <equation frefnum="(2)" refnum="2" xml:id="S0.E2" labels="LABEL:xx">
-      <Math mode="display" xml:id="S0.E2.m1" tex="\begin{split}\displaystyle a&amp;\displaystyle=b+c-c\\&#10;&amp;\displaystyle\quad+e-f\\&#10;&amp;\displaystyle=g+h\\&#10;&amp;\displaystyle=i\end{split}" text="a = (((b + c) - c) + e) - f = g + h = i">
+      <Math mode="display" xml:id="S0.E2.m1" tex="\label{xx}\begin{split}\displaystyle a&amp;\displaystyle=b+c-c\\&#10;&amp;\displaystyle\quad+e-f\\&#10;&amp;\displaystyle=g+h\\&#10;&amp;\displaystyle=i\end{split}" text="a = (((b + c) - c) + e) - f = g + h = i">
         <XMath>
           <XMDual>
             <XMApp>

--- a/t/theorem/amstheorem.xml
+++ b/t/theorem/amstheorem.xml
@@ -51,7 +51,7 @@ be the diagonal pigspan of a pig <Math mode="inline" xml:id="S1.Thmthm2.p1.m5" t
 Then <Math mode="inline" xml:id="S1.Thmthm2.p1.m6" tex="P" text="P"><XMath><XMTok role="UNKNOWN">P</XMTok></XMath></Math> is capable of standing on the corners of <Math mode="inline" xml:id="S1.Thmthm2.p1.m7" tex="Q" text="Q"><XMath><XMTok role="UNKNOWN">Q</XMTok></XMath></Math> iff</text>
         </p>
         <equation frefnum="(1)" refnum="1" xml:id="S1.E1" labels="LABEL:sdq">
-          <Math mode="display" xml:id="S1.E1.m1" tex="\sigma\geq\sqrt{d_{\max}^{2}+d_{\min}^{2}}." text="sigma &gt;= square-root@((d _ maximum) ^ 2 + (d _ minimum) ^ 2)">
+          <Math mode="display" xml:id="S1.E1.m1" tex="\label{sdq}\sigma\geq\sqrt{d_{\max}^{2}+d_{\min}^{2}}." text="sigma &gt;= square-root@((d _ maximum) ^ 2 + (d _ minimum) ^ 2)">
             <XMath>
               <XMApp punctuation=".">
                 <XMTok meaning="greater-than-or-equals" name="geq" role="RELOP">≥</XMTok>
@@ -231,7 +231,7 @@ be the diagonal pigspan of a pig <Math mode="inline" xml:id="S4.Thmthmsw2.p1.m5"
 Then <Math mode="inline" xml:id="S4.Thmthmsw2.p1.m6" tex="P" text="P"><XMath><XMTok role="UNKNOWN">P</XMTok></XMath></Math> is capable of standing on the corners of <Math mode="inline" xml:id="S4.Thmthmsw2.p1.m7" tex="Q" text="Q"><XMath><XMTok role="UNKNOWN">Q</XMTok></XMath></Math> iff</text>
         </p>
         <equation frefnum="(2)" refnum="2" xml:id="S4.E2" labels="LABEL:sdqsw">
-          <Math mode="display" xml:id="S4.E2.m1" tex="\sigma\geq\sqrt{d_{\max}^{2}+d_{\min}^{2}}." text="sigma &gt;= square-root@((d _ maximum) ^ 2 + (d _ minimum) ^ 2)">
+          <Math mode="display" xml:id="S4.E2.m1" tex="\label{sdqsw}\sigma\geq\sqrt{d_{\max}^{2}+d_{\min}^{2}}." text="sigma &gt;= square-root@((d _ maximum) ^ 2 + (d _ minimum) ^ 2)">
             <XMath>
               <XMApp punctuation=".">
                 <XMTok meaning="greater-than-or-equals" name="geq" role="RELOP">≥</XMTok>

--- a/t/theorem/latextheorem.xml
+++ b/t/theorem/latextheorem.xml
@@ -33,7 +33,7 @@ be the diagonal pigspan of a pig <Math mode="inline" xml:id="S1.Thmthm2.p1.m5" t
 Then <Math mode="inline" xml:id="S1.Thmthm2.p1.m6" tex="P" text="P"><XMath><XMTok role="UNKNOWN">P</XMTok></XMath></Math> is capable of standing on the corners of <Math mode="inline" xml:id="S1.Thmthm2.p1.m7" tex="Q" text="Q"><XMath><XMTok role="UNKNOWN">Q</XMTok></XMath></Math> iff</text>
         </p>
         <equation frefnum="(1)" refnum="1" xml:id="S1.E1" labels="LABEL:sdq">
-          <Math mode="display" xml:id="S1.E1.m1" tex="\sigma\geq\sqrt{d_{\max}^{2}+d_{\min}^{2}}." text="sigma &gt;= square-root@((d _ maximum) ^ 2 + (d _ minimum) ^ 2)">
+          <Math mode="display" xml:id="S1.E1.m1" tex="\label{sdq}\sigma\geq\sqrt{d_{\max}^{2}+d_{\min}^{2}}." text="sigma &gt;= square-root@((d _ maximum) ^ 2 + (d _ minimum) ^ 2)">
             <XMath>
               <XMApp punctuation=".">
                 <XMTok meaning="greater-than-or-equals" name="geq" role="RELOP">≥</XMTok>


### PR DESCRIPTION
The actual change here is a single line, which sets the label reversion to:
```
   reversion   => '\label{#1}', 
```

The rest of the pull request is updating all tests files. @brucemiller do you see any issues with making label revertable? It makes preserving the literal math tex even better (esp. for eqnarrays)