### PR TITLE
Safe no-op for \advance when missing definition

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1216,6 +1216,7 @@ DefPrimitive('\advance Variable SkipKeyword:by', sub {
     my ($stomach, $var) = @_;
     return () unless $var;
     my ($defn, @args) = @$var;
+    return () if !$defn || $defn eq "missing";
     local $LaTeXML::CURRENT_TOKEN = $defn;
     $defn->setValue($defn->valueOf(@args)->add($stomach->getGullet->readValue($defn->isRegister)), @args); });
 


### PR DESCRIPTION
Fixes #878 

It upgrades the fatal message from the example:
```
Fatal:misdefined:LaTeXML::Package::Pool::__ANON__ Can't locate method 'valueOf' via 'missing'
	at /home/deyan/perl5/lib/perl5/LaTeXML/Package/TeX.pool.ltxml line 1221, <$IN> line 3.
	In Core::Definition::Primitive[\advance ... from TeX.pool.ltxml line 1221
	 <= Core::Stomach[@0x55f4b4414ec8] <= Core::Definition::Primitive[Begin] <= Core::Stomach[@0x55f4b4414ec8]
3 errors; 1 fatal error; 1 undefined macro[\AtBeginPart]
```

To a less critical error report:
```
Conversion complete: 3 errors; 1 undefined macro[\AtBeginPart].
```

Which is still sufficiently informative about the root cause. Feel free to review & merge @brucemiller 