### PR TITLE
Also use same perl between Test.pm and system()

### DIFF
--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -12,6 +12,7 @@ use File::Spec::Functions;
 use LaTeXML::Post;
 use LaTeXML::Post::MathML::Presentation;
 use LaTeXML::Post::XMath;
+use Config;
 
 use base qw(Exporter);
 #  @Test::More::EXPORT);
@@ -221,7 +222,9 @@ sub daemon_ok {
 
   my $latexmlc = catfile($FindBin::Bin, '..', 'blib', 'script', 'latexmlc');
   $latexmlc =~ s/^\.\///;
-  my $invocation = "perl " . join(" ", map { ("-I", $_) } @INC) . " " . $latexmlc . ' ';
+  my $path_to_perl = $Config{perlpath};
+
+  my $invocation = $path_to_perl . " " . join(" ", map { ("-I", $_) } @INC) . " " . $latexmlc . ' ';
   my $timed = undef;
   foreach my $opt (@$opts) {
     if ($$opt[0] eq 'timeout') {    # Ensure .opt timeout takes precedence


### PR DESCRIPTION
Config is a core module, and I got this solution from:

["How should I invoke perl from my test scripts?"](http://wiki.cpantesters.org/wiki/CPANAuthorNotes)

Could help with using the correct Cwd.so, which I see is the next CPANTesters issue. It may also be the case that we shouldn't pass *all* `@INC` paths onto the call, which would be my next step if this PR doesn't suffice.
