### PR TITLE
Fix misc fatal:misdefined:ANON problems

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2982,8 +2982,9 @@ DefConstructor('\@@tabular[] Undigested DigestedBody',
   sizer        => '#3',
   afterDigest  => sub {
     my ($stomach, $whatsit) = @_;
-    my $attr = LookupValue('Alignment')->getProperty('attributes');
-    $$attr{vattach} = translateAttachment($whatsit->getArg(1));
+    if (my $alignment = LookupValue('Alignment')) {
+      my $attr = $alignment->getProperty('attributes');
+      $$attr{vattach} = translateAttachment($whatsit->getArg(1)); }
     return; },
   mode => 'text');
 
@@ -3856,6 +3857,7 @@ DefPrimitive('\@begin@lrbox Token', sub {
 
 DefPrimitive('\usebox {Register}', sub {
     my ($defn) = @{ $_[1] };
+    return Box() unless $defn && ($defn ne 'missing');
     my $value = $defn->valueOf()->valueOf;
     LookupValue('box' . $value) || Box(); });
 

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -907,7 +907,7 @@ DefMacro('\the Register', sub {
     my ($gullet, $variable) = @_;
     return () unless $variable;
     my ($defn, @args) = @$variable;
-    if (!$defn) {
+    if (!$defn || $defn eq 'missing') {
       Error('expected', "<register>", $gullet, "a register was expected to be here"); return (); }
     my $type = $defn->isRegister;
     if (!$type) {
@@ -2631,9 +2631,10 @@ DefConstructor('\@open@alignment SkipSpaces DigestedBody',
   beforeDigest => sub { $_[0]->bgroup; },
   afterDigest  => sub {
     my ($stomach, $whatsit) = @_;
-    my $alignment = LookupValue('Alignment');
-    $whatsit->setProperty(alignment => $alignment);
-    $alignment->setBody($whatsit); });
+    if (my $alignment = LookupValue('Alignment')) {
+      $whatsit->setProperty(alignment => $alignment);
+      $alignment->setBody($whatsit); }
+    return; });
 
 #----------------------------------------------------------------------
 # Row; The content is stuffed into the Alignment, so we don't construct anything here.

--- a/lib/LaTeXML/Package/calc.sty.ltxml
+++ b/lib/LaTeXML/Package/calc.sty.ltxml
@@ -30,11 +30,13 @@ DefPrimitive('\addtocounter{}{}', sub {
 DefPrimitive('\setlength{Variable}{}', sub {
     my ($stomach, $var, $arg) = @_;
     my ($defn, @args) = @$var;
+    return unless $defn && ($defn ne 'missing');
     $defn->setValue(readExpression($stomach->getGullet, 'Glue', $arg), @args); });
 
 DefPrimitive('\addtolength{Variable}{}', sub {
     my ($stomach, $var, $arg) = @_;
     my ($defn, @args) = @$var;
+    return unless $defn && ($defn ne 'missing');
     $defn->setValue($defn->valueOf(@args)->add(readExpression($stomach->getGullet, 'Glue', $arg)),
       @args); });
 
@@ -42,23 +44,27 @@ DefPrimitive('\settowidth{Variable}{}', sub {
     my ($stomach, $var, $arg) = @_;
     my ($defn, @args) = @$var;
     my $box = Digest($arg);
+    return unless $defn && ($defn ne 'missing');
     $defn->setValue($box->getWidth, @args); });
 
 DefPrimitive('\settoheight{Variable}{}', sub {
     my ($stomach, $var, $arg) = @_;
     my ($defn, @args) = @$var;
+    return unless $defn && ($defn ne 'missing');
     my $box = Digest($arg);
     $defn->setValue($box->getHeight, @args); });
 
 DefPrimitive('\settodepth{Variable}{}', sub {
     my ($stomach, $var, $arg) = @_;
     my ($defn, @args) = @$var;
+    return unless $defn && ($defn ne 'missing');
     my $box = Digest($arg);
     $defn->setValue($box->getDepth, @args); });
 
 DefPrimitive('\settototalheight{Variable}{}', sub {
     my ($stomach, $var, $arg) = @_;
     my ($defn, @args) = @$var;
+    return unless $defn && ($defn ne 'missing');
     my $box = Digest($arg);
     $defn->setValue($box->getHeight + $box->getDepth, @args); });
 

--- a/lib/LaTeXML/Package/multirow.sty.ltxml
+++ b/lib/LaTeXML/Package/multirow.sty.ltxml
@@ -18,8 +18,9 @@ use LaTeXML::Package;
 DefPrimitive('\multirowsetup', undef);
 DefPrimitive('\multirow{Number}[Number]{}[Dimension]{}', sub {
     my ($stomach, $nrows, $bigstruts, $width, $fixup, $content) = @_;
-    my $colspec = LookupValue('Alignment')->currentColumn;
-    $$colspec{rowspan} = $nrows->valueOf;
+    if (my $alignment = LookupValue('Alignment')) {
+        my $colspec = $alignment->currentColumn;
+        $$colspec{rowspan} = $nrows->valueOf; }
     Digest(Tokens(T_CS('\hbox'), T_BEGIN, T_CS('\multirowsetup'), $content->unlist, T_END)); });
 
 #**********************************************************************

--- a/lib/LaTeXML/Package/pstricks.sty.ltxml
+++ b/lib/LaTeXML/Package/pstricks.sty.ltxml
@@ -175,15 +175,18 @@ DefParameterType('Arrows', \&ReadArrows,
     $number = Float(0) unless $number;
     my $starred = ($pre =~ /\*/); my $value;
     if (ref $number) {
-      $number = $number->multiply(360 / LookupValue('\degrees')->valueOf);
+      my $degrees = LookupValue('\degrees');
+      my $degrees_value = $degrees ? $degrees->valueOf : 1;
+      $number = $number->multiply(360 / $degrees_value);
       $value  = $number; }
     else {
       $starred = ($number =~ /N|W|S|E/) || $starred;
       $value   = $angleVals{$number}    || 0;
       $value   = Float($value); }
     if ($starred) {
-      $value = $value->subtract(Float(LookupValue('_psActiveSRotation')));
-      LaTeXML::Package::Pool::t_undoSRotation(); }
+      if (my $active_rotation = LookupValue('_psActiveSRotation')) {
+        $value = $value->subtract(Float($active_rotation));
+        LaTeXML::Package::Pool::t_undoSRotation(); } }
     return bless [$value, $number, $pre], $class; }
 
   sub starred {


### PR DESCRIPTION
I took a pass through one example document, but also went through all line numbers in the 92 Fatal messages reported at:
```
   fatal >  misdefined >  LaTeXML::Package::Pool::__ANON__
```

https://corpora.mathweb.org/corpus/%2Fdata%2Farxiv_1802%2F/tex_to_html/fatal/misdefined

and patched them. Just some minor code hardening.