### PR TITLE
Default inputencoding (utf-8)

### DIFF
--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -67,7 +67,7 @@ sub getopt_specification {
     "mode=s"      => \$$opts{profile},
     "source=s"    => \$$opts{source},
     # Output framing
-    "embed"      => sub { $$opts{whatsout} = 'fragment'; },
+    "embed" => sub { $$opts{whatsout} = 'fragment'; },
     "whatsin=s"  => \$$opts{whatsin},
     "whatsout=s" => \$$opts{whatsout},
     # Daemon options
@@ -186,12 +186,12 @@ sub read {
   my $getOptions_success = GetOptions(%{$spec});
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   if (!$silent && $$opts{help}) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', output => \*STDOUT);
   }
 
@@ -237,7 +237,7 @@ sub scan_to_keyvals {
   my $getOptions_success = GetOptions(%$spec);
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   CORE::push @$keyvals, ['source', $ARGV[0]] if $ARGV[0];
@@ -375,6 +375,7 @@ sub _prepare_options {
   $$opts{timeout}     = 600          unless defined $$opts{timeout};       # 10 minute timeout default
   $$opts{expire}      = 600          unless defined $$opts{expire};        # 10 minute timeout default
   $$opts{mathparse}   = 'RecDescent' unless defined $$opts{mathparse};
+  $$opts{inputencoding} = "utf-8" unless defined $$opts{inputencoding};
   if ($$opts{mathparse} eq 'no') {
     $$opts{mathparse}   = 0;
     $$opts{nomathparse} = 1; }                                             #Backwards compatible

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -67,7 +67,7 @@ sub getopt_specification {
     "mode=s"      => \$$opts{profile},
     "source=s"    => \$$opts{source},
     # Output framing
-    "embed" => sub { $$opts{whatsout} = 'fragment'; },
+    "embed"      => sub { $$opts{whatsout} = 'fragment'; },
     "whatsin=s"  => \$$opts{whatsin},
     "whatsout=s" => \$$opts{whatsout},
     # Daemon options
@@ -118,7 +118,7 @@ sub getopt_specification {
     "javascript=s"      => \@{ $$opts{javascript} },
     "icon=s"            => \$$opts{icon},
     # Options for broader document set processing
-    "split!" => \$$opts{split},
+    "split!"    => \$$opts{split},
     "splitat=s" => sub { $$opts{splitat} = $_[1];
       $$opts{split} = 1 unless defined $$opts{split}; },
     "splitpath=s" => sub { $$opts{splitpath} = $_[1];
@@ -158,15 +158,15 @@ sub getopt_specification {
   };
   return ($spec, $opts) unless ($options{type} && ($options{type} eq 'keyvals'));
   # Representation use case:
-  my $keyvals = $options{keyvals} || [];
-  my $rep_spec = {};    # Representation specification
+  my $keyvals  = $options{keyvals} || [];
+  my $rep_spec = {};                        # Representation specification
   foreach my $key (keys %$spec) {
     if ($key =~ /^(.+)=\w$/) {
       my $name = $1;
       $$rep_spec{$key} = sub { CORE::push @$keyvals, [$name, $_[1]] };
     } else {
       $$rep_spec{$key} = sub {
-        my $ctl = $_[0]->{ctl};
+        my $ctl  = $_[0]->{ctl};
         my $used = ($$ctl[0] ? 'no' : '') . $$ctl[1];
         CORE::push @$keyvals, [$used, undef] };
     }
@@ -182,16 +182,16 @@ sub read {
   my $opts = $$self{opts};
   local @ARGV = @$argref;
   my ($spec) = getopt_specification(options => $opts);
-  my $silent = %read_options && $read_options{silent};
+  my $silent             = %read_options && $read_options{silent};
   my $getOptions_success = GetOptions(%{$spec});
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   if (!$silent && $$opts{help}) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', output => \*STDOUT);
   }
 
@@ -233,11 +233,11 @@ sub scan_to_keyvals {
   my ($self, $argref, %read_options) = @_;
   local @ARGV = @$argref;
   my ($spec, $keyvals) = getopt_specification(type => 'keyvals');
-  my $silent = %read_options && $read_options{silent};
+  my $silent             = %read_options && $read_options{silent};
   my $getOptions_success = GetOptions(%$spec);
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   CORE::push @$keyvals, ['source', $ARGV[0]] if $ARGV[0];
@@ -308,7 +308,7 @@ sub check {
 sub _obey_profile {
   my ($self) = @_;
   $$self{dirty} = 1;
-  my $opts = $$self{opts};
+  my $opts    = $$self{opts};
   my $profile = lc($$opts{profile} || 'custom');
   $profile =~ s/\.opt$//;
   # Look at the PROFILES_DB or find a profiles file (otherwise fallback to custom)
@@ -561,7 +561,7 @@ sub _prepare_options {
   }
   # If really nothing hints to define format, then default it to XML
   $$opts{format} = 'xml' unless defined $$opts{format};
-  $$self{dirty} = 0;
+  $$self{dirty}  = 0;
   return; }
 
 ## Utilities:

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -52,7 +52,10 @@ sub new {
   $state->assignValue(GRAPHICSPATHS => [map { pathname_absolute(pathname_canonical($_)) }
         @{ $options{graphicspaths} || [] }], 'global');
   $state->assignValue(INCLUDE_STYLES => $options{includestyles} || 0, 'global');
-  $state->assignValue(PERL_INPUT_ENCODING => $options{inputencoding}) if $options{inputencoding};
+  # Core has to ensure a default input encoding, and we default towards modern utf-8 documents
+  # This can be removed when all executables rely on LaTeXML::Common::Config
+  $options{inputencoding} = "utf-8" unless $options{inputencoding};
+  $state->assignValue(PERL_INPUT_ENCODING => $options{inputencoding});
   $state->assignValue(NOMATHPARSE => $options{nomathparse} || 0, 'global');
   return bless { state => $state,
     nomathparse => $options{nomathparse} || 0,

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -37,7 +37,7 @@ sub new {
   my ($class, %options) = @_;
   my $state = LaTeXML::Core::State->new(catcodes => 'standard',
     stomach => LaTeXML::Core::Stomach->new(),
-    model => $options{model} || LaTeXML::Common::Model->new());
+    model   => $options{model} || LaTeXML::Common::Model->new());
   $state->assignValue(VERBOSITY => (defined $options{verbosity} ? $options{verbosity} : 0),
     'global');
   $state->assignValue(STRICT => (defined $options{strict} ? $options{strict} : 0),
@@ -56,10 +56,10 @@ sub new {
   # This can be removed when all executables rely on LaTeXML::Common::Config
   $options{inputencoding} = "utf-8" unless $options{inputencoding};
   $state->assignValue(PERL_INPUT_ENCODING => $options{inputencoding});
-  $state->assignValue(NOMATHPARSE => $options{nomathparse} || 0, 'global');
+  $state->assignValue(NOMATHPARSE         => $options{nomathparse} || 0, 'global');
   return bless { state => $state,
     nomathparse => $options{nomathparse} || 0,
-    preload => $options{preload},
+    preload     => $options{preload},
   }, $class; }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -111,10 +111,10 @@ sub digestFile {
   my ($dir, $name, $ext);
   my $mode = $options{mode} || 'TeX';
   if (pathname_is_literaldata($request)) {
-    $dir = undef; $ext = $MODE_EXTENSION{$mode};
+    $dir  = undef; $ext = $MODE_EXTENSION{$mode};
     $name = "Anonymous String"; }
   elsif (pathname_is_url($request)) {
-    $dir = undef; $ext = $MODE_EXTENSION{$mode};
+    $dir  = undef; $ext = $MODE_EXTENSION{$mode};
     $name = $request;
   }
   else {

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -341,7 +341,7 @@ sub readRawLine {
     $line = $self->getNextLine;
     if (!defined $line) {
       $$self{at_eof} = 1;
-      $$self{chars} = []; $$self{nchars} = 0; $$self{colno} = 0; }
+      $$self{chars}  = []; $$self{nchars} = 0; $$self{colno} = 0; }
     else {
       $$self{lineno}++;
       $$self{chars}  = splitChars($line);


### PR DESCRIPTION
Foundation for #1116 

A big part of the fragility and double-encoding in the various unicode tests one can try with the executables comes from there being *no* default input encoding in play. That implies that latexml treats any input as a perl byte string and an author of a TeX document unfamiliar with Perl finds the behavior hard to predict.

From a usability standpoint, it seems more direct that when we say "latexml is unicode native" we also imply a default input encoding of UTF-8. This PR changes that, and all tests continue to pass without need for extra intervention (luckily the ascii origins are invariant to unicode decoding).

I also have ensured that string mouths also use the inputencoding logic, as so far we only employed it for file mouths.

This PR can be followed up with my partial restructuring on the output side at #1114 . 

I think enforcing a default input encoding allows for additional predictability for a lay user. For advanced use cases (such as arXiv), the latexml build systems already set their own input encoding 
(`--inputencoding='iso-8859-1'`). Additionally, web service uses of latexml have worked seamlessly so far, as the frontend code prepared correctly decoded utf-8 strings which were passed through the
 `LaTeXML::convert` API, and hence avoid the command-line underspecification of #1116 .

Happy to discuss further, but it feels like an elegant way of reducing the encoding complexity.