### PR TITLE
Also record labels as metadata for longtables, when requested in lxRDFa

### DIFF
--- a/lib/LaTeXML/Package/lxRDFa.sty.ltxml
+++ b/lib/LaTeXML/Package/lxRDFa.sty.ltxml
@@ -19,7 +19,10 @@ use LaTeXML::Package;
 # Package Options
 DeclareOption('labels', sub {
   Let(T_CS('\lxRDF@original@label'),T_CS('\label'));
+  Let(T_CS('\lxRDF@original@longtable@label'),T_CS('\@longtable@label'));
   DefMacro('\label Semiverbatim','\lxRDF@original@label{#1}\lxRDFa{property=dcterms:alternative,content=#1}');
+  DefMacro('\@longtable@label Semiverbatim',
+           '\lxRDF@original@longtable@label{#1}\lxRDFa{property=dcterms:alternative,content=#1}');
 });
 
 ProcessOptions();


### PR DESCRIPTION
This PR is a follow-up to #596 and I would appreciate a quick review & merge, if possible.

It turns out that my generic recording of `\label` as metadata did not extend to packages redefining it, such as longtable.

The problem there is that longtable redefines (via `Let`) the `\label` macro on each environment start, which makes it impossible to maintain the RDFa hook I introduced globally in the preamble. However, I _can_ hook into the lower level `\@longtable@label` macro, and it all works great again!

Example test being:
```tex
\documentclass{article}
\usepackage{longtable}
\usepackage[labels]{lxRDFa}
\begin{document}

\begin{longtable}[]{@{}lccc@{}}
1 & 2 & 3 & 4 \\

\caption{\label{table:long} caption}
\end{longtable}

I should be able to refer to Table \ref{table:long}.

\end{document}
```

with the expected snippet of metadata produced:
```html
<figcaption class="ltx_caption" property="dcterms:alternative" content="table:long">
```

Tested locally and all works well.