### PR TITLE
Add Makefile.old to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 MYMETA.json
 MYMETA.yml
 Makefile
+Makefile.old
 # And of course the whole compiled lib
 pm_to_blib
 blib/


### PR DESCRIPTION
When running `make clean`, the `Makefile` is moved to `Makefile.old`. To prevent accidental committing of the file, this PR adds it to gitignore.