### PR TITLE
Fix the empty items when CommaList parameterType actually takes a list

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -469,7 +469,8 @@ DefParameterType('CommaList', sub {
         elsif ($token->equals($comma)) {
           push(@items, Tokens(@tokens)); @tokens = (); }
         elsif ($token->equals(T_BEGIN)) {
-          push(@tokens, $token, $gullet->readBalanced->unlist, T_END); } }
+          push(@tokens, $token, $gullet->readBalanced->unlist, T_END); }
+        else {push(@tokens, $token); }}
       if ($typedef) {
         @items = map { [$typedef->reparseArgument($gullet, $_)]->[0] } @items; } }
     else {


### PR DESCRIPTION
In https://github.com/KWARC/LaTeXML-Plugin-sTeX/issues/20 we discovered that parameter of type `CommaList` becomes empty when we provide it with a list. The primary cause is that the original `CommaList` when taking a list of arguments always pushes an empty `@tokens` to the `@items` and we construct an Array based on the item list.

Because the if else snippet does not capture the situation when the `$token` is a regular token and thus the tokens we want were never added to the `@tokens`

```perl
 if ($token->equals(T_END)) {
          push(@items, Tokens(@tokens));
          last; }
        elsif ($token->equals($comma)) {
          push(@items, Tokens(@tokens)); @tokens = (); }
        elsif ($token->equals(T_BEGIN)) {
          push(@tokens, $token, $gullet->readBalanced->unlist, T_END); }
```