### PR TITLE
Log file only gets written in archive for --whatsout=archive

### DIFF
--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -139,14 +139,16 @@ if ((!$sock) && $local && ($expire == -1)) {
 # Special features for latexmls:
 if ($log) {
   if ($opts->get('log')) {
-    my $clog = $opts->get('log');
-    my $log_handle;
-    if (!open($log_handle, ">", $clog)) {
-      print STDERR "Fatal:IO:forbidden Couldn't open log file $clog : $!\n";
-      exit 1;
+    if ($opts->get('whatsout') !~ /^archive/) { # archives only have the archive file
+      my $clog = $opts->get('log');
+      my $log_handle;
+      if (!open($log_handle, ">", $clog)) {
+        print STDERR "Fatal:IO:forbidden Couldn't open log file $clog : $!\n";
+        exit 1;
+      }
+      print $log_handle $log;
+      close $log_handle;
     }
-    print $log_handle $log;
-    close $log_handle;
   } else { print STDERR $log, "\n"; }    #STDERR log otherwise
 }
 


### PR DESCRIPTION
This PR fixes a minor (but relevant) file pollution when running:
```
latexmlc --log=some.log --whatsout=archive
```

As it were, the log file was written inside the archive (as intended) **and** on the file system itself (unintended). latexmlc should simply avoid creating log files when an archive is requested (but still print out log info to STDERR otherwise).

The unintended log files were polluting my CorTeX runs - which I am basing on latexmlc now.