### PR TITLE
Add math lexeme test

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -828,6 +828,9 @@ t/daemon/formats/citationraw.xml
 t/daemon/formats/jats.spec
 t/daemon/formats/jats.status
 t/daemon/formats/jats.xml
+t/daemon/formats/lexmath.spec
+t/daemon/formats/lexmath.status
+t/daemon/formats/lexmath.xml
 t/daemon/formats/makebib.spec
 t/daemon/formats/makebib.status
 t/daemon/formats/makebib.xml
@@ -852,6 +855,7 @@ t/daemon/formats/parallel-math-xmath.xml
 t/daemon/formats/tei.spec
 t/daemon/formats/tei.status
 t/daemon/formats/tei.xml
+t/daemon/lexmath.tex
 t/daemon/fragment.tex
 t/daemon/mixedmath.latexml
 t/daemon/mixedmath.tex

--- a/t/daemon/formats/lexmath.spec
+++ b/t/daemon/formats/lexmath.spec
@@ -1,0 +1,10 @@
+source = ../lexmath.tex
+preload = llamapun.sty
+preload = amsmath.sty
+preload = bm.sty
+whatsin = fragment
+whatsout = fragment
+pmml =
+mathlex =
+format = html5
+nodefaultresources =

--- a/t/daemon/formats/lexmath.status
+++ b/t/daemon/formats/lexmath.status
@@ -1,0 +1,2 @@
+No obvious problems
+Wrote lexmath.test.xml

--- a/t/daemon/formats/lexmath.xml
+++ b/t/daemon/formats/lexmath.xml
@@ -1,0 +1,5 @@
+<article class="ltx_document">
+<div id="p1" class="ltx_para">
+<p class="ltx_p">For vector-valued variables, we would write the random variable as <math id="p1.m1" class="ltx_Math" alttext="\bm{\mathrm{x}}" display="inline"><semantics><mi>𝐱</mi><annotation encoding="application/x-llamapun">bold-x</annotation></semantics></math> and one of its values as <math id="p1.m2" class="ltx_Math" alttext="\bm{x}" display="inline"><semantics><mi>𝒙</mi><annotation encoding="application/x-llamapun">bold-italic-x</annotation></semantics></math>.</p>
+</div>
+</article>

--- a/t/daemon/lexmath.tex
+++ b/t/daemon/lexmath.tex
@@ -1,0 +1,2 @@
+For vector-valued variables, we would write the random variable as $\bm{\mathrm{x}}$ and one of its values as $\bm{x}$.
+% Source: Deep Learning, p.54, https://www.deeplearningbook.org/contents/prob.html


### PR DESCRIPTION
PR is ready for review and merge.

I found a pretty good example in a DL textbook I am reading for a semantic difference for a bold-x (a vector-valued random variable) and a bold-italic-x -- one of the individual values of bold-x.

So I decided to turn that into a test, also so that we exercise the option and avoid regressions.

That led me back into one of my most frustrating bits of programming, at the end of the convert call in LaTeXML.pm, where serializing into a UTF-8 marked string becomes an outright ordeal. I reread `XML::LibXML` carefully, and left detailed notes on my updated understanding of the circumstances. I think the code is now extra-robust, but I really dislike the design of the serialization in `XML::LibXML`. Not only are the defaults inconsistent between classes (Document doesn't encode, Node does), but they are also inconsistent between platform installations. If the `HAVE_UTF8` compile flag is used as false, the default behavior of Node's `toString` method *flips* to using byte strings. Which makes latexml's output unpredictable, if we use Node's `toString` anywhere. There is an explicit escape hatch, where we request to encode using the document's encoding, which is what I refactored into. Which lead to all tests passing without the "wide character" warnings, which lead me here in the first place.

So hopefully this PR provides both a useful test, and some useful cleanup on the serialization for the latexmlc-near API.