### PR TITLE
Make abstract, references, etc <h2>

### DIFF
--- a/lib/LaTeXML/resources/CSS/ltx-apj.css
+++ b/lib/LaTeXML/resources/CSS/ltx-apj.css
@@ -6,12 +6,12 @@
 .ltx_role_author .ltx_personname {
     font-family:serif; font-weight:normal; font-variant:small-caps; font-size: 100%; }
 .ltx_abstract { margin-left:4em; margin-right:4em; }
-.ltx_abstract h6 {
+.ltx_abstract h2 {
     text-transform:uppercase; font-family:serif; font-weight:normal; font-size: 100%; 
     display:block; text-align:center; margin-bottom:0.1ex; }
 .ltx_keywords    {
     margin-top:0.5em; margin-left:4em; margin-right:4em; }
-.ltx_keywords h6 {
+.ltx_keywords h2 {
     font-weight:normal; font-style:italic; }
 
 .ltx_title_bibliography,
@@ -31,4 +31,3 @@
     font-family:serif; font-variant:small-caps;
     display:block; text-align:center; }
 .ltx_table .ltx_caption { font-variant:small-caps; } /* ! */
-

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -107,7 +107,7 @@
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>
       <xsl:if test="@name">
-        <xsl:element name="h6" namespace="{$html_ns}">  
+        <xsl:element name="h2" namespace="{$html_ns}">
           <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
           <xsl:attribute name="class">ltx_title ltx_title_abstract</xsl:attribute>
           <xsl:apply-templates select="@name">
@@ -136,7 +136,7 @@
       </xsl:apply-templates>
       <xsl:if test="@name">
         <xsl:text>&#x0A;</xsl:text>
-        <xsl:element name="h6" namespace="{$html_ns}">  
+        <xsl:element name="h2" namespace="{$html_ns}">
           <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
           <xsl:attribute name="class">ltx_title ltx_title_acknowledgements</xsl:attribute>
           <xsl:apply-templates select="@name">
@@ -167,7 +167,7 @@
       </xsl:apply-templates>
       <xsl:if test="@name">
         <xsl:text>&#x0A;</xsl:text>
-        <xsl:element name="h6" namespace="{$html_ns}">
+        <xsl:element name="h2" namespace="{$html_ns}">
           <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
           <xsl:attribute name="class">ltx_title ltx_title_keywords</xsl:attribute>
           <xsl:apply-templates select="@name">
@@ -196,7 +196,7 @@
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>
-      <xsl:element name="h6" namespace="{$html_ns}"> <!--should be italic ? -->
+      <xsl:element name="h2" namespace="{$html_ns}"> <!--should be italic ? -->
         <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
         <xsl:attribute name="class">ltx_title ltx_title_classification</xsl:attribute>
         <xsl:choose>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -818,7 +818,7 @@
           <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
         </xsl:call-template>
         <xsl:if test="ltx:title">
-          <xsl:element name="h6" namespace="{$html_ns}">
+          <xsl:element name="h2" namespace="{$html_ns}">
             <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
             <xsl:apply-templates select="ltx:title/node()">
               <xsl:with-param name="context" select="$innercontext"/>


### PR DESCRIPTION
Abstract, references, acknowledgements, keywords, classification, and TOC headings were all previously `<h6>`. I think they all appear a level directly under the title, which is `<h1>`. So, to be semantically correct, they should be `<h2>`.

I imagine this was originally done to make them smaller. This should be styled with CSS instead of using incorrect heading levels. I have converted some documents with the default stylesheet and the abstract and references headings still look fine.