### PR TITLE
Fix extra space in JATS output (fixes #864)

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-jats.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-jats.xsl
@@ -199,7 +199,7 @@
       <given-names>
 	<xsl:for-each select="str:tokenize(./text(),' ')">
 	  <xsl:if test="position()!=last()">
-	    <xsl:value-of select="."/>&#160;
+	    <xsl:value-of select="."/>
 	  </xsl:if>
 	</xsl:for-each>
       </given-names>


### PR DESCRIPTION
This PR removes an extra non-breakable space character when using
the JATS output format.