### PR TITLE
Add support for quantumarticle.cls

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -574,6 +574,7 @@ lib/LaTeXML/Package/pst-node.sty.ltxml
 lib/LaTeXML/Package/pstricks.sty.ltxml
 lib/LaTeXML/Package/pxfonts.sty.ltxml
 lib/LaTeXML/Package/pzd.fontmap.ltxml
+lib/LaTeXML/Package/quantumarticle.cls.ltxml
 lib/LaTeXML/Package/ragged2e.sty.ltxml
 lib/LaTeXML/Package/relsize.sty.ltxml
 lib/LaTeXML/Package/report.cls.ltxml

--- a/lib/LaTeXML/Package/quantumarticle.cls.ltxml
+++ b/lib/LaTeXML/Package/quantumarticle.cls.ltxml
@@ -1,0 +1,49 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  quantumarticle                                                     | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+# Quantum Journal
+# See https://github.com/quantum-journal/quantum-journal
+
+LoadClass('article');
+ProcessOptions();
+
+RequirePackage('bbm');
+RequirePackage('inst_support');
+RequirePackage('xcolor');
+
+DefConstructor('\@@@email{}{}', "^ <ltx:contact role='#2'>#1</ltx:contact>");
+DefMacro('\email{}', '\@add@to@frontmatter{ltx:creator}{\@@@email{#1}{email}}');
+DefConstructor('\@@@address{}', "^ <ltx:contact role='address'>#1</ltx:contact>");
+DefConstructor('\@@@affiliation{}', "^ <ltx:contact role='affiliation'>#1</ltx:contact>");
+DefConstructor('\@@@homepage{}', "^ <ltx:contact role='homepage'>#1</ltx:contact>");
+DefMacro('\address[]{}',   '\@add@to@frontmatter{ltx:creator}{\@@@address{#2}}');
+DefMacro('\affiliation{}', '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
+DefMacro('\homepage{}', '\@add@to@frontmatter{ltx:creator}{\@@@homepage{#1}}');
+DefMacro('\orcid{}', '');
+
+RawTeX(<<'EoTeX');
+\DeclareRobustCommand\openone{\mathbbm{1}}
+\definecolor{quantumviolet}{HTML}{53257F} %Quantum violet
+\definecolor{quantumgray}{HTML}{555555} %Quantum gray
+\DeclareRobustCommand{\Quantum}{Quantum}
+
+\newenvironment{acknowledgements}{\section*{Acknowledgements}}{}
+\newenvironment{widetext}{}{}
+EoTeX
+
+#**********************************************************************
+1;

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -591,6 +591,30 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="ltx:contact[@role='homepage']">
+    <xsl:param name="context"/>
+    <xsl:text>&#x0A;</xsl:text>
+    <xsl:element name="span" namespace="{$html_ns}">
+      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:call-template name="add_id"/>
+      <xsl:call-template name="add_attributes">
+      </xsl:call-template>
+      <xsl:apply-templates select="." mode="begin">
+        <xsl:with-param name="context" select="$innercontext"/>
+      </xsl:apply-templates>
+      <xsl:element name="a" namespace="{$html_ns}">      
+        <xsl:attribute name="href"><xsl:value-of select="text()"/></xsl:attribute>
+        <xsl:apply-templates>
+          <xsl:with-param name="context" select="$innercontext"/>
+        </xsl:apply-templates>
+      </xsl:element>
+      <xsl:apply-templates select="." mode="end">
+        <xsl:with-param name="context" select="$innercontext"/>
+      </xsl:apply-templates>
+      <xsl:text>&#x0A;</xsl:text>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template match="ltx:contact[@role='dedicatory' or @role='mobile']">
     <xsl:param name="context"/>
     <xsl:text>&#x0A;</xsl:text>


### PR DESCRIPTION
https://quantum-journal.org/instructions/authors/
https://github.com/quantum-journal/quantum-journal

I think this is everything needed from the .cls file. I have tested with the template and a real paper from the journal and both render without errors.

I wanted to include the template as a test, but I don't think I can because it is licensed under LPPL. Is that right? I don't think I can even write my own test because the .cls file is not in texlive, so I'd have to commit it to the repo to get the PDF to render.

ref https://github.com/arxiv-vanity/engrafo/issues/316