### PR TITLE
Guard against empty parens in citations with missing metadata (natbib-style)

### DIFF
--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -491,7 +491,12 @@ sub make_bibcite {
       elsif ($show =~ s/^refnum//i) {
         push(@stuff, $doc->cloneNodes(@{ $$datum{refnum} })); }
       elsif ($show =~ s/^phrase(\d)//i) {
-        push(@stuff, $phrases[$1 - 1]->childNodes) if $phrases[$1 - 1]; }
+        if (my $current_phrase = $phrases[$1 - 1]) {
+          if (($current_phrase->textContent eq ')') && (!@stuff || (ref $stuff[-1] && $stuff[-1]->textContent eq '('))) {
+            pop @stuff;
+            if (@stuff && $stuff[-1] eq ' ') { pop @stuff; }
+          } else {
+            push(@stuff, $phrases[$1 - 1]->childNodes); } } }
       elsif ($show =~ s/^year//i) {
         if (!$$datum{year}) {
           $self->note_missing('warn', 'Date for citation', $$datum{key}); }


### PR DESCRIPTION
Currently we see empty parens in the recent arxiv conversion run, for documents using revtex4-1, and i assume other natbib-based citation styles.  Example:

https://corpora.mathweb.org/preview/arxmliv/tex_to_html/cond-mat0001224?style=simple

Note `KR1 ()` , etc.

The core of the issue is the arxiv setup - there is no `.bib` file to consult for metadata, just the final `.bbl` - in some cases directly embedded into the main document source. So we end up with having only the bib key -- which latexml already falls back to. I localized the code path to this fallback in natbib.sty.ltxml:

```
        Invocation(T_CS('\@@cite'),
          Tokens(Explode('cite')),
          Invocation(T_CS('\@@bibref'),
            Tokens(Explode("Authors Phrase1YearPhrase2")),
            $keys,
            Invocation(T_CS('\@@citephrase'), $open),
            Invocation(T_CS('\@@citephrase'), $close))); } }
```

Even Authors is not available, so latexml falls back to the citation key, which is a good alternative here. 

So this PR "guesses at a fix" -- I check if a phrase happens to be a closing paren, then check for an immediately preceding open - and then remove them all, as well as any potential whitespace prior. This fixes the issue as seen in arXiv, so the fallback goes from `KR1 ()` to just `KR`, which is a tad bit cleaner.

I wouldn't classify this as a bug or deficiency with latexml, closer to "fallback polish" really.