### PR TITLE
Unified error-reporting in core+post processing

### DIFF
--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -385,7 +385,6 @@ sub _prepare_options {
       $$opts{whatsin} = 'fragment'; }
     else {    # Default input chunk is a document
       $$opts{whatsin} = 'document'; } }
-  $$opts{whatsout} = 'document' unless defined $$opts{whatsout};
   $$opts{type}     = 'auto'     unless defined $$opts{type};
   unshift(@{ $$opts{preload} }, ('TeX.pool', 'LaTeX.pool', 'BibTeX.pool')) if ($$opts{type} eq 'BibTeX');
 
@@ -393,9 +392,8 @@ sub _prepare_options {
   if ((!defined $$opts{extension}) && (defined $$opts{destination})) {
     if ($$opts{destination} =~ /\.([^.]+)$/) {
       $$opts{extension} = $1; } }
-  if ((!defined $$opts{format}) && (defined $$opts{destination})) {
-    if ($$opts{destination} =~ /\.([^.]+)$/) {
-      $$opts{format} = $1; } }
+  if ((!defined $$opts{format}) && (defined $$opts{extension})) {
+      $$opts{format} = $$opts{extension}; }
   if ((!defined $$opts{extension}) && (defined $$opts{format})) {
     if ($$opts{format} =~ /^html/) {
       $$opts{extension} = 'html'; }
@@ -403,6 +401,12 @@ sub _prepare_options {
       $$opts{extension} = 'xhtml'; }
     else {
       $$opts{extension} = 'xml'; } }
+  if (!defined $$opts{whatsout}) {
+    if ((defined $$opts{extension}) && ($$opts{extension} eq 'zip')) {
+      $$opts{whatsout} = 'archive';
+    } else {
+      $$opts{whatsout} = 'document';
+    } }
   if ($$opts{format}) {
     # Lower-case for sanity's sake
     $$opts{format} = lc($$opts{format});


### PR DESCRIPTION
The core+post workflow now has unified error-reporting, with more robust reports for post-proc and archive whatsouts.

As it turns out, if there was a Fatal error (via a Perl die) in post-processing, when creating an archive as output, the entire log was not being written out, as the archive was never created in the first place.

The reason for that was that the ```eval``` guard was wrapping the entire post-processing call, wrapping also the archive creation logic.

In this PR I have improved on that end, and finally unified the error-reporting codes (albeit in a hacky way) by:
 * Making the ```eval``` guard only wrap ```$latexmlpost->ProcessChain```, hence always writing an archive with a log file (in the CorTeX setup).
 * Ensuring that the final ```status_code``` is the max of the combined core and post-processing status codes, so that a no problem core run (code 0) and a fatal post run (code 3) return an overall fatal code, and vice versa.
 * I also added a minor update to Config.pm, where any destination ending with a ```.zip``` extension forces the ```archive``` whatsout setting. I had a few test runs where latexml was writing out HTML5 in a .zip file, which felt very unintuitive.

All of these problems were originally created by me, so I take the full blame for them lurking around for this long. The solution is still slightly patchy, and can be streamlined once we have a flow where both core and post-processing use the same State object.

I would appreciate it if we could merge this PR (or a slight improvement of it) soon, so that the CorTeX reruns can move forward, even if it's not the ultimate state of the joint error-reporting.

Feedback welcome!
