### PR TITLE
Add error when readBalanced fails to balance at end of Mouth

### DIFF
--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -361,6 +361,11 @@ sub readBalanced {
       push(@tokens, $token); }
     elsif ($cc == CC_MARKER) {
       LaTeXML::Core::Definition::stopProfiling($token, 'expand'); } }
+  if ($level > 0) {
+    # TODO: The current implementation has a limitation where if the balancing end is in a different mouth,
+    #       it will not be recognized.
+    Error('expected', "}", $self, "Gullet->readBalanced ran out of input in an unbalanced state.");
+  }
   return Tokens(@tokens); }
 
 sub ifNext {
@@ -819,7 +824,7 @@ sub readInternalMuGlue {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -963,7 +968,7 @@ and return the value.  Returns undef if the next token isn't such a register.
 =item C<< $number = $gullet->readNumber; >>
 
 Read a L<LaTeXML::Common::Number> according to TeX's rules of the various things that
-can be used as a numerical value. 
+can be used as a numerical value.
 
 =item C<< $dimension = $gullet->readDimension; >>
 


### PR DESCRIPTION
This was a bit of a shocker in Authorea editing. There were obvious pieces of wrong LaTeX content that never returned an error from latexml, such as:

```
\textbf{some text here
```

Importantly, this is being converted in fragment mode, and has no `\end{document}` in _the same mouth_ to throw a grouping error. This revealed a particular case of unreported errors in LaTeXML:

**When a Gullet->readBalanced call does not have a closing brace, the read silently succeeds to slurp all content until the end of the Mouth**

This can cause some serious issues if the error is committed early in a large chunk of latex, naturally. So I suggest throwing an informative error, and then proceeding as usual. It is good enough for users to correct their mistake in online editing. Example interface from Authorea:
![selection_999 032](https://user-images.githubusercontent.com/348975/30984329-025234ac-a45b-11e7-86da-0f1cfa5d4861.png)

Feedback welcome on how exactly to structure the error.