### PR TITLE
add copy of utf8.def as utf8x.def.ltxml

### DIFF
--- a/lib/LaTeXML/Package/utf8x.def.ltxml
+++ b/lib/LaTeXML/Package/utf8x.def.ltxml
@@ -1,0 +1,36 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  utf8x.def                                                          | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+# Note: this is a copy of utf8.def.ltxml for now, please report back any inaccuracies.
+
+#**********************************************************************
+# Override the LaTeX distribution's implementation.
+# (1) I don't know if we want(need) to get into reassembling bytes to decode utf8.
+# (2) why bother?
+#**********************************************************************
+# Undo disabling all the upper half plane (ascii) chars
+foreach my $code ((0 .. 8), 0xB, (0xE .. 0x1E), (128 .. 255)) {
+  my $char = pack('C', $code);
+  AssignCatcode($char, CC_OTHER); }
+AssignValue(INPUT_ENCODING => undef);
+
+# And set the Mouth to simply pass-thru the utf8.
+AssignValue(PERL_INPUT_ENCODING => 'UTF8');
+
+#**********************************************************************
+
+1;


### PR DESCRIPTION
As discussed in #983 , adding a copy of the `utf8.def` binding for `utf8x.def`.

I tried the example from stackexchange (https://tex.stackexchange.com/a/184628/78008) and it seemed to look correct:

![utf8x](https://user-images.githubusercontent.com/348975/39586985-25343f00-4f01-11e8-952d-e6b4a58a559e.png)

example source:
```tex
\documentclass[welsh]{article}
\usepackage[T1]{fontenc}
\usepackage[utf8x]{inputenc}
\usepackage{babel}
\begin{document}

 Ââ Êê Îî Ôô Ŵŵ Ŷŷ Ïï

\end{document}
```