### PR TITLE
Freshen up: tools/maketest for spec tests

### DIFF
--- a/tools/maketests
+++ b/tools/maketests
@@ -102,7 +102,7 @@ sub maketest_daemon {
   my ($source) = @_;
   $source .= ".spec" unless $source =~ /\.spec$/;
   my ($dir, $name, $ext) = pathname_split($source);
-  my $cwd = pathname_cwd();
+  my $cwd  = pathname_cwd();
   my $opts = read_options($source, "$dir/$name");
   push @$opts, (['destination', "$name.test.xml"],
     ['log',                "/dev/null"],
@@ -114,7 +114,7 @@ sub maketest_daemon {
     ['nocomments',         '']);
 
   my $invocation = catfile($FindBin::Bin, '..', 'blib', 'script', 'latexmlc') . ' ';
-  my $timed = undef;
+  my $timed      = undef;
   foreach my $opt (@$opts) {
     if ($$opt[0] eq 'timeout') {    # Ensure .opt timeout takes precedence
       if ($timed) { next; } else { $timed = 1; }
@@ -129,18 +129,23 @@ sub maketest_daemon {
     die "Failed to execute '$invocation': $!"; }
   if ($docompare) {
     my $ndiffs = 0;
-    print "\n" . ("=" x 40) . "\nCompare Expected $dir/$name to current output XML:\n";
+    print STDERR "\n" . ("=" x 40) . "\nCompare Expected $dir/$name to current output XML:\n";
     $ndiffs += compareLines(readXML("$name.xml"), readXML("$name.test.xml"));
-    print "\n" . ("=" x 40) . "\nCompare Expected Status $dir/$name to current status:\n";
+    print STDERR "\n" . ("=" x 40) . "\nCompare Expected Status $dir/$name to current status:\n";
     $ndiffs += compareLines(readText("$name.status"), readText("$name.test.status"));
     unlink "$name.test.xml"    if -e "$name.test.xml";
     unlink "$name.test.status" if -e "$name.test.status";
-    print "" . ("=" x 40) . "\n\n";
+    print STDERR "" . ("=" x 40) . "\n\n";
     ($ndiffs ? push(@FAIL, $name) : push(@PASS, $name)); }
-  elsif ($doxml) {
-    print "\n" . ("=" x 40) . "\nReplacing $dir/$name.xml and status.\n";
-    move("$name.test.xml",    "$name.xml")    if -e "$name.test.xml";
-    move("$name.test.status", "$name.status") if -e "$name.test.status"; }
+  else {
+    if (!defined $doxml) {
+      my $src_time = pathname_timestamp($source);
+      my $xml_time = pathname_timestamp("$name.xml");
+      $doxml = !(-f "$name.xml") || ($src_time > $xml_time); }
+    if ($doxml) {
+      print STDERR "\n" . ("=" x 40) . "\nReplacing $dir/$name.xml and status.\n";
+      move("$name.test.xml",    "$name.xml")    if -e "$name.test.xml";
+      move("$name.test.status", "$name.status") if -e "$name.test.status"; } }
   pathname_chdir($cwd);
   return; }
 
@@ -175,15 +180,15 @@ sub compare_xml {
 
   #========================================
   # Do the comparison
-  print "\n" . ("=" x 40) . "\nCompare Expected $dir/$name to current output XML:\n";
+  print STDERR "\n" . ("=" x 40) . "\nCompare Expected $dir/$name to current output XML:\n";
   my $result = compareLines(readXML($xml), readXML($test));
-  print "" . ("=" x 40) . "\n\n";
+  print STDERR "" . ("=" x 40) . "\n\n";
   unlink $test if -e $test;
   return $result; }
 
 sub compareLines {
   my ($oldlines, $newlines) = @_;
-  my $diff = Algorithm::Diff->new($oldlines, $newlines);
+  my $diff   = Algorithm::Diff->new($oldlines, $newlines);
   my $ndiffs = 0;
   while ($diff->Next()) {
     next if $diff->Same();


### PR DESCRIPTION
I was advertising the `tools/maketest` utility script today [here](https://github.com/MathWebSearch/LaTeXML-Plugin-MathWebSearch/pull/7) and realized it is missing a piece of default logic that makes it useful with the simplest invocation.

 Just matching the `doxml` default logic in the regular testing path actually.

So that:
```
perl tools/maketests t/daemon/profiles/fragment.spec
```
automatically creates the .xml file when it is missing or stale.