### PR TITLE
Fixes #792 (regression with latexmlc documentation)

### DIFF
--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -232,13 +232,13 @@ __END__
 
 =head1 NAME
 
-C<latexmlc> - A omni-executable for LaTeXML, capable of
-  stand-alone socket-server and (soon) web service conversion.
+C<latexmlc> - An omni-executable for LaTeXML, capable of
+  stand-alone, socket-server and web service conversion.
+  Supports both core processing and post-processing.
 
 =head1 SYNOPSYS
 
 See the OPTIONS section in L<LaTeXML::Common::Config> for usage information.
-  Also consult latexmlc --help
 
 =head1 DESCRIPTION
 
@@ -247,10 +247,10 @@ L<latexmlc> provides a client which automatically sets up a LaTeXML local server
 
   If such server already exists, the client proceeds to communicate normally.
 
-  A stand-alone conversion (the default) can also be requested via --timeout=-1
+  A stand-alone conversion (the default) can also be requested via --expire=-1
 
 =head1 SEE ALSO
 
-L<latexmls>, L<ltxmojo>, L<LaTeXML::Common::Config>
+L<LaTeXML::Common::Config>
 
 =cut

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -185,12 +185,12 @@ sub read {
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
       -input => pod_where({ -inc => 1 }, __PACKAGE__),
-      -sections => 'OPTIONS/SYNOPSIS', -output => \*STDERR);
+      -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   if (!$silent && $$opts{help}) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
       -input => pod_where({ -inc => 1 }, __PACKAGE__),
-      -sections => 'OPTIONS/SYNOPSIS', output => \*STDOUT);
+      -sections => 'OPTION SYNOPSIS', output => \*STDOUT);
   }
 
   # Check that options for system I/O (destination and log) are valid before wasting any time...
@@ -236,7 +236,7 @@ sub scan_to_keyvals {
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
       -input => pod_where({ -inc => 1 }, __PACKAGE__),
-      -sections => 'OPTIONS/SYNOPSIS', -output => \*STDERR);
+      -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   CORE::push @$keyvals, ['source', $ARGV[0]] if $ARGV[0];
   return $getOptions_success && $keyvals;
@@ -730,7 +730,7 @@ Clones $config into a new LaTeXML::Common::Config object, $config_clone.
 
 =head1 OPTION SYNOPSIS
 
-latexmls/latexmlc [options]
+latexmlc [options]
 
  Options:
  --VERSION               show version number.


### PR DESCRIPTION
I had rearranged the docs, and had forgotten that I am using an advanced sections selector of pod2usage, which made ```latexmlc --help``` return an empty value, rather than the synopsis string.

This pull request fixes this.