### PR TITLE
more rules for SKIP

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -16,6 +16,8 @@
 \.log$
 \.tdy$
 \.test.status$
+\.test\.xml$
 \.fls$
 \.synctex\.gz$
 \.fdb_latexmk$
+^931_test(\w+)\.epub$


### PR DESCRIPTION
A few quick rules that get the most recent daemon tests to pass without complaints -- the failures only become visible if you run `make test` on a multi-threaded setup.

 I run 32 tests in parallel so a lot of the temporary files are visible when the manifest check is run.