### PR TITLE
Localized search for `.bib` paths

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1731,7 +1731,7 @@ sub pathname_is_raw {
   return ($pathname =~ /\.(tex|pool|sty|cls|clo|cnf|cfg|ldf|def|dfu)$/); }
 
 my $findfile_options = {    # [CONSTANT]
-  type => 1, notex => 1, noltxml => 1, nokpsewhich => 1 };
+  type => 1, notex => 1, noltxml => 1 };
 
 sub FindFile {
   my ($file, %options) = @_;
@@ -1795,18 +1795,10 @@ sub FindFile_aux {
         # Do we need to sanitize these environment variables?
   my @candidates = (((!$options{noltxml} && !$nopaths) ? ("$file.ltxml") : ()),
     (!$options{notex} ? ($file) : ()));
-  if ($options{nokpsewhich}) {    # don't search into the installed TeX toolchain
-    my @custom_tex_paths = split($Config::Config{'path_sep'}, $ENV{TEXINPUTS} || '');
-    if ($options{type} eq 'bib') {
-      push @custom_tex_paths, split($Config::Config{'path_sep'}, $ENV{BIBINPUTS} || ''); }
-    if (@custom_tex_paths) {
-      if (my $result = pathname_find($candidates[0], paths => \@custom_tex_paths)) {
-        return (-f $result ? $result : undef); } } }
-  else {
-    local $ENV{TEXINPUTS} = join($Config::Config{'path_sep'},
-      @$paths, $ENV{TEXINPUTS} || $Config::Config{'path_sep'});
-    if (my $result = pathname_kpsewhich(@candidates)) {
-      return (-f $result ? $result : undef); } }
+  local $ENV{TEXINPUTS} = join($Config::Config{'path_sep'},
+    @$paths, $ENV{TEXINPUTS} || $Config::Config{'path_sep'});
+  if (my $result = pathname_kpsewhich(@candidates)) {
+    return (-f $result ? $result : undef); }
   if ($urlbase && ($path = url_find($file, urlbase => $urlbase))) {
     return $path; }
   return; }

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1731,7 +1731,7 @@ sub pathname_is_raw {
   return ($pathname =~ /\.(tex|pool|sty|cls|clo|cnf|cfg|ldf|def|dfu)$/); }
 
 my $findfile_options = {    # [CONSTANT]
-  type => 1, notex => 1, noltxml => 1 };
+  type => 1, notex => 1, noltxml => 1, nokpsewhich => 1 };
 
 sub FindFile {
   my ($file, %options) = @_;
@@ -1793,12 +1793,20 @@ sub FindFile_aux {
   # The main point, though, is to we make only ONE (more) call.
   return if grep { pathname_is_nasty($_) } @$paths;    # SECURITY! No nasty paths in cmdline
         # Do we need to sanitize these environment variables?
-  local $ENV{TEXINPUTS} = join($Config::Config{'path_sep'},
-    @$paths, $ENV{TEXINPUTS} || $Config::Config{'path_sep'});
   my @candidates = (((!$options{noltxml} && !$nopaths) ? ("$file.ltxml") : ()),
     (!$options{notex} ? ($file) : ()));
-  if (my $result = pathname_kpsewhich(@candidates)) {
-    return (-f $result ? $result : undef); }
+  if ($options{nokpsewhich}) {    # don't search into the installed TeX toolchain
+    my @custom_tex_paths = split($Config::Config{'path_sep'}, $ENV{TEXINPUTS} || '');
+    if ($options{type} eq 'bib') {
+      push @custom_tex_paths, split($Config::Config{'path_sep'}, $ENV{BIBINPUTS} || ''); }
+    if (@custom_tex_paths) {
+      if (my $result = pathname_find($candidates[0], paths => \@custom_tex_paths)) {
+        return (-f $result ? $result : undef); } } }
+  else {
+    local $ENV{TEXINPUTS} = join($Config::Config{'path_sep'},
+      @$paths, $ENV{TEXINPUTS} || $Config::Config{'path_sep'});
+    if (my $result = pathname_kpsewhich(@candidates)) {
+      return (-f $result ? $result : undef); } }
   if ($urlbase && ($path = url_find($file, urlbase => $urlbase))) {
     return $path; }
   return; }

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3411,17 +3411,20 @@ DefMacro('\lx@ifusebbl{}{}{}', sub {
 
     my $bbl_path     = FindFile($jobname, type => 'bbl');
     my $missing_bibs = '';
-    for my $bf (split(',', $bib_files)) {
-      my $bib_path = FindFile($bf, type => 'bib', nokpsewhich => 1);
-      if (not $bib_path) {
-        $missing_bibs .= ',' unless length($missing_bibs) == 0;
-        $missing_bibs .= $bf; } }
-
-    if (length($missing_bibs) == 0 or not $bbl_path) {
-      return $bib_clause->unlist; }
+    if (LookupValue("NO_BIBTEX")) {
+      Info('expected', "bbl", $_[0], "Couldn't find bbl file, bibliography may be empty.") if not $bbl_path;
+      return $bbl_clause->unlist; }
     else {
-      Info('expected', $missing_bibs, $_[0], "Couldn't find all bib files, using " . $jobname . ".bbl instead");
-      return $bbl_clause->unlist; } });
+      for my $bf (split(',', $bib_files)) {
+        my $bib_path = FindFile($bf, type => 'bib');
+        if (not $bib_path) {
+          $missing_bibs .= ',' unless length($missing_bibs) == 0;
+          $missing_bibs .= $bf; } }
+      if (length($missing_bibs) == 0 or not $bbl_path) {
+        return $bib_clause->unlist; }
+      else {
+        Info('expected', $missing_bibs, $_[0], "Couldn't find all bib files, using " . $jobname . ".bbl instead");
+        return $bbl_clause->unlist; } } });
 
 AssignMapping('BACKMATTER_ELEMENT', 'ltx:bibliography' => 'ltx:section');
 AssignMapping('BACKMATTER_ELEMENT', 'ltx:index'        => 'ltx:section');

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3412,7 +3412,7 @@ DefMacro('\lx@ifusebbl{}{}{}', sub {
     my $bbl_path     = FindFile($jobname, type => 'bbl');
     my $missing_bibs = '';
     for my $bf (split(',', $bib_files)) {
-      my $bib_path = FindFile($bf, type => 'bib');
+      my $bib_path = FindFile($bf, type => 'bib', nokpsewhich => 1);
       if (not $bib_path) {
         $missing_bibs .= ',' unless length($missing_bibs) == 0;
         $missing_bibs .= $bf; } }

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -44,6 +44,11 @@ DeclareOption('noprofiling', sub { AssignValue('PROFILING' => 0, 'global'); });
 DeclareOption('mathparserspeculate',   sub { AssignValue('MATHPARSER_SPECULATE' => 1, 'global'); });
 DeclareOption('nomathparserspeculate', sub { AssignValue('MATHPARSER_SPECULATE' => 0, 'global'); });
 
+# 'nobibtex' intended to be used for arXiv-like build harnesses, where there
+# is explicit instruction to only use ".bbl" and that bibtex will not be ran.
+DeclareOption('bibtex',   sub { AssignValue('NO_BIBTEX' => 0, 'global'); });
+DeclareOption('nobibtex', sub { AssignValue('NO_BIBTEX' => 1, 'global'); });
+
 ProcessOptions();
 #======================================================================
 # From latexml.sty

--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -132,8 +132,10 @@ sub getBibliographies {
       # NOTE: When better integrated with Core, should also check for cached bib documents.
       if (my $xmlpath = pathname_find($bib, paths => [@paths], types => ['xml'])) {
         $bibdoc = $doc->newFromFile($xmlpath); }    # doc will do the searching...
-      elsif (my $bibpath = pathname_find($bib, paths => [@paths], types => ['bib'])
-        || pathname_kpsewhich($bib)) {
+      elsif (my $bibpath = pathname_find($bib, paths => [@paths], types => ['bib'])) {
+     # Note: this seems to create unexpected wrong bibliography loads for generic names such as "biblio.bib"
+     #       where the intent was for the bibliography to not be found, and the .bbl file to be loaded.
+     # || pathname_kpsewhich($bib))
         $bibdoc = $self->convertBibliography($doc, $bibpath); }
       else {
         Error('missing_file', $bib, $self,
@@ -782,4 +784,3 @@ $FMT_SPEC{techreport}            = $FMT_SPEC{report};
 
 # ================================================================================
 1;
-

--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -132,10 +132,8 @@ sub getBibliographies {
       # NOTE: When better integrated with Core, should also check for cached bib documents.
       if (my $xmlpath = pathname_find($bib, paths => [@paths], types => ['xml'])) {
         $bibdoc = $doc->newFromFile($xmlpath); }    # doc will do the searching...
-      elsif (my $bibpath = pathname_find($bib, paths => [@paths], types => ['bib'])) {
-     # Note: this seems to create unexpected wrong bibliography loads for generic names such as "biblio.bib"
-     #       where the intent was for the bibliography to not be found, and the .bbl file to be loaded.
-     # || pathname_kpsewhich($bib))
+      elsif (my $bibpath = pathname_find($bib, paths => [@paths], types => ['bib'])
+        || pathname_kpsewhich($bib)) {
         $bibdoc = $self->convertBibliography($doc, $bibpath); }
       else {
         Error('missing_file', $bib, $self,


### PR DESCRIPTION
Currently we search the entirety of `kpsewhich` for .bib paths. While that may sound perfectly legal for an ordinary document, it is not "careful enough" for the arXiv conversion.

In particular, I have an example document which depends on a `biblio.bib`, but in reality using `paper.bbl` for its arXiv compilation. The paper does not even include the .bib file in the bundle. However, in this case latexml finds a biblio.bib if you have a texlive installation, in particular:
```
$ kpsewhich biblio.bib
/usr/share/texlive/texmf-dist/bibtex/bib/msc/biblio.bib
```

Which leads to a couple of macro errors, as that bibliography contains macros. This PR is based on my claim that looking for `.bib` files inside the texlive installation should never be latexml's intent. Instead, we may want to look into the user-defined `TEXINPUTS` and `BIBINPUTS` variables, which may contain custom bib paths.

This is more frequent of a situation than one might suspect -- all cases of the `\mscversion` undefined error seem to be caused by loading the wrong `biblio.bib` : 

https://corpora.mathweb.org/corpus/arxiv_testbench/tex_to_html/error/undefined

Using the PR to convert the first report (0705.2800) moves the document from Error to a "no problem" entry, and attaches the right bibliography.