### PR TITLE
Only run manifest test in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ before_install:
 
 # Run the docker test image
 script:
-  - docker run --rm -v $(pwd):/root/latexml -t -i latexml/latexml-test-runtime:${PERL}_$TEX
+  - docker run --env "CI=true" --rm -v $(pwd):/root/latexml -t -i latexml/latexml-test-runtime:${PERL}_$TEX

--- a/t/97_manifest.t
+++ b/t/97_manifest.t
@@ -1,9 +1,14 @@
 use ExtUtils::Manifest qw(fullcheck);
 use Test::More;
 
-my($missing, $extra) = fullcheck();
+if ($ENV{"CI"}) {
+  plan tests => 2;
+  my($missing, $extra) = fullcheck();
 
-ok(!@$missing, "MANIFEST contains outdated files: \n\t".join("\n\t", @$missing));
-ok(!@$extra, "Files missing from MANIFEST: \n\t".join("\n\t", @$extra));
+  ok(!@$missing, "MANIFEST contains outdated files: \n\t".join("\n\t", @$missing));
+  ok(!@$extra, "Files missing from MANIFEST: \n\t".join("\n\t", @$extra));
+} else {
+  plan skip_all => "Only checked in continuous integration.";
+}
 
- done_testing();
+done_testing();

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -8,6 +8,7 @@ use warnings;
 use strict;
 use File::Spec::Functions qw(catfile splitpath splitdir);
 use File::Temp qw(tempdir);
+use ExtUtils::Manifest qw(fullcheck);
 use Term::ANSIColor;
 
 my $changes = `git status --porcelain`;
@@ -34,7 +35,7 @@ if (my @modified_files =
     system("git show ':$modified_file' > $temp_file");
     # Finally run latexmllint on it.
     my $status = system(catfile('tools', 'latexmllint'), "--precommit", $temp_file);
-    my $code = $status >> 8;
+    my $code   = $status >> 8;
     if ($code) {
       push(@failed_files, $modified_file);    # Note the original file name
       $exit_code = $code; } }
@@ -43,15 +44,10 @@ if (my @modified_files =
       . "; To correct these, run:\n tools/latexmllint <files>.\n"; }
 
   # Also, Check if files are missing from the manifest
-  my %manifest = ();
-  open(my $fh, "<", "MANIFEST") or die "Missing MANIFEST file?\n";
-  while (<$fh>) {
-    next if /^[#]/;
-    chomp;
-    $manifest{$_} = 1; }
-  close($fh);
+  my ($manifest_missing, $manifest_extra) = fullcheck();
   # Not in MANIFEST, (or in tools)
-  my @missing_files = grep { !($_ =~ /^tools|MANIFEST/ || $manifest{$_}) } @modified_files;
+  my %manifest_missing = map  { $_ => 1 } @$manifest_missing;
+  my @missing_files    = grep { $manifest_missing{$_} } @modified_files;
   if (@missing_files) {
     print STDERR "Some files are missing from MANIFEST, please add them: \n\t"
       . join(',\n\t', @missing_files) . ";\n";


### PR DESCRIPTION
Main need for the manifest test is so that Travis/Appveyor informs us about any inconsistent pull requests. For main developer flow, we have a pre-commit hook which suffices.

Here are two example runs with this changeset:
```
$ make test
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/97_manifest.t ........ skipped: Only checked in continuous integration.

$ CI=true make test
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/97_manifest.t ........ ok                                             
```