### PR TITLE
Bugfix for older Parse::RecDescent versions

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -175,6 +175,9 @@ pure_all :: $(INST_LIBDIR)/LaTeXML/MathGrammar.pm
 
 $(INST_LIBDIR)/LaTeXML/MathGrammar.pm: lib/LaTeXML/MathGrammar
 	$(PERLRUN) -MParse::RecDescent - lib/LaTeXML/MathGrammar LaTeXML::MathGrammar Parse::RecDescent
+	@$(PERLRUN) -e 'exit(1) unless -e "MathGrammar.pm";' || \
+		(echo "Parse::RecDescent failed to created parser, trying to use old implementation. " && \
+		$(PERLRUN) -MParse::RecDescent - lib/LaTeXML/MathGrammar LaTeXML::MathGrammar)
 	$(NOECHO) $(MKPATH) $(INST_LIBDIR)/LaTeXML
 	$(MV) MathGrammar.pm blib/lib/LaTeXML/MathGrammar.pm
 


### PR DESCRIPTION
Older versions of Parse::RecDescent did not support the third argument
to parser pre-compilation introduced in
b5aa3d04474538ea0d601d99e3e45d7a4df89aaa. This caused installation
problems for LaTeXML on older systems.

This PR fixes the problem by introducing a fallback that does not
use the third argument. This only gets triggered when the MathGrammar is
not created.