### PR TITLE
\@protected@testopt definition from latex.ltx, allows loading ucs.sty

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -5080,7 +5080,14 @@ DefMacro('\@testopt{}{}', sub {
     my ($gullet, $cmd, $option) = @_;
     ($gullet->ifNext(T_OTHER('[')) ? $cmd->unlist
       : ($cmd->unlist, T_OTHER('['), $option->unlist, T_OTHER(']'))); });
-Let('\@protected@testopt', '\@testopt');    # ?
+RawTeX(<<'EoTeX');
+\def\@protected@testopt#1{%%
+  \ifx\protect\@typeset@protect
+    \expandafter\@testopt
+  \else
+    \@x@protect#1%
+  \fi}
+EoTeX
 
 Let('\l@ngrel@x', '\relax');                # Never actually used anywhere, but...
 DefMacro('\@star@or@long{}', '\@ifstar{\let\l@ngrel@x\relax#1}{\let\l@ngrel@x\long#1}');


### PR DESCRIPTION
Fixes #982 

There was a rather nasty infinite loop when loading `ucs.sty` with the `--includestyles` option, which kept allocating new memory.

Turns out using the native definition of `\@protected@testopt` from latex.ltx allows for the package to load completely smoothly and error-free. So I'm submitting this PR to address the original report on the mailing list.

That said, looking at the documentation of ucs:
https://mirrors.sorengard.com/ctan/macros/latex/contrib/ucs/ucs.pdf

I am tempted to add a trivial binding for latexml, that sets the input encoding to utf8. Will wait for feedback from @brucemiller 