### PR TITLE
Add Dockerfile for use with Docker

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,0 +1,67 @@
+
+# /=====================================================================\ #
+# | LaTeXML Dockerfile                                                  | #
+# | A Dockerfile to create a Docker Image with LaTeXML preinstalled.    | #
+# |=====================================================================| #
+# | Thanks to Tom Wiesing <tom.wiesing@gmail.com>                       | #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+
+# This Dockerfile expects the root directory of LaTeXML as a build context. 
+# To achieve this run the following command from the root directory:
+#
+# > docker build -t latexml -f release/Dockerfile .
+
+# We start from alpine linux 3.7
+FROM alpine:3.7
+
+# Install the dependencies
+RUN apk add --no-cache \
+    db-dev \
+    gcc \
+    libc-dev \
+    libgcrypt \
+    libgcrypt-dev \
+    libxml2 \
+    libxml2-dev \
+    libxslt \
+    libxslt-dev \
+    make \
+    perl \
+    perl-dev \
+    perl-utils \
+    wget \
+    zlib \
+    zlib-dev
+
+# Install cpanminus from edge
+RUN apk add --no-cache -U --repository http://dl-3.alpinelinux.org/alpine/edge/community perl-app-cpanminus
+
+# Make a directory for latexml
+RUN mkdir -p /opt/latexml
+
+# Add all of the source files
+ADD bin/            /opt/latexml/bin
+#ADD doc/            /opt/latexml/doc/
+ADD lib/            /opt/latexml/lib 
+#ADD release/        /opt/latexml/release/
+ADD t/              /opt/latexml/t/
+ADD tools/          /opt/latexml/tools/
+#ADD Changes         /opt/latexml/Changes
+#ADD INSTALL         /opt/latexml/INSTALL
+#ADD INSTALL.SKIP    /opt/latexml/INSTALL.SKIP
+ADD LICENSE         /opt/latexml/LICENSE
+ADD Makefile.PL     /opt/latexml/Makefile.PL
+#ADD MANIFEST        /opt/latexml/MANIFEST
+#ADD MANIFEST.SKIP   /opt/latexml/MANIFEST.SKIP
+#ADD manual.pdf      /opt/latexml/manual.pdf
+#ADD README.pod      /opt/README.pod
+
+# Installing  via cpanm
+WORKDIR /opt/latexml
+RUN cpanm .

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -17,6 +17,16 @@
 #
 # > docker build -t latexml -f release/Dockerfile .
 
+# Optionally, this Dockerfile includes a full TeXLive installation. 
+# By default, this is disabled, however it can be enabled by providing a
+# build argument like so:
+#
+# > docker build -t latexml --build-arg WITH_TEXLIVE=yes -f release/Dockerfile .
+#
+# Please be aware that including a full TeXLive installation can take a
+# significant amount of time (depending on network connection) and will
+# increase the image size to several Gigabytes. 
+
 # We start from alpine linux 3.7
 FROM alpine:3.7
 
@@ -38,6 +48,17 @@ RUN apk add --no-cache \
     wget \
     zlib \
     zlib-dev
+
+# Configure TeXLive Support
+# Set to "no" to disable, "yes" to enable
+ARG WITH_TEXLIVE="no"
+
+# Install TeXLive if not disabled
+RUN [ "$WITH_TEXLIVE" == "no" ] || (\
+           apk add --no-cache -U --repository http://dl-3.alpinelinux.org/alpine/edge/main      poppler harfbuzz-icu \
+        && apk add --no-cache -U --repository http://dl-3.alpinelinux.org/alpine/edge/community zziplib texlive-full \
+        && ln -s /usr/bin/mktexlsr /usr/bin/mktexlsr.pl \
+    )
 
 # Install cpanminus from edge
 RUN apk add --no-cache -U --repository http://dl-3.alpinelinux.org/alpine/edge/community perl-app-cpanminus

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -17,11 +17,11 @@
 #
 # > docker build -t latexml -f release/Dockerfile .
 
-# Optionally, this Dockerfile includes a full TeXLive installation. 
-# By default, this is disabled, however it can be enabled by providing a
+# This Dockerfile can include a full TeXLive installation. 
+# This is enabled by default however it can be disabled by providing a
 # build argument like so:
 #
-# > docker build -t latexml --build-arg WITH_TEXLIVE=yes -f release/Dockerfile .
+# > docker build -t latexml --build-arg WITH_TEXLIVE=no -f release/Dockerfile .
 #
 # Please be aware that including a full TeXLive installation can take a
 # significant amount of time (depending on network connection) and will
@@ -51,7 +51,7 @@ RUN apk add --no-cache \
 
 # Configure TeXLive Support
 # Set to "no" to disable, "yes" to enable
-ARG WITH_TEXLIVE="no"
+ARG WITH_TEXLIVE="yes"
 
 # Install TeXLive if not disabled
 RUN [ "$WITH_TEXLIVE" == "no" ] || (\


### PR DESCRIPTION
This commit adds a Dockerfile to LaTeXML to be able to use latexml easily within a Docker container. 