### PR TITLE
--includestyles fix for latexmlc and 1011.5551 fixes

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -599,7 +599,7 @@ sub new_latexml {
     verbosity       => $$opts{verbosity}, strict => $$opts{strict},
     includeComments => $$opts{comments},
     inputencoding   => $$opts{inputencoding},
-    includeStyles   => $$opts{includestyles},
+    includestyles   => $$opts{includestyles},
     documentid      => $$opts{documentid},
     nomathparse     => $$opts{nomathparse},                           # Backwards compatibility
     mathparse       => $$opts{mathparse});

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -51,7 +51,7 @@ sub new {
     'global');
   $state->assignValue(GRAPHICSPATHS => [map { pathname_absolute(pathname_canonical($_)) }
         @{ $options{graphicspaths} || [] }], 'global');
-  $state->assignValue(INCLUDE_STYLES => $options{includeStyles} || 0, 'global');
+  $state->assignValue(INCLUDE_STYLES => $options{includestyles} || 0, 'global');
   $state->assignValue(PERL_INPUT_ENCODING => $options{inputencoding}) if $options{inputencoding};
   $state->assignValue(NOMATHPARSE => $options{nomathparse} || 0, 'global');
   return bless { state => $state,

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2177,7 +2177,7 @@ sub RequirePackage {
   return; }
 
 my $loadclass_options = {    # [CONSTANT]
-  options => 1, withoptions => 1, after => 1 };
+  options => 1, withoptions => 1, after => 1, notex=>1 };
 
 sub LoadClass {
   my ($class, %options) = @_;

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2181,6 +2181,9 @@ my $loadclass_options = {    # [CONSTANT]
 
 sub LoadClass {
   my ($class, %options) = @_;
+  $options{notex} = 1
+    if !defined $options{notex} && !LookupValue('INCLUDE_STYLES') && !$options{noltxml};
+
   $class = ToString($class) if ref $class;
   CheckOptions("LoadClass ($class)", $loadclass_options, %options);
   #  AssignValue(class_options => [$options{options} ? @{ $options{options} } : ()]);
@@ -2189,7 +2192,7 @@ sub LoadClass {
       # ? Expand {\zap@space#2 \@empty}%
       DefMacroI('\@classoptionslist',undef, join(',',@$op)); }
   # Note that we'll handle errors specifically for this case.
-  if (my $success = InputDefinitions($class, type => 'cls', notex => 1, handleoptions => 1, noerror => 1,
+  if (my $success = InputDefinitions($class, type => 'cls', notex => $options{notex}, handleoptions => 1, noerror => 1,
       %options)) {
     return $success; }
   else {

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3297,9 +3297,12 @@ DefMacro('\stretch{}', '0pt plus #1fill\relax');
 DefPrimitive('\@check@length DefToken', sub {
     my ($stomach, $cs) = @_;
     my $defn = LookupDefinition($cs);
-    if (!$defn || !$defn->isRegister) {
+    if (!$defn) {
       Warn('undefined', $cs, $stomach, "'" . ToString($cs) . "' is not a length; defining it now");
       DefRegisterI($cs, undef, Dimension(0)); }
+    elsif (!$defn->isRegister) {
+      Error('misdefined', $cs, $stomach, "'" . ToString($cs) . "' length was expected, got ".ref($defn)." instead of register.");
+    }
     return; });
 
 DefPrimitive('\newlength DefToken', sub {
@@ -3479,6 +3482,7 @@ DefConstructor('\parbox[][Dimension][]{Dimension}{}', sub {
   beforeDigest => sub {
     AssignValue('\hsize' => $_[4]);
     Let('\\\\', '\par'); });
+DefMacroI('\@parboxrestore', undef, Tokens());
 
 DefConditional('\if@minipage');
 DefEnvironment('{minipage}[][][]{Dimension}', sub {
@@ -4490,6 +4494,8 @@ DefMacroI('\@charrb',        undef, T_LETTER('}'));
 
 DefMacroI('\check@mathfonts', undef, Tokens());
 DefMacro('\fontsize{}{}', Tokens());
+# https://tex.stackexchange.com/questions/112492/setfontsize-vs-fontsize#112501
+DefMacro('\@setfontsize{}{}{}', Tokens());
 
 DefMacroI('\defaultscriptratio',       undef, '.7');
 DefMacroI('\defaultscriptscriptratio', undef, '.5');


### PR DESCRIPTION
I was investigating a Fatal conversion job from the cortex report over arXiv for a change, which happened to be a very impressive 85 manuscript:
https://arxiv.org/abs/1011.5551

They use a custom documentclass, and rather advanced latex, so we're far from "no problem" land, but can find interesting low-level fixes:

 1. I wanted to quickly check if running with `--includestyles` helps, and noticed that a) latexmlc does not enable the behavior when given the option, and b) the option doesn't propagate to `LoadClass` in general. 
    - The first was due to a camelCase name mismatch, the second was just never added I think.

 2. Since enabling includestyles didn't really help (the loading got stuck in an infinite loop!), I next tried gradually improving coverage to avoid the Fatal error in the regular conversion pass from cortex, which is:
```
Fatal:unexpected:<endgroup> Attempt to pop last locked stack frame
```

It is related to a curious issue with using `\sfcode`\.=1000` I think (at least that is the first obvious error), so I started adding small patches along the way. I haven't yet escaped the Fatal, so this PR may stay open for a little. 