### PR TITLE
\fmtversion and empty mouthstack fallback

### DIFF
--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -79,8 +79,8 @@ sub mouthIsOpen {
 # Corresponds (I think) to TeX's \endinput
 sub flushMouth {
   my ($self) = @_;
-  $$self{mouth}->finish;;    # but not close!
-  $$self{pushback}  = [];    # And don't read anytyhing more from it.
+  $$self{mouth}->finish;    # but not close!
+  $$self{pushback}  = [];   # And don't read anytyhing more from it.
   $$self{autoclose} = 1;
   return; }
 
@@ -117,7 +117,7 @@ sub readingFromMouth {
       $self->closeMouth(1); last; }
     elsif (!@{ $$self{mouthstack} }) {
       Error('unexpected', '<closed>', $self, "Mouth is unexpectedly already closed",
-        "Reading from " . Stringify($mouth) . ", but it has already been closed."); }
+        "Reading from " . Stringify($mouth) . ", but it has already been closed."); last; }
     elsif (!$$self{autoclose} || @{ $$self{pushback} } || $$self{mouth}->hasMoreInput) {
       my $next = Stringify($self->readToken);
       Error('unexpected', $next, $self, "Unexpected input remaining: '$next'",
@@ -1011,4 +1011,3 @@ Public domain software, produced as part of work done by the
 United States Government & not subject to copyright in the US.
 
 =cut
-

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -395,7 +395,7 @@ DefConstructorI(T_CS('\end{document}'), undef, sub {
 DefConstructorI('\LaTeX',  undef, 'LaTeX');
 DefConstructorI('\LaTeXe', undef, 'LaTeX2e');
 DefMacroI('\fmtname',    undef, 'LaTeX2e');
-DefMacroI('\fmtversion', undef, 'XXXX/XX/XX');
+DefMacroI('\fmtversion', undef, '2018/12/01');
 
 DefMacroI('\today', undef, sub { ExplodeText(today()); });
 


### PR DESCRIPTION
I was checking the too_many_fatals page, as it has been a long while since I looked at it, and the first entry already showed two patch opportunities that upgraded the task to a usable "error" status:
https://corpora.mathweb.org/corpus/arxiv_testbench/tex_to_html/fatal/too_many_errors/100?all=false

1. `\fmtversion` is apparently parsed at times, so it should really contain a real date to make the parse succeed. I used the date in my local `latex.ltx` file.

2. Curiously, when a `mouthstack` is empty during Gullet's `readingFromMouth`, it currently loops indefinitely, firing an error on each step and hence always Fatal-ing with "100 errors reached". So I just added a `last;` escape hatch, which lets the conversion continue and recovers at least part of the document. In the document I am testing on, all of the content actually appears in the final document, so I assume it may have been a macro termination/argument error due to missing definitions.

I'll check a couple more files, will file separate PRs if I spot easy fixes.