### PR TITLE
Change shebang to /usr/bin/env/perl

### DIFF
--- a/bin/latexml
+++ b/bin/latexml
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  latexml                                                            | #
 # | main conversion program                                             | #

--- a/bin/latexml
+++ b/bin/latexml
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  latexml                                                            | #
 # | main conversion program                                             | #

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  latexmlc                                                           | #
 # | client/server conversion program                                    | #

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  latexmlc                                                           | #
 # | client/server conversion program                                    | #

--- a/bin/latexmlfind
+++ b/bin/latexmlfind
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  latexmlfind                                                        | #
 # | xml search utility program                                          | #

--- a/bin/latexmlfind
+++ b/bin/latexmlfind
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  latexmlfind                                                        | #
 # | xml search utility program                                          | #

--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  latexmlmath                                                        | #
 # | math conversion program                                             | #

--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  latexmlmath                                                        | #
 # | math conversion program                                             | #

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  latexmlpost                                                        | #
 # | post processing conversion program                                  | #

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  latexmlpost                                                        | #
 # | post processing conversion program                                  | #

--- a/doc/makemanual
+++ b/doc/makemanual
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/doc/makemanual
+++ b/doc/makemanual
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 use strict;
 use warnings;
 use FindBin;

--- a/doc/makesite
+++ b/doc/makesite
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/doc/makesite
+++ b/doc/makesite
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 use strict;
 use warnings;
 use FindBin;

--- a/doc/manual/genpods
+++ b/doc/manual/genpods
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/doc/manual/genpods
+++ b/doc/manual/genpods
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 use strict;
 use warnings;
 use FindBin;

--- a/doc/manual/genschema
+++ b/doc/manual/genschema
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use FindBin;

--- a/doc/manual/genschema
+++ b/doc/manual/genschema
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 use strict;
 use warnings;
 use FindBin;

--- a/release/checkinst
+++ b/release/checkinst
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 use strict;
 
 print "Searching.... (warnings may appear)\n";

--- a/release/checkinst
+++ b/release/checkinst
@@ -1,5 +1,6 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 use strict;
+use warnings;
 
 print "Searching.... (warnings may appear)\n";
 my $latexml = `which latexml`; chomp($latexml);

--- a/tools/cluster
+++ b/tools/cluster
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  cluster                                                            | #
 # | determine similary style files by signature                         | #

--- a/tools/cluster
+++ b/tools/cluster
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  cluster                                                            | #
 # | determine similary style files by signature                         | #

--- a/tools/genencoded
+++ b/tools/genencoded
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  genencoded                                                         | #
 # | generate an input encoding test case                                | #

--- a/tools/genencoded
+++ b/tools/genencoded
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  genencoded                                                         | #
 # | generate an input encoding test case                                | #

--- a/tools/genfontmap
+++ b/tools/genfontmap
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  genfontmap                                                         | #
 # | generate a font map declaration                                     | #

--- a/tools/genfontmap
+++ b/tools/genfontmap
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  genfontmap                                                         | #
 # | generate a font map declaration                                     | #

--- a/tools/kwalitee
+++ b/tools/kwalitee
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  kwalitee                                                           | #
 # | generate a cpants kwalitee report                                   | #

--- a/tools/kwalitee
+++ b/tools/kwalitee
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  kwalitee                                                           | #
 # | generate a cpants kwalitee report                                   | #

--- a/tools/latexmllint
+++ b/tools/latexmllint
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  latexmllint                                                        | #
 # | style & conformance tool for LaTeXML files                          | #

--- a/tools/latexmllint
+++ b/tools/latexmllint
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  latexmllint                                                        | #
 # | style & conformance tool for LaTeXML files                          | #

--- a/tools/maketests
+++ b/tools/maketests
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  maketests                                                          | #
 # | Test Maintenance tool                                               | #

--- a/tools/maketests
+++ b/tools/maketests
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  maketests                                                          | #
 # | Test Maintenance tool                                               | #

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 #======================================================================
 # pre-commit hook for LaTeXML development
 # do

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 #======================================================================
 # pre-commit hook for LaTeXML development
 # do

--- a/tools/symbolscan
+++ b/tools/symbolscan
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  symbolscan                                                         | #
 # | scan & analyze style files for math symbols                         | #

--- a/tools/symbolscan
+++ b/tools/symbolscan
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  symbolscan                                                         | #
 # | scan & analyze style files for math symbols                         | #

--- a/tools/texscan
+++ b/tools/texscan
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  texscan                                                            | #
 # | scan & analyze style, class file coverage                           | #

--- a/tools/texscan
+++ b/tools/texscan
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  texscan                                                            | #
 # | scan & analyze style, class file coverage                           | #

--- a/tools/xtest
+++ b/tools/xtest
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # /=====================================================================\ #
 # |  compileschema                                                      | #
 # | Convert test cases to (x)html(5) for visual comparisons             | #

--- a/tools/xtest
+++ b/tools/xtest
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # /=====================================================================\ #
 # |  compileschema                                                      | #
 # | Convert test cases to (x)html(5) for visual comparisons             | #


### PR DESCRIPTION
On certain machines, when run directly, all scripts would default to use
the perl interpreter located in /usr/bin. This can cause problems on
machines where perl is located in a different path, or where multiple
perl instances are present on a system (such as on Mac when using
homebrew).

This PR updates the shebang, the line which starting with #!
indicating the interpreter to use when running a file, from
/usr/bin/perl to /usr/bin/env perl. This makes sure not to hard-code the
perl path to /usr/bin, but to instead search $PATH for the appropriate
file.