### PR TITLE
Fallback to files without extensions, when no .tex file is present

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -174,7 +174,7 @@ sub convert {
     if (!defined $source) {    # Unpacking failed to find a source
       $$opts{sourcedirectory} = $$opts{archive_sourcedirectory};
       my $log = $self->flush_log;
-      return { result => undef, log => $log, status => "Fatal:I/O:Archive Can't detect a source TeX file!", status_code => 3 }; }
+      return { result => undef, log => $log, status => "Fatal:invalid:Archive Can't detect a source TeX file!", status_code => 3 }; }
 # Destination magic: If we expect an archive on output, we need to invent the appropriate destination ourselves when not given.
 # Since the LaTeXML API never writes the final archive file to disk, we just use a pretend sourcename.zip:
     if (($$opts{whatsout} =~ /^archive/) && (!$$opts{destination})) {

--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -40,6 +40,9 @@ sub unpack_source {
     $zip_handle->extractMember($member, catfile($sandbox_directory, $member)); }
   # Set $source to point to the main TeX file in that directory
   my @TeX_file_members = map { $_->fileName() } $zip_handle->membersMatching('\.tex$');
+  if (!@TeX_file_members) { # No .tex file? Try files without extensions!
+    @TeX_file_members = map { $_->fileName() } grep {!/\./ || /\.[^.]{4,}$/} $zip_handle->members();
+  }
   if (scalar(@TeX_file_members) == 1) {
     # One file, that's the input!
     $main_source = catfile($sandbox_directory, $TeX_file_members[0]); }
@@ -263,7 +266,7 @@ sub get_embeddable {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -296,7 +299,7 @@ In this regard, we implement a simplified form of the logic in
 Packs a collection of documents using the packing method specified via the 'whatsout' option.
     If 'fragment' or 'math' are chosen, each input document is transformed into
     an embeddable fragment or a single formula, respectively.
-    If 'archive' is chose, all input documents are written into an archive in the specified 'siteDirectory'. 
+    If 'archive' is chose, all input documents are written into an archive in the specified 'siteDirectory'.
     The name of the archive is provided by the 'destination' property of the first provided $document object.
     Each document is expected to be a LaTeXML::Post::Document object.
 


### PR DESCRIPTION
1.52% of arXMLiv's conversion currently exhibits "no message" fatals, a lot of which seem to be caused by a failure to detect the main TeX file in the source archives.

This PR checks if there is no .tex file present in the archive, and if so checks all files without extensions as possible candidates for a main source file.

I have tried it on a couple of arXiv papers and it converted both to no problems, which seemed promising!