### PR TITLE
do not Fatal when dimension flow goes awry, recover with an Error

### DIFF
--- a/lib/LaTeXML/Common/Dimension.pm
+++ b/lib/LaTeXML/Common/Dimension.pm
@@ -14,6 +14,7 @@ use strict;
 use warnings;
 use LaTeXML::Global;
 use LaTeXML::Common::Object;
+use LaTeXML::Common::Error; 
 use base qw(LaTeXML::Common::Number);
 use base qw(Exporter);
 our @EXPORT = (qw(&Dimension));
@@ -64,6 +65,28 @@ sub pointformat {
 sub attributeformat {
   my ($sp) = @_;
   return sprintf('%.1fpt', LaTeXML::Common::Number::roundto($sp / 65536, 1)); }
+
+sub getDepth { # ??? 
+  #  sometimes Dimension(0) is used as a default value
+  #  and errors in the flow invoke getDepth on that dimension
+  #
+  #  probably safe to assume asking for the depth of a dimension 
+  #  was caused by a bug in execution, and recover by returning the dimension itself?
+  my ($self) = @_;
+  Error('expected','Box', undef, 'getDepth invoked on a Dimension, returning self');
+  return $self;
+}
+# Might as well add the defaults for width and height while we're at it.
+sub getWidth {
+  my ($self) = @_;
+  Error('expected','Box', undef, 'getWidth invoked on a Dimension, returning self');
+  return $self;
+}
+sub getHeight {
+  my ($self) = @_;
+  Error('expected','Box', undef, 'getHeight invoked on a Dimension, returning self');
+  return $self;
+}
 
 #======================================================================
 1;

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1429,11 +1429,11 @@ DefRegister('\wd Number', Dimension(0),
 DefRegister('\dp Number', Dimension(0),
   getter => sub {
     my ($n) = @_;
-    my $stuff = LookupValue('box' . $_[0]->valueOf);
+    my $stuff = $n && LookupValue('box' . $n->valueOf);
     return ($stuff ? $stuff->getDepth : Dimension(0)); },
   setter => sub {
     my ($value, $n) = @_;
-    my $stuff = LookupValue('box' . $n->valueOf);
+    my $stuff = $n && LookupValue('box' . $n->valueOf);
     $stuff->setDepth($value) if $stuff;
     return; });
 


### PR DESCRIPTION
Recovers 20 out of ~650 Fatals in the single month (feb 18) arXiv rerun I did yesterday.

Basic gain is avoiding a hard Fatal, and producing a reasonable Error-severity HTML output.