### PR TITLE
Auto Scrolling Table-Of-Contents for navigation

### DIFF
--- a/lib/LaTeXML/resources/CSS/LaTeXML-navbar-left.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-navbar-left.css
@@ -3,7 +3,7 @@
 .ltx_page_navbar {
     display:block!important; position:fixed; left:0px; top:0px; width:170px;
     margin:0em; padding:1em; font: bold 75% sans-serif; 
-    border: 3px double; overflow-y: auto; height: 95vh; }
+    border: 3px double; overflow-y: auto; max-height: 95vh; }
 .ltx_page_navbar ul {
     margin-left:-2em; }
 .ltx_page_main {

--- a/lib/LaTeXML/resources/CSS/LaTeXML-navbar-left.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-navbar-left.css
@@ -3,7 +3,7 @@
 .ltx_page_navbar {
     display:block!important; position:fixed; left:0px; top:0px; width:170px;
     margin:0em; padding:1em; font: bold 75% sans-serif; 
-    border: 3px double; }
+    border: 3px double; overflow-y: auto; height: 95vh; }
 .ltx_page_navbar ul {
     margin-left:-2em; }
 .ltx_page_main {

--- a/lib/LaTeXML/resources/CSS/LaTeXML-navbar-right.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-navbar-right.css
@@ -2,7 +2,7 @@
 
 .ltx_page_navbar {
     display:block!important; position:fixed; left:80%; top:0px; width:20%;
-    margin:0em; padding:1em; font: bold 75% sans-serif; overflow-y: auto; height: 95vh; }
+    margin:0em; padding:1em; font: bold 75% sans-serif; overflow-y: auto; max-height: 95vh; }
 .ltx_page_navbar ul {
     margin-left:-2em; }
 .ltx_page_main {

--- a/lib/LaTeXML/resources/CSS/LaTeXML-navbar-right.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-navbar-right.css
@@ -2,7 +2,7 @@
 
 .ltx_page_navbar {
     display:block!important; position:fixed; left:80%; top:0px; width:20%;
-    margin:0em; padding:1em; font: bold 75% sans-serif; }
+    margin:0em; padding:1em; font: bold 75% sans-serif; overflow-y: auto; height: 95vh; }
 .ltx_page_navbar ul {
     margin-left:-2em; }
 .ltx_page_main {


### PR DESCRIPTION
If the table of contents as left/right navigation pane was too long we found it was impossible to reach all sections. The attachment contains the test-file and the commands.

The pull-request fixes this by adding auto-scrolling for the navigation panes in the css-files. The automatic part means that it is only active for large table-of-contents; so it should be unproblematic for other cases.

[Test.zip](https://github.com/brucemiller/LaTeXML/files/2904894/Test.zip)
