### PR TITLE
Disable math ligatures for --noparse option

### DIFF
--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -53,6 +53,7 @@ sub new {
         @{ $options{graphicspaths} || [] }], 'global');
   $state->assignValue(INCLUDE_STYLES => $options{includeStyles} || 0, 'global');
   $state->assignValue(PERL_INPUT_ENCODING => $options{inputencoding}) if $options{inputencoding};
+  $state->assignValue(NOMATHPARSE => $options{nomathparse} || 0, 'global');
   return bless { state => $state,
     nomathparse => $options{nomathparse} || 0,
     preload => $options{preload},
@@ -280,7 +281,7 @@ sub writeDOM {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -302,11 +303,11 @@ But also see the convenient command line script L<latexml> which suffices for mo
 
 =item C<< my $latexml = LaTeXML::Core->new(%options); >>
 
-Creates a new LaTeXML object for transforming TeX files into XML. 
+Creates a new LaTeXML object for transforming TeX files into XML.
 
  verbosity  : Controls verbosity; higher is more verbose,
               smaller is quieter. 0 is the default.
- strict     : If true, undefined control sequences and 
+ strict     : If true, undefined control sequences and
               invalid document constructs give fatal
               errors, instead of warnings.
  includeComments : If false, comments will be excluded
@@ -332,7 +333,7 @@ B<OBSOLETE> Use C<$latexml->convertFile("literal:$string");> instead.
 
 =item C<< $latexml->writeDOM($doc,$name); >>
 
-Writes the XML document to $name.xml. 
+Writes the XML document to $name.xml.
 
 =item C<< $box = $latexml->digestFile($file); >>
 
@@ -353,7 +354,7 @@ returning the L<XML::LibXML::Document>.
 
 In the simplest case, LaTeXML will understand your source file and convert it
 automatically.  With more complicated (realistic) documents, you will likely
-need to make document specific declarations for it to understand local macros, 
+need to make document specific declarations for it to understand local macros,
 your mathematical notations, and so forth.  Before processing a file
 I<doc.tex>, LaTeXML reads the file I<doc.latexml>, if present.
 Likewise, the LaTeXML implementation of a TeX style file, say
@@ -381,7 +382,7 @@ variables, definitions, etc.
 
 =item  L<LaTeXML::Core::Token>, L<LaTeXML::Core::Mouth> and L<LaTeXML::Core::Gullet>
 
-deal with tokens, tokenization of strings and files, and 
+deal with tokens, tokenization of strings and files, and
 basic TeX sequences such as arguments, dimensions and so forth.
 
 =item L<LaTeXML::Core::Box> and  L<LaTeXML::Core::Stomach>

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -1025,7 +1025,9 @@ sub openMathText_internal {
   my $font = $self->getNodeFont($node);
   $node->appendText($string);
   ##print STDERR "Trying Math Ligatures at \"$string\"\n";
-  $self->applyMathLigatures($node);
+  if (!$STATE->lookupValue('NOMATHPARSE')) {
+    $self->applyMathLigatures($node);
+  }
   return $node; }
 
 # New stategy (but inefficient): apply ligatures until one succeeds,
@@ -1740,7 +1742,7 @@ sub appendTree {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -1749,7 +1751,7 @@ C<LaTeXML::Core::Document> - represents an XML document under construction.
 =head1 DESCRIPTION
 
 A C<LaTeXML::Core::Document> represents an XML document being constructed by LaTeXML,
-and also provides the methods for constructing it.  
+and also provides the methods for constructing it.
 It extends L<LaTeXML::Common::Object>.
 
 LaTeXML will have digested the source material resulting in a L<LaTeXML::Core::List> (from a L<LaTeXML::Core::Stomach>)
@@ -1775,7 +1777,7 @@ to the a Namespace URI that was registered for the DTD.
 
 The arguments named C<$node> are an XML::LibXML node.
 
-The methods here are grouped into three sections covering basic access to the 
+The methods here are grouped into three sections covering basic access to the
 document, insertion methods at the current insertion point,
 and less commonly used, lower-level, document manipulation methods.
 
@@ -1928,7 +1930,7 @@ and inserting the string C<$text> into it.
 =item C<< $document->openElement($qname,%attributes); >>
 
 Open an element, named C<$qname> and with the given attributes.
-This will be inserted into the current node while  performing 
+This will be inserted into the current node while  performing
 any required automatic opening and closing of intermedate nodes.
 The new element is returned, and also becomes the current insertion point.
 An error (fatal if in C<Strict> mode) is signalled if there is no allowed way
@@ -2004,7 +2006,7 @@ to what is allowed by the document model.
 
 Returns a list of elements where an arbitrary insertion might take place.
 Roughly this is a list starting with C<$node>,
-followed by its parent and the parents siblings (in reverse order), 
+followed by its parent and the parents siblings (in reverse order),
 followed by the grandparent and siblings (in reverse order).
 
 =item C<< $node = $document->floatToElement($qname); >>


### PR DESCRIPTION
Basic fix for #741 , which disables math ligatures entirely, when the noparse option is specified.

A more advanced fix would attack the problem at its root and e.g. only apply ligatures to the last N children of the current parent, using efficient libxml methods such as a combination of ```->lastChild``` and ```->previousSibling```. 