### PR TITLE
Texlive more tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ doc/site/examples/tabular/tabular.xml
 doc/site/index.xml
 doc/site/releases.tex
 auto
+# Travis built things
+tools/travis/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,37 @@
-language: perl
+language: generic
 sudo: required
 dist: trusty
 
-addons:
-  apt:
-    packages:
-     - libdb-dev
-     - libxml2-dev
-     - libxslt1-dev
-
-perl:
-  - "5.26"
-  - "5.24"
-  - "5.20"
-  - "5.10"
+services:
+  - docker
 
 env:
-  - TEX=none
-  - TEX=texlive
+  ## Testing without texlive  -- perl 5.28, 5.26.2, 5.24.4
+  - PERL=5.28.0 TEX=none
+  - PERL=5.26.2 TEX=none
+  - PERL=5.24.4 TEX=none
+  - PERL=5.20.3 TEX=none
+  - PERL=5.10.1 TEX=none
+  ## Testing with texlive 2018 -- perl 5.28
+  - PERL=5.28.0 TEX=texlive-2018
+  ## Testing with texlive 2016 -- perl 5.26
+  - PERL=5.26.2 TEX=texlive-2016
+  ## Testing with texlive 2015 -- perl 5.22
+  - PERL=5.22.4 TEX=texlive-2015
 
+matrix:
+  # We allow failures for all the TeXLives excepts the 2016 ones
+  allow_failures:
+    - env: PERL=5.28.0 TEX=texlive-2018
+    - env: PERL=5.22.4 TEX=texlive-2015
+  # don't wait for the allow_failures to finish
+  # just mark the results as done. 
+  fast_finish: true
+
+# Pull the given docker image
 before_install:
-  - if [[ "$TEX" != "none" ]]; then sudo apt-get update -q; fi
-  - if [[ "$TEX" == "texlive" ]]; then sudo apt-get install -y texlive-full -q; fi
+  - docker pull latexml/latexml-test-runtime:${PERL}_$TEX
 
-install:
-  - cpanm -v --installdeps --notest .
-
+# Run the docker test image
 script:
-  - perl Makefile.PL && make test
+  - docker run --rm -v $(pwd):/root/latexml -t -i latexml/latexml-test-runtime:${PERL}_$TEX

--- a/t/81_babel.t
+++ b/t/81_babel.t
@@ -6,7 +6,7 @@ use LaTeXML::Util::Test;
 
 latexml_tests("t/babel",
 	      requires=>{'*'=>['babel.sty','babel.def'],
-		     csquotes=>['skipbecauseofoldtexliveintravis', 'csquotes.sty', 'frenchb.ldf', 'germanb.ldf'],
+		     csquotes=>['csquotes.sty', 'frenchb.ldf', 'germanb.ldf'],
 			 numprints=>'numprint.sty',
 			 german=>'germanb.ldf',
 			 greek=>['greek.ldf','lgrenc.def'],

--- a/tools/travis/README.md
+++ b/tools/travis/README.md
@@ -1,0 +1,82 @@
+# Travis Test README
+
+This directory contains tools to prepare and use inside the Travis Tests. 
+
+The Travis Tests are intended to test the behaviour of LaTeXML under different environments using multiple TexLive and Perl versions. 
+
+The different environments can be split into two main categories:
+
+* those with a TeXLive installation
+* those without a TeXLive installation
+
+Both scenarios internally run the same test suite (`make test`), however because of the way it is set up the latter one will skip a number of tests. 
+
+## The Testing Docker Images
+
+The different testing environments are defined in `.travis.yml` using the `env` key. 
+Each testing environment corresponds to a single docker image. 
+
+Each docker image is based on `Ubuntu Xenial`. 
+These come preinstalled with the respective perl version (by using `perlbrew`) and LaTeXML versions (via the package manager). 
+
+At testing time travis then:
+
+* pulls each of the docker images
+* mounts the version of LaTeXML to be tested using a volume and finally
+* executes the standard test suite inside the resulting container
+
+Using this docker-based setup allows the travis tests to not spend time on downloading, installing, and configuring individual dependencies; 
+instead they can focus on running the test suite itself. 
+
+The travis tests not using any TeX take around 5 minutes to run, whereas the tests using LaTeXML take around 15 minutes. 
+
+## Building && Maintaining the test images
+
+Usually, a Dockerfile is built using a `Dockerfile` and an appropriate `build context` (i.e. a set of files that might be included into the docker image). 
+Since the travis tests need a set of docker images (one for each combination of perl and tex to be tested), these `Dockerfile`s are created using an automated script. 
+
+The `src/build-test-image.sh` takes two arguments (the `TEX` and `PERL` versions to be used), generates a `Dockerfile` into the `dist/$PERL_$TEX` directory, and then builds the docker image. 
+
+For example, to generate a test image for perl `5.22.4` and `texlive-2015` it can be invoked like so:
+
+    src/build-test-image.sh 5.22.4 texlive-2015
+
+This will build the image `latexml/latexml-test-runtime:5.22.4_texlive-2015`. 
+
+
+To build all test images required by the tests, the `src/build-all.sh` can be used. 
+After building, this script will upload each image to [latexml/latexml-test-runtime](https://hub.docker.com/r/latexml/latexml-test-runtime/) on DockerHub. 
+
+Please note that this script:
+
+* makes use of docker build cache; in case of a clean build it is up to the user to remove all old images & cache first;
+* does not perform any magical authentication; instead to upload the images it is required to be a logged into the docker daemon;
+* may take several hours to run, depending on speed of the internet connection. 
+
+## Running Tests locally
+
+With this setup it is possible to run each test environment locally using Docker. 
+
+To run a specific test, first either build the appropriate image using the build script or pull it from DockerHub: 
+
+    docker pull latexml/latexml-test-runtime:$PERL_$TEX
+
+Next, you can run the tests by mounting the directory containing your LaTeXML repository into a new container:
+
+    docker run --rm -t -i -v /path/to/latexml/repository:/root/latexml latexml/latexml-test-runtime:$PERL_$TEX
+
+By default, this will run the equivalent of:
+
+    cpanm -v --installdeps --notest .
+    perl Makefile.PL && make test
+
+If instead you would liek to run these command manually (e.g. to debug a failed test), run:
+
+    docker run --rm -t -i -v /path/to/latexml/repository:/root/latexml latexml/latexml-test-runtime:$PERL_$TEX /bin/bash
+
+This will start a bash shell inside the Docker container. 
+To load the approrpiate version from perlbrew, it is then required to load:
+
+    source /usr/local/perlbrew/etc/bashrc
+
+Afterwards, you can run any test command manually. 

--- a/tools/travis/scripts/build-all.sh
+++ b/tools/travis/scripts/build-all.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# cd into the travis/ directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd "$DIR/.."
+
+# function to build a single image
+function build_image() {
+    IMAGE="latexml/latexml-test-runtime:$1_$2"
+    docker rmi "$IMAGE" || /bin/true
+    /bin/bash ./scripts/build-test-image.sh "$1" "$2"
+    docker push "$IMAGE"
+}
+
+# Do the building of all the images
+# This might take a bit. 
+build_image 5.28.0 none
+build_image 5.26.2 none
+build_image 5.24.4 none
+build_image 5.20.3 none
+build_image 5.10.1 none
+build_image 5.28.0 texlive-2018
+build_image 5.26.2 texlive-2016
+build_image 5.22.4 texlive-2015

--- a/tools/travis/scripts/build-test-image.sh
+++ b/tools/travis/scripts/build-test-image.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -e
+
+# cd into the travis/ directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd "$DIR/.."
+
+# Read in the arguments
+PERL="$1"
+TEX="$2"
+
+# figure out the image tag and basic paths
+IMAGE_TAG="latexml/latexml-test-runtime:${PERL}_${TEX}"
+DOCKERPATH="dist/${PERL}_${TEX}"
+DOCKERFILE="$DOCKERPATH/Dockerfile"
+
+# if we don't have a tex, then comment out all the TeX lines
+if [[ "$TEX" == "none" ]]; then
+    TLP="#"
+fi
+
+# Prepare the Dockerfile
+echo " => Writing $DOCKERFILE"
+mkdir -p "$DOCKERPATH"; touch "$DOCKERFILE"
+
+cat > "$DOCKERFILE" <<- EOF
+## Dockerfile for LaTeXML Testing Runtime (Perl $PERL, LaTeX $TEX)
+##################################################################
+# This file has been generated automatically and should not be   #
+# modified by hand.                                              #
+##################################################################
+
+FROM ubuntu:xenial
+
+# Install packages required by perlbrew and LaTeXML
+RUN apt-get update && \
+    apt-get -y install git curl build-essential perl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Prepare perlbrew installation
+RUN mkdir -p /usr/local/perlbrew /root
+ENV HOME /root
+ENV PERLBREW_ROOT /usr/local/perlbrew
+ENV PERLBREW_HOME /root/.perlbrew
+
+# run the perlbrew installation
+RUN curl -kL http://install.perlbrew.pl | bash
+ENV PATH /usr/local/perlbrew/bin:$PATH
+ENV PERLBREW_PATH /usr/local/perlbrew/bin
+RUN perlbrew install-cpanm && \
+    perlbrew info
+
+# set perl version
+ENV PERL $PERL
+
+# run the installation of the given version of perl
+RUN /bin/bash -c "source /usr/local/perlbrew/etc/bashrc; perlbrew --notest install $PERL; perlbrew clean; perlbrew switch $PERL"
+
+# set tex version
+ENV TEX $TEX
+
+${TLP}# run the texlive script
+${TLP}ADD installtex.sh /root/installtex.sh
+${TLP}RUN /bin/bash /root/installtex.sh
+
+# Install LaTeXML Dependencies
+ADD installdeps.sh /root/installdeps.sh
+RUN /bin/bash /root/installdeps.sh
+
+# Make latexml directory
+VOLUME /root/latexml
+WORKDIR /root/latexml
+
+# Add the testing script
+ADD entrypoint.sh /root/entrypoint.sh
+CMD ["/bin/bash", "/root/entrypoint.sh"]
+
+EOF
+
+echo " => copy build context"
+cp "src/installdeps.sh" "$DOCKERPATH/installdeps.sh"
+cp "src/entrypoint.sh" "$DOCKERPATH/entrypoint.sh"
+
+if [[ "$TEX" != "none" ]]; then
+    cp "src/$TEX.sh" "$DOCKERPATH/installtex.sh";
+fi
+
+echo " => docker build -t $IMAGE_TAG $DOCKERPATH"
+docker build -t "$IMAGE_TAG" "$DOCKERPATH"
+
+echo " => rm -rf $DOCKERPATH"
+rm -rf "$DOCKERPATH"
+
+echo "Done. Built $IMAGE_TAG. "

--- a/tools/travis/src/entrypoint.sh
+++ b/tools/travis/src/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Script to run the latexml tests
+set -e
+
+# Load the current perl
+source /usr/local/perlbrew/etc/bashrc
+
+# Print some information
+
+cat <<- EOM
+# 
+###################################################################
+#                     LaTeXML Testing Runtime                     #
+###################################################################
+# Built with PERL=$PERL TEX=$TEX
+###################################################################
+EOM
+
+echo " => perl --version"
+perl --version
+
+if [[ "$TEX" != "none" ]]; then
+    echo " => tex --version";
+    tex --version;
+fi
+
+echo "###################################################################"
+
+echo " => cpanm -v --installdeps --notest ."
+cpanm -v --installdeps --notest .
+
+echo "###################################################################"
+
+echo " => perl Makefile.PL && make test"
+perl Makefile.PL && make test

--- a/tools/travis/src/installdeps.sh
+++ b/tools/travis/src/installdeps.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Script to install all the LaTeXML dependencies
+set -e
+
+# Use perlbrew
+source /usr/local/perlbrew/etc/bashrc
+
+# Update apt
+apt-get update
+
+# Install system dependencies
+apt-get install -y \
+    libdb-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    zlib1g-dev
+
+# Cleanup apt cache
+rm -rf /var/lib/apt/lists/*
+
+# try to install the cpanm dependencies
+cpanm \
+    Archive::Zip \
+    DB_File \
+    File::Which \
+    Getopt::Long \
+    Image::Size \
+    IO::String \
+    JSON::XS \
+    LWP \
+    MIME::Base64 \
+    Parse::RecDescent \
+    Pod::Parser \
+    Text::Unidecode \
+    Test::More \
+    URI \
+    XML::LibXML \
+    XML::LibXSLT \
+    UUID::Tiny \
+|| /bin/true
+
+# cleanup cpanm cache
+rm -rf $HOME/.cpanm

--- a/tools/travis/src/texlive-2015.sh
+++ b/tools/travis/src/texlive-2015.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Installing TeXLive 2015 via packages ..."
+
+echo " => apt-get update"
+apt-get update
+
+echo " => apt-get install texlive-full -y"
+apt-get install texlive-full -y
+
+echo " => rm -rf /var/lib/apt/lists/*"
+rm -rf /var/lib/apt/lists/*

--- a/tools/travis/src/texlive-2016.sh
+++ b/tools/travis/src/texlive-2016.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Installing TeXLive 2016 from ppa jonathonf/texlive-2016 ..."
+
+echo " => apt-get update"
+apt-get update
+
+echo " => apt-get install software-properties-common -y"
+apt-get install software-properties-common -y
+
+echo " => add-apt-repository ppa:jonathonf/texlive-2016 -y"
+add-apt-repository ppa:jonathonf/texlive-2016 -y
+
+echo " => apt-get update"
+apt-get update
+
+echo " => apt-get install texlive-full -y"
+apt-get install texlive-full -y
+
+echo " => rm -rf /var/lib/apt/lists/*"
+rm -rf /var/lib/apt/lists/*

--- a/tools/travis/src/texlive-2018.sh
+++ b/tools/travis/src/texlive-2018.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Installing TeXLive 2018 from ppa jonathonf/texlive-2018 ..."
+
+echo " => apt-get update"
+apt-get update
+
+echo " => apt-get install software-properties-common -y"
+apt-get install software-properties-common -y
+
+echo " => add-apt-repository ppa:jonathonf/texlive-2018 -y"
+add-apt-repository ppa:jonathonf/texlive-2018 -y
+
+echo " => apt-get update"
+apt-get update
+
+echo " => apt-fast install texlive-full -y"
+apt-get install texlive-full -y
+
+echo " => rm -rf /var/lib/apt/lists/*"
+rm -rf /var/lib/apt/lists/*

--- a/tools/travis/src/texlive-latest.sh
+++ b/tools/travis/src/texlive-latest.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Installing latest TeXLive manually ..."
+
+# curl and unpack
+echo " => curl -#L http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz | tar zxf -"
+curl -#L http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz | tar zxf -
+
+# Move into appropriate directory
+mv install-tl-* install-tl
+
+# Setup profile
+echo "selected_scheme scheme-full" > install-tl/profile
+echo "TEXDIR /opt/texlive/" >> install-tl/profile
+
+# Run the command with arguments
+echo " => ./install-tl/install-tl -profile install-tl/profile"
+./install-tl/install-tl -profile install-tl/profile
+
+# Setup path
+echo " => echo \"PATH=/opt/texlive/bin/x86_64-linux/\$PATH\" >> \$HOME/.bashrc"
+echo "PATH=/opt/texlive/bin/x86_64-linux/\$PATH" >> $HOME/.bashrc
+
+# and cleanup
+echo " => rm -rf install-tl"
+rm -rf install-tl


### PR DESCRIPTION
This commit completly overhauls the way Travis tests are done. Previously, these were used by manually installing appropriate versions of perl and tex into the testing environment and then running a script.

This commit introduces a scheme for building appropriate docker test runtime images. 
This allows for a lot more flexibility and reliable when running tests.
It also makes the tests run faster, as it is no longer neccessary to download, install and configure several dependencies.
These images are then pulled and used by Travis at testing time. 