### PR TITLE
Preserve image graphic in fragment when not found

### DIFF
--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -431,12 +431,13 @@ sub _prepare_options {
   # Any post switch implies post (TODO: whew, lots of those, add them all!):
   $$opts{math_formats} = [] unless defined $$opts{math_formats};
   $$opts{post} = 1 if ((!defined $$opts{post}) &&
-    (scalar(@{ $$opts{math_formats} }))
+    (scalar(@{ $$opts{math_formats} })
     || ($$opts{stylesheet})
     || $$opts{is_html}
     || $$opts{is_xhtml}
     || (($$opts{format}||'') eq 'jats')
     || ($$opts{whatsout} && ($$opts{whatsout} ne 'document'))
+    )
   );
 # || ... || ... || ...
 # $$opts{post}=0 if (defined $$opts{mathparse} && (! $$opts{mathparse})); # No-parse overrides post-processing
@@ -493,7 +494,6 @@ sub _prepare_options {
         qw(id idrelative label labelrelative));
       $$opts{splitat} = _checkOptionValue('--splitat', $$opts{splitat}, CORE::keys %{ $$opts{splitpaths} });
       $$opts{splitpath} = $$opts{splitpaths}->{ $$opts{splitat} } unless defined $$opts{splitpath}; }
-
     # Check for appropriate combination of split, scan, prescan, dbfile, crossref
     if ($$opts{split} && (!defined $$opts{destination}) && ($$opts{whatsout} !~ /^archive/)) {
       croak("Must supply --destination when using --split"); }
@@ -511,16 +511,21 @@ sub _prepare_options {
       croak("Cannot generate index (--index) without --scan or --dbfile"); }
     if (!$$opts{prescan} && @{ $$opts{bibliographies} } && !($$opts{scan} || defined $$opts{crossref})) {
       croak("Cannot generate bibliography (--bibliography) without --scan or --dbfile"); }
-    if ((!defined $$opts{destination}) && ($$opts{whatsout} !~ /^archive/)
-      && (_checkMathFormat($opts, 'images') || _checkMathFormat($opts, 'svg')
-        || $$opts{dographics} || $$opts{picimages})) {
-      croak("Must supply --destination unless all auxilliary file writing is disabled"
-          . "(--nomathimages --nomathsvg --nographicimages --nopictureimages --nodefaultcss)"); }
+
+    # There is now a legitimate case to preserve graphics here.
+    # if ((!defined $$opts{destination}) && ($$opts{whatsout} !~ /^archive/)
+    #   && (_checkMathFormat($opts, 'images') || _checkMathFormat($opts, 'svg')
+    #     || $$opts{dographics} || $$opts{picimages})) {
+    #   croak("Must supply --destination unless all auxilliary file writing is disabled"
+    #       . "(--nomathimages --nomathsvg --nographicimages --nopictureimages --nodefaultcss)"); }
 
     # Format:
     #Default is XHTML, XML otherwise (TODO: Expand)
-    $$opts{format} = "xml" if ($$opts{stylesheet}) && (!defined $$opts{format});
-    $$opts{format} = "xhtml" unless defined $$opts{format};
+    if (!defined $$opts{format}) {
+      if ($$opts{stylesheet}) { $$opts{format} = "xml"; }
+      else { $$opts{format} = "xhtml"; }
+    }
+
     if (!$$opts{stylesheet}) {
       if    ($$opts{format} eq 'xhtml')       { $$opts{stylesheet} = "LaTeXML-xhtml.xsl"; }
       elsif ($$opts{format} eq "html4")       { $$opts{stylesheet} = "LaTeXML-html4.xsl"; }

--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -169,7 +169,9 @@ sub processGraphic {
   my ($self, $doc, $node) = @_;
   my $source = $self->findGraphicFile($doc, $node);
   if (!$source) {
-    Warn('expected', 'source', $node, "No graphic source specified; skipping"); return; }
+    Warn('expected', 'source', $node, "No graphic source specified; skipping");
+    $node->setAttribute('imagesrc', $node->getAttribute('graphic'));
+    return; }
   my $transform = $self->getTransform($node);
   my ($image, $width, $height) = $self->transformGraphic($doc, $node, $source, $transform);
   # $image should probably be relative already, except corner applications?


### PR DESCRIPTION
So, one more interesting use case for me today, with an interesting issue.

I needed to run through some latex through latexml that was "detached" from its auxiliary files (crucially: images), but I wanted to eventually reconnect the HTML result to the original images. I am happy to do some post-processing after latexml, in essence all I needed was to have the includegraphics file argument preserved in the final `src` attribute of the HTML `img` tag.

That's really easy to do! And in fact should be better practice than the current master behavior, which is to leave an empty `src=""` attribute, which is technically invalid / discouraged HTML.

I also caught a tiny bug with one conditional (for activate latexmlc post-processing) and disabled a somewhat useless guard that stops you from using `--graphicimages` in certain modes. I think there are legitimate use cases now to allow that.

Maybe not the ideal fix - open to feedback. The true core of this PR is the line:
```
+    $node->setAttribute('imagesrc', $node->getAttribute('graphic'));
```

which is what I truly need.

P.S. I ended up laughing to myself after finally seeing (or yet again remembering?) the double entendre of the `--graphicimages` and `--nographicimages` options. To the careless observer this may look like we are running our own content safety filters!