### PR TITLE
Use library to generate XML in maketests instead of system()

### DIFF
--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -65,9 +65,9 @@ sub new {
 sub convertAndWriteFile {
   my ($self, $file) = @_;
   $file =~ s/\.tex$//;
-  my $dom = $self->convertFile($file);
-  $dom->toFile("$file.xml", 1) if $dom;
-  return $dom; }
+  my $doc = $self->convertFile($file);
+  $doc->getDocument->toFile("$file.xml", 1) if $doc;
+  return $doc; }
 
 sub convertFile {
   my ($self, $file) = @_;

--- a/tools/maketests
+++ b/tools/maketests
@@ -252,18 +252,6 @@ sub gen_xml {
     or die "Failed to create $file.xml: $!";
   return; }
 
-sub gen_xml {
-  my ($dir, $name) = @_;
-  my $source = pathname_make(dir => $dir, name => $name, type => 'tex');
-  my $xml    = pathname_make(dir => $dir, name => $name, type => 'xml');
-  if (-f $xml) {
-    rename($xml, $xml . '.bak'); }
-  system('latexml', $source,
-    "--destination=" . $xml,
-    "--nocomments", (map { "--verbose" } 1 .. $verbosity)) == 0
-    or die "Failed to create $xml: $!";
-  return; }
-
 sub gen_pdf {
   my ($dir, $name) = @_;
   my $cwd = pathname_cwd();


### PR DESCRIPTION
Oddly, there were two `gen_xml` methods. The one being used was shelling out to `latexml`. I am running a development environment where I haven't run `make install` and everything is in the working directory, so this doesn't work.

The other `gen_xml` method uses the library, which works with my local development environment. A nice side-effect is this is the same approach used by `make test`, which seems more resilient somehow.

Also, `convertAndWriteFile()` was broken, so I've fixed that.