### PR TITLE
Robust preloads for daemon reruns, unlink cache for mathsvg

### DIFF
--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -196,7 +196,8 @@ sub convertDocument {
       if (my $paths = $state->lookupValue('SEARCHPATHS')) {
         if ($state->lookupValue('INCLUDE_COMMENTS')) {
           $document->insertPI('latexml', searchpaths => join(',', @$paths)); } }
-      foreach my $preload (@{ $$self{preload} }) {
+      foreach my $preload_by_reference (@{ $$self{preload} }) {
+        my $preload = $preload_by_reference; # copy preload value, as we want to preserve the hash as-is, for (potential) future daemon calls
         next if $preload =~ /\.pool$/;
         my $options = undef;                                 # Stupid perlcritic policy
         if ($preload =~ s/^\[([^\]]*)\]//) { $options = $1; }

--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -167,7 +167,8 @@ sub pack_collection {
     elsif ($whatsout eq 'math') {
       # Math output - least common ancestor of all math in the document
       print STDERR "REQUESTING MATH\n";
-      push @packed_docs, get_math($doc); }
+      push @packed_docs, get_math($doc);
+      unlink('LaTeXML.cache'); }
     else { push @packed_docs, $doc; } }
   return @packed_docs; }
 


### PR DESCRIPTION
This PR is a bit more critical as it fixes a long-standing (and shocking) bug with daemonized runs.

Namely, the preload `insertPI` logic was wrongly modifying the preloads directly in the latexml object, so reruns would see all preloads as extension-free and mistreat classes as packages.

if we `--preload=article.cls`, the first run would run correct, but overwrite the value to `article` (no extension) and the second daemonized run would wrongly try to load article as a package. Pretty shocking! It is painfully obvious with `--mathsvg` as the resulting `\usepackage{article}` makes the SVG conversion fail entirely, which lead me to debugging & fixing.

Additionally, I made sure to remove the cache file, which is something I borrowed from latexmlmath.