### PR TITLE
add onlyPreamble checks for \documentclass and \documentstyle

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -47,6 +47,7 @@ AssignValue(inPreamble => 1);    # \begin{document} will clear this.
 
 DefConstructor('\documentclass OptionalSemiverbatim SkipSpaces Semiverbatim []',
   "<?latexml class='#2' ?#1(options='#1')?>",
+  beforeDigest => sub { onlyPreamble('\documentclass'); },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $options = $whatsit->getArg(1);
@@ -66,7 +67,8 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
   "<?latexml class='#2' ?#1(options='#1') oldstyle='true'?>",
   beforeDigest => sub {
     Info('unexpected', '\documentstyle', $_[0], "Entering LaTeX 2.09 Compatibility mode");
-    AssignValue('2.09_COMPATIBILITY' => 1, 'global'); },
+    AssignValue('2.09_COMPATIBILITY' => 1, 'global');
+    onlyPreamble('\documentstyle'); },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $class   = ToString($whatsit->getArg(2));
@@ -4311,77 +4313,77 @@ RawTeX(<<'EOTeX');
   \iterate
   \let\iterate\relax
 }
-\newdimen\@ydim 							
+\newdimen\@ydim
 \let\@@hyph=\-
-\newbox\@arstrutbox							
-\newbox\@begindvibox							
-\newcount\@botnum							
-\newdimen\@botroom							 
-\newcount\@chclass							 
-\newcount\@chnum							
-\newdimen\@clnht							
-\newdimen\@clnwd							
-\newdimen\@colht							
-\newcount\@colnum							 
-\newdimen\@colroom							
-\newbox\@curfield							 
-\newbox\@curline							 
-\newcount\@currtype							 
-\newcount\@curtab							 
-\newcount\@curtabmar							
-\newbox\@dashbox							
-\newcount\@dashcnt							 
-\newdimen\@dashdim							 
-\newcount\@dbltopnum							
-\newdimen\@dbltoproom							
+\newbox\@arstrutbox
+\newbox\@begindvibox
+\newcount\@botnum
+\newdimen\@botroom
+\newcount\@chclass
+\newcount\@chnum
+\newdimen\@clnht
+\newdimen\@clnwd
+\newdimen\@colht
+\newcount\@colnum
+\newdimen\@colroom
+\newbox\@curfield
+\newbox\@curline
+\newcount\@currtype
+\newcount\@curtab
+\newcount\@curtabmar
+\newbox\@dashbox
+\newcount\@dashcnt
+\newdimen\@dashdim
+\newcount\@dbltopnum
+\newdimen\@dbltoproom
 \let\@dischyph=\-
-\newcount\@enumdepth 
-\newcount\@floatpenalty							
-\newdimen\@fpmin							
-\newcount \@fpstype							
-\newcount\@highpenalty							
-\newcount\@hightab							
-\newbox\@holdpg								
+\newcount\@enumdepth
+\newcount\@floatpenalty
+\newdimen\@fpmin
+\newcount \@fpstype
+\newcount\@highpenalty
+\newcount\@hightab
+\newbox\@holdpg
 \newinsert \@kludgeins
-\newcount\@lastchclass							
-\newbox\@leftcolumn							
-\newbox\@linechar							
-\newdimen\@linelen							
-\newcount\@lowpenalty							
-\newdimen\@maxdepth							 
-\newcount\@medpenalty							
+\newcount\@lastchclass
+\newbox\@leftcolumn
+\newbox\@linechar
+\newdimen\@linelen
+\newcount\@lowpenalty
+\newdimen\@maxdepth
+\newcount\@medpenalty
 \newdimen\@mparbottom \@mparbottom\z@
-\newinsert\@mpfootins							 
-\newcount\@mplistdepth							
-\newcount\@multicnt							
-\newcount\@nxttabmar							
-\newbox\@outputbox							
-\newdimen\@pagedp							
-\newdimen\@pageht							
-\newbox\@picbox								
-\newdimen\@picht							
-\newdimen \@reqcolroom							
-\newskip\@rightskip \@rightskip \z@skip					
-\newcount\@savsf							
-\newdimen\@savsk							
-\newcount\@secpenalty							
+\newinsert\@mpfootins
+\newcount\@mplistdepth
+\newcount\@multicnt
+\newcount\@nxttabmar
+\newbox\@outputbox
+\newdimen\@pagedp
+\newdimen\@pageht
+\newbox\@picbox
+\newdimen\@picht
+\newdimen \@reqcolroom
+\newskip\@rightskip \@rightskip \z@skip
+\newcount\@savsf
+\newdimen\@savsk
+\newcount\@secpenalty
 \def\@sqrt[#1]{\root #1\of}
-\newbox\@tabfbox							
-\newcount\@tabpush							
-\newdimen \@textfloatsheight						
-\newdimen\@textmin							
-\newcount\@topnum							
-\newdimen\@toproom							
-\newcount\@xarg								
-\newdimen\@xdim								
-\newcount\@yarg								
-\newdimen\@ydim								
-\newcount\@yyarg							
+\newbox\@tabfbox
+\newcount\@tabpush
+\newdimen \@textfloatsheight
+\newdimen\@textmin
+\newcount\@topnum
+\newdimen\@toproom
+\newcount\@xarg
+\newdimen\@xdim
+\newcount\@yarg
+\newdimen\@ydim
+\newcount\@yyarg
 \newtoks\every@math@size
-\newif \if@fcolmade							 
-\newdimen\lower@bound							
-\newcount\par@deathcycles						 
-\newdimen\upper@bound							
+\newif \if@fcolmade
+\newdimen\lower@bound
+\newcount\par@deathcycles
+\newdimen\upper@bound
 \newif\if@insert
 \newif\if@colmade
 \newif\if@specialpage   \@specialpagefalse


### PR DESCRIPTION
Add `onlyPreamble` guards for class-selection LaTeX macros. The absence of these errors became apparent during an Authorea debugging session, so I'm contributing them back upstream.

The goal is that given input such as:
```
\documentclass[11pt,letter]{article}


\begin{document}

\documentclass[letterpaper,10pt]{article}
...
\end{document}
```

We would like LaTeXML to report a preamble violation error as in:
```
Error:unexpected:\documentclass The current command '\documentclass' can only appear in the preamble
```

This is all setup already for usepackage, so just leveraging that infrastructure in this PR.

Bonus: My sublime editing environment removes trailing whitespace (that is actually a tiny speedup for RawTeX I believe)