### PR TITLE
Add pre-commit check for MANIFEST membership

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -694,6 +694,8 @@ t/93_formats.t
 t/931_epub.t
 t/94_runtimes.t
 t/95_complex_config.t
+t/96_fatal.t
+t/97_manifest.t
 t/alignment/algx.pdf
 t/alignment/algx.tex
 t/alignment/algx.xml
@@ -771,6 +773,9 @@ t/ams/matrix.xml
 t/ams/sideset.pdf
 t/ams/sideset.tex
 t/ams/sideset.xml
+t/babel/csquotes.pdf
+t/babel/csquotes.tex
+t/babel/csquotes.xml
 t/babel/french.pdf
 t/babel/french.tex
 t/babel/french.xml
@@ -802,6 +807,7 @@ t/complex/xii.pdf
 t/complex/xii.tex
 t/complex/xii.xml
 t/daemon/amsarticle.tex
+t/daemon/broken.tex
 t/daemon/api/port.spec
 t/daemon/api/port.status
 t/daemon/api/port.xml
@@ -1448,4 +1454,3 @@ t/tokenize/verb.xml
 t/tokenize/verbata.pdf
 t/tokenize/verbata.tex
 t/tokenize/verbata.xml
-

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -3,6 +3,7 @@
 ^\.
 ^Makefile$
 ^Makefile.old$
+^MYMETA
 \.bak$
 ($|/)TAGS$
 (^|/)\.svn/
@@ -11,3 +12,10 @@
 ^release/
 ^tools/
 ^pm_to_blib$
+\.aux$
+\.log$
+\.tdy$
+\.test.status$
+\.fls$
+\.synctex\.gz$
+\.fdb_latexmk$

--- a/t/97_manifest.t
+++ b/t/97_manifest.t
@@ -1,0 +1,9 @@
+use ExtUtils::Manifest qw(fullcheck);
+use Test::More;
+
+my($missing, $extra) = fullcheck();
+
+ok(!@$missing, "MANIFEST contains outdated files: \n\t".join("\n\t", @$missing));
+ok(!@$extra, "Files missing from MANIFEST: \n\t".join("\n\t", @$extra));
+
+ done_testing();

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -39,7 +39,23 @@ if (my @modified_files =
       push(@failed_files, $modified_file);    # Note the original file name
       $exit_code = $code; } }
 
-  print STDERR "Some files had issues: " . join(',', @failed_files)
-    . "; To correct these, run:\n tools/latexmllint <files>.\n"
-    . colored("COMMIT ABORTED", 'red') . "\n" if @failed_files;
+  if (@failed_files) {
+    print STDERR "Some files had issues: " . join(',', @failed_files)
+      . "; To correct these, run:\n tools/latexmllint <files>.\n"
+      . colored("COMMIT ABORTED", 'red') . "\n"; }
+  else {
+    # Check if files are missing from the manifest
+    my %manifest = ();
+    open(my $fh, "<", "MANIFEST") or die "Missing MANIFEST file?\n";
+    while (<$fh>) {
+      next if /^[#]/;
+      chomp;
+      $manifest{$_} = 1; }
+    close($fh);
+    # Not in MANIFEST, (or in tools)
+    if (my @missing_files = grep { !($_ =~ /^tools/ || $manifest{$_}) } @modified_files) {
+      print STDERR "Some files are missing from MANIFEST, please add them: \n\t"
+        . join(',\n\t', @missing_files) . ";\n"
+        . colored("COMMIT ABORTED", 'red') . "\n";
+      exit 1; } }
   exit $exit_code; }

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -38,24 +38,25 @@ if (my @modified_files =
     if ($code) {
       push(@failed_files, $modified_file);    # Note the original file name
       $exit_code = $code; } }
-
   if (@failed_files) {
     print STDERR "Some files had issues: " . join(',', @failed_files)
-      . "; To correct these, run:\n tools/latexmllint <files>.\n"
-      . colored("COMMIT ABORTED", 'red') . "\n"; }
-  else {
-    # Check if files are missing from the manifest
-    my %manifest = ();
-    open(my $fh, "<", "MANIFEST") or die "Missing MANIFEST file?\n";
-    while (<$fh>) {
-      next if /^[#]/;
-      chomp;
-      $manifest{$_} = 1; }
-    close($fh);
-    # Not in MANIFEST, (or in tools)
-    if (my @missing_files = grep { !($_ =~ /^tools/ || $manifest{$_}) } @modified_files) {
-      print STDERR "Some files are missing from MANIFEST, please add them: \n\t"
-        . join(',\n\t', @missing_files) . ";\n"
-        . colored("COMMIT ABORTED", 'red') . "\n";
-      exit 1; } }
+      . "; To correct these, run:\n tools/latexmllint <files>.\n"; }
+
+  # Also, Check if files are missing from the manifest
+  my %manifest = ();
+  open(my $fh, "<", "MANIFEST") or die "Missing MANIFEST file?\n";
+  while (<$fh>) {
+    next if /^[#]/;
+    chomp;
+    $manifest{$_} = 1; }
+  close($fh);
+  # Not in MANIFEST, (or in tools)
+  my @missing_files = grep { !($_ =~ /^tools|MANIFEST/ || $manifest{$_}) } @modified_files;
+  if (@missing_files) {
+    print STDERR "Some files are missing from MANIFEST, please add them: \n\t"
+      . join(',\n\t', @missing_files) . ";\n";
+    $exit_code = 1; }
+
+  if (@missing_files || @failed_files) {
+    print STDERR colored("COMMIT ABORTED", 'red') . "\n"; }
   exit $exit_code; }


### PR DESCRIPTION
Example effect, when adding a new binding and forgetting to update the MANIFEST:

```
Some files are missing from MANIFEST, please add them: 
	lib/LaTeXML/Package/new.sty.ltxml;
COMMIT ABORTED
```

Hopefully can make the @brucemiller 's reviewer life a little more pleasant!