### PR TITLE
revtex4 option of emulateapj and aastex should load the binding

### DIFF
--- a/lib/LaTeXML/Package/aastex.cls.ltxml
+++ b/lib/LaTeXML/Package/aastex.cls.ltxml
@@ -32,6 +32,9 @@ foreach my $option (qw(10pt 11pt 12pt
 # Number equations within sections
 DeclareOption('eqsecnum', sub { Digest(Tokenize('\AtEndOfClass{\eqsecnum}')); });
 
+# revtex4 option from emulateapj.cls loads revtex4.cls
+DeclareOption('revtex4', sub { LoadClass('revtex4'); return; });
+
 DeclareOption(undef, sub {
     PassOptions('article', 'cls', ToString(Expand(T_CS('\CurrentOption')))); });
 


### PR DESCRIPTION
Another quick fix turning a Fatal into a warning (100 alignment errors again). Example was:
```tex
\documentclass[iop,revtex4]{emulateapj}
```

which (in pdflatex) lead to loading revtex4.cls , then longtable.sty, which defined `{longtable*}` which is where the 100 alignment errors were being triggered. Simply adding the loading behavior to the binding allowed for an error-free conversion run with a beautiful output, quite neat.