### PR TITLE
Introducing UNSAFE_FATAL, trimming insertion context traces

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -101,7 +101,12 @@ sub initialize_session {
   my $latexml;
   my $init_eval_return = eval {
     # Prepare LaTeXML object
+    local $SIG{'ALRM'} = sub { die "Fatal:conversion:init Failed to initialize LaTeXML state\n" };
+    alarm($$self{opts}{timeout});
+
     $latexml = new_latexml($$self{opts});
+
+    alarm(0);
     1;
   };
   ## NOTE: This will give double errors, if latexml has already handled it!
@@ -252,6 +257,11 @@ sub convert {
       $state->popDaemonFrame;
       $$state{status} = {};
   });
+  if ($LaTeXML::UNSAFE_FATAL) {
+    # If the conversion hit an unsafe fatal, we need to reinitialize
+    $LaTeXML::UNSAFE_FATAL = 0;
+    $$self{ready} = 0;
+  }
   if ($eval_report || ($$runtime{status_code} == 3)) {
     # Terminate immediately on Fatal errors
     $$runtime{status_code} = 3;
@@ -546,7 +556,7 @@ sub convert_post {
   my @postdocs;
   my $latexmlpost = LaTeXML::Post->new(verbosity => $verbosity || 0);
   my $post_eval_return = eval {
-    local $SIG{'ALRM'} = sub { die "alarm\n" };
+   local $SIG{'ALRM'} = sub { die "Fatal:conversion:post-processing timed out.\n" };
     alarm($$opts{timeout});
     @postdocs = $latexmlpost->ProcessChain($DOCUMENT, @procs);
     alarm(0);

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -735,7 +735,7 @@ sub closeElement {
   if ($node->nodeType == XML_DOCUMENT_NODE) {    # Didn't find $qname at all!!
     Error('malformed', $qname, $self,
       "Attempt to close " . ($qname eq '#PCDATA' ? $qname : '</' . $qname . '>') . ", which isn't open",
-      "Currently in " . $self->getInsertionContext(5));
+      "Currently in " . $self->getInsertionContext());
     return; }
   else {                                         # Found node.
                                                  # Intervening non-auto-closeable nodes!!
@@ -799,7 +799,7 @@ sub closeToNode {
   if ($t == XML_DOCUMENT_NODE) {    # Didn't find $node at all!!
     Error('malformed', $model->getNodeQName($node), $self,
       "Attempt to close " . Stringify($node) . ", which isn't open",
-      "Currently in " . $self->getInsertionContext(5)) unless $ifopen;
+      "Currently in " . $self->getInsertionContext()) unless $ifopen;
     return; }
   else {                            # Found node.
     Error('malformed', $model->getNodeQName($node), $self,
@@ -821,7 +821,7 @@ sub closeNode {
   if ($t == XML_DOCUMENT_NODE) {    # Didn't find $qname at all!!
     Error('malformed', $model->getNodeQName($node), $self,
       "Attempt to close " . Stringify($node) . ", which isn't open",
-      "Currently in " . $self->getInsertionContext(5)); }
+      "Currently in " . $self->getInsertionContext()); }
   else {                            # Found node.
                                     # Intervening non-auto-closeable nodes!!
     Error('malformed', $model->getNodeQName($node), $self,
@@ -853,6 +853,9 @@ sub addAttribute {
 # if $levels is defined, show only that many levels
 sub getInsertionContext {
   my ($self, $levels) = @_;
+  if (! defined $levels) { # Default depth is based on verbosity
+    my $verbosity = $STATE && $STATE->lookupValue('VERBOSITY') || 0;
+    $levels = 5 if ($verbosity <= 1); }
   my $node = $$self{node};
   my $type = $node->nodeType;
   if (($type != XML_TEXT_NODE) && ($type != XML_ELEMENT_NODE) && ($type != XML_DOCUMENT_NODE)) {

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -898,7 +898,7 @@ sub find_insertion_point {
     else {                                             # Didn't find a legit place.
       Error('malformed', $qname, $self,
         ($qname eq '#PCDATA' ? $qname : '<' . $qname . '>') . " isn't allowed here",
-        "Currently in " . $self->getInsertionContext(5));
+        "Currently in " . $self->getInsertionContext());
       return $$self{node}; } } }                       # But we'll do it anyway, unless Error => Fatal.
 
 sub getInsertionCandidates {
@@ -953,7 +953,7 @@ sub floatToElement {
       return $savenode; } }
   else {
     Warn('malformed', $qname, $self, "No open node can contain element '$qname'",
-      $self->getInsertionContext(5))
+      $self->getInsertionContext())
       unless $self->canContainSomehow($$self{node}, $qname); }
   return; }
 
@@ -969,7 +969,7 @@ sub floatToAttribute {
     return $savenode; }
   else {
     Warn('malformed', $key, $self, "No open node can get attribute '$key'",
-      $self->getInsertionContext(5));
+      $self->getInsertionContext());
     return; } }
 
 # find a node that can accept a label.
@@ -999,7 +999,7 @@ sub floatToLabel {
     return $savenode; }
   else {
     Warn('malformed', $key, $self, "No open node with an xml:id can get attribute '$key'",
-      $self->getInsertionContext(5));
+      $self->getInsertionContext());
     return; } }
 
 sub openText_internal {

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -735,7 +735,7 @@ sub closeElement {
   if ($node->nodeType == XML_DOCUMENT_NODE) {    # Didn't find $qname at all!!
     Error('malformed', $qname, $self,
       "Attempt to close " . ($qname eq '#PCDATA' ? $qname : '</' . $qname . '>') . ", which isn't open",
-      "Currently in " . $self->getInsertionContext);
+      "Currently in " . $self->getInsertionContext(5));
     return; }
   else {                                         # Found node.
                                                  # Intervening non-auto-closeable nodes!!
@@ -799,7 +799,7 @@ sub closeToNode {
   if ($t == XML_DOCUMENT_NODE) {    # Didn't find $node at all!!
     Error('malformed', $model->getNodeQName($node), $self,
       "Attempt to close " . Stringify($node) . ", which isn't open",
-      "Currently in " . $self->getInsertionContext) unless $ifopen;
+      "Currently in " . $self->getInsertionContext(5)) unless $ifopen;
     return; }
   else {                            # Found node.
     Error('malformed', $model->getNodeQName($node), $self,
@@ -821,7 +821,7 @@ sub closeNode {
   if ($t == XML_DOCUMENT_NODE) {    # Didn't find $qname at all!!
     Error('malformed', $model->getNodeQName($node), $self,
       "Attempt to close " . Stringify($node) . ", which isn't open",
-      "Currently in " . $self->getInsertionContext); }
+      "Currently in " . $self->getInsertionContext(5)); }
   else {                            # Found node.
                                     # Intervening non-auto-closeable nodes!!
     Error('malformed', $model->getNodeQName($node), $self,
@@ -895,7 +895,7 @@ sub find_insertion_point {
     else {                                             # Didn't find a legit place.
       Error('malformed', $qname, $self,
         ($qname eq '#PCDATA' ? $qname : '<' . $qname . '>') . " isn't allowed here",
-        "Currently in " . $self->getInsertionContext);
+        "Currently in " . $self->getInsertionContext(5));
       return $$self{node}; } } }                       # But we'll do it anyway, unless Error => Fatal.
 
 sub getInsertionCandidates {
@@ -950,7 +950,7 @@ sub floatToElement {
       return $savenode; } }
   else {
     Warn('malformed', $qname, $self, "No open node can contain element '$qname'",
-      $self->getInsertionContext())
+      $self->getInsertionContext(5))
       unless $self->canContainSomehow($$self{node}, $qname); }
   return; }
 
@@ -966,7 +966,7 @@ sub floatToAttribute {
     return $savenode; }
   else {
     Warn('malformed', $key, $self, "No open node can get attribute '$key'",
-      $self->getInsertionContext());
+      $self->getInsertionContext(5));
     return; } }
 
 # find a node that can accept a label.
@@ -996,7 +996,7 @@ sub floatToLabel {
     return $savenode; }
   else {
     Warn('malformed', $key, $self, "No open node with an xml:id can get attribute '$key'",
-      $self->getInsertionContext());
+      $self->getInsertionContext(5));
     return; } }
 
 sub openText_internal {


### PR DESCRIPTION
A number of stability improvements for daemonized processing here:
 1. The daemon initialization code was never wrapped in a timeout, I have added one
 2. Marked some Fatal errors as explicitly "unsafe", so that daemon processes are forced to reinitialize from scratch (motivation below)
 3. The reporting of "insertion context" for absorbtion errors prints enormous XML dumps on screen, which are almost always unnecessary/overwhelming, even to a developer. I have found the context of 5 levels deep to be both brief and sufficiently informative for the examples I have. Maybe this should also depend on verbosity?
 4. Minor: improved ALRM message text a little

**Motivation:**

Some Fatals have proven to corrupt the State. In particular certain deep recursions (inf. loops?) in the absorbtion stage leave follow-up jobs on the same daemon process to Fatal with ```internal:<recursion>``` errors. I have experienced this on a production server where hundreds of jobs ended up broken due to a malformed State, which was quite unfortunate. It seemed safest to mark any terminations caused by signals, as well as "too_many_error" fatals, as requiring a new init phase.

I have coupled this with a couple of robustness patches to the latexmls socket server as well, which can be [found here](https://github.com/dginev/LaTeXML-Plugin-latexmls/commits/master).

I have a couple of examples that exhibit the described behaviour, but they are very pathologically broken and are probably not too interesting (definitely not valid TeX). Again, mostly ensuring production stability of long-lived daemon processes here.