### PR TITLE
Refactor LaTeXML::Core::Box blessed objects

### DIFF
--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -41,7 +41,10 @@ sub Box {
 
 sub new {
   my ($class, $string, $font, $locator, $tokens, %properties) = @_;
-  return bless [$string, $font, $locator, $tokens, {%properties}], $class; }
+  return bless { string => $string,
+    tokens => $tokens,
+    properties => { font => $font, locator => $locator, %properties }
+    }, $class; }
 
 # Accessors
 sub isaBox {
@@ -49,27 +52,28 @@ sub isaBox {
 
 sub getString {
   my ($self) = @_;
-  return $$self[0]; }    # Return the string contents of the box
+  return $$self{string}; }    # Return the string contents of the box
 
 sub getFont {
   my ($self) = @_;
-  return $$self[1]; }    # Return the font this box uses.
+  return $$self{properties}{font}; }    # and if undef ????
 
 sub setFont {
   my ($self, $font) = @_;
-  return $$self[1] = $font; }
+  $$self{properties}{font} = $font;
+  return; }
 
 sub isMath {
   my ($self) = @_;
-  return ($$self[4]{mode} || 'text') eq 'math'; }
+  return ($$self{properties}{mode} || 'text') eq 'math'; }
 
 sub getLocator {
   my ($self) = @_;
-  return $$self[2]; }
+  return $$self{properties}{locator}; }
 
 sub getSource {
   my ($self) = @_;
-  return $$self[2]; }
+  return $$self{properties}{locator}; }
 
 # So a Box can stand in for a List
 sub unlist {
@@ -78,58 +82,58 @@ sub unlist {
 
 sub revert {
   my ($self) = @_;
-  return ($$self[3] ? $$self[3]->unlist : ()); }
+  return ($$self{tokens} ? $$self{tokens}->unlist : ()); }
 
 sub toString {
   my ($self) = @_;
-  return $$self[0] // ''; }
+  return $$self{string} // ''; }
 
 # Methods for overloaded operators
 sub stringify {
   my ($self) = @_;
   my $type = ref $self;
   $type =~ s/^LaTeXML::Core:://;
-  my $font = (defined $$self[1]) && $$self[1]->stringify;    # show font, too, if interesting
+  my $font = (defined $$self{properties}{font}) && $$self{properties}{font}->stringify; # show font, too, if interesting
   return $type . '['
-    . (defined $$self[0] ? $$self[0]
-    : (defined $$self[3] ? '[' . ToString($$self[3]) . ']' : ''))
+    . (defined $$self{string} ? $$self{string}
+    : (defined $$self{tokens} ? '[' . ToString($$self{tokens}) . ']' : ''))
     . ($font && ($font ne 'Font[]') ? ' ' . $font : '')
     . ']'; }
 
 # Should this compare fonts too?
 sub equals {
   my ($a, $b) = @_;
-  return (defined $b) && ((ref $a) eq (ref $b)) && ($$a[0] eq $$b[0]) && ($$a[1]->equals($$b[1])); }
+  return (defined $b) && ((ref $a) eq (ref $b)) && ($$a{string} eq $$b{string}) && ($$a{properties}{font}->equals($$b{properties}{font})); }
 
 sub beAbsorbed {
   my ($self, $document) = @_;
-  my $string = $$self[0];
-  my $mode = $$self[4]{mode} || 'text';
+  my $string = $$self{string};
+  my $mode = $$self{properties}{mode} || 'text';
   return ((defined $string) && ($string ne '')
     ? ($mode eq 'math'
-      ? $document->insertMathToken($string, font => $$self[1], %{ $$self[4] })
-      : $document->openText($string, $$self[1]))
+      ? $document->insertMathToken($string, %{ $$self{properties} })
+      : $document->openText($string, $$self{properties}{font}))
     : undef); }
 
 sub getProperty {
   my ($self, $key) = @_;
   if ($key eq 'isSpace') {
-    my $tex = LaTeXML::Core::Token::UnTeX($$self[3]);    # !
-    return (defined $tex) && ($tex =~ /^\s*$/); }        # Check the TeX code, not (just) the string!
+    my $tex = LaTeXML::Core::Token::UnTeX($$self{tokens});    # !
+    return (defined $tex) && ($tex =~ /^\s*$/); }    # Check the TeX code, not (just) the string!
   else {
-    return $$self[4]{$key}; } }
+    return $$self{properties}{$key}; } }
 
 sub getProperties {
   my ($self) = @_;
-  return %{ $$self[4] }; }
+  return %{ $$self{properties} }; }
 
 sub getPropertiesRef {
   my ($self) = @_;
-  return $$self[4]; }
+  return $$self{properties}; }
 
 sub setProperty {
   my ($self, $key, $value) = @_;
-  $$self[4]{$key} = $value;
+  $$self{properties}{$key} = $value;
   return; }
 
 sub setProperties {
@@ -217,8 +221,8 @@ sub computeSize {
   $options{width}  = $$props{width}  if $$props{width};
   $options{height} = $$props{height} if $$props{height};
   $options{depth}  = $$props{depth}  if $$props{depth};
-  my ($w, $h, $d) = ($$self[1]
-      || LaTeXML::Common::Font->textDefault)->computeStringSize($$self[0], %options);
+  my ($w, $h, $d) = ($$props{font}
+      || LaTeXML::Common::Font->textDefault)->computeStringSize($$self{string}, %options);
   $$props{cwidth}  = $w unless defined $$props{width};
   $$props{cheight} = $h unless defined $$props{height};
   $$props{cdepth}  = $d unless defined $$props{depth};

--- a/lib/LaTeXML/Core/Comment.pm
+++ b/lib/LaTeXML/Core/Comment.pm
@@ -22,7 +22,7 @@ sub toString { return ''; }
 
 sub beAbsorbed {
   my ($self, $document) = @_;
-  return $document->insertComment($$self[0]); }
+  return $document->insertComment($$self{string}); }
 
 sub getWidth       { return Dimension(0); }
 sub getHeight      { return Dimension(0); }

--- a/lib/LaTeXML/Core/List.pm
+++ b/lib/LaTeXML/Core/List.pm
@@ -53,15 +53,14 @@ sub new {
   # Maybe the most representative font for a List is the font of the LAST box (that _has_ a font!) ???
   while (defined($bx = pop(@bxs)) && (!defined $font)) {
     $font = $bx->getFont unless defined $font; }
-  return bless [[@boxes], $font, $locator || '', undef, {}], $class; }
-
-sub isMath {
-  my ($self) = @_;
-  return ($$self[4]{mode} || 'text') eq 'math'; }
+  #return bless [[@boxes], $font, $locator || '', undef, {}], $class; }
+  return bless { boxes => [@boxes],
+    properties => { font => $font, locator => $locator || '', }
+    }, $class; }
 
 sub unlist {
   my ($self) = @_;
-  return @{ $$self[0] }; }
+  return @{ $$self{boxes} }; }
 
 sub revert {
   my ($self) = @_;
@@ -99,8 +98,8 @@ sub computeSize {
   $options{width}  = $$props{width}  if $$props{width};
   $options{height} = $$props{height} if $$props{height};
   $options{depth}  = $$props{depth}  if $$props{depth};
-  my ($w, $h, $d) = ($$self[1] || LaTeXML::Common::Font->textDefault)
-    ->computeBoxesSize($$self[0], %options);
+  my ($w, $h, $d) = ($$props{font} || LaTeXML::Common::Font->textDefault)
+    ->computeBoxesSize($$self{boxes}, %options);
   $$props{width}  = $w unless defined $$props{width};
   $$props{height} = $h unless defined $$props{height};
   $$props{depth}  = $d unless defined $$props{depth};

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -50,41 +50,9 @@ sub isMath {
   my ($self) = @_;
   return $$self{properties}{isMath}; }
 
-sub getFont {
-  my ($self) = @_;
-  return $$self{properties}{font}; }    # and if undef ????
-
-sub setFont {
-  my ($self, $font) = @_;
-  $$self{properties}{font} = $font;
-  return; }
-
-sub getLocator {
-  my ($self) = @_;
-  return $$self{properties}{locator}; }
-
 sub getProperty {
   my ($self, $key) = @_;
   return $$self{properties}{$key}; }
-
-sub getProperties {
-  my ($self) = @_;
-  return %{ $$self{properties} }; }
-
-sub getPropertiesRef {
-  my ($self) = @_;
-  return $$self{properties}; }
-
-sub setProperty {
-  my ($self, $key, $value) = @_;
-  $$self{properties}{$key} = $value;
-  return; }
-
-sub setProperties {
-  my ($self, %props) = @_;
-  while (my ($key, $value) = each %props) {
-    $$self{properties}{$key} = $value if defined $value; }
-  return; }
 
 sub getArg {
   my ($self, $n) = @_;


### PR DESCRIPTION
Previously, objects representing a `LaTeXML::Core::Box` were an array, whereas objects representing `LaTeXML::Core::Whatsit` (which inherit from Box) were a hash.  This led to duplication of several methods in the Whatsit class.

This PR refactors `LaTeXML::Core::Box` (and `LaTeXML::Core::List`, `LaTeXML::Core::Comment`, `LaTeXML::Core::Whatsit` that inherit from it) to be a blessed hash reference instead. This makes code within between the four classes consistent with each other, and also makes code more readable due to named access of properties.