### PR TITLE
auto-detect UTF-8 encoding in Mouth::file, when no encoding is given

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -72,6 +72,7 @@ WriteMakefile(NAME => 'LaTeXML',
     'Time::HiRes'       => 0,
     'URI'               => 0,
     'version'           => 0,
+    'Encode::Detect::Detector' => 0,
     # If we have an "old" version of XML::LibXML,
     # we also need XPathContext.
     # But we can't determine that additional dependence


### PR DESCRIPTION
Fixes #919 (experimental)

I tried my hand at adding a dependency and try to proactively guess the encoding of a given file, looking for  UTF-8 lines.

I expect the biggest drawback here would be (large?) performance slowdown, as the naive first stab would test every line as a file is being read-in, for every file latexml ingests.

However the examples at #919 all work correctly, which makes it a decent proof-of-concept. Maybe gets a discussion started?