### PR TITLE
pass @INC to latexmlc invocation in tests

### DIFF
--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -219,7 +219,9 @@ sub daemon_ok {
     ['xsltparameter',      'LATEXML_VERSION:TEST'],
     ['nocomments',         '']);
 
-  my $invocation = catfile($FindBin::Bin, '..', 'blib', 'script', 'latexmlc') . ' ';
+  my $latexmlc = catfile($FindBin::Bin, '..', 'blib', 'script', 'latexmlc');
+  $latexmlc =~ s/^\.\///;
+  my $invocation = "perl " . join(" ", map { ("-I", $_) } @INC) . " " . $latexmlc . ' ';
   my $timed = undef;
   foreach my $opt (@$opts) {
     if ($$opt[0] eq 'timeout') {    # Ensure .opt timeout takes precedence


### PR DESCRIPTION
Ideally this helps with CPANTesters, should be just redundant information for a regular Perl installation.

One key question is whether a call to `perl` will use the correct version of Perl on CPANTesters. If this fails, there seem to be alternatives that can be tried without a system call, such as:
```
{
    local @ARGV = qw<param1 param2 param3>;
    do "$latexmlc";
}

```

but that would need a slightly larger rewrite of the Test.pm setup