### PR TITLE
Auto-load LaTeX when braced form is seen in TeXFileName parameters

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -340,6 +340,16 @@ DefParameterType('TeXFileName', sub {
       && (($cc = $token->getCatcode) != CC_SPACE) && ($cc != CC_EOL) && ($cc != CC_COMMENT) && ($cc != CC_CS)) {
       push(@tokens, $token); }
     $gullet->unread($token) unless ($cc == CC_SPACE) || ($cc == CC_EOL) || ($cc == CC_COMMENT);
+    my $lead_cc = @tokens && $tokens[0]->getCatcode();
+    if ($lead_cc == CC_BEGIN) {
+      my $trail_cc = @tokens && $tokens[-1]->getCatcode();
+      if ($trail_cc == CC_END) {
+        # A begin-end wrapper indicates latex style {filename} use,
+        # so first unwrap,
+        @tokens = @tokens[1..$#tokens-1];
+        # then load latex, and proceed
+        if (!LookupValue('LaTeX.pool_loaded')) { # if already loaded, DONT redefine!
+          LoadPool("LaTeX"); } } }
     Tokens(@tokens); });
 
 # A LaTeX style directory List


### PR DESCRIPTION
The real-world example I am looking at had a ```\input{preamble.tex}``` at the top of its main file, which worked just fine when typeset with ```pdflatex```.

To emulate that, I suggest that LaTeXML keeps an eye for braced ```{filename}``` wrappers in the bare ```TeXFileName``` paramater type, and load the LaTeX.pool definitions when spotted.

I probably have a blind spot for unexpected side-effects, especially since I am not familiar with all cases in which ```TeXFileName``` is used. So I am open to refactor if you can predict side-effects.

Thanks for reviewing!