### PR TITLE
Check single-file archives, as some may have %auto-ignore from arXiv

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -43,80 +43,76 @@ sub unpack_source {
   if (!@TeX_file_members) { # No .tex file? Try files without extensions!
     @TeX_file_members = map { $_->fileName() } grep {!/\./ || /\.[^.]{4,}$/} $zip_handle->members();
   }
-  if (scalar(@TeX_file_members) == 1) {
-    # One file, that's the input!
-    $main_source = catfile($sandbox_directory, $TeX_file_members[0]); }
-  else {
-    # Heuristically determine the input (borrowed from arXiv::FileGuess)
-    my %Main_TeX_likelihood;
-    foreach my $tex_file (@TeX_file_members) {
-      # Read in the content
-      $tex_file = catfile($sandbox_directory, $tex_file);
-      # Open file and read first few bytes to do magic sequence identification
-      # note that file will be auto-closed when $FILE_TO_GUESS goes out of scope
-      open(my $FILE_TO_GUESS, '<', $tex_file) ||
-        (print STDERR "failed to open '$tex_file' to guess its format: $!. Continuing.\n");
-      local $/ = "\n";
-      my ($maybe_tex, $maybe_tex_priority, $maybe_tex_priority2);
-    TEX_FILE_TRAVERSAL:
-      while (<$FILE_TO_GUESS>) {
-        if ((/\%auto-ignore/ && $. <= 10) ||    # Ignore
-          ($. <= 10 && /\\input texinfo/) ||    # TeXInfo
-          ($. <= 10 && /\%auto-include/))       # Auto-include
-        { $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }    # Not primary
-        if ($. <= 12 && /^\r?%\&([^\s\n]+)/) {
-          if ($1 eq 'latex209' || $1 eq 'biglatex' || $1 eq 'latex' || $1 eq 'LaTeX') {
-            $Main_TeX_likelihood{$tex_file} = 3; last TEX_FILE_TRAVERSAL; }    # LaTeX
-          else {
-            $Main_TeX_likelihood{$tex_file} = 1; last TEX_FILE_TRAVERSAL; } }    # Mac TeX
-            # All subsequent checks have lines with '%' in them chopped.
-            #  if we need to look for a % then do it earlier!
-        s/\%[^\r]*//;
-        if (/(?:^|\r)\s*\\document(?:style|class)/) {
+
+  # Heuristically determine the input (borrowed from arXiv::FileGuess)
+  my %Main_TeX_likelihood;
+  foreach my $tex_file (@TeX_file_members) {
+    # Read in the content
+    $tex_file = catfile($sandbox_directory, $tex_file);
+    # Open file and read first few bytes to do magic sequence identification
+    # note that file will be auto-closed when $FILE_TO_GUESS goes out of scope
+    open(my $FILE_TO_GUESS, '<', $tex_file) ||
+      (print STDERR "failed to open '$tex_file' to guess its format: $!. Continuing.\n");
+    local $/ = "\n";
+    my ($maybe_tex, $maybe_tex_priority, $maybe_tex_priority2);
+  TEX_FILE_TRAVERSAL:
+    while (<$FILE_TO_GUESS>) {
+      if ((/\%auto-ignore/ && $. <= 10) ||    # Ignore
+        ($. <= 10 && /\\input texinfo/) ||    # TeXInfo
+        ($. <= 10 && /\%auto-include/))       # Auto-include
+      { $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }    # Not primary
+      if ($. <= 12 && /^\r?%\&([^\s\n]+)/) {
+        if ($1 eq 'latex209' || $1 eq 'biglatex' || $1 eq 'latex' || $1 eq 'LaTeX') {
           $Main_TeX_likelihood{$tex_file} = 3; last TEX_FILE_TRAVERSAL; }    # LaTeX
-        if (/(?:^|\r)\s*(?:\\font|\\magnification|\\input|\\def|\\special|\\baselineskip|\\begin)/) {
-          $maybe_tex = 1;
-          if (/\\input\s+amstex/) {
-            $Main_TeX_likelihood{$tex_file} = 2; last TEX_FILE_TRAVERSAL; } }    # TeX Priority
-        if (/(?:^|\r)\s*\\(?:end|bye)(?:\s|$)/) {
-          $maybe_tex_priority = 1; }
-        if (/\\(?:end|bye)(?:\s|$)/) {
-          $maybe_tex_priority2 = 1; }
-        if (/\\input *(?:harv|lanl)mac/ || /\\input\s+phyzzx/) {
-          $Main_TeX_likelihood{$tex_file} = 1; last TEX_FILE_TRAVERSAL; }        # Mac TeX
-        if (/beginchar\(/) {
-          $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }        # MetaFont
-        if (/(?:^|\r)\@(?:book|article|inbook|unpublished)\{/i) {
-          $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }        # BibTeX
-        if (/^begin \d{1,4}\s+[^\s]+\r?$/) {
-          if ($maybe_tex_priority) {
-            $Main_TeX_likelihood{$tex_file} = 2; last TEX_FILE_TRAVERSAL; }      # TeX Priority
-          if ($maybe_tex) {
-            $Main_TeX_likelihood{$tex_file} = 1; last TEX_FILE_TRAVERSAL; }      # TeX
-          $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }        # UUEncoded or PC
-        if (m/paper deliberately replaced by what little/) {
-          $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }
-      }
-      close $FILE_TO_GUESS || warn "couldn't close file: $!";
-      if (!defined $Main_TeX_likelihood{$tex_file}) {
-        if ($maybe_tex_priority) {
-          $Main_TeX_likelihood{$tex_file} = 2; }
-        elsif ($maybe_tex_priority2) {
-          $Main_TeX_likelihood{$tex_file} = 1.5; }
-        elsif ($maybe_tex) {
-          $Main_TeX_likelihood{$tex_file} = 1; }
         else {
-          $Main_TeX_likelihood{$tex_file} = 0; }
-      }
+          $Main_TeX_likelihood{$tex_file} = 1; last TEX_FILE_TRAVERSAL; } }    # Mac TeX
+          # All subsequent checks have lines with '%' in them chopped.
+          #  if we need to look for a % then do it earlier!
+      s/\%[^\r]*//;
+      if (/(?:^|\r)\s*\\document(?:style|class)/) {
+        $Main_TeX_likelihood{$tex_file} = 3; last TEX_FILE_TRAVERSAL; }    # LaTeX
+      if (/(?:^|\r)\s*(?:\\font|\\magnification|\\input|\\def|\\special|\\baselineskip|\\begin)/) {
+        $maybe_tex = 1;
+        if (/\\input\s+amstex/) {
+          $Main_TeX_likelihood{$tex_file} = 2; last TEX_FILE_TRAVERSAL; } }    # TeX Priority
+      if (/(?:^|\r)\s*\\(?:end|bye)(?:\s|$)/) {
+        $maybe_tex_priority = 1; }
+      if (/\\(?:end|bye)(?:\s|$)/) {
+        $maybe_tex_priority2 = 1; }
+      if (/\\input *(?:harv|lanl)mac/ || /\\input\s+phyzzx/) {
+        $Main_TeX_likelihood{$tex_file} = 1; last TEX_FILE_TRAVERSAL; }        # Mac TeX
+      if (/beginchar\(/) {
+        $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }        # MetaFont
+      if (/(?:^|\r)\@(?:book|article|inbook|unpublished)\{/i) {
+        $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }        # BibTeX
+      if (/^begin \d{1,4}\s+[^\s]+\r?$/) {
+        if ($maybe_tex_priority) {
+          $Main_TeX_likelihood{$tex_file} = 2; last TEX_FILE_TRAVERSAL; }      # TeX Priority
+        if ($maybe_tex) {
+          $Main_TeX_likelihood{$tex_file} = 1; last TEX_FILE_TRAVERSAL; }      # TeX
+        $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }        # UUEncoded or PC
+      if (m/paper deliberately replaced by what little/) {
+        $Main_TeX_likelihood{$tex_file} = 0; last TEX_FILE_TRAVERSAL; }
     }
-    # The highest likelihood (>0) file gets to be the main source.
-    my @files_by_likelihood = sort { $Main_TeX_likelihood{$b} <=> $Main_TeX_likelihood{$a} } grep { $Main_TeX_likelihood{$_} > 0 } keys %Main_TeX_likelihood;
-    if (@files_by_likelihood) {
-     # If we have a tie for max score, grab the alphanumerically first file (to ensure deterministic runs)
-      my $max_likelihood = $Main_TeX_likelihood{ $files_by_likelihood[0] };
-      @files_by_likelihood = sort { $a cmp $b } grep { $Main_TeX_likelihood{$_} == $max_likelihood } @files_by_likelihood;
-      $main_source = shift @files_by_likelihood; }
+    close $FILE_TO_GUESS || warn "couldn't close file: $!";
+    if (!defined $Main_TeX_likelihood{$tex_file}) {
+      if ($maybe_tex_priority) {
+        $Main_TeX_likelihood{$tex_file} = 2; }
+      elsif ($maybe_tex_priority2) {
+        $Main_TeX_likelihood{$tex_file} = 1.5; }
+      elsif ($maybe_tex) {
+        $Main_TeX_likelihood{$tex_file} = 1; }
+      else {
+        $Main_TeX_likelihood{$tex_file} = 0; }
+    }
   }
+  # The highest likelihood (>0) file gets to be the main source.
+  my @files_by_likelihood = sort { $Main_TeX_likelihood{$b} <=> $Main_TeX_likelihood{$a} } grep { $Main_TeX_likelihood{$_} > 0 } keys %Main_TeX_likelihood;
+  if (@files_by_likelihood) {
+   # If we have a tie for max score, grab the alphanumerically first file (to ensure deterministic runs)
+    my $max_likelihood = $Main_TeX_likelihood{ $files_by_likelihood[0] };
+    @files_by_likelihood = sort { $a cmp $b } grep { $Main_TeX_likelihood{$_} == $max_likelihood } @files_by_likelihood;
+    $main_source = shift @files_by_likelihood; }
 
   # If failed, clean up sandbox directory.
   rmtree($sandbox_directory) unless $main_source;


### PR DESCRIPTION
The size of the diff is misleading here, it's mostly a re-indent of a block. The PR does a single change - removes the early exit if there is a single .tex file in a ZIP archive.

Instead, it still performs the heuristic check, which can determine the .tex file is invalid and throw a "Fatal:invalid:Archive" rather than a rather bizarre alternative error. It also has the nice side-effect of filtering out withdrawn papers from the corpus.

If we merge here, I would need to rerun both Fatals and no-problems (as many withdrawn papers may have ended as "no problem" snippets), and will add a special "invalid" category for the reports, based on the "Fatal:invalid" messages.