### PR TITLE
Fix missing runtime_class warning

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -174,7 +174,7 @@ sub compile_MathGrammar {
 pure_all :: $(INST_LIBDIR)/LaTeXML/MathGrammar.pm
 
 $(INST_LIBDIR)/LaTeXML/MathGrammar.pm: lib/LaTeXML/MathGrammar
-	$(PERLRUN) -MParse::RecDescent - lib/LaTeXML/MathGrammar LaTeXML::MathGrammar
+	$(PERLRUN) -MParse::RecDescent - lib/LaTeXML/MathGrammar LaTeXML::MathGrammar Parse::RecDescent
 	$(NOECHO) $(MKPATH) $(INST_LIBDIR)/LaTeXML
 	$(MV) MathGrammar.pm blib/lib/LaTeXML/MathGrammar.pm
 


### PR DESCRIPTION
When generating `LaTeXML::MathGrammar`, recent versions of `Parse::RecDescent` were generating a warning about the missing `runtime_class` option. This warning indiciated that the grammar may stop working with future versions of the RecDescent package.

This PR adds the missing option to the call inside of Makefile.PL, ensuring that the default runtime `Parse::RecDescent` will continue to be used.