### PR TITLE
Fix bug with wrongly checking all files inside archive input

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -41,8 +41,8 @@ sub unpack_source {
     $zip_handle->extractMember($member, catfile($sandbox_directory, $member)); }
   # Set $source to point to the main TeX file in that directory
   my @TeX_file_members = map { $_->fileName() } $zip_handle->membersMatching('\.tex$');
-  if (!@TeX_file_members) { # No .tex file? Try files without extensions!
-    @TeX_file_members = map { $_->fileName() } grep {!/\./ || /\.[^.]{4,}$/} $zip_handle->members();
+  if (!@TeX_file_members) { # No .tex file? Try files with no, or unusually long, extensions
+    @TeX_file_members = grep {!/\./ || /\.[^.]{4,}$/} map { $_->fileName() } $zip_handle->members();
   }
 
   # Heuristically determine the input (borrowed from arXiv::FileGuess)


### PR DESCRIPTION
This is an embarrassing oversight on my part - i had swapped the places of the grep/map pair, grepping on perl objects, instead of the file name held by them.

That lead to archives with no TeX file from the arXiv corpus to be falsely searched through, and in fact often ```.cls``` and ```.sty``` files were being converted in the absence of a real source, due to this error.

An example directory tree I just tested with looks like:
```
-rw-r--r-- 1 dreamweaver dreamweaver  41139 Jun 29  2004 llncs.cls
-rw-r--r-- 1 dreamweaver dreamweaver  12121 Jun 29  2004 mathpartir.sty
-rw-r--r-- 1 dreamweaver dreamweaver   4209 Jun 29  2004 welldef.bbl
-rw-r--r-- 1 dreamweaver dreamweaver  87850 Jun 29  2004 welldef.tex.cry
```

As the authors used an encrypted ```.cry``` file, this archive contains no usable tex source and should be marked invalid by latexml. Which was the intention all along, and is indeed what happens with the patch here. But with the current master, converting the archive holding these files identifies ```llncs.cls``` as the main TeX file and tries to convert it, failing with a Fatal.

I'd appreciate a quick merge, would be happy to rerun the [unexpected](http://cortex.mathweb.org/corpus/arXMLiv/tex_to_html/fatal/unexpected) Fatals, which look to be largely due to this oversight. There may be other harder to detect cases of this, but they'll come to light in further reruns.