### PR TITLE
Ensure raw binmode when writing archive files in latexmlc

### DIFF
--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -162,6 +162,9 @@ if ($result) {
     if (!open($output_handle, ">", $opts->get('destination'))) {
       print STDERR "Fatal:I/O:forbidden Couldn't open output file " . $opts->get('destination') . ": $!";
       exit 1; }
+    if ($whatsout eq 'archive') {
+      binmode($output_handle, ':raw');
+    }
     print $output_handle $result;
     close $output_handle;
   } else {

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -546,7 +546,7 @@ sub convert_post {
   # If our format requires a manifest, create one
   if (($$opts{whatsout} =~ /^archive/) && ($format !~ /^x?html|xml/)) {
     require LaTeXML::Post::Manifest;
-    my $manifest_maker = LaTeXML::Post::Manifest->new(db => $DB, format => $format, %PostOPS);
+    my $manifest_maker = LaTeXML::Post::Manifest->new(db => $DB, format => $format, log=>$$opts{log}, %PostOPS);
     $manifest_maker->process(@postdocs); }
   # Archives: when a relative --log is requested, write to sandbox prior packing
   if ($$opts{log} && ($$opts{whatsout} =~ /^archive/) && (!pathname_is_absolute($$opts{log}))) {

--- a/t/931_epub.t
+++ b/t/931_epub.t
@@ -1,0 +1,47 @@
+# -*- CPERL -*-
+#**********************************************************************
+# Test cases for EPUB generation integrity
+#**********************************************************************
+use strict;
+use warnings;
+
+use Test::More;
+
+use FindBin;
+use File::Temp qw(tempfile);
+use File::Spec::Functions qw(catfile);
+use Archive::Zip qw(:CONSTANTS :ERROR_CODES);
+
+
+my ($tmp_fh, $epub_filename) = tempfile('931_testXXXX', SUFFIX => '.epub');
+close $tmp_fh;
+
+my $log_filename = "931_test.log";
+
+my $latexmlc = catfile($FindBin::Bin, '..', 'blib', 'script', 'latexmlc');
+my $invocation = "$latexmlc --dest=$epub_filename --log=$log_filename literal:test";
+
+is(system($invocation), 0, "latexmlc invocation for test 931_epub.t");
+
+ok(-f $epub_filename, 'epub file generated');
+ok(!-z $epub_filename, 'epub file has content');
+
+my $zip_file = Archive::Zip->new();
+is($zip_file->read($epub_filename), AZ_OK, 'epub file successfully loads as Archive::Zip object');
+is($zip_file->numberOfMembers, 9, "correct number of files were present in final ePub");
+my $names = join(", ",sort($zip_file->memberNames));
+ok($names =~ /^META-INF\/, META-INF\/container\.xml, OPS\/, OPS\/931_test\.log, OPS\/931_test....\.xhtml, OPS\/LaTeXML\.css, OPS\/content\.opf, OPS\/nav\.xhtml, mimetype$/, "correct files were present in final ePub: $names");
+
+my $log_member = $zip_file->memberNamed("OPS/$log_filename");
+ok($log_member, "log file was written to epub");
+my $log_content = $log_member->contents();
+ok($log_content =~ /No obvious problems/, 'epub conversion was error-free');
+
+if (-f $epub_filename) {
+  ok(unlink($epub_filename), "clean up generated epub file");
+}
+
+done_testing();
+
+#**********************************************************************
+1;


### PR DESCRIPTION
Fixes #827 and #806 

This is a platform-specific fix, and in fact I need to double-check this keeps the epub generation as-is on Linux. 

It turns out that without an explicit `:raw` binmode, printing out binary data on Windows 10 leads to corrupted archives, for reasons I do not fully understand at the moment. 

While debugging, I first verified the archive integrity, all EPUB-needed files were added to the Archive::Zip object and then serialized via IO::String. However, the same payload lead to different `.epub` file contents when e.g. the compression level was changed, leading to the OPS subdirectory completely disappearing when the archive is viewed in 7zip. 

In the end, it turned out the produced archives were partially readable by 7zip (my Win10 archive reader of choice), but were silently corrupted at some hard to predict point in the file-writing process.

Adding an explicit `:raw` binmode to the file handle in latexmlc resolved this fully, and created a fully functioning `.epub` file in Windows 10.
