### PR TITLE
Basic support for the family of nameref macros

### DIFF
--- a/lib/LaTeXML/Package/nameref.sty.ltxml
+++ b/lib/LaTeXML/Package/nameref.sty.ltxml
@@ -21,4 +21,14 @@ DefConstructor('\nameref Semiverbatim',
   "<ltx:ref class='ltx_refmacro_nameref' show='title' labelref='#label'/>",
   properties => sub { (label => CleanLabel($_[1])); });
 
+DefMacro('\Nameref','\nameref'); #\def\Nameref#1{‘\nameref{#1}’ on page~\pageref{#1}}
+
+DefMacro('\Sectionformat{}{}','#1');
+
+DefMacro('\Ref','\ref'); # can be improved if "varioref.sty" is loaded?
+
+DefMacro('\slabel', '\label');#The original nameref docs say: "Overload an AMS LaTEX command, which uses \newlabel. Sigh!"
+
+DefMacro('\vnameref','\nameref'); # We can improve if we had \vpageref 
+
 1;


### PR DESCRIPTION
I wanted to see if we can get #611 closed with a simple binding extension. Some of the details around the page-enhanced referencing simply don't apply to HTML, and while they can be reimagined, I don't have the incentive to get the perfectly right now.

The docs for the package are [here](http://mirror.ctan.org/macros/latex/contrib/hyperref/nameref.pdf)