### PR TITLE
Add a maybeAltimg script to lib/LaTeXML/resources/javascript. #652

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -290,6 +290,7 @@ lib/LaTeXML/resources/CSS/ltx-apj.css
 lib/LaTeXML/resources/CSS/ltx-listings.css
 lib/LaTeXML/resources/CSS/ltx-svjour.css
 lib/LaTeXML/resources/CSS/ltx-ulem.css
+lib/LaTeXML/resources/javascript/LaTeXML-maybeAltimg.js
 lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
 lib/LaTeXML/resources/Profiles/fragment-html.opt
 lib/LaTeXML/resources/Profiles/fragment-xhtml.opt

--- a/lib/LaTeXML/resources/javascript/LaTeXML-maybeAltimg.js
+++ b/lib/LaTeXML/resources/javascript/LaTeXML-maybeAltimg.js
@@ -1,0 +1,49 @@
+//======================================================================
+// Display altimg, IFF the current browser can't handle MathML natively.
+
+(function() {
+    function refreshMath() {
+        var mathml_namespace = "http://www.w3.org/1998/Math/MathML";
+        if (document.body != null) {
+            // Replace each <math> tag with an <img> tag. Note that each such
+            // replacement automatically decreases the length of the maths list
+            // so we always work on the 0-th item.
+            var maths =
+                document.getElementsByTagNameNS(mathml_namespace, "math");
+            while (maths.length > 0) {
+                var math = maths[0];
+                var img = document.createElement("img");
+                img.src = math.getAttribute("altimg") || "";
+                img.alt = math.getAttribute("alttext") || "";
+
+                // MathML attributes and CSS properties have slightly different
+                // syntaxes, but this should work for most length values with
+                // explicit unit.
+                if (math.hasAttribute("altimg-width")) {
+                    img.style.width = math.getAttribute("altimg-width");
+                }
+                if (math.hasAttribute("altimg-height")) {
+                    img.style.height = math.getAttribute("altimg-height");
+                }
+                if (math.hasAttribute("altimg-valign")) {
+                    img.style.verticalAlign = math.getAttribute("altimg-valign");
+                }
+
+                math.parentNode.replaceChild(img, math);
+            }
+        }
+    }
+
+    // Use alt images unless we can handle MathML
+    var agent = navigator.userAgent;
+    var is_gecko = (agent.indexOf("Gecko") > -1 &&
+                    agent.indexOf("KHTML") === -1 &&
+                    agent.indexOf("Trident") === -1);
+    var has_mathplayer = agent.match(/MathPlayer/);
+    if (!is_gecko && !has_mathplayer) {
+        refreshMath();
+        // Maybe unnecessary, or overkill, but...
+        window.addEventListener("DOMContentReady", refreshMath);
+        window.addEventListener("load", refreshMath);
+    }
+}());

--- a/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
+++ b/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
@@ -1,29 +1,32 @@
 //======================================================================
 // Load MathJax, IFF the current browser can't handle MathML natively.
 
-var LTX_mathjax_url = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML";
+(function() {
+    var mathjax_url =
+        "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML";
 
-function LTX_refreshMath(){
-    // Maybe unnecessary, or overkill, but...
-    if(typeof MathJax != "undefined"){
-	MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
-    }}
+    function refreshMath() {
+        // Maybe unnecessary, or overkill, but...
+        if (typeof MathJax != "undefined") {
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+        }
+    }
 
-var LTX_agent = navigator.userAgent;
-// Add script element loading MathJax unless we can handle MathML
-if (! ( ((LTX_agent.indexOf('Gecko') > -1)
-         && (LTX_agent.indexOf('KHTML') === -1) && (LTX_agent.indexOf('Trident') === -1))
-        || LTX_agent.match(/MathPlayer/) ) ){
-    var script = document.createElement('script');
-    var head = document.getElementsByTagName("head")[0];
-    if(head != null){
-        script.type = "text/javascript";
-        script.src = LTX_mathjax_url;
-
-        script.onreadystatechange = LTX_refreshMath;
-        script.onload = LTX_refreshMath;
-
-        head.appendChild(script); 
-}}
-
-    
+    // Add script element loading MathJax unless we can handle MathML
+    var agent = navigator.userAgent;
+    var is_gecko = (agent.indexOf("Gecko") > -1 &&
+                    agent.indexOf("KHTML") === -1 &&
+                    agent.indexOf("Trident") === -1);
+    var has_mathplayer = agent.match(/MathPlayer/);
+    if (!is_gecko && !has_mathplayer) {
+        var head = document.getElementsByTagName("head")[0];
+        if (head != null) {
+            var script = document.createElement("script");
+            script.type = "text/javascript";
+            script.src = mathjax_url;
+            script.onreadystatechange = refreshMath;
+            script.onload = refreshMath;
+            head.appendChild(script);
+        }
+    }
+}());


### PR DESCRIPTION
Here is a proposal for #652.

Only tested with Chromium on Linux.

(I was not able to use the --mathsvg option though)