### PR TITLE
Teasing away Perl-level dies for 100+ error document

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -894,6 +894,8 @@ DefMacro('\the Register', sub {
     my ($gullet, $variable) = @_;
     return () unless $variable;
     my ($defn, @args) = @$variable;
+    if (!$defn) {
+      Error('expected', "<register>", $gullet, "a register was expected to be here"); return (); }
     my $type = $defn->isRegister;
     if (!$type) {
       my $cs = ToString($defn->getCS);
@@ -3268,7 +3270,7 @@ sub cleanup_XMText {
 ##                                 .' | ltx:tabular/ltx:tr/ltx:td[not(ltx:Math)]'
 ##                                 .' | ltx:tabular/ltx:tbody/ltx:tr/ltx:td[not(ltx:Math)]',
 ##                                 $textnode)
-    ) {
+  ) {
     # First step is remove any ltx:tbody from the tabular!
     foreach my $tb ($document->findnodes('ltx:tabular/ltx:tbody', $textnode)) {
       $document->unwrapNodes($tb); }
@@ -3283,7 +3285,7 @@ sub cleanup_XMText {
             $document->replaceNode($m, map { $_->childNodes } $m->childNodes); }
           else {                                           # Otherwise, wrap whatever it is in an XMText
             $document->wrapNodes('ltx:XMText', $m); }
-        } } }
+    } } }
     # And now we don't need the XMText any more.
     foreach my $attr ($textnode->attributes) {    # Copy the child's attributes (should Merge!!)
       $table->setAttribute($attr->nodeName => $attr->getValue); }
@@ -3540,7 +3542,7 @@ DefMacroI('\eqno', undef, sub {
         || (ToString($t) =~ /^\\(?:begin|end)\{/)    # any sort of environ begin or end???
                                                      # This seems needed within AmSTeX environs
         || Equals($t, T_CS('\@@close@inner@column'))
-        ) {
+      ) {
         #       || Equals($t,T_CS('\end{equation}'))|| Equals($t,T_CS('\end{equation*}'))){
         return (Invocation(T_CS('\@@eqno'), Tokens(@stuff)), $t); }
       else {
@@ -3694,7 +3696,7 @@ sub scriptHandler {
     my $c = (($op eq 'SUPERSCRIPT') ? '^' : '_');
     Error('unexpected', $c, $stomach, "Script $c can only appear in math mode");
     return Box($c, undef, undef, (($op eq 'SUPERSCRIPT') ? T_SUPER : T_SUB));
-  } }
+} }
 
 DefPrimitiveI(T_SUPER, undef, sub { scriptHandler($_[0], 'SUPERSCRIPT'); });
 DefPrimitiveI(T_SUB,   undef, sub { scriptHandler($_[0], 'SUBSCRIPT'); });
@@ -5354,7 +5356,7 @@ DefConstructor('\@@joinrel{}{}', sub {
         my $role = (scalar(keys %roles) == 1 ? [keys %roles]->[0] : ($roles{ARROW} ? 'ARROW' : 'RELOP'));
         map { $node->removeChild($_) } @rels;
         $document->insertElement('ltx:XMTok', [map { $_->textContent } @rels], role => $role);
-      } } },
+  } } },
   reversion => '#1\joinrel #2');
 
 #----------------------------------------------------------------------

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -268,7 +268,7 @@ sub pgfmathparse {
 ###    if ($string =~/^+/){        # Don't parse as expression, just as glue. ???
   #    print STDERR "\nPGF Math Parse: $string\n";
   $PGFMATHGrammar = Parse::RecDescent->new($PGFMATHGrammarSpec) unless $PGFMATHGrammar;
-  my $result = $PGFMATHGrammar->expr(\$string);
+  my $result = $PGFMATHGrammar->expr(\$string) || 0.0;
   #  $result = "0.0" if $result eq "0";
   #    print STDERR "  GOT " . (defined $result ? $result : '<fail>') . "\n";
   if ($string) {
@@ -370,6 +370,8 @@ sub pgfmath_register {
   my ($cs) = @_;
   my $reg = LookupRegister($cs);
   SetCondition(T_CS('\ifpgfmathunitsdeclared'), 1, 'global');
+  if (!$reg) {
+    return 0.0; }
   return (ref $reg eq 'LaTeXML::Common::Number' ? $reg->valueOf : $reg->valueOf / 65536); }
 
 sub pgfmath_setunitsdeclared {


### PR DESCRIPTION
Just took a quick look at the Perl-level fatal errors of `1802.08337` in arXiv, and teased them away so that the Fatal comes from having 100+ errors. The document itself has some serious problems with tikz interpretation, so I won't attempt to resolve it to a non-error state now.