### PR TITLE
More encoding cleanup

### DIFF
--- a/bin/latexml
+++ b/bin/latexml
@@ -116,6 +116,8 @@ eval {
           my $dom = $latexml->convertDocument($digested);
           $serialized = $dom->toString(1);
         }
+        # NOTE that we are serializing via LaTeXML's Document::serialize_aux
+        # which has NOT been encoded into bytes, so we need an explicit encode before printing/returning
         $serialized = Encode::encode('UTF-8', $serialized) if $serialized;
         }); }
 };

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -155,6 +155,8 @@ if ($log) {
 }
 
 if ($result) {
+  # NOTE that we are serializing the XML::LibXML::Document whose toString
+  # has ALREADY encoded (in this case to utf8), so NO encode is needed!
   if ($opts->get('destination')) {
     my $output_handle;
     if (!open($output_handle, ">", $opts->get('destination'))) {

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -316,6 +316,8 @@ sub convert {
   if ((defined $result) && ref($result) && (ref($result) =~ /^(:?LaTe)?XML/)) {
     if (($$opts{format} =~ /x(ht)?ml/) || ($$opts{format} eq 'jats')) {
       $serialized = $result->toString(1); 
+      # NOTE that we are serializing here via LaTeXML's Document::serialize_aux
+      # which has NOT been encoded into bytes, so we need an explicit encode before printing/returning
       $serialized = Encode::encode('UTF-8', $serialized) if $serialized; }
     elsif ($$opts{format} =~ /^html/) {
       if (ref($result) =~ /^LaTeXML::(Post::)?Document$/) {    # Special for documents
@@ -324,7 +326,6 @@ sub convert {
         do {
           local $XML::LibXML::setTagCompression = 1;
           $serialized = $result->toString(1);
-          $serialized = Encode::encode('UTF-8', $serialized) if $serialized;
           } } }
     elsif ($$opts{format} eq 'dom') {
       $serialized = $result; } }


### PR DESCRIPTION
Follow-up to #938 .

In fact I think this PR demonstrates why I think leaving things in the current state will cause more trouble (at least for me) down the line when I forget this discussion thread. Having identically named `toString` methods that return different types of data (unencoded Perl chars vs encoded Unicode bytes) is just awkward.

Then again I realize there are more toString methods out there, and they all use characters internally. So might as well punt with this... I just caught myself again mistakenly double-encoding in LaTeXML.pm (see line 327 in diff), it's just too opaque to easily notice which method is getting called.
