### PR TITLE
make DirectoryList tolerant of spaces

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -361,13 +361,16 @@ DefParameterType('TeXFileName', sub {
 # A LaTeX style directory List
 DefParameterType('DirectoryList', sub {
     my ($gullet) = @_;
+    $gullet->skipSpaces;
     if ($gullet->ifNext(T_BEGIN)) {
       $gullet->readToken;
       my @dirs = ();
+      $gullet->skipSpaces;
       while ($gullet->ifNext(T_BEGIN)) {
         # Should these be Semiverbatim ??
         push(@dirs, $gullet->readArg);
         $gullet->readMatch(T_OTHER(',')); }
+      $gullet->skipSpaces;
       if ($gullet->ifNext(T_END)) {
         $gullet->readToken; }
       else {


### PR DESCRIPTION
The specific use in arXiv 1802.01430 was causing a Fatal error:
```
\graphicspath{ {./Figs/} } 
```

as the argument was being misinterpreted. Please check if this fix is the most accurate upgrade, it certainly makes the document work with a decent HTML output.