### PR TITLE
Integrate logs from separate bibliography converts in post-processing

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -210,6 +210,7 @@ sub convert {
   my $latexml = $$self{latexml};
   $latexml->withState(sub {
       my ($state) = @_;    # Sandbox state
+      $$state{status} = {};
       $state->pushDaemonFrame;
       $state->assignValue('_authlist', $$opts{authlist}, 'global');
       $state->assignValue('REMOTE_REQUEST', (!$$opts{local}), 'global');
@@ -255,7 +256,6 @@ sub convert {
       my ($state) = @_;    # Remove current state frame
       $$opts{searchpaths} = $state->lookupValue('SEARCHPATHS'); # save the searchpaths for post-processing
       $state->popDaemonFrame;
-      $$state{status} = {};
   });
   if ($LaTeXML::UNSAFE_FATAL) {
     # If the conversion hit an unsafe fatal, we need to reinitialize

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -357,11 +357,9 @@ sub MergeStatus {
     if ($type eq 'undefined' or $type eq 'missing') {
       my $table = $$external_status{$type};
       foreach my $subtype(keys %$table) {
-        $$status{$type}{$subtype} ||= 0;
         $$status{$type}{$subtype} += $$table{$subtype};
       }
     } else {
-      $$status{$type} ||= 0;
       $$status{$type} += $$external_status{$type};
     }
   }

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -346,11 +346,10 @@ sub generateMessage {
   # finally, join the result into a block of lines, indenting all but the 1st line.
   return "\n" . join("\n\t", @lines) . "\n"; }
 
-use Data::Dumper;
 sub MergeStatus {
   my ($external_state) = @_;
   my $state = $STATE;
-  # return unless $state && $external_state;
+  return unless $state && $external_state;
   my $status = $$state{status};
   my $external_status = $$external_state{status};
   # Should this be a state method? I suspect XS-ive conflicts later on...

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -23,7 +23,9 @@ our @EXPORT = (
   # Progress reporting
   qw(&NoteProgress &NoteProgressDetailed &NoteBegin &NoteEnd),
   # Colored-logging related functions
-  qw(&colorizeString)
+  qw(&colorizeString),
+  # Status management
+  qw(&MergeStatus),
 );
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -343,6 +345,28 @@ sub generateMessage {
 
   # finally, join the result into a block of lines, indenting all but the 1st line.
   return "\n" . join("\n\t", @lines) . "\n"; }
+
+use Data::Dumper;
+sub MergeStatus {
+  my ($external_state) = @_;
+  my $state = $STATE;
+  # return unless $state && $external_state;
+  my $status = $$state{status};
+  my $external_status = $$external_state{status};
+  # Should this be a state method? I suspect XS-ive conflicts later on...
+  foreach my $type(keys %$external_status) {
+    if ($type eq 'undefined' or $type eq 'missing') {
+      my $table = $$external_status{$type};
+      foreach my $subtype(keys %$table) {
+        $$status{$type}{$subtype} ||= 0;
+        $$status{$type}{$subtype} += $$table{$subtype};
+      }
+    } else {
+      $$status{$type} ||= 0;
+      $$status{$type} += $$external_status{$type};
+    }
+  }
+}
 
 sub Locator {
   my ($object) = @_;


### PR DESCRIPTION
Fixes #916 

A bit tricky, since managing the STDERR redirects is getting wild, but it works nicely. Unsure about the final log to print, attaching screenshots with this version. I did not want to indent the messages, so that automated regexes (e.g. from cortex) can still parse the log as usual.

Here are the logs converting the the issue example, with `master`:

![master](https://user-images.githubusercontent.com/348975/38731053-a1f2a9ae-3f21-11e8-8c90-87b8820c5788.png)

And the logs after this PR is installed:

![new](https://user-images.githubusercontent.com/348975/38731061-aaba3502-3f21-11e8-9bfe-c3fbe4b58171.png)
