### PR TITLE
Ensure mathsvg produces svg in whatsout=math when html format

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -226,6 +226,11 @@ sub get_math {
   return unless defined $doc;
   my @mnodes     = $doc->findnodes($math_xpath);
   my $math_count = scalar(@mnodes);
+  if (!$math_count) { # If no real math nodes, look for math image nodes
+    my $math_img_xpath = '//*[local-name()="img" and @class="ltx_Math"]';
+    @mnodes         = $doc->findnodes($math_img_xpath);
+    $math_count = scalar(@mnodes);
+  }
   if (!$math_count) {
     return get_embeddable($doc); }
   my $math = $mnodes[0];
@@ -238,7 +243,7 @@ sub get_math {
     }
     $math = $math->parentNode while ($math->nodeName =~ '^t[rd]$'); }
   if ($math) {
-    my $imagesrc = $math->getAttribute('imagesrc');
+    my $imagesrc = $math->getAttribute('imagesrc') || $math->getAttribute('src');
     if ($imagesrc && $imagesrc =~ /[.]svg$/) {
       # Return the SVG directly
       $math = LaTeXML::Common::XML::Parser->new()->parseFile($imagesrc);


### PR DESCRIPTION
Me again. Turns out my PR yesterday was operation on `--whatsout=math` but only for the `xml` format target. I added some extra robustness so that the html family out whatsouts is also recognized.

I don't need this in a rush, since I can happily use the `xml` format myself, but may be useful in general.