### PR TITLE
whatsout math returns image content when imagesrc attr is set

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -16,6 +16,7 @@ use warnings;
 use LaTeXML::Util::Pathname;
 use File::Spec::Functions qw(catfile);
 use File::Path qw(rmtree);
+use File::Slurp qw(read_file);
 use IO::String;
 use Archive::Zip qw(:CONSTANTS :ERROR_CODES);
 
@@ -210,7 +211,13 @@ sub get_math {
   if (!$math_count) {
     return get_embeddable($doc); }
   elsif ($math_count == 1) {
-    return $mnodes[0]; }
+    # A bit unusual, but if the math has an SVG/other image representation in an external file,
+    # we really just want to return the contents of that file
+    if (my $image_src = $mnodes[0]->getAttribute('imagesrc')) {
+      my $image_content = read_file(pathname_find($image_src));
+      return $image_content; }
+    else {
+      return $mnodes[0]; } }
   elsif ($math_count > 1) {
     my $math       = $mnodes[0];
     my $math_found = 0;


### PR DESCRIPTION
First CICM pull request! Moritz wanted an easy access to the SVG content of the math conversion, see discussion here:
https://github.com/dginev/LaTeXML-Plugin-ltxpsgi/issues/3

I am quite unsure if File::Slurp is the best way to read the content, but this actually works, so that you get only SVG when you do:
```
latexmlc --whatsin=math 'literal:abc' --whatsout=math --mathsvg 
```

But I would really appreciate advice and a code review by @brucemiller , since I'm not sure I fully understand how imagesrc attributes interact with formulas, in particular when there is parallel markup.