### PR TITLE
Defensive upper-bounds for ImageMagick conversion jobs

### DIFF
--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -38,6 +38,12 @@ our $DPI            = 90;               # [CONSTANT]
 our $DOTS_PER_POINT = ($DPI / 72.0);    # [CONSTANT] Dots per point.
 our $BACKGROUND     = "#FFFFFF";        # [CONSTANT]
 
+# We also provide defaults for certain defensive environmental variables, if not yet set
+$ENV{MAGICK_DISK_LIMIT} = "2GiB" unless defined $ENV{MAGICK_DISK_LIMIT};
+$ENV{MAGICK_MEMORY_LIMIT} = "512MiB" unless defined $ENV{MAGICK_MEMORY_LIMIT};
+$ENV{MAGICK_MAP_LIMIT} = "1GiB" unless defined $ENV{MAGICK_MAP_LIMIT};
+$ENV{MAGICK_TIME_LIMIT} = "300" unless defined $ENV{MAGICK_TIME_LIMIT};
+
 # Note that Image::Size my, itself, use Image::Magick, if available,
 # as a fallback for getting image size & type!!!
 sub image_type {


### PR DESCRIPTION
This was a bit tricky to get right, but I think I got the best possible solution here.

I started with a pure-Perl solution adding:
```perl
push(@args, 'memory-limit', '512MiB',
                      'map-limit', '1GiB',
                      'disk-limit', '2GiB',
                      'time-limit', 300);
```
before the first 'Set' operation. However, with testing I found out that these options **override** the environmental variables, which means that users would be unable to modify these LaTeXML settings.

The solution in the PR allows users to specify ImageMagick environmental variables **from outside** to LaTeXML, and thus adjust the settings as needed. I only set a default (arXMLiv-motivated) upper bound for memory, map, disk and time, if they were not already set prior to the latexml process starting. I tested this extensively and it works exactly as expected.

@brucemiller had mentioned he would enjoy also having a time upper bound - and I bring good news - ImageMagick indeed has such a bound, and it seems to work rather nicely for the examples I have. I set it to 5 minutes (300 seconds) for this PR, as it seemed a reasonable time to wait for an image conversion job. It indeed works well - I tested it with 1 second as the bound and it performed exactly as you would expect.

The disk limit is set surprisingly (to me) high, because I had worst-case examples (selected arXiv ```.eps``` images) that took 1.7 GB of scratch disk space before it generated the final 330KB PNG image (!!). 

The really good news for me: when an ImageMagick job terminates because of surpassing the upper bounds, the Perl wrapper manages to receive a clean return code and - and this is crucial for arXMLiv - **correctly clean up the temporary files from the disk**. Which avoids memory overflows due to accumulated failed jobs.

I have very high hopes that with this PR merged, CorTeX will be able to convert all of arXiv without further ImageMagick issues.