### PR TITLE
Cleanup and Refactor Locators

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -125,6 +125,7 @@ lib/LaTeXML/Common/Error.pm
 lib/LaTeXML/Common/Float.pm
 lib/LaTeXML/Common/Font.pm
 lib/LaTeXML/Common/Glue.pm
+lib/LaTeXML/Common/Locator.pm
 lib/LaTeXML/Common/Model.pm
 lib/LaTeXML/Common/Model/DTD.pm
 lib/LaTeXML/Common/Model/RelaxNG.pm

--- a/doc/manual/genpods
+++ b/doc/manual/genpods
@@ -46,6 +46,7 @@ my @modules = (
     LaTeXML::Common::Dimension
     LaTeXML::Common::Glue
     LaTeXML::Common::Font
+    LaTeXML::Common::Locator
     LaTeXML::Common::Model
     LaTeXML::Common::Model::DTD
     LaTeXML::Common::Model::RelaxNG

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -393,7 +393,7 @@ sub getLocation {
     # NOTE: Problems here.
     # (1) With obsoleting Tokens as a Mouth, we can get pointless "Anonymous String" locators!
     # (2) If gullet is the source, we probably want to include next token, etc or
-    return $gullet->getLocator(); }
+    return $gullet->getLocator; }
   # # If in postprocessing
   # if($LaTeXML::Post::PROCESSOR && $LaTeXML::Post::DOCUMENT){
   #   return 'in '. $LaTeXML::Post::PROCESSOR->getName

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -287,6 +287,7 @@ sub generateMessage {
   # Generate location information; basic and for stack trace.
   # If we've been given an object $where, where the error occurred, use it.
   my $docloc = getLocation($where);
+  $docloc = defined $docloc ? ToString($docloc) : '';
 
   # $message and each of @extra should be single lines
   @extra = grep { $_ ne '' } map { split("\n", $_) } grep { defined $_ } $message, @extra;
@@ -299,7 +300,7 @@ sub generateMessage {
     # Start with the error code & primary error message
     $errorcode . ' ' . $message,
     # Followed by single line location of where the message occurred (if we know)
-    ($docloc ? ($docloc) : ()),
+    ($docloc ? ('at ' . $docloc) : ()),
     # and then any additional message lines supplied
     @extra);
 
@@ -365,9 +366,10 @@ sub MergeStatus {
   }
 }
 
+# returns the locator of an object, or undef
 sub Locator {
   my ($object) = @_;
-  return ($object && $object->can('getLocator') ? $object->getLocator : "???"); }
+  return ($object && $object->can('getLocator') ? $object->getLocator : undef); }
 
 # A more organized abstraction along there likes of $where->whereAreYou
 # might be useful?
@@ -393,7 +395,7 @@ sub getLocation {
     # NOTE: Problems here.
     # (1) With obsoleting Tokens as a Mouth, we can get pointless "Anonymous String" locators!
     # (2) If gullet is the source, we probably want to include next token, etc or
-    return $gullet->getLocator; }
+    return Locator($gullet); }
   # # If in postprocessing
   # if($LaTeXML::Post::PROCESSOR && $LaTeXML::Post::DOCUMENT){
   #   return 'in '. $LaTeXML::Post::PROCESSOR->getName

--- a/lib/LaTeXML/Common/Locator.pm
+++ b/lib/LaTeXML/Common/Locator.pm
@@ -1,0 +1,84 @@
+# /=====================================================================\ #
+# |  LaTeXML::Common::Locator                                           | #
+# | Locators                                                            | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Common::Locator;
+use LaTeXML::Global;
+use strict;
+use warnings;
+
+use base qw(LaTeXML::Common::Object);
+
+sub new {
+    my ($class, $source, $line, $col) = @_;
+    return bless { source => $source, line => $line, col => $col}, $class; }
+
+sub toString {
+  my ($self) = @_;
+  my $loc = defined $$self{source} ? $$self{source} : 'Anonymous String';
+  $loc .= "; line $$self{line}" if defined($$self{line});
+  $loc .= " col $$self{col}" if defined($$self{line}) && defined($$self{col});
+  return $loc; }
+
+sub stringify {
+    # TODO: Do we want an 'at' here?
+    my ($self) = @_;
+    return $self->toString; }
+
+sub getLocator {
+    # getting the locator of a locator should return itself
+    my $self = @_;
+    return $self; }
+
+
+
+#**********************************************************************
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+C<LaTeXML::Common::Locator> - represents a reference to a single point in a source file
+
+=head1 DESCRIPTION
+
+C<LaTeXML::Common::Locator> contains a reference to a single point within a source file. 
+This data structure is intended to be used both programtically (for "source references")
+and to display error messages to the user. 
+
+It extends L<LaTeXML::Common::Object>.
+
+=head2 Locator Creation
+
+=over 4
+
+=item C<< $locator = LaTeXML::Common::Locator->new($source, $line, $col); >>
+
+Creates a new locator. C<$source> should be a string containing the full path
+of the source file, or undef in case of an anonymous string. C<$line> and
+C<$col> should be integers containing the line and column numbers of the
+point in the source file, or undef if unknown. 
+
+=back
+
+=head1 AUTHOR
+
+Bruce Miller <bruce.miller@nist.gov>
+Tom Wiesing <tom.wiesing@gmail.com>
+
+=head1 COPYRIGHT
+
+Public domain software, produced as part of work done by the
+United States Government & not subject to copyright in the US.
+
+=cut

--- a/lib/LaTeXML/Common/Locator.pm
+++ b/lib/LaTeXML/Common/Locator.pm
@@ -13,31 +13,106 @@ package LaTeXML::Common::Locator;
 use LaTeXML::Global;
 use strict;
 use warnings;
-
 use base qw(LaTeXML::Common::Object);
 
+use LaTeXML::Util::Pathname;
+use LaTeXML::Util::WWW;
+
 sub new {
-    my ($class, $source, $line, $col) = @_;
-    return bless { source => $source, line => $line, col => $col}, $class; }
+  my ($class, $source, $fromLine, $fromCol, $toLine, $toCol) = @_;
+  my $locator = bless { source => $source,
+    fromLine => $fromLine, fromCol => $fromCol,
+    toLine   => $toLine,   toCol   => $toCol
+  }, $class;
+  return $locator; }
+
+# creates a new locator range from a given start and end
+sub newRange {
+  my ($class, $from, $to) = @_;
+  # make sure that either parameters are defined
+  return $to   unless defined($from);
+  return $from unless defined($to);
+  # bail if we have differnt sources
+  return unless ($$from{source} || '') eq ($$to{source} || '');
+  # the end coordinates depend on
+  my ($toLine, $toCol);
+  if ($to->isRange) {
+    $toLine = $$to{toLine};
+    $toCol  = $$to{toCol}; }
+  else {
+    $toLine = $$to{fromLine};
+    $toCol  = $$to{fromCol}; }
+  return new($class, $$from{source}, $$from{fromLine}, $$from{fromCol}, $toLine, $toCol); }
+
+sub isRange {
+  my ($self) = @_;
+  return defined($$self{toLine}) || defined($$self{toCol}); }
+
+sub getShortSource {
+  my ($self, $stringSource) = @_;
+  my $source = $$self{source};
+  return ($stringSource || 'String') unless ((defined $source) && $source);
+  if (index($source, ':') != -1) {
+    my ($path, $base, $ext) = url_split($source);
+    return "$base.$ext"; }
+  else {
+    my ($path, $base, $ext) = pathname_split($source);
+    return "$base.$ext"; } }
 
 sub toString {
   my ($self) = @_;
-  my $loc = defined $$self{source} ? $$self{source} : 'Anonymous String';
-  $loc .= "; line $$self{line}" if defined($$self{line});
-  $loc .= " col $$self{col}" if defined($$self{line}) && defined($$self{col});
+  my $loc = $self->getShortSource;
+  $loc .= "; line $$self{fromLine}" if defined($$self{fromLine});
+  $loc .= " col $$self{fromCol}"    if defined($$self{fromLine}) && defined($$self{fromCol});
+  $loc .= " - line $$self{toLine}"  if defined($$self{toLine});
+  $loc .= " col $$self{toCol}"      if defined($$self{toLine}) && defined($$self{toCol});
   return $loc; }
 
 sub stringify {
-    # TODO: Do we want an 'at' here?
-    my ($self) = @_;
-    return $self->toString; }
+  my ($self) = @_;
+  my $loc       = defined $$self{source} ? $$self{source} : 'Anonymous String';
+  my $rangeFrom = $self->isRange         ? ' from'        : '';
+  $loc .= ";$rangeFrom line $$self{fromLine}" if defined($$self{fromLine});
+  $loc .= " col $$self{fromCol}" if defined($$self{fromLine}) && defined($$self{fromCol});
+  $loc .= " to line $$self{toLine}" if defined($$self{toLine});
+  $loc .= " col $$self{toCol}" if defined($$self{toLine}) && defined($$self{toCol});
+  return $loc; }
+
+sub toAttribute {
+  my ($self) = @_;
+  my $loc = $self->getShortSource('anonymous_string') . '#text';
+  if ($self->isRange) {
+    $loc .= 'range(from=';
+    $loc .= "$$self{fromLine}" if defined($$self{fromLine});
+    $loc .= ";$$self{fromCol}" if defined($$self{fromCol});
+    $loc .= ',to=';
+    $loc .= "$$self{toLine}" if defined($$self{toLine});
+    $loc .= ";$$self{toCol}" if defined($$self{toCol});
+    $loc .= ')';
+    return $loc; }
+  else {
+    $loc .= 'point(';
+    $loc .= "$$self{fromLine}" if defined($$self{fromLine});
+    $loc .= ";$$self{fromCol}" if defined($$self{fromCol});
+    $loc .= ')';
+    return $loc; } }
 
 sub getLocator {
-    # getting the locator of a locator should return itself
-    my $self = @_;
-    return $self; }
+  # getting the locator of a locator should return itself
+  my ($self) = @_;
+  return $self; }
 
+sub getSource {
+  my ($self) = @_;
+  return $self; }
 
+sub getFromLocator {
+  my ($self) = @_;
+  return LaTeXML::Common::Locator->new($$self{source}, $$self{fromLine}, $$self{fromCol}); }
+
+sub getToLocator {
+  my ($self) = @_;
+  return LaTeXML::Common::Locator->new($$self{source}, $$self{toLine}, $$self{toCol}); }
 
 #**********************************************************************
 1;
@@ -48,11 +123,12 @@ __END__
 
 =head1 NAME
 
-C<LaTeXML::Common::Locator> - represents a reference to a single point in a source file
+C<LaTeXML::Common::Locator> - represents a reference to a point or range in the source
+file. 
 
 =head1 DESCRIPTION
 
-C<LaTeXML::Common::Locator> contains a reference to a single point within a source file. 
+C<LaTeXML::Common::Locator> contains a reference to a point or range within a source file. 
 This data structure is intended to be used both programtically (for "source references")
 and to display error messages to the user. 
 
@@ -62,12 +138,58 @@ It extends L<LaTeXML::Common::Object>.
 
 =over 4
 
-=item C<< $locator = LaTeXML::Common::Locator->new($source, $line, $col); >>
+=item C<< $locator = LaTeXML::Common::Locator->new($source, $fromLine, $fromCol, $toLine, $toCol); >>
 
 Creates a new locator. C<$source> should be a string containing the full path
-of the source file, or undef in case of an anonymous string. C<$line> and
-C<$col> should be integers containing the line and column numbers of the
-point in the source file, or undef if unknown. 
+of the source file, or undef in case of an anonymous string. C<$fromLine> and
+C<$fromCol> should be integers containing the line and column numbers of the
+start of the range in the source file, or undef if unknown. C<$toLine> and
+C<$toCol> should be the integers containing the line and column numbers of
+the end of the range, or undef if a point is being refered to. 
+
+=item C<< $locator = LaTeXML::Common::Locator->newRange($from, $to); >>
+
+Creates a new locator, starting at the locator C<$from> and ending at the
+locator C<$to>. Either locator may be undef, in which case the other one is
+returned.
+=back
+
+=head2 Methods
+
+=over 4
+
+=item C<< $str = $locator->toString; >>
+
+Turns this locator into a short string for output in user messages. 
+
+=item C<< $str = $locator->stringify; >>
+
+Turns this locator into a long string, including the full filename of the
+input. 
+
+=item C<< $attr = $locator->toAttribute; >>
+
+Turns this locator into an XPointer expression, for usage within an XML attribute. 
+
+=item C<< $isRange = $locator->isRange; >>
+
+Checks if this locator points to a range or a point. 
+
+=item C<< $source = $locator->getShortSource($stringSource); >>
+
+Gets a short string refering to the source of this locator. 
+C<$stringSource> will be used if the source refers to an
+anonymous or literal string input. 
+
+=item C<< $from = $locator->getFromLocator; >>
+
+Gets a locator pointing to the first point in the range of this locator. 
+Works for both point and range locators. 
+
+=item C<< $from = $locator->getToLocator; >>
+
+Gets a locator pointing to the last point in the range of this locator. 
+Does not work for point locators. 
 
 =back
 

--- a/lib/LaTeXML/Common/Locator.pm
+++ b/lib/LaTeXML/Common/Locator.pm
@@ -70,8 +70,8 @@ sub toString {
 
 sub stringify {
   my ($self) = @_;
-  my $loc       = defined $$self{source} ? $$self{source} : 'Anonymous String';
-  my $rangeFrom = $self->isRange         ? ' from'        : '';
+  my $loc = defined $$self{source} ? ($$self{source} || 'Literal String') : 'Anonymous String';
+  my $rangeFrom = $self->isRange ? ' from' : '';
   $loc .= ";$rangeFrom line $$self{fromLine}" if defined($$self{fromLine});
   $loc .= " col $$self{fromCol}" if defined($$self{fromLine}) && defined($$self{fromCol});
   $loc .= " to line $$self{toLine}" if defined($$self{toLine});
@@ -141,11 +141,12 @@ It extends L<LaTeXML::Common::Object>.
 =item C<< $locator = LaTeXML::Common::Locator->new($source, $fromLine, $fromCol, $toLine, $toCol); >>
 
 Creates a new locator. C<$source> should be a string containing the full path
-of the source file, or undef in case of an anonymous string. C<$fromLine> and
-C<$fromCol> should be integers containing the line and column numbers of the
-start of the range in the source file, or undef if unknown. C<$toLine> and
-C<$toCol> should be the integers containing the line and column numbers of
-the end of the range, or undef if a point is being refered to. 
+of the source file, an empty string in case of a literal string, or undef in 
+case of an anonymous string. C<$fromLine> and C<$fromCol> should be integers
+containing the line and column numbers of the start of the range in the source
+file, or undef if unknown. C<$toLine> and C<$toCol> should be the integers
+containing the line and column numbers of the end of the range, or undef 
+if a point is being refered to. 
 
 =item C<< $locator = LaTeXML::Common::Locator->newRange($from, $to); >>
 

--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -290,7 +290,7 @@ created) it.
 
 =item C<< $string = $digested->getLocator; >>
 
-Get a string describing the location in the original source that gave rise
+Get an object describing the location in the original source that gave rise
 to C<$digested>.
 
 =item C<< $digested->beAbsorbed($document); >>

--- a/lib/LaTeXML/Core/Definition/CharDef.pm
+++ b/lib/LaTeXML/Core/Definition/CharDef.pm
@@ -25,7 +25,7 @@ sub new {
   return bless { cs => $cs, parameters => undef,
     value => $value, internalcs => $internalcs,
     registerType => 'Number', readonly => 1,
-    locator => "from " . $STATE->getStomach->getGullet->getMouth->getLocator(-1),
+    locator => $STATE->getStomach->getGullet->getMouth->getLocator,
     %traits }, $class; }
 
 sub valueOf {

--- a/lib/LaTeXML/Core/Definition/Conditional.pm
+++ b/lib/LaTeXML/Core/Definition/Conditional.pm
@@ -27,7 +27,7 @@ sub new {
   my ($class, $cs, $parameters, $test, %traits) = @_;
   my $source = $STATE->getStomach->getGullet->getMouth;
   return bless { cs => $cs, parameters => $parameters, test => $test,
-    locator      => "from " . $source->getLocator(-1),
+    locator      => $source->getLocator,
     isExpandable => 1,
     %traits }, $class; }
 
@@ -138,7 +138,7 @@ sub skipConditionalBody {
       $$stack[0]{elses} = 1;
       return $t; } }    # } #}
   Error('expected', '\fi', $gullet, "Missing \\fi or \\else, conditional fell off end",
-    "Conditional started at $start");
+    "Conditional started at ". ToString($start));
   return; }
 
 sub invoke_else {
@@ -154,7 +154,7 @@ sub invoke_else {
   elsif ($$stack[0]{elses}) {       # Already seen an \else's at this level?
     Error('unexpected', $LaTeXML::CURRENT_TOKEN, $gullet,
       "Extra " . Stringify($LaTeXML::CURRENT_TOKEN),
-"already saw \\else for " . Stringify($$stack[0]{token}) . " [" . $$stack[0]{ifid} . "] at " . $$stack[0]{start});
+"already saw \\else for " . Stringify($$stack[0]{token}) . " [" . $$stack[0]{ifid} . "] at " . ToString($$stack[0]{start}));
     return; }
   else {
     local $LaTeXML::IFFRAME = $$stack[0];

--- a/lib/LaTeXML/Core/Definition/Constructor.pm
+++ b/lib/LaTeXML/Core/Definition/Constructor.pm
@@ -43,7 +43,7 @@ sub new {
     "Replacement is $replacement")
     if !(defined $replacement) || ((ref $replacement) && !(ref $replacement eq 'CODE'));
   return bless { cs => $cs, parameters => $parameters, replacement => $replacement,
-    locator => "from " . $source->getLocator(-1), %traits,
+    locator => $source->getLocator, %traits,
 ##    nargs => (defined $traits{nargs} ? $traits{nargs}
     ##  : ($parameters ? $parameters->getNumArgs : 0))
     nargs => $traits{nargs}

--- a/lib/LaTeXML/Core/Definition/Expandable.pm
+++ b/lib/LaTeXML/Core/Definition/Expandable.pm
@@ -35,7 +35,7 @@ sub new {
   }
   return bless { cs => $cs, parameters => $parameters, expansion => $expansion,
     trivial_expansion => $trivexpansion,
-    locator           => "from " . $source->getLocator(-1),
+    locator           => $source->getLocator,
     isProtected       => $traits{protected} || $STATE->getPrefix('protected'),
     isOuter           => $traits{outer} || $STATE->getPrefix('outer'),
     isLong            => $traits{long} || $STATE->getPrefix('long'),

--- a/lib/LaTeXML/Core/Definition/Primitive.pm
+++ b/lib/LaTeXML/Core/Definition/Primitive.pm
@@ -27,7 +27,7 @@ sub new {
     "Replacement is $replacement")
     unless ref $replacement eq 'CODE';
   return bless { cs => $cs, parameters => $parameters, replacement => $replacement,
-    locator => "from " . $source->getLocator(-1),
+    locator => $source->getLocator,
     %traits }, $class; }
 
 sub isPrefix {

--- a/lib/LaTeXML/Core/Definition/Register.pm
+++ b/lib/LaTeXML/Core/Definition/Register.pm
@@ -24,7 +24,7 @@ use base qw(LaTeXML::Core::Definition::Primitive);
 sub new {
   my ($class, $cs, $parameters, %traits) = @_;
   return bless { cs => $cs, parameters => $parameters,
-    locator => "from " . $STATE->getStomach->getGullet->getMouth->getLocator(-1),
+    locator => $STATE->getStomach->getGullet->getMouth->getLocator,
     %traits }, $class; }
 
 sub isPrefix {

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -84,7 +84,7 @@ sub getLocator {
   if (my $box = $self->getNodeBox($$self{node})) {
     return $box->getLocator; }
   else {
-    return 'EOF?'; } }    # well?
+    return; } }    # well?
 
 # Get the element at (or containing) the current insertion point.
 sub getElement {

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -80,9 +80,9 @@ sub setNode {
   return; }
 
 sub getLocator {
-  my ($self, @args) = @_;
+  my ($self) = @_;
   if (my $box = $self->getNodeBox($$self{node})) {
-    return $box->getLocator(@args); }
+    return $box->getLocator; }
   else {
     return 'EOF?'; } }    # well?
 

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -130,17 +130,17 @@ sub readingFromMouth {
 
 # User feedback for where something (error?) occurred.
 sub getLocator {
-  my ($self, $long) = @_;
+  my ($self) = @_;
   my $mouth = $$self{mouth};
   my $i     = 0;
   while ((defined $mouth) && (($$mouth{source} || '') eq 'Anonymous String')
     && ($i < scalar(@{ $$self{mouthstack} }))) {
     $mouth = $$self{mouthstack}[$i++][0]; }
-  my $loc = (defined $mouth ? $mouth->getLocator : '');
-  return $loc if $loc;
+  my $loc = (defined $mouth ? $mouth->getLocator : undef);
+  return $loc if defined $loc;
   foreach my $frame (@{ $$self{mouthstack} }) {
     my $ml = $$frame[0]->getLocator;
-    return ' ' . $ml if $ml; } }
+    return $ml if defined $ml; } }
 
 sub getSource {
   my ($self) = @_;
@@ -870,7 +870,7 @@ Is this public? Clears all inputs.
 
 =item C<< $gullet->getLocator; >>
 
-Returns a string describing the current location in the input stream.
+Returns an object describing the current location in the input stream.
 
 =back
 

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -145,21 +145,21 @@ sub getLocator {
 sub getSource {
   my ($self) = @_;
   my $source = defined $$self{mouth} && $$self{mouth}->getSource;
-  if (!$source) {
+  if (!defined($source)) {
     foreach my $frame (@{ $$self{mouthstack} }) {
       $source = $$frame[0]->getSource;
-      last if $source; } }
+      last if defined($source); } }
   return $source; }
 
 sub getSourceMouth {
   my ($self) = @_;
   my $mouth = $$self{mouth};
   my $source = defined $mouth && $mouth->getSource;
-  if (!$source || !defined($source)) {
+  if (!defined($source)) {
     foreach my $frame (@{ $$self{mouthstack} }) {
       $mouth  = $$frame[0];
       $source = $mouth->getSource;
-      last if $source; } }
+      last if defined($source); } }
   return $mouth; }
 
 # Handy message generator when we didn't get something expected.

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -133,7 +133,7 @@ sub getLocator {
   my ($self) = @_;
   my $mouth = $$self{mouth};
   my $i     = 0;
-  while ((defined $mouth) && (($$mouth{source} || '') eq 'Anonymous String')
+  while ((defined $mouth) && (!defined $$mouth{source})
     && ($i < scalar(@{ $$self{mouthstack} }))) {
     $mouth = $$self{mouthstack}[$i++][0]; }
   my $loc = (defined $mouth ? $mouth->getLocator : undef);
@@ -155,11 +155,11 @@ sub getSourceMouth {
   my ($self) = @_;
   my $mouth = $$self{mouth};
   my $source = defined $mouth && $mouth->getSource;
-  if (!$source || ($source eq "Anonymous String")) {
+  if (!$source || !defined($source)) {
     foreach my $frame (@{ $$self{mouthstack} }) {
       $mouth  = $$frame[0];
       $source = $mouth->getSource;
-      last if $source && $source ne "Anonymous String"; } }
+      last if $source; } }
   return $mouth; }
 
 # Handy message generator when we didn't get something expected.

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -136,15 +136,11 @@ sub getLocator {
   while ((defined $mouth) && (($$mouth{source} || '') eq 'Anonymous String')
     && ($i < scalar(@{ $$self{mouthstack} }))) {
     $mouth = $$self{mouthstack}[$i++][0]; }
-  my $loc = (defined $mouth ? $mouth->getLocator($long) : '');
-  if (!$loc || $long) {
-    $loc .= show_pushback($$self{pushback}) if $long;
-    foreach my $frame (@{ $$self{mouthstack} }) {
-      my $ml = $$frame[0]->getLocator($long);
-      $loc .= ' ' . $ml if $ml;
-      last if $loc && !$long;
-      $loc .= show_pushback($$frame[1]) if $long; } }
-  return $loc; }
+  my $loc = (defined $mouth ? $mouth->getLocator : '');
+  return $loc if $loc;
+  foreach my $frame (@{ $$self{mouthstack} }) {
+    my $ml = $$frame[0]->getLocator;
+    return ' ' . $ml if $ml; } }
 
 sub getSource {
   my ($self) = @_;

--- a/lib/LaTeXML/Core/KeyVals.pm
+++ b/lib/LaTeXML/Core/KeyVals.pm
@@ -311,7 +311,7 @@ sub readFrom {
     # if there was no delimiter at the end, we throw an error
     Error('expected', $until, $gullet,
       "Fell off end expecting " . Stringify($until) . " while reading KeyVal key",
-      "key started at $startloc")
+      "key started at " . ToString($startloc))
       unless $delim;
 
     # turn the key tokens into a string and normalize

--- a/lib/LaTeXML/Core/KeyVals.pm
+++ b/lib/LaTeXML/Core/KeyVals.pm
@@ -287,7 +287,7 @@ sub readFrom {
     $$self{hookMissing} = undef; }
 
   # read the opening token and figure out where we are
-  my $startloc = $gullet->getLocator();
+  my $startloc = $gullet->getLocator;
 
   # set and read tokens
   my $open   = $gullet->readToken;

--- a/lib/LaTeXML/Core/List.pm
+++ b/lib/LaTeXML/Core/List.pm
@@ -55,7 +55,7 @@ sub new {
     $font = $bx->getFont unless defined $font; }
   #return bless [[@boxes], $font, $locator || '', undef, {}], $class; }
   return bless { boxes => [@boxes],
-    properties => { font => $font, locator => $locator || '', }
+    properties => { font => $font, locator => $locator || undef, }
     }, $class; }
 
 sub unlist {

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -35,7 +35,8 @@ sub create {
     $options{shortsource} = "$name.$ext";
     return $class->new($options{content}, %options); }
   elsif ($source =~ s/^literal://) {    # we've supplied literal data
-    $options{source} = "Literal String " . substr($source, 0, 10) unless defined $options{source};
+    # TODO: Consider what we want to do with this string
+    # $options{source} = "Literal String " . substr($source, 0, 10) unless defined $options{source};
     return $class->new($source, %options); }
   elsif (!defined $source) {
     return $class->new('', %options); }
@@ -49,8 +50,8 @@ sub create {
 sub new {
   my ($class, $string, %options) = @_;
   $string               = q{}                unless defined $string;
-  $options{source}      = "Anonymous String" unless defined $options{source};
-  $options{shortsource} = "String"           unless defined $options{shortsource};
+  #$options{source}      = "Anonymous String" unless defined $options{source};
+  #$options{shortsource} = "String"           unless defined $options{shortsource};
   my $self = bless { source => $options{source},
     shortsource    => $options{shortsource},
     fordefinitions => ($options{fordefinitions} ? 1 : 0),
@@ -73,8 +74,9 @@ sub initialize {
   $$self{chars}  = [];
   $$self{nchars} = 0;
   if ($$self{notes}) {
+    my $source = $$self{source} || 'Anonymous String';
     $$self{note_message} = "Processing " . ($$self{fordefinitions} ? "definitions" : "content")
-      . " " . $$self{source};
+      . " " . ($$self{source} || 'Anonymous String');
     NoteBegin($$self{note_message}); }
   if ($$self{fordefinitions}) {
     $$self{saved_at_cc}            = $STATE->lookupCatcode('@');
@@ -279,7 +281,7 @@ sub readToken {
 
       # Sneak a comment out, every so often.
       if ((($$self{lineno} % 25) == 0) && $STATE->lookupValue('INCLUDE_COMMENTS')) {
-        return T_COMMENT("**** $$self{shortsource} Line $$self{lineno} ****"); }
+        return T_COMMENT("**** " . ($$self{shortsource} || 'String') . " Line $$self{lineno} ****"); }
     }
     # ==== Extract next token from line.
     my ($ch, $cc) = getNextChar($self);

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -35,8 +35,7 @@ sub create {
     $options{shortsource} = "$name.$ext";
     return $class->new($options{content}, %options); }
   elsif ($source =~ s/^literal://) {    # we've supplied literal data
-    # TODO: Consider what we want to do with this string
-    # $options{source} = "Literal String " . substr($source, 0, 10) unless defined $options{source};
+    $options{source} = ''; # the source does not have a corresponding file name
     return $class->new($source, %options); }
   elsif (!defined $source) {
     return $class->new('', %options); }
@@ -74,9 +73,9 @@ sub initialize {
   $$self{chars}  = [];
   $$self{nchars} = 0;
   if ($$self{notes}) {
-    my $source = $$self{source} || 'Anonymous String';
+    my $source = defined($$self{source}) ? ($$self{source} || 'Literal String') : 'Anonymous String';
     $$self{note_message} = "Processing " . ($$self{fordefinitions} ? "definitions" : "content")
-      . " " . ($$self{source} || 'Anonymous String');
+      . " " . $source;
     NoteBegin($$self{note_message}); }
   if ($$self{fordefinitions}) {
     $$self{saved_at_cc}            = $STATE->lookupCatcode('@');

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -163,7 +163,19 @@ sub stringify {
 #**********************************************************************
 sub getLocator {
   my ($self) = @_;
-  return LaTeXML::Common::Locator->new($$self{source}, $$self{lineno}, $$self{colno}); }
+  my ($l, $c, $lstart, $cstart) = ($$self{lineno}, $$self{colno});
+  #Deyan: Upgrade message to XPointer style
+  my $nc = $$self{nchars} - 1;    #There is always a weird (end of line?) char that gets counted
+  if ((defined $c) && ($c >= $nc)) {
+    $lstart = $l;
+    $cstart = $c - $nc; }
+  else {
+    #Very rough and dirty approximation, not to be relied on.
+    #One would need to keep all line lengths to properly establish the start and end
+    # or just remember the initial char of the token's position
+    $lstart = $l - 1;
+    $cstart = $nc - $c; }
+  return LaTeXML::Common::Locator->new($$self{source}, $lstart, $cstart, $l, $c); }
 
 sub getSource {
   my ($self) = @_;

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -161,20 +161,8 @@ sub stringify {
 sub getLocator {
   my ($self, $length) = @_;
   my ($l, $c) = ($$self{lineno}, $$self{colno});
-  if ($length && ($length < 0)) {
+  if ($length) {
     return "at $$self{shortsource}; line $l col $c"; }
-  elsif ($length && (defined $l || defined $c)) {
-    my $msg   = "at $$self{source}; line $l col $c";
-    my $chars = $$self{chars};
-    if (my $n = $$self{nchars}) {
-      $c = $n - 1 if $c >= $n;
-      my $c0 = ($c > 50      ? $c - 40 : 0);
-      my $cm = ($c < 1       ? 0       : $c - 1);
-      my $cn = ($n - $c > 50 ? $c + 40 : $n - 1);
-      my $p1 = ($c0 <= $cm ? join('', @$chars[$c0 .. $cm]) : ''); chomp($p1);
-      my $p2 = ($c <= $cn  ? join('', @$chars[$c .. $cn])  : ''); chomp($p2);
-      $msg .= "\n  " . $p1 . "\n  " . (' ' x ($c - $c0)) . '^' . ' ' . $p2; }
-    return $msg; }
   else {
     return "at $$self{source}; line $l col $c"; } }
 
@@ -396,7 +384,7 @@ Returns the next L<LaTeXML::Core::Token> from the source.
 
 Returns whether there is more data to read.
 
-=item C<< $string = $mouth->getLocator($long); >>
+=item C<< $string = $mouth->getLocator; >>
 
 Return a description of current position in the source, for reporting errors.
 

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -14,6 +14,7 @@ use strict;
 use warnings;
 use LaTeXML::Global;
 use LaTeXML::Common::Object;
+use LaTeXML::Common::Locator;
 use LaTeXML::Common::Error;
 use LaTeXML::Core::Token;
 use LaTeXML::Core::Tokens;
@@ -159,12 +160,8 @@ sub stringify {
 
 #**********************************************************************
 sub getLocator {
-  my ($self, $length) = @_;
-  my ($l, $c) = ($$self{lineno}, $$self{colno});
-  if ($length) {
-    return "at $$self{shortsource}; line $l col $c"; }
-  else {
-    return "at $$self{source}; line $l col $c"; } }
+  my ($self) = @_;
+  return LaTeXML::Common::Locator->new($$self{source}, $$self{lineno}, $$self{colno}); }
 
 sub getSource {
   my ($self) = @_;

--- a/lib/LaTeXML/Core/Mouth/Binding.pm
+++ b/lib/LaTeXML/Core/Mouth/Binding.pm
@@ -13,6 +13,7 @@ package LaTeXML::Core::Mouth::Binding;
 use strict;
 use warnings;
 use LaTeXML::Global;
+use LaTeXML::Common::Locator;
 use LaTeXML::Common::Error;
 use LaTeXML::Util::Pathname;
 
@@ -38,12 +39,11 @@ sub finish {
 sub getLocator {
   my ($self, $length) = @_;
   my $path  = $$self{source};
-  my $loc   = ($length && $length < 0 ? $$self{shortsource} : $$self{source});
   my $frame = 2;
   my ($pkg, $file, $line);
   while (($pkg, $file, $line) = caller($frame++)) {
     last if $file eq $path; }
-  return $loc . ($line ? " line $line" : ''); }
+  return LaTeXML::Common::Locator->new($$self{source}, $line ? $line : undef); }
 
 sub getSource {
   my ($self) = @_;

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -457,12 +457,12 @@ sub installDefinition {
   my $token = $definition->getCS;
   my $cs = ($LaTeXML::Core::Token::PRIMITIVE_NAME[$$token[1]] || $$token[0]);
   if ($self->lookupValue("$cs:locked") && !$LaTeXML::Core::State::UNLOCKED) {
-    if (my $s = $self->getStomach->getGullet->getSource) {
-      # report if the redefinition seems to come from document source
-      if ((($s eq "Anonymous String") || ($s =~ /\.(tex|bib)$/))
-        && ($s !~ /\.code\.tex$/)) {
-        Info('ignore', $cs, $self->getStomach, "Ignoring redefinition of $cs"); }
-      return; } }
+    my $s = $self->getStomach->getGullet->getSource;
+    # report if the redefinition seems to come from document source
+    if (((!defined($s)) || ($s =~ /\.(tex|bib)$/))
+      && ($s !~ /\.code\.tex$/)) {
+      Info('ignore', $cs, $self->getStomach, "Ignoring redefinition of $cs"); }
+    return; }
   assign_internal($self, 'meaning', $cs => $definition, $scope);
   return; }
 

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -58,8 +58,8 @@ sub getGullet {
   return $$self{gullet}; }
 
 sub getLocator {
-  my ($self, @args) = @_;
-  return $$self{gullet}->getLocator(@args); }
+  my ($self) = @_;
+  return $$self{gullet}->getLocator; }
 
 sub getBoxingLevel {
   my ($self) = @_;

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use LaTeXML::Global;
 use LaTeXML::Common::Object;
+use LaTeXML::Common::Locator;
 use LaTeXML::Common::Error;
 use LaTeXML::Core::Token;
 use LaTeXML::Core::Tokens;
@@ -33,7 +34,7 @@ use base qw(LaTeXML::Core::Box);
 
 # Specially recognized (some required?) properties:
 #  font    : The font object
-#  locator : a locator string, where in the source this whatsit was created
+#  locator : a locator object, where in the source this whatsit was created
 #  isMath  : whether this is a math object
 #  id
 #  body
@@ -79,6 +80,7 @@ sub setBody {
   $$self{properties}{trailer} = $trailer;
   # And copy any otherwise undefined properties from the trailer
   if ($trailer) {
+    $$self{properties}{locator} = LaTeXML::Common::Locator->newRange($self->getLocator, $trailer->getLocator);
     my %trailerhash = $trailer->getProperties;
     foreach my $prop (keys %trailerhash) {
       $$self{properties}{$prop} = $trailer->getProperty($prop) unless defined $$self{properties}{$prop}; } }

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -654,7 +654,7 @@ sub parse_single {
     my $box = $document->getNodeBox($mathnode);
     print STDERR "\n" . ('=' x 60) .
       "\nParsing formula \"" . ToString($box) . "\""
-      . "\n from " . $box->getLocator
+      . "\n from " . ToString($box->getLocator)
       . "\n == \"" . join(' ', map { node_string($_, $document) } @nodes) . "\""
       . "\n == " . ToString($mathnode)
       . "\n"; }

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1591,7 +1591,8 @@ sub DefEnvironmentI {
             for (my $f = 0 ; $f <= $nf ; $f++) {    # Get currently open environments & locators
               if (my $e = $STATE->isValueBound('current_environment', $f)
                 && $STATE->valueInFrame('current_environment', $f)) {
-                push(@lines, $e . ' ' . $STATE->valueInFrame('groupInitiatorLocator', $f) || ''); } }
+                my $locator = ToString($STATE->valueInFrame('groupInitiatorLocator', $f));
+                push(@lines, $e . ' ' . $locator); } }
             Error('unexpected', "\\end{$name}", $_[0],
               "Can't close environment $name;", "Current are:", @lines); }
           return; },

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -346,7 +346,8 @@ DefConstructorI(T_CS('\end{document}'), undef, sub {
         || ($STATE->valueInFrame('current_environment', 0) ne 'document')) {
         # my $nonbox = $STATE->valueInFrame('groupNonBoxing',0) || 0;
         my $tok = $STATE->valueInFrame('groupInitiator',        0) || '<unknown>';
-        my $loc = $STATE->valueInFrame('groupInitiatorLocator', 0) || '<unknown>';
+        my $loc = $STATE->valueInFrame('groupInitiatorLocator', 0);
+        $loc = defined $loc ? ToString($loc) : '<unknown>';
         my $env = $STATE->isValueBound('current_environment', 0)
           && $STATE->valueInFrame('current_environment', 0);
         if ($env) {

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -3604,7 +3604,7 @@ DefMacroI('\eqno', undef, sub {
       else {
         push(@stuff, $t); } }
     Error('unexpected', '\eqno', $gullet, "Fell of the end reading tag for \\eqno!",
-      "started $locator");
+      "started ". ToString($locator));
     return Tokens(@stuff); });
 
 Let('\leqno', '\eqno');

--- a/lib/LaTeXML/Pre/BibTeX.pm
+++ b/lib/LaTeXML/Pre/BibTeX.pm
@@ -124,7 +124,9 @@ sub toTeX {
 # This lets Bib support formatted error messages.
 sub getLocator {
   my ($self) = @_;
-  return "at $$self{source}; line $$self{lineno}\n  $$self{line}"; }
+  # TODO: The content of $$self{line} is not used here anymore
+  # do we really need it?
+  return LaTeXML::Common::Locator->new($$self{source}, $$self{lineno}); }
 
 #======================================================================
 #  Greg Ward has a pretty good description of the BibTeX data format

--- a/lib/LaTeXML/Pre/BibTeX.pm
+++ b/lib/LaTeXML/Pre/BibTeX.pm
@@ -76,7 +76,7 @@ sub newFromFile {
 
 sub newFromString {
   my ($class, $string) = @_;
-  my $self = { source => "<Unknown>", preamble => [], entries => [], macros => {%default_macros} };
+  my $self = { source => undef, preamble => [], entries => [], macros => {%default_macros} };
   bless $self, $class;
 
   $$self{file}   = "<anonymous>";
@@ -105,7 +105,7 @@ sub newFromGullet {
 
 sub toString {
   my ($self) = @_;
-  return "Bibliography[$$self{source}]"; }
+  return 'Bibliography[' . ($$self{source} || '<Unknown>') . ']'; }
 
 sub toTeX {
   my ($self) = @_;
@@ -137,7 +137,8 @@ sub getLocator {
 # and parse the body according to the type.
 sub parseTopLevel {
   my ($self) = @_;
-  NoteBegin("Preparsing Bibliography $$self{source}");
+  my $note = "Preparsing Bibliography " . ($$self{source} || "<Unknown>");
+  NoteBegin($note);
   while ($self->skipJunk) {
     my $type = $self->parseEntryType;
     if    ($type eq 'preamble') { $self->parsePreamble; }
@@ -145,7 +146,7 @@ sub parseTopLevel {
     elsif ($type eq 'comment')  { $self->parseComment; }
     else                        { $self->parseEntry($type); }
   }
-  NoteEnd("Preparsing Bibliography $$self{source}");
+  NoteEnd($note);
   $$self{parsed} = 1;
   return; }
 


### PR DESCRIPTION
This pull request refactors the behaviour of locators. In particular, it turns locators into a new class `LaTeXML::Common::Locator`, that is then only `ToString`ed when displayed to the user. 

The locator class also improves upon the old locators and is internally a quintuple consisting of
* the source filename, or `undef` in case of an anonymous string source, or `''` in case of a literal string source
* the starting line and column numbers of the locator
* the ending line and column numbers of the locator (or `undef` if not applicable)

This means that an instance of a locator class can refer either to a point, or an entire range in the source file. When requesting a Locator from the Mouth, the code tries to estimate the location and length of the last token, thereby returning a range. 

The new locator class also has a toAttribute method, that turns an instance of a locator into an XPointer and thereby supersedes #739.  