### PR TITLE
Improve enumitem binding

### DIFF
--- a/lib/LaTeXML/Package/enumitem.sty.ltxml
+++ b/lib/LaTeXML/Package/enumitem.sty.ltxml
@@ -41,6 +41,10 @@ DefEnvironment('{description} OptionalUndigested',
   beforeDigestEnd => sub { Digest('\par'); },
   locked => 1, mode => 'text');
 
+# TODO: Manage and store the options and maximum depth
+DefMacro('\newlist{}{}{}',   '\newenvironment{#1}[1]{\begin{#2}##1}{\end{#2}}');
+DefMacro('\renewlist{}{}{}', '\renewenvironment{#1}[1]{\begin{#2}##1}{\end{#2}}');
+
 DefMacro('\setlist OptionalUndigested {}', '');
 
 #======================================================================


### PR DESCRIPTION
This commit improves the enumitem binding, in that it defines `\newlist` and `\renewlist` to create and update stub environments for the appropriate list types.