### PR TITLE
Revert "oops, forgot to update test files"

### DIFF
--- a/t/alignment/eqnarray.xml
+++ b/t/alignment/eqnarray.xml
@@ -54,7 +54,7 @@
       </equation>
       <equation labels="LABEL:e2" xml:id="S0.E2" refnum="2" frefnum="(2)">
         <MathFork>
-          <Math xml:id="S0.E2.m4" tex="\displaystyle y&gt;a+b+c+d+e+f+g+h+i+j+\nonumber k+l+m+n+o+p" text="y &gt; a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p">
+          <Math xml:id="S0.E2.m4" tex="\displaystyle y&gt;a+b+c+d+e+f+g+h+i+j+k+l+m+n+o+p" text="y &gt; a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p">
             <XMath>
               <XMApp>
                 <XMTok meaning="greater-than" role="RELOP">&gt;</XMTok>
@@ -98,7 +98,7 @@
                 </Math>
               </td>
               <td align="left">
-                <Math mode="inline" xml:id="S0.Ex1.m3" tex="\displaystyle a+b+c+d+e+f+g+h+i+j+\nonumber" text="a + b + c + d + e + f + g + h + i + limit-from@(j, +)">
+                <Math mode="inline" xml:id="S0.Ex1.m3" tex="\displaystyle a+b+c+d+e+f+g+h+i+j+" text="a + b + c + d + e + f + g + h + i + limit-from@(j, +)">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="plus" role="ADDOP">+</XMTok>
@@ -195,7 +195,7 @@
       </equation>
       <equation labels="LABEL:e4" xml:id="S0.E5" refnum="5" frefnum="(5)">
         <MathFork>
-          <Math xml:id="S0.E5.m4" tex="\displaystyle y&gt;a+b+c+d+e+f+g+h+i+j+\nonumber k+l+m+n+o+p" text="y &gt; a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p">
+          <Math xml:id="S0.E5.m4" tex="\displaystyle y&gt;a+b+c+d+e+f+g+h+i+j+k+l+m+n+o+p" text="y &gt; a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p">
             <XMath>
               <XMApp>
                 <XMTok meaning="greater-than" role="RELOP">&gt;</XMTok>
@@ -239,7 +239,7 @@
                 </Math>
               </td>
               <td align="left">
-                <Math mode="inline" xml:id="S0.Ex2.m3" tex="\displaystyle a+b+c+d+e+f+g+h+i+j+\nonumber" text="a + b + c + d + e + f + g + h + i + limit-from@(j, +)">
+                <Math mode="inline" xml:id="S0.Ex2.m3" tex="\displaystyle a+b+c+d+e+f+g+h+i+j+" text="a + b + c + d + e + f + g + h + i + limit-from@(j, +)">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="plus" role="ADDOP">+</XMTok>


### PR DESCRIPTION
Reverts brucemiller/LaTeXML#637
Sorry, this just really isn't the right way to go for this. The TeX string ought, in my view, to be "clean" math markup. nonumbers, labels, etc are document-level stuff, that are embedded in the math.