### PR TITLE
Use utf8 when writing to stdout in latexml

### DIFF
--- a/bin/latexml
+++ b/bin/latexml
@@ -131,6 +131,7 @@ elsif ($destination) {
   print $OUTPUT $serialized;
   close($OUTPUT); }
 else {
+  binmode(STDOUT, ":encoding(UTF-8)");
   print $serialized; }
 
 # ========================================
@@ -162,7 +163,7 @@ latexml [options] I<texfile>
  --includestyles    allows latexml to load raw *.sty file;
                     by default it avoids this.
  --path=dir         adds to the paths searched for files,
-                    modules, etc; 
+                    modules, etc;
  --documentid=id    assign an id to the document root.
  --quiet            suppress messages (can repeat)
  --verbose          more informative output (can repeat)

--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -65,7 +65,7 @@ GetOptions(
   "debug=s"       => sub { no strict 'refs'; ${ 'LaTeXML::' . $_[1] . '::DEBUG' } = 1; },
   "documentid=s"  => \$documentid,
   "help"          => \$help,
-  ) or pod2usage(-message => $LaTeXML::IDENTITY,
+) or pod2usage(-message => $LaTeXML::IDENTITY,
   -exitval => 1, -verbose => 0, -output => \*STDERR);
 pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 2, -output => \*STDOUT)
   if $help;
@@ -254,6 +254,7 @@ sub outputXML {
     $xml->setNamespaceDeclPrefix($oldprefix, undef); }
   my $serialized = $newdoc->toString(1);
   if ($xmldestination eq '-') {
+    binmode(STDOUT, ":encoding(UTF-8)");
     print $serialized; }
   else {
     $xmldestination = pathname_canonical($xmldestination);

--- a/lib/LaTeXML/Post/Writer.pm
+++ b/lib/LaTeXML/Post/Writer.pm
@@ -39,7 +39,7 @@ sub process {
   # Note that this will NOT RE-format a document read in from xml,
   # (providing no_blanks is false; which it should be, since it is dangerous.
   #  it can also remove significant spaces between elements!)
-  my $string = ($$self{is_html} ? $xmldoc->toStringHTML : $xmldoc->toString(1));
+  my $serialized = ($$self{is_html} ? $xmldoc->toStringHTML : $xmldoc->toString(1));
 
   if (my $destination = $doc->getDestination) {
     my $destdir = $doc->getDestinationDirectory;
@@ -49,10 +49,11 @@ sub process {
     my $OUT;
     open($OUT, '>', $destination)
       or return Fatal('I/O', $destdir, undef, "Couldn't write '$destination'", "Response was: $!");
-    print $OUT $string;
+    print $OUT $serialized;
     close($OUT); }
   else {
-    print $string; }
+    binmode(STDOUT, ":encoding(UTF-8)");
+    print $serialized; }
   return $doc; }
 
 # ================================================================================


### PR DESCRIPTION
Fixes #918

No rocket science here. Maybe before merging I should go through all executables in `bin/` and ensure all default prints are using the utf8 encoding? cc @brucemiller 

