### PR TITLE
Change xsl inclusions.

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-all-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-all-xhtml.xsl
@@ -20,19 +20,19 @@
 
   <!-- Include all LaTeXML to xhtml modules -->
   <!-- Note that you can include these in your own stylesheet using urns like:
-       <xsl:import href="urn:x-LaTeXML:XSLT:LaTeXML-common.xsl"/>
+       <xsl:include href="urn:x-LaTeXML:XSLT:LaTeXML-common.xsl"/>
   -->
 
-  <xsl:import href="LaTeXML-common.xsl"/>
-  <xsl:import href="LaTeXML-inline-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-block-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-misc-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-meta-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-para-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-math-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-tabular-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-picture-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-structure-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-bib-xhtml.xsl"/>
-  <xsl:import href="LaTeXML-webpage-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-common.xsl"/>
+  <xsl:include href="LaTeXML-inline-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-block-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-misc-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-meta-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-para-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-math-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-tabular-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-picture-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-structure-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-bib-xhtml.xsl"/>
+  <xsl:include href="LaTeXML-webpage-xhtml.xsl"/>
 </xsl:stylesheet>


### PR DESCRIPTION
This is suggested for two reasons:

(1) changing `import` to 'include' doesn't really have any impact on `LaTeXML-all-xhtml.xsl` itself since this file only centralizes the inclusions but doesn't really contain any template that will be influenced by the precedence of stylesheet.

(2) for the use cases as I reported in https://github.com/KWARC/sTeX/issues/133, the developers will tend to include the LaTeXML stylesheet directly, so it is much better if the LaTeXML's stylesheets use `include` as well, to avoid cases like the null-function of the deletion function, since very likely the users will have a copy template in the root stylesheet to include all the elements, which overwrites the deletion functions.
```
<xsl:template match="*">
  <xsl:copy><xsl:apply-templates select="*|@*|text()"/></xsl:copy>
</xsl:template>
<xsl:template match="@*"><xsl:copy-of select="."/></xsl:template>
``` 

P.S. for someone who is not really familiar with the stylesheet, like me, messing with `XSLT` is really a danger zone :>