### PR TITLE
Soften heuristic, was breaking mathbf macro

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1485,7 +1485,7 @@ DefMacro('\@ensuremath{}', sub {
     else { (T_MATH, $stuff->unlist, T_MATH); } });
 
 # Magic check that math-mode trigger follows
-our $MATHENVS = 'math|displaymath|equation*?|eqnarray*?'
+our $MATHENVS = 'displaymath|equation*?|eqnarray*?'
   . '|multline*?|align*?|falign*?|alignat*?|xalignat*?|xxalignat*?|gather*?';
 DefMacro('\ensuremathfollows', sub {
     my ($gullet) = @_;


### PR DESCRIPTION
Fixes #931 . 

Simple case of over-eager heuristics, any macro that started with `\math` was treated as a signal that math mode was already activated during `--whatsin=math` processing. Clearly not the case.