### PR TITLE
Continuous Integration for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+cache:
+  - C:\strawberry
+
+install:
+  - if not exist "C:\strawberry" choco install strawberryperl -y
+  - set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - cpanm --quiet --installdeps --with-develop --notest .
+
+build_script:
+  - perl Makefile.PL
+  - gmake
+
+test_script:
+  - gmake test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,23 @@
 cache:
   - C:\strawberry
+  - C:\miktex
+
+environment:
+  matrix:
+    - setup: "miktex"
+    - setup: "bare"
+
+matrix:
+  fast_finish: true
 
 install:
+  # Install miktex to get pdflatex, if we don't get it from the cache
+  - if "%setup%"=="miktex" choco install -y miktex
+  - cmd: refreshenv
+  # autoinstall latex packages (0=no, 1=autoinstall, 2=ask)
+  # this adds this to the registry!
+  - if "%setup%"=="miktex" initexmf --set-config-value "[MPM]AutoInstall=1" 
+  - cmd: refreshenv
   - if not exist "C:\strawberry" choco install strawberryperl -y
   - set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ install:
   - cmd: refreshenv
   # autoinstall latex packages (0=no, 1=autoinstall, 2=ask)
   # this adds this to the registry!
-  - if "%setup%"=="miktex" initexmf --set-config-value "[MPM]AutoInstall=1" 
+  - if "%setup%"=="miktex" initexmf --admin --enable-installer --verbose --set-config-value "[MPM]AutoInstall=1" 
   - cmd: refreshenv
   - if not exist "C:\strawberry" choco install strawberryperl -y
   - set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,7 +28,8 @@ use FindBin;
 
 our $OLD_LIBXML = grep { /OLD_LIBXML/ } @ARGV;
 our $NOMKTEXLSR = grep { /NOMKTEXLSR/ } @ARGV;
-our $TEXMF;
+our $KPSE_TOOLCHAIN = "";
+our ($KPSEV, $TEXMF);
 my ($texmfspec) = grep { /^TEXMF/ } @ARGV;
 if ($texmfspec && $texmfspec =~ /^TEXMF\s*=(.*)$/) {
   $TEXMF = $1;
@@ -120,6 +121,7 @@ sub record_revision {
   ##  $$MORE_MACROS{REVISION} = '$(shell svnversion $(REVISION_BASE))';
   ## This command is appropriate for git (I think)
   if ((-d '.git') && (system("git --version") == 0)) {    # If a git checkout & can run git?
+    print STDERR "\n";                                    # space out messages
     $$MORE_MACROS{REVISION} = '$(shell git log --max-count=1 --abbrev-commit --pretty="%h")'; }
   # Extract the previously recorded revision from the revision file (awkward)
   $$MORE_MACROS{OLD_REVISION}
@@ -151,7 +153,7 @@ RecordRevision
 #======================================================================
 # We'll compile the RecDescent grammar during make; don't need to install grammar.
 sub compile_MathGrammar {
-  push(@EXCLUSIONS, 'blib/lib/LaTeXML/MathGrammar');
+  push(@EXCLUSIONS, 'README.pod', 'blib/lib/LaTeXML/MathGrammar');
   $MORE_MAKERULES .= <<'MakeGrammar';
 
 # Precompile the (Recursive Descent) MathGrammar
@@ -199,8 +201,10 @@ MakeGrammar
 #    embedded spaces.
 sub install_TeXStyles {
   if (!$TEXMF) {
-    if (system("kpsewhich --expand-var='\$TEXMFLOCAL'") == 0) {    # can run kpsewhich?
-      $TEXMF = `kpsewhich --expand-var='\$TEXMFLOCAL'`;
+    if ($ENV{"APPVEYOR"}) {    # assume miktex admin on windows CI
+      $KPSE_TOOLCHAIN = "--miktex-admin"; }
+    if (system("kpsewhich --version $KPSE_TOOLCHAIN") == 0) {    # can run kpsewhich?
+      $TEXMF = `kpsewhich --expand-var='\$TEXMFLOCAL' $KPSE_TOOLCHAIN`;
       # Strip the quotes (they appear in windows, when spaces in pathnames(?))
       # These quotes inhibit pasting pathnames togheter,
       # but we DO need to wrap quotes around all completed paths!!

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,7 +33,7 @@ our ($KPSEV, $TEXMF);
 my ($texmfspec) = grep { /^TEXMF/ } @ARGV;
 if ($texmfspec && $texmfspec =~ /^TEXMF\s*=(.*)$/) {
   $TEXMF = $1;
-  @ARGV = grep { $_ ne $texmfspec } @ARGV; }    # Remove so MakeMaker doesn't fret.
+  @ARGV  = grep { $_ ne $texmfspec } @ARGV; }    # Remove so MakeMaker doesn't fret.
 our @EXCLUSIONS     = ();
 our $MORE_MACROS    = {};
 our $MORE_MAKERULES = '';
@@ -87,7 +87,7 @@ WriteMakefile(NAME => 'LaTeXML',
   # link to  github location to newer MakeMaker
   (eval { ExtUtils::MakeMaker->VERSION(6.46) } ? (META_MERGE => {
         'meta-spec' => { version => 2 },
-        resources => {
+        resources   => {
           repository => {
             type => 'git',
             url  => 'https://github.com/brucemiller/LaTeXML.git',

--- a/README.pod
+++ b/README.pod
@@ -2,7 +2,7 @@
 
 =head1 L<LaTeXML|http://dlmf.nist.gov/LaTeXML/>
 
-=for html <a href="https://travis-ci.org/brucemiller/LaTeXML"><img src="https://travis-ci.org/brucemiller/LaTeXML.svg?branch=master"></a><a href="https://ci.appveyor.com/project/dginev/latexml"><img src="https://ci.appveyor.com/api/projects/status/urebpds4q6subyvc?svg=true"></a>
+=for html <a href="https://travis-ci.org/brucemiller/LaTeXML"><img src="https://travis-ci.org/brucemiller/LaTeXML.svg?branch=master"></a> <a href="https://ci.appveyor.com/project/dginev/latexml"><img src="https://ci.appveyor.com/api/projects/status/urebpds4q6subyvc?svg=true"></a>
   <a href="https://raw.githubusercontent.com/brucemiller/LaTeXML/master/LICENSE"><img src="https://camo.githubusercontent.com/60ffad3138b8c6d483ff061480f4bb50f27be37a/687474703a2f2f696d672e736869656c64732e696f2f62616467652f6c6963656e73652d4343302d626c75652e737667" alt="license" data-canonical-src="http://img.shields.io/badge/license-CC0-blue.svg" style="max-width:100%;"></a>
   <a href="https://metacpan.org/release/LaTeXML"><img src="https://badge.fury.io/pl/LaTeXML.svg" alt="CPAN version" height="18"></a>
 

--- a/README.pod
+++ b/README.pod
@@ -2,7 +2,7 @@
 
 =head1 L<LaTeXML|http://dlmf.nist.gov/LaTeXML/>
 
-=for html <a href="https://travis-ci.org/brucemiller/LaTeXML"><img src="https://travis-ci.org/brucemiller/LaTeXML.svg?branch=master"></a><a href="https://ci.appveyor.com/project/dginev/latexml"><img src="https://ci.appveyor.com/api/projects/status/github/brucemiller/latexml?svg=true"></a>
+=for html <a href="https://travis-ci.org/brucemiller/LaTeXML"><img src="https://travis-ci.org/brucemiller/LaTeXML.svg?branch=master"></a><a href="https://ci.appveyor.com/project/dginev/latexml"><img src="https://ci.appveyor.com/api/projects/status/urebpds4q6subyvc?svg=true"></a>
   <a href="https://raw.githubusercontent.com/brucemiller/LaTeXML/master/LICENSE"><img src="https://camo.githubusercontent.com/60ffad3138b8c6d483ff061480f4bb50f27be37a/687474703a2f2f696d672e736869656c64732e696f2f62616467652f6c6963656e73652d4343302d626c75652e737667" alt="license" data-canonical-src="http://img.shields.io/badge/license-CC0-blue.svg" style="max-width:100%;"></a>
   <a href="https://metacpan.org/release/LaTeXML"><img src="https://badge.fury.io/pl/LaTeXML.svg" alt="CPAN version" height="18"></a>
 

--- a/README.pod
+++ b/README.pod
@@ -2,7 +2,7 @@
 
 =head1 L<LaTeXML|http://dlmf.nist.gov/LaTeXML/>
 
-=for html <a href="https://travis-ci.org/brucemiller/LaTeXML"><img src="https://travis-ci.org/brucemiller/LaTeXML.svg?branch=master"></a>
+=for html <a href="https://travis-ci.org/brucemiller/LaTeXML"><img src="https://travis-ci.org/brucemiller/LaTeXML.svg?branch=master"></a><a href="https://ci.appveyor.com/project/dginev/latexml"><img src="https://ci.appveyor.com/api/projects/status/github/brucemiller/latexml?svg=true"></a>
   <a href="https://raw.githubusercontent.com/brucemiller/LaTeXML/master/LICENSE"><img src="https://camo.githubusercontent.com/60ffad3138b8c6d483ff061480f4bb50f27be37a/687474703a2f2f696d672e736869656c64732e696f2f62616467652f6c6963656e73652d4343302d626c75652e737667" alt="license" data-canonical-src="http://img.shields.io/badge/license-CC0-blue.svg" style="max-width:100%;"></a>
   <a href="https://metacpan.org/release/LaTeXML"><img src="https://badge.fury.io/pl/LaTeXML.svg" alt="CPAN version" height="18"></a>
 

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -543,7 +543,7 @@ sub ComposeURL {
 #======================================================================
 
 my $parameter_options = {    # [CONSTANT]
-  nargs        => 1, reversion   => 1, optional => 1, novalue => 1,
+  nargs => 1, reversion => 1, optional => 1, novalue => 1,
   beforeDigest => 1, afterDigest => 1,
   semiverbatim => 1, undigested  => 1 };
 
@@ -1589,7 +1589,7 @@ sub DefEnvironmentI {
       afterConstruct => flatten($options{afterConstruct}, sub { $STATE->popFrame; }),
       nargs          => $options{nargs},
       captureBody    => 1,
-      properties     => $options{properties} || {},
+      properties => $options{properties} || {},
       (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
       (defined $sizer ? (sizer => $sizer) : ()),
       ), $options{scope});
@@ -1653,7 +1653,7 @@ sub DefEnvironmentI {
 
 # Specify the properties of a Node tag.
 my $tag_options = {    # [CONSTANT]
-  autoOpen          => 1, autoClose          => 1, afterOpen => 1, afterClose => 1,
+  autoOpen => 1, autoClose => 1, afterOpen => 1, afterClose => 1,
   'afterOpen:early' => 1, 'afterClose:early' => 1,
   'afterOpen:late'  => 1, 'afterClose:late'  => 1 };
 my $tag_prepend_options = {    # [CONSTANT]
@@ -1716,8 +1716,8 @@ sub RegisterDocumentNamespace {
 # should we assume a raw type can be processed if being read from within a raw type????
 # yeah, that sounds about right...
 my %definition_name = (    # [CONSTANT]
-  sty   => 'package',              cls   => 'class', clo => 'class options',
-  'cnf' => 'configuration',        'cfg' => 'configuration',
+  sty => 'package', cls => 'class', clo => 'class options',
+  'cnf' => 'configuration', 'cfg' => 'configuration',
   'ldf' => 'language definitions', 'def' => 'definitions', 'dfu' => 'definitions');
 
 sub pathname_is_raw {
@@ -1787,7 +1787,6 @@ sub FindFile_aux {
   # The main point, though, is to we make only ONE (more) call.
   return if grep { pathname_is_nasty($_) } @$paths;    # SECURITY! No nasty paths in cmdline
         # Do we need to sanitize these environment variables?
-  my $kpsewhich = which($ENV{LATEXML_KPSEWHICH} || 'kpsewhich');
   local $ENV{TEXINPUTS} = join($Config::Config{'path_sep'},
     @$paths, $ENV{TEXINPUTS} || $Config::Config{'path_sep'});
   my @candidates = (((!$options{noltxml} && !$nopaths) ? ("$file.ltxml") : ()),

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -319,7 +319,7 @@ sub XEquals {
 # Is defined in the LaTeX-y sense of also not being let to \relax.
 sub IsDefined {
   my ($name) = @_;
-  my $cs = (ref $name ? $name : T_CS($name));
+  my $cs      = (ref $name ? $name : T_CS($name));
   my $meaning = $STATE->lookupMeaning($cs);
   return $meaning
     && ($meaning->isa('LaTeXML::Core::Token') || ($meaning->getCSName ne '\relax'))
@@ -414,7 +414,7 @@ sub DigestIf {
 
 sub ReadParameters {
   my ($gullet, $spec) = @_;
-  my $for = T_OTHER("Anonymous");
+  my $for  = T_OTHER("Anonymous");
   my $parm = parseParameters($spec, $for);
   return ($parm ? $parm->readArguments($gullet, $for) : ()); }
 
@@ -485,7 +485,7 @@ sub CleanIndexKey {
   my ($key) = @_;
   $key = ToString($key);
   $key =~ s/^\s+//s; $key =~ s/\s+$//s;    # Trim leading/trailing, in any case
-       # We don't want accented chars (do we?) but we need to decompose the accents!
+        # We don't want accented chars (do we?) but we need to decompose the accents!
 ## No, leave in the unicode at this point (strip them later)
 ##  $key = NFD($key);
 ##  $key =~ s/[^a-zA-Z0-9]//g;
@@ -499,7 +499,7 @@ sub CleanClassName {
   my ($key) = @_;
   $key = ToString($key);
   $key =~ s/^\s+//s; $key =~ s/\s+$//s;    # Trim leading/trailing, in any case
-       # We don't want accented chars (do we?) but we need to decompose the accents!
+        # We don't want accented chars (do we?) but we need to decompose the accents!
   $key = NFD($key);
   $key =~ s/[^a-zA-Z0-9]//g;
   $key = NFC($key);    # just to be safe(?)
@@ -543,7 +543,7 @@ sub ComposeURL {
 #======================================================================
 
 my $parameter_options = {    # [CONSTANT]
-  nargs => 1, reversion => 1, optional => 1, novalue => 1,
+  nargs        => 1, reversion   => 1, optional => 1, novalue => 1,
   beforeDigest => 1, afterDigest => 1,
   semiverbatim => 1, undigested  => 1 };
 
@@ -693,7 +693,7 @@ sub RefStepCounter {
   my $id = $has_id && ToString(DigestLiteral(T_CS("\\the$ctr\@ID")));
 
   my $refnum = DigestText(T_CS("\\the$ctr"));
-  my $tags = Digest(Invocation(T_CS('\lx@make@tags'), $type));
+  my $tags   = Digest(Invocation(T_CS('\lx@make@tags'), $type));
   # Any scopes activated for previous value of this counter (& any nested counters) must be removed.
   # This may also include scopes activated for \label
   deactivateCounterScope($ctr);
@@ -718,7 +718,7 @@ sub deactivateCounterScope {
 # For UN-numbered units
 sub RefStepID {
   my ($type) = @_;
-  my $ctr = LookupMapping('counter_for_type', $type) || $type;
+  my $ctr   = LookupMapping('counter_for_type', $type) || $type;
   my $unctr = "UN$ctr";
   StepCounter($unctr);
   DefMacroI(T_CS("\\\@$ctr\@ID"), undef,
@@ -1039,7 +1039,7 @@ my $primitive_options = {    # [CONSTANT]
   requireMath  => 1, forbidMath  => 1,
   beforeDigest => 1, afterDigest => 1,
   bounded => 1, locked => 1, alias => 1,
-  outer => 1, long => 1 };
+  outer   => 1, long   => 1 };
 
 sub DefPrimitive {
   my ($proto, $replacement, %options) = @_;
@@ -1327,15 +1327,15 @@ sub createXMRefs {
 # When to make a dual ?
 # If the $presentation seems to be TeX (ie. it involves #1... but not ONLY!)
 my $math_options = {    # [CONSTANT]
-  name => 1, meaning => 1, omcd => 1, reversion => 1, sizer => 1, alias => 1,
-  role => 1, operator_role => 1, reorder => 1, dual => 1,
+  name => 1, meaning       => 1, omcd    => 1, reversion => 1, sizer => 1, alias => 1,
+  role => 1, operator_role => 1, reorder => 1, dual      => 1,
   mathstyle    => 1, font               => 1,
   scriptpos    => 1, operator_scriptpos => 1,
   stretchy     => 1, operator_stretchy  => 1,
   beforeDigest => 1, afterDigest        => 1, scope => 1, nogroup => 1, locked => 1,
   hide_content_reversion => 1 };
 my $simpletoken_options = {    # [CONSTANT]
-  name => 1, meaning => 1, omcd => 1, role => 1, mathstyle => 1,
+  name => 1, meaning   => 1, omcd  => 1, role   => 1, mathstyle => 1,
   font => 1, scriptpos => 1, scope => 1, locked => 1 };
 
 sub DefMath {
@@ -1476,7 +1476,7 @@ sub defmath_dual {
   $presentation = TokenizeInternal($presentation) unless ref $presentation;
   $STATE->installDefinition(LaTeXML::Core::Definition::Expandable->new($pres_cs, $paramlist, $presentation),
     $options{scope});
-  my $nargs = ($paramlist ? scalar($paramlist->getParameters) : 0);
+  my $nargs     = ($paramlist ? scalar($paramlist->getParameters) : 0);
   my $cons_attr = "name='#name' meaning='#meaning' omcd='#omcd' mathstyle='#mathstyle'";
 
   $STATE->installDefinition(LaTeXML::Core::Definition::Constructor->new($cont_cs, $paramlist,
@@ -1493,7 +1493,7 @@ sub defmath_dual {
 
 sub defmath_prim {
   my ($cs, $paramlist, $presentation, %options) = @_;
-  my $string = ToString($presentation);
+  my $string  = ToString($presentation);
   my $reqfont = $options{font} || {};
   delete $options{locked};
   delete $options{font};
@@ -1557,7 +1557,7 @@ sub DefEnvironment {
 ##  my $paramlist=parseParameters($proto,"Environment $name");
 ##  my $name = $1;
   my ($name, $paramlist) = Text::Balanced::extract_bracketed($proto, '{}');
-  $name =~ s/[\{\}]//g;
+  $name      =~ s/[\{\}]//g;
   $paramlist =~ s/^\s*//;
 ##  $paramlist = parseParameters($paramlist, "Environment $name");
   DefEnvironmentI($name, $paramlist, $replacement, %options);
@@ -1589,7 +1589,7 @@ sub DefEnvironmentI {
       afterConstruct => flatten($options{afterConstruct}, sub { $STATE->popFrame; }),
       nargs          => $options{nargs},
       captureBody    => 1,
-      properties => $options{properties} || {},
+      properties     => $options{properties} || {},
       (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
       (defined $sizer ? (sizer => $sizer) : ()),
       ), $options{scope});
@@ -1628,9 +1628,9 @@ sub DefEnvironmentI {
       beforeConstruct => flatten(sub { $STATE->pushFrame; }, $options{beforeConstruct}),
       # Curiously, it's the \begin whose afterConstruct gets called.
       afterConstruct => flatten($options{afterConstruct}, sub { $STATE->popFrame; }),
-      nargs => $options{nargs},
-      captureBody => T_CS("\\end$name"),          # Required to capture!!
-      properties => $options{properties} || {},
+      nargs          => $options{nargs},
+      captureBody => T_CS("\\end$name"),           # Required to capture!!
+      properties  => $options{properties} || {},
       (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
       (defined $sizer ? (sizer => $sizer) : ()),
       ), $options{scope});
@@ -1653,7 +1653,7 @@ sub DefEnvironmentI {
 
 # Specify the properties of a Node tag.
 my $tag_options = {    # [CONSTANT]
-  autoOpen => 1, autoClose => 1, afterOpen => 1, afterClose => 1,
+  autoOpen          => 1, autoClose          => 1, afterOpen => 1, afterClose => 1,
   'afterOpen:early' => 1, 'afterClose:early' => 1,
   'afterOpen:late'  => 1, 'afterClose:late'  => 1 };
 my $tag_prepend_options = {    # [CONSTANT]
@@ -1716,8 +1716,8 @@ sub RegisterDocumentNamespace {
 # should we assume a raw type can be processed if being read from within a raw type????
 # yeah, that sounds about right...
 my %definition_name = (    # [CONSTANT]
-  sty => 'package', cls => 'class', clo => 'class options',
-  'cnf' => 'configuration', 'cfg' => 'configuration',
+  sty   => 'package',              cls   => 'class', clo => 'class options',
+  'cnf' => 'configuration',        'cfg' => 'configuration',
   'ldf' => 'language definitions', 'def' => 'definitions', 'dfu' => 'definitions');
 
 sub pathname_is_raw {
@@ -1935,7 +1935,7 @@ sub loadTeXDefinitions {
   $stomach->getGullet->readingFromMouth(
     LaTeXML::Core::Mouth->create($pathname,
       fordefinitions => 1, notes => 1,
-      content => LookupValue($pathname . '_contents')),
+      content        => LookupValue($pathname . '_contents')),
     sub {
       my ($gullet) = @_;
       my $token;
@@ -2001,7 +2001,7 @@ sub ProcessOptions {
   my $name = $STATE->lookupDefinition(T_CS('\@currname')) && ToString(Expand(T_CS('\@currname')));
   my $ext  = $STATE->lookupDefinition(T_CS('\@currext'))  && ToString(Expand(T_CS('\@currext')));
   my @declaredoptions = @{ LookupValue('@declaredoptions') };
-  my @curroptions = @{ (defined($name) && defined($ext)
+  my @curroptions     = @{ (defined($name) && defined($ext)
         && LookupValue('opt@' . $name . '.' . $ext)) || [] };
   my @classoptions = @{ LookupValue('class_options') || [] };
   # print STDERR "\nProcessOptions for $name.$ext\n"
@@ -2091,7 +2091,7 @@ sub AddToMacro {
 #======================================================================
 my $inputdefinitions_options = {    # [CONSTANT]
   options => 1, withoptions => 1, handleoptions => 1,
-  type => 1, as_class => 1, noltxml => 1, notex => 1, noerror => 1, after => 1 };
+  type    => 1, as_class    => 1, noltxml       => 1, notex => 1, noerror => 1, after => 1 };
 #   options=>[options...]
 #   withoptions=>boolean : pass options from calling class/package
 #   after=>code or tokens or string as $name.$type-h@@k macro. (executed after the package is loaded)
@@ -2368,7 +2368,7 @@ sub FontDecode {
   return if !defined $code || ($code < 0);
   my ($map, $font);
   if (!$encoding) {
-    $font = LookupValue('font');
+    $font     = LookupValue('font');
     $encoding = $font->getEncoding || 'OT1'; }
   if ($encoding && ($map = LoadFontMap($encoding))) {    # OK got some map.
     my ($family, $fmap);
@@ -2499,16 +2499,16 @@ sub DefLigature {
       %options });
   return; }
 
-my $old_math_ligature_options = {};                                                  # [CONSTANT]
-my $math_ligature_options = { matcher => 1, role => 1, name => 1, meaning => 1 };    # [CONSTANT]
+my $old_math_ligature_options = {};                                                     # [CONSTANT]
+my $math_ligature_options     = { matcher => 1, role => 1, name => 1, meaning => 1 };   # [CONSTANT]
 
 sub DefMathLigature {
-  if ((scalar(@_) % 2) == 1) {                                                       # Old style!
+  if ((scalar(@_) % 2) == 1) {                                                          # Old style!
     my ($matcher, %options) = @_;
     Info('deprecated', 'ligature', undef, "Old style arguments to DefMathLigature; please update");
     CheckOptions("DefMathLigature", $old_math_ligature_options, %options);
-    UnshiftValue('MATH_LIGATURES', { old_style => 1, matcher => $matcher }); }       # Install it...
-  else {                                                                             # new style!
+    UnshiftValue('MATH_LIGATURES', { old_style => 1, matcher => $matcher }); }          # Install it...
+  else {                                                                                # new style!
     my (%options) = @_;
     my $matcher = $options{matcher};
     delete $options{matcher};
@@ -2581,7 +2581,7 @@ sub addResource {
 sub ProcessPendingResources {
   my ($document) = @_;
   if (my $resources = LookupValue('PENDING_RESOURCES')) {
-    my %seen = ();
+    my %seen             = ();
     my @unique_resources = grep { my $new = !$seen{$_}; $seen{$_} = 1; $new; } @$resources;
     for my $resource (@unique_resources) {
       addResource($document, @$resource); }

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -73,7 +73,7 @@ sub pathname_make {
       $pathname =~ s|\Q$SEP\E$||; $dir =~ s|^\Q$SEP\E||;
       $pathname .= $SEP . $dir; } }
   $pathname .= $SEP if $pathname && $pieces{name} && $pathname !~ m|\Q$SEP\E$|;
-  $pathname .= $pieces{name} if $pieces{name};
+  $pathname .= $pieces{name}       if $pieces{name};
   $pathname .= '.' . $pieces{type} if $pieces{type};
   return pathname_canonical($pathname); }
 
@@ -381,7 +381,7 @@ sub build_kpse_cache {
   # These are directories which contain the tex related files we're interested in.
   # (but they're typically below where the ls-R indexes are!)
   my $texpaths = `"$kpsewhich" --show-path tex $kpse_toolchain`; chomp($texpaths);
-  my @filters = ();
+  my @filters  = ();
   foreach my $path (split(/$KPATHSEP/, $texpaths)) {
     $path =~ s/^!!//; $path =~ s|//+$|/|;
     push(@filters, $path) if -d $path; }

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -19,7 +19,6 @@ use base qw(Exporter);
 our @EXPORT = (qw(&latexml_ok &latexml_tests),
   qw(&process_domstring &process_xmlfile &is_strings),
   @Test::More::EXPORT);
-my $kpsewhich = which($ENV{LATEXML_KPSEWHICH} || 'kpsewhich');    # [CONFIGURATION]
 # Note that this is a singlet; the same Builder is shared.
 
 # Test the conversion of all *.tex files in the given directory (typically t/something)
@@ -81,7 +80,7 @@ sub check_requirements {
   foreach my $reqmts (@reqmts) {
     next unless defined $reqmts;
     foreach my $reqmt (!$reqmts ? () : (ref $reqmts ? @$reqmts : $reqmts)) {
-      if (($kpsewhich && (`"$kpsewhich" $reqmt`)) || (pathname_find($reqmt))) { }
+      if (pathname_kpsewhich($reqmt) || pathname_find($reqmt)) { }
       else {
         my $message = "Missing requirement $reqmt for $test";
         diag("Skip: $message");

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -130,7 +130,7 @@ sub postprocess_xmlfile {
   my $xmath = LaTeXML::Post::XMath->new();
   return do_fail($name, "Couldn't instanciate LaTeXML::Post::XMath") unless $xmath;
   $xmath->setParallel(LaTeXML::Post::MathML::Presentation->new());
-  my @procs = ($xmath);
+  my @procs       = ($xmath);
   my $latexmlpost = LaTeXML::Post->new(verbosity => -1);
   return do_fail($name, "Couldn't instanciate LaTeXML::Post:") unless $latexmlpost;
 
@@ -164,9 +164,9 @@ sub process_xmlfile {
 
 sub process_domstring {
   my ($domstring, $name, $compare_kind) = @_;
-  if ($compare_kind && $compare_kind eq 'words') { # words
+  if ($compare_kind && $compare_kind eq 'words') {    # words
     return [split(/\s+/, $domstring)]; }
-  else { # lines
+  else {                                              # lines
     return [split('\n', $domstring)]; } }
 
 # $strings1 is the currently generated material
@@ -174,7 +174,7 @@ sub process_domstring {
 sub is_strings {
   my ($strings1, $strings2, $name) = @_;
   my $max = $#$strings1 > $#$strings2 ? $#$strings1 : $#$strings2;
-  my $ok = 1;
+  my $ok  = 1;
   for (my $i = 0 ; $i <= $max ; $i++) {
     my $string1 = $$strings1[$i];
     my $string2 = $$strings2[$i];
@@ -213,7 +213,7 @@ sub daemon_ok {
   my $path_to_perl = $Config{perlpath};
 
   my $invocation = $path_to_perl . " " . join(" ", map { ("-I", $_) } @INC) . " " . $latexmlc . ' ';
-  my $timed = undef;
+  my $timed      = undef;
   foreach my $opt (@$opts) {
     if ($$opt[0] eq 'timeout') {    # Ensure .opt timeout takes precedence
       if ($timed) { next; } else { $timed = 1; }

--- a/t/81_babel.t
+++ b/t/81_babel.t
@@ -11,4 +11,7 @@ latexml_tests("t/babel",
 			 german=>'germanb.ldf',
 			 greek=>['greek.ldf','lgrenc.def'],
 			 french=>['frenchb.ldf','numprint.sty'],
-                         page545=>['germanb.ldf','frenchb.ldf']});
+                         page545=>['germanb.ldf','frenchb.ldf']},
+		# babel is a bit iffy between versions, especially in introducing/retracting line breaks in the language macros
+		# so compare it in a space-neutral manner
+		compare=>'words');

--- a/t/daemon/formats/citation.test.status
+++ b/t/daemon/formats/citation.test.status
@@ -1,0 +1,2 @@
+No obvious problems
+Wrote citation.test.xml

--- a/t/daemon/formats/citation.test.status
+++ b/t/daemon/formats/citation.test.status
@@ -1,2 +1,0 @@
-No obvious problems
-Wrote citation.test.xml


### PR DESCRIPTION
This was simpler than I thought. I copied the first [example appveyor build](http://blogs.perl.org/users/mauke/2017/10/automated-testing-on-windows-with-appveyor.html) online, and enabled appveyor on my fork, resulting in a working build:

https://ci.appveyor.com/project/dginev/latexml-hu4m2

I also added a nice visual badge to the README as an example. This only runs CI on a Windows installation without a MikTeX present, I am eagerly awaiting an opportunity to borrow the install steps for free from the [chocolatey-latexml](https://github.com/metanorma/chocolatey-latexml) bundle that inspired pushing this PR out today.