### PR TITLE
Robust NCNames in LaTeX counter-based xml:ids

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -702,6 +702,11 @@ sub RefStepCounter {
   my $scope = $ctr . ':' . ToString($refnum);
   AssignValue('scopes_for_counter:' . $ctr => [$scope], 'local');
   $STATE->activateScope($scope);
+  # Demanding a *valid* NCNAME sanitation here. At the very minimum, leading dots are unexpected errors
+  # and need to be softened with a leading 0
+  if ($id =~ /^\./) {
+    $id = "0$id";
+  }
   return (
     ($tags   ? (tags => $tags) : ()),
     ($has_id ? (id   => $id)   : ())); }
@@ -725,7 +730,11 @@ sub RefStepID {
     Tokens(T_OTHER('x'), Explode(LookupValue('\c@' . $unctr)->valueOf)),
     scope => 'global');
   DefMacroI(T_CS('\@currentID'), undef, T_CS("\\the$ctr\@ID"));
-  return (id => ToString(DigestLiteral(T_CS("\\the$ctr\@ID")))); }
+  my $id = ToString(DigestLiteral(T_CS("\\the$ctr\@ID")));
+  if ($id =~ /^\./) {
+    $id = "0$id";
+  }
+  return (id => $id) }
 
 sub ResetCounter {
   my ($ctr) = @_;


### PR DESCRIPTION
So it turns out TeX can get away with doing nasty hacks related to "namespacing" stepped counters, while latexml can't, mostly due to the requirement for xml:ids to be NCNames.

I traced down an example of this class of issues from the arXiv reports, a good paper being: https://arxiv.org/abs/1103.4198

which was dying with a Fatal when cross-referencing an equation, as its id was not valid for the XML parser. This is otherwise a very well-converting warning-level (math parsing) document, which really shouldn't have to suffer a Fatal.

The offending line of TeX that lead to all the drama was:
```tex
%                TO NUMBER EQUATIONS BY SECTION
%
\makeatletter \@addtoreset{equation}{chapter} \makeatother
```

Which, when used in this `\documentclass{article}` document, implied the leading prefix to the equation xml:ids was going to be missing - there are no chapters in the document. This is - I believe - the exact internal behavior in latex, but latex doesn't have the NCName constraint, and also likely doesn't use the information in a similar manner.

After spending most of the time diagnozing, I am offering a simple patch - which could be improved with a more high-level robustness NCName strategy - which gets this document to convert without issue. Should get us some fractions of a percept up in the arXiv conversion?