### PR TITLE
Write invalid fatal info to log

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -174,6 +174,7 @@ sub convert {
     if (!defined $source) {    # Unpacking failed to find a source
       $$opts{sourcedirectory} = $$opts{archive_sourcedirectory};
       my $log = $self->flush_log;
+      $log .= "\nFatal:invalid:Archive Can't detect a source TeX file!\nStatus:conversion:3\n";
       return { result => undef, log => $log, status => "Fatal:invalid:Archive Can't detect a source TeX file!", status_code => 3 }; }
 # Destination magic: If we expect an archive on output, we need to invent the appropriate destination ourselves when not given.
 # Since the LaTeXML API never writes the final archive file to disk, we just use a pretend sourcename.zip:

--- a/lib/LaTeXML/Core/Mouth/file.pm
+++ b/lib/LaTeXML/Core/Mouth/file.pm
@@ -32,11 +32,11 @@ sub openFile {
   my ($self, $pathname) = @_;
   my $IN;
   if (!-r $pathname) {
-    Fatal('I/O', $pathname, $self, "File $pathname is not readable."); }
+    Fatal('I/O', 'unreadable', $self, "File $pathname is not readable."); }
   elsif ((!-z $pathname) && (-B $pathname)) {
-    Fatal('I/O', $pathname, $self, "Input file $pathname appears to be binary."); }
+    Fatal('invalid', 'binary', $self, "Input file $pathname appears to be binary."); }
   open($IN, '<', $pathname)
-    || Fatal('I/O', $pathname, $self, "Can't open $pathname for reading", $!);
+    || Fatal('I/O', 'open', $self, "Can't open $pathname for reading", $!);
   $$self{IN}     = $IN;
   $$self{buffer} = [];
   return; }
@@ -88,7 +88,7 @@ sub stringify {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 


### PR DESCRIPTION
My last PR was not explicit enough with writing the invalid fatal to the log file (it's in LaTeXML.pm, so it is hard-printed, rather than using the Error API)

So here is one more commit that adds the info to the log, and makes it parseable by systems such as CorTeX.