### PR TITLE
Setting secnumdepth had no effect (for report)

### DIFF
--- a/lib/LaTeXML/Package/report.cls.ltxml
+++ b/lib/LaTeXML/Package/report.cls.ltxml
@@ -64,15 +64,10 @@ NewCounter('subparagraph', 'paragraph', idprefix => 'SP', nested => ['equation',
 
 DefMacro('\thepart',          '\Roman{part}');
 DefMacro('\thechapter',       (CounterValue('secnumdepth')>=0) ? '\arabic{chapter}' : '');
-
 DefMacro('\thesection',       (CounterValue('secnumdepth')>=1) ? '\thechapter.\arabic{section}' : '');
-
 DefMacro('\thesubsection',    (CounterValue('secnumdepth')>=2) ? '\thesection.\arabic{subsection}' : '');
-
 DefMacro('\thesubsubsection', (CounterValue('secnumdepth')>=3) ? '\thesubsection.\arabic{subsubsection}' : '');
-
 DefMacro('\theparagraph',     (CounterValue('secnumdepth')>=4) ? '\thesubsubsection.\arabic{paragraph}' : '');
-
 DefMacro('\thesubparagraph',  (CounterValue('secnumdepth')>=5) ? '\theparagraph.\arabic{subparagraph}' : '');
 
 DefMacro('\chaptermark{}', '');

--- a/lib/LaTeXML/Package/report.cls.ltxml
+++ b/lib/LaTeXML/Package/report.cls.ltxml
@@ -63,12 +63,17 @@ NewCounter('paragraph',     'subsubsection', idprefix => 'P',   nested => ['subp
 NewCounter('subparagraph', 'paragraph', idprefix => 'SP', nested => ['equation', 'figure', 'table']);
 
 DefMacro('\thepart',          '\Roman{part}');
-DefMacro('\thechapter',       '\arabic{chapter}');
-DefMacro('\thesection',       '\thechapter.\arabic{section}');
-DefMacro('\thesubsection',    '\thesection.\arabic{subsection}');
-DefMacro('\thesubsubsection', '');
-DefMacro('\theparagraph',     '');
-DefMacro('\thesubparagraph',  '');
+DefMacro('\thechapter',       (CounterValue('secnumdepth')>=0) ? '\arabic{chapter}' : '');
+
+DefMacro('\thesection',       (CounterValue('secnumdepth')>=1) ? '\thechapter.\arabic{section}' : '');
+
+DefMacro('\thesubsection',    (CounterValue('secnumdepth')>=2) ? '\thesection.\arabic{subsection}' : '');
+
+DefMacro('\thesubsubsection', (CounterValue('secnumdepth')>=3) ? '\thesubsection.\arabic{subsubsection}' : '');
+
+DefMacro('\theparagraph',     (CounterValue('secnumdepth')>=4) ? '\thesubsubsection.\arabic{paragraph}' : '');
+
+DefMacro('\thesubparagraph',  (CounterValue('secnumdepth')>=5) ? '\theparagraph.\arabic{subparagraph}' : '');
 
 DefMacro('\chaptermark{}', '');
 


### PR DESCRIPTION
Using `\setcounter{secnumdepth}{3}` in LaTeX should number subsubsections as explained in the answer in  https://tex.stackexchange.com/questions/17877/how-to-show-subsections-and-subsubsections-in-toc/17879 

However, it had no effect on the generated HTML. 

This pull-request corrects it for the report-class (and also allows skipping section-numbers or having sub-paragraph numbers, just in case). 

I have not ported it to other styles. 