### PR TITLE
More careful location range heuristic

### DIFF
--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -35,7 +35,7 @@ sub create {
     $options{shortsource} = "$name.$ext";
     return $class->new($options{content}, %options); }
   elsif ($source =~ s/^literal://) {    # we've supplied literal data
-    $options{source} = ''; # the source does not have a corresponding file name
+    $options{source} = '';              # the source does not have a corresponding file name
     return $class->new($source, %options); }
   elsif (!defined $source) {
     return $class->new('', %options); }
@@ -48,7 +48,7 @@ sub create {
 
 sub new {
   my ($class, $string, %options) = @_;
-  $string               = q{}                unless defined $string;
+  $string = q{} unless defined $string;
   #$options{source}      = "Anonymous String" unless defined $options{source};
   #$options{shortsource} = "String"           unless defined $options{shortsource};
   my $self = bless { source => $options{source},
@@ -135,16 +135,16 @@ sub getNextChar {
   if ($$self{colno} < $$self{nchars}) {
     my $ch = $$self{chars}[$$self{colno}++];
     my $cc = $$STATE{catcode}{$ch}[0] // CC_OTHER;    # $STATE->lookupCatcode($ch); OPEN CODED!
-    if (($cc == CC_SUPER)    # Possible convert ^^x
+    if (($cc == CC_SUPER)                             # Possible convert ^^x
       && ($$self{colno} + 1 < $$self{nchars}) && ($ch eq $$self{chars}[$$self{colno}])) {
       my ($c1, $c2);
-      if (($$self{colno} + 2 < $$self{nchars})    # ^^ followed by TWO LOWERCASE Hex digits???
+      if (($$self{colno} + 2 < $$self{nchars})        # ^^ followed by TWO LOWERCASE Hex digits???
         && (($c1 = $$self{chars}[$$self{colno} + 1]) =~ /^[0-9a-f]$/)
         && (($c2 = $$self{chars}[$$self{colno} + 2]) =~ /^[0-9a-f]$/)) {
         $ch = chr(hex($c1 . $c2));
         splice(@{ $$self{chars} }, $$self{colno} - 1, 4, $ch);
         $$self{nchars} -= 3; }
-      else {                                      # OR ^^ followed by a SINGLE Control char type code???
+      else {    # OR ^^ followed by a SINGLE Control char type code???
         my $c  = $$self{chars}[$$self{colno} + 1];
         my $cn = ord($c);
         $ch = chr($cn + ($cn > 64 ? -64 : 64));
@@ -162,19 +162,15 @@ sub stringify {
 #**********************************************************************
 sub getLocator {
   my ($self) = @_;
-  my ($l, $c, $lstart, $cstart) = ($$self{lineno}, $$self{colno});
-  #Deyan: Upgrade message to XPointer style
-  my $nc = $$self{nchars} - 1;    #There is always a weird (end of line?) char that gets counted
-  if ((defined $c) && ($c >= $nc)) {
-    $lstart = $l;
-    $cstart = $c - $nc; }
+  my ($toLine, $toCol, $fromLine, $fromCol) = ($$self{lineno}, $$self{colno});
+  my $maxCol = $$self{nchars} - 1;    #There is always a trailing EOL char
+  if ((defined $toCol) && ($toCol >= $maxCol)) {
+    $fromLine = $toLine;
+    $fromCol  = 0; }
   else {
-    #Very rough and dirty approximation, not to be relied on.
-    #One would need to keep all line lengths to properly establish the start and end
-    # or just remember the initial char of the token's position
-    $lstart = $l - 1;
-    $cstart = $nc - $c; }
-  return LaTeXML::Common::Locator->new($$self{source}, $lstart, $cstart, $l, $c); }
+    $fromLine = $toLine;
+    $fromCol  = $toCol; }
+  return LaTeXML::Common::Locator->new($$self{source}, $fromLine, $fromCol, $toLine, $toCol); }
 
 sub getSource {
   my ($self) = @_;


### PR DESCRIPTION
 * standardized variable names to Tom's from/to pairs, which are more readable
 * removed the rather bizarre column arithmetic in the locator heuristic
 * replaced with a simple "zero or here" rule

More work can be done, but this provides slightly more meaningful locator ranges for the stex tests.