### PR TITLE
avoid Fatal for tikz matrices

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2631,9 +2631,10 @@ DefConstructor('\@open@alignment SkipSpaces DigestedBody',
   beforeDigest => sub { $_[0]->bgroup; },
   afterDigest  => sub {
     my ($stomach, $whatsit) = @_;
-    my $alignment = LookupValue('Alignment');
-    $whatsit->setProperty(alignment => $alignment);
-    $alignment->setBody($whatsit); });
+    if (my $alignment = LookupValue('Alignment')) {
+      $whatsit->setProperty(alignment => $alignment);
+      $alignment->setBody($whatsit); }
+    return; });
 
 #----------------------------------------------------------------------
 # Row; The content is stuffed into the Alignment, so we don't construct anything here.


### PR DESCRIPTION
While it's hard to fully fix #794 , we can at least keep it from regressing into a Fatal.