### PR TITLE
Add --inputencoding to latexmlmath

### DIFF
--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -40,6 +40,7 @@ my $cmml  = undef;
 my $om    = undef;
 my @paths = ('.');
 my @preload;
+my $inputencoding;
 GetOptions(
   # No provision for parallel output (yet)
   "mathimage=s"               => \$mathimage,
@@ -55,16 +56,17 @@ GetOptions(
 
   "noparse" => \$noparse,
 
-  "preload=s"     => \@preload,
-  "includestyles" => \$includestyles,
-  "path=s"        => \@paths,
-  "quiet"         => sub { $verbosity--; },
-  "verbose"       => sub { $verbosity++; },
-  "strict"        => \$strict,
-  "VERSION"       => \$showversion,
-  "debug=s"       => sub { no strict 'refs'; ${ 'LaTeXML::' . $_[1] . '::DEBUG' } = 1; },
-  "documentid=s"  => \$documentid,
-  "help"          => \$help,
+  "preload=s"       => \@preload,
+  "includestyles"   => \$includestyles,
+  "inputencoding=s" => \$inputencoding,
+  "path=s"          => \@paths,
+  "quiet"           => sub { $verbosity--; },
+  "verbose"         => sub { $verbosity++; },
+  "strict"          => \$strict,
+  "VERSION"         => \$showversion,
+  "debug=s"         => sub { no strict 'refs'; ${ 'LaTeXML::' . $_[1] . '::DEBUG' } = 1; },
+  "documentid=s"    => \$documentid,
+  "help"            => \$help,
 ) or pod2usage(-message => $LaTeXML::IDENTITY,
   -exitval => 1, -verbose => 0, -output => \*STDERR);
 pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 2, -output => \*STDOUT)
@@ -128,7 +130,9 @@ if (my @baddirs = grep { !-d $_ } @paths) {
 
 my $latexml = LaTeXML::Core->new(preload => ['LaTeX.pool', @preload], searchpaths => [@paths],
   verbosity => $verbosity, strict => $strict,
-  includecomments => 0, includestyles => $includestyles,
+  includecomments => 0,
+  includestyles   => $includestyles,
+  inputencoding   => $inputencoding,
   documentid      => $documentid,
   nomathparse     => $noparse);
 
@@ -319,6 +323,7 @@ latexmlmath [options] I<texmath>
  --documentid=id            assign an id to the document root.
  --debug=package            enables debugging output for the
                             named package
+ --inputencoding=enc specify the input encoding.
  --VERSION                  show version number and exit.
  --help                     shows this help message.
  --                         ends options
@@ -462,6 +467,16 @@ Can be useful for getting more details when errors occur.
 Specifies a strict processing mode. By default, undefined control sequences and
 invalid document constructs (that violate the DTD) give warning messages, but attempt
 to continue processing.  Using --strict makes them generate fatal errors.
+
+=item C<--inputencoding=>I<encoding>
+
+Specify the input encoding, eg. C<--inputencoding=iso-8859-1>.
+The encoding must be one known to Perl's Encode package.
+Note that this only enables the translation of the input bytes to
+UTF-8 used internally by LaTeXML, but does not affect catcodes.
+It is usually better to use LaTeX's inputenc package.
+Note that this does not affect the output encoding, which is
+always UTF-8.
 
 =item C<--VERSION>
 


### PR DESCRIPTION
Fixes #1111 

I simply copied the inputencoding handling from the `latexml` executable, and reformatted with `latexmllint`. 