### PR TITLE
use double quotes for XPath attribute values

### DIFF
--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -491,7 +491,7 @@ sub associateNode {
     # But ONLY if that XMDual is the "direct" parent, or is parent of XRef that points to $current
     if (my $container = $document->findnode('parent::ltx:XMDual[1]', $sourcenode)
       || ($sid &&
-        $document->findnode("ancestor-or-self::ltx:XMDual[ltx:XMRef[\@idref='$sid']][1]",
+        $document->findnode('ancestor-or-self::ltx:XMDual[ltx:XMRef[@idref="'.$sid.'"]][1]',
           $sourcenode))) {
       $sourcenode = $container; } }
   # If the current node is appropriately visible, use it.


### PR DESCRIPTION
Fixes a Perl fatal in post-processing caused by the amazing:
```
\newtheorem*{thm1.2'}{Theorem 1.2$'$}
```

of 1802.04737 in arXiv.

Apparently XPath has no way of escaping apostrophes, so the attribute value selectors need to always be in double quotes.