### PR TITLE
Allow pre-comma spaces in package option lists

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -52,7 +52,7 @@ DefConstructor('\documentclass OptionalSemiverbatim SkipSpaces Semiverbatim []',
     my ($stomach, $whatsit) = @_;
     my $options = $whatsit->getArg(1);
     LoadClass(ToString($whatsit->getArg(2)),
-      options => [($options ? split(/,\s*/, ToString($options)) : ())],
+      options => [($options ? split(/\s*,\s*/, ToString($options)) : ())],
       after   => Tokens(T_CS('\AtBeginDocument'), T_CS('\warn@unusedclassoptions')));
     return; });
 
@@ -73,7 +73,7 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
     my ($stomach, $whatsit) = @_;
     my $class   = ToString($whatsit->getArg(2));
     my $options = $whatsit->getArg(1);
-    $options = [($options ? split(/,\s*/, ToString($options)) : ())];
+    $options = [($options ? split(/\s*,\s*/, ToString($options)) : ())];
     # Watch out; In principle, compatibility mode wants a .sty, not a .cls!!!
     # But, we'd prefer .cls, since we'll have better bindings.
     # And in fact, nobody's likely to write a binding for a .sty that wants to be a class anyway.
@@ -722,8 +722,8 @@ DefConstructor('\usepackage OptionalSemiverbatim Semiverbatim []',
   afterDigest => sub { my ($stomach, $whatsit) = @_;
     my $options  = $whatsit->getArg(1);
     my $packages = $whatsit->getArg(2);
-    my @pkgs     = grep { $_ } grep { !/^\s*%/ } split(/,\s*/, ToString($packages));
-    $options = [($options ? split(/,\s*/, (ToString($options))) : ())];
+    my @pkgs     = grep { $_ } grep { !/^\s*%/ } split(/\s*,\s*/, ToString($packages));
+    $options = [($options ? split(/\s*,\s*/, (ToString($options))) : ())];
     map { RequirePackage($_, options => $options) } @pkgs;
     return });
 
@@ -733,8 +733,8 @@ DefConstructor('\RequirePackage OptionalSemiverbatim Semiverbatim []',
   afterDigest => sub { my ($stomach, $whatsit) = @_;
     my $options  = $whatsit->getArg(1);
     my $packages = $whatsit->getArg(2);
-    my @pkgs     = grep { $_ } grep { !/^\s*%/ } split(/,\s*/, ToString($packages));
-    $options = [($options ? split(/,\s*/, (ToString($options))) : ())];
+    my @pkgs     = grep { $_ } grep { !/^\s*%/ } split(/\s*,\s*/, ToString($packages));
+    $options = [($options ? split(/\s*,\s*/, (ToString($options))) : ())];
     map { RequirePackage($_, options => $options) } @pkgs;
     return });
 
@@ -744,7 +744,7 @@ DefConstructor('\LoadClass OptionalSemiverbatim Semiverbatim []',
   afterDigest => sub { my ($stomach, $whatsit) = @_;
     my $options = $whatsit->getArg(1);
     my $class   = $whatsit->getArg(2);
-    $options = [($options ? split(/,\s*/, (ToString($options))) : ())];
+    $options = [($options ? split(/\s*,\s*/, (ToString($options))) : ())];
     LoadClass(ToString($class), options => $options);
     return; });
 
@@ -776,11 +776,11 @@ DefPrimitive('\DeclareOption{}{}', sub {
 
 DefPrimitive('\PassOptionsToPackage{}{}', sub {
     my ($stomach, $name, $options) = @_;
-    PassOptions($name, 'sty', split(/,\s*/, ToString(Expand($options)))); });
+    PassOptions($name, 'sty', split(/\s*,\s*/, ToString(Expand($options)))); });
 
 DefPrimitive('\PassOptionsToClass{}{}', sub {
     my ($stomach, $name, $options) = @_;
-    PassOptions($name, 'cls', split(/,\s*/, ToString(Expand($options)))); });
+    PassOptions($name, 'cls', split(/\s*,\s*/, ToString(Expand($options)))); });
 
 DefConstructor('\RequirePackageWithOptions Semiverbatim []',
   "<?latexml package='#1'?>",
@@ -816,7 +816,7 @@ DefPrimitiveI('\@unknownoptionerror', undef, sub {
 
 DefPrimitive('\ExecuteOptions{}', sub {
     my ($gullet, $options) = @_;
-    ExecuteOptions(split(/,\s*/, ToString(Expand($options)))); });
+    ExecuteOptions(split(/\s*,\s*/, ToString(Expand($options)))); });
 
 DefPrimitive('\ProcessOptions OptionalMatch:*', sub {
     my ($stomach, $star) = @_;


### PR DESCRIPTION
This was a satisfying fix, as it may be responsible for a range of hard-to-trace Fatal errors in arXiv. It may also be a very rare error, as it is a subtle edge case in splitting out the package options, combined with advanced option logic for revtex4.

A rather innocent looking minimal tex snippet is:
```tex
\documentclass[twocolumn,superscriptaddress,showpacs,preprintnumbers,amsmath
,amssymb,aps,prd]{revtex4}
\begin{document}
minimal
\end{document}
```

As it turns out, the master branch of latexml splits by `,\s*`, hence obtaining the `amsmath\n` name and failing to load amsmath, which it kindly told me via:
```
Info:unexpected:options Unused global options: amsmath
	at paper.tex; line 62 col 0 - line 62 col 16
```

In the example I was looking at, that in turn was followed by an error:
```
Error:undefined:{align} The environment {align} is not defined.
```

then followed by 100 alignment errors, and thus a Fatal. Once the regex was fixed and amsmath got loaded correctly again, `{align}` was available and the conversion succeeded (with 1 minor error).