### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: perl
+perl:
+  - "5.20"
+  - "5.18"
+  - "5.14"
+  - "5.10"
+
+sudo: false
+addons:
+  apt:
+    packages:
+     - libdb-dev
+     - libxml2-dev
+     - libxslt1-dev

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -350,6 +350,7 @@ our $kpse_cache = undef;
 
 sub pathname_kpsewhich {
   my (@candidates) = @_;
+  return unless $kpsewhich;
   build_kpse_cache() unless $kpse_cache;
   foreach my $file (@candidates) {
     if (my $result = $$kpse_cache{$file}) {
@@ -364,6 +365,7 @@ sub pathname_kpsewhich {
 
 sub build_kpse_cache {
   $kpse_cache = {};    # At least we've tried.
+  return unless $kpsewhich;
        # This finds ALL the directories looked for for any purposes, including docs, fonts, etc
   my $texmf = `"$kpsewhich" --expand-var \'\\\$TEXMF\'`; chomp($texmf);
   # These are directories which contain the tex related files we're interested in.


### PR DESCRIPTION
[ @dginev edited with description]

Thanks to @physikerwelt  for opening the pull request and initiating the Travis discussion via email. I assume the travis file is borrowed from KWARC/LaTeXML.

Let me write a brief justification for @brucemiller since I suspect he hasn't been sucked in the Travis madness.

The idea is that while CPAN Testers would provide us a test harness for the releases, Travis can already provide us with quick regression testing on every push to git. It is usual to combine the build with a badge, you can see the "build |passing" button in the README of [KWARC/LaTeXML](https://github.com/KWARC/LaTeXML) for an example.

After merging the ```.travis.yml``` file, you also need to enable builds from the travis site, after which each push to git will be build and recorded, so that there is a clear visual indication if the latest repository head has a successfully building test suite. Here is the [travis page](https://travis-ci.org/KWARC/LaTeXML) for the KWARC fork as an example.
