### PR TITLE
\sloppypar is always a macro

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3844,6 +3844,7 @@ DefPrimitiveI('\-', undef, undef);    # We don't do hyphenation.
 DefPrimitiveI('\sloppy', undef, undef);
 DefPrimitiveI('\fussy',  undef, undef);
 DefEnvironment('{sloppypar}', '#body');
+DefMacro('\sloppypar','\par\sloppy');
 DefMacroI('\nobreakdashes', undef, T_OTHER('-'));
 
 DefMacro('\showhyphens{}', '#1');     # ?


### PR DESCRIPTION
Fixes #1059 . See issue for details.