### PR TITLE
fixes typo in LaTeXML::Core::Token documentation

### DIFF
--- a/lib/LaTeXML/Core/Token.pm
+++ b/lib/LaTeXML/Core/Token.pm
@@ -373,7 +373,7 @@ Return a string representing C<$object>.
 =item C<< $string = $token->getCSName; >>
 
 Return the string or character part of the C<$token>; for the special category
-codes, returns the standard string (eg. C<T_BEGIN->getCSName> returns "{").
+codes, returns the standard string (eg. C<< T_BEGIN->getCSName >> returns "{").
 
 =item C<< $string = $token->getString; >>
 


### PR DESCRIPTION
This fixes the typo at the bottom of http://dlmf.nist.gov/LaTeXML/manual/coremodules/LaTeXML_Core_Token.html
in the description of getCSName  
