### PR TITLE
Redetermine colorize logging any time we rebind STDERR

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -650,6 +650,7 @@ sub bind_log {
     *STDERR_SAVED = *STDERR;
     *STDERR       = *$log_handle;
     binmode(STDERR, ':encoding(UTF-8)');
+    $LaTeXML::Common::Error::COLORIZED_LOGGING = -t STDERR;
     $$self{log_handle} = $log_handle;
   }
   return; }
@@ -665,6 +666,7 @@ sub flush_log {
     close $$self{log_handle};
     delete $$self{log_handle};
     *STDERR = *STDERR_SAVED;
+    $LaTeXML::Common::Error::COLORIZED_LOGGING = -t STDERR;
   }
   my $log = $$self{log};
   $$self{log} = q{};


### PR DESCRIPTION
I was bitten by the colors while parsing STDERR from latexmls, which binds STDERR **after** the Error module is loaded.

Using a package-level var for ```COLORIZED_LOGGING``` is nice for performance, so I kept that as-is, but also added the checks to ```bind_log``` and ```flush_log``` which are responsible for changing STDERR.