### PR TITLE
Version-aware behavior of pgf macro, different in texlive 2018

### DIFF
--- a/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
@@ -416,7 +416,8 @@ DefMacro('\pgfkeysdefnargs@{}{}{}{}', sub {
                 # ugly patchy fishing, we found {\pgfkeyssetvalue} , texlive 2018 tikz case
                 $v_pgf_texlive_year = 2018; } } } } } }
     if ($v_pgf_texlive_year != 2018) {
-      # return whatever was fished for
+      # fishing expedition came back with an empty net, return whichever tokens we scanned over to
+      # the gullet, so that the correct (old?) behavior may take place.
       $gullet->unread(grep { defined } ($next1, $next2, $next3)); }
     $key   = ToString(Expand($key));
     $nargs = ToString($nargs);

--- a/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
@@ -125,7 +125,7 @@ DefPrimitive('\pgfkeys{}', sub {
 DefPrimitive('\pgfqkeys{}{}', sub {
     my ($stomach, $path, $keyvals) = @_;
     my $savedpath = Expand(T_CS('\pgfkeysdefaultpath'));
-    my $newpath = Tokens(Expand($path)->unlist, T_OTHER('/'));
+    my $newpath   = Tokens(Expand($path)->unlist, T_OTHER('/'));
     DefMacroI('\pgfkeysdefaultpath', undef, $newpath);
     my @results = parsePGFKeys($stomach, $keyvals);
     DefMacroI('\pgfkeysdefaultpath', undef, $savedpath);
@@ -404,6 +404,20 @@ DefMacro('\pgfkeysedefargs{}{}{}', sub {
 # called by \pgfkeysdefnargs and \pgfkeysedefnargs
 DefMacro('\pgfkeysdefnargs@{}{}{}{}', sub {
     my ($gullet, $key, $nargs, $body, $def) = @_;
+    # Latest tikz (in texlive 2018) has a fifth argument
+    my $v_pgf_texlive_year = 2015;
+    my ($next1, $next2, $next3);
+    if ($next1 = $gullet->readToken()) {
+      if ($next1->equals(T_BEGIN)) {
+        if ($next2 = $gullet->readToken()) {
+          if ($next2->equals(T_CS("\\pgfkeyssetvalue"))) {
+            if ($next3 = $gullet->readToken()) {
+              if ($next3->equals(T_END)) {
+                # ugly patchy fishing, we found {\pgfkeyssetvalue} , texlive 2018 tikz case
+                $v_pgf_texlive_year = 2018; } } } } } }
+    if ($v_pgf_texlive_year != 2018) {
+      # return whatever was fished for
+      $gullet->unread(grep { defined } ($next1, $next2, $next3)); }
     $key   = ToString(Expand($key));
     $nargs = ToString($nargs);
     $nargs =~ s/^#//;
@@ -417,7 +431,12 @@ DefMacro('\pgfkeysdefnargs@{}{}{}{}', sub {
     DefMacroI(pgfkeyCS($key . '/.@cmd'), $PGF_1ARG, sub {
         (pgfkeyCS($key . '/.@@body'), $_[1]->unlist); });
     # Store the body
-    DefMacroI(pgfkeyCS($key . '/.@body'), undef, $body); },
+    if ($v_pgf_texlive_year == 2018) {
+      # in texlive 2018, .@body needs to be expanded
+      DefMacroI(pgfkeyCS($key . '/.@body'), undef,
+        (ToString($def) eq '\edef' ? eExpand($body) : $body)); }
+    else {
+      DefMacroI(pgfkeyCS($key . '/.@body'), undef, $body); } },
   locked => 1);
 
 #DefMacro('\pgfkeys@error{}','PackageWarning{pgfkeys}{#1}{}',
@@ -480,7 +499,7 @@ DefPrimitive('\pgfqkeysfiltered{}{}', sub {
     my ($stomach, $path, $keyvals) = @_;
     pgfStartFiltering();
     my $savedpath = Expand(T_CS('\pgfkeysdefaultpath'));
-    my $newpath = Tokens(Expand($path)->unlist, T_OTHER('/'));
+    my $newpath   = Tokens(Expand($path)->unlist, T_OTHER('/'));
     DefMacroI('\pgfkeysdefaultpath', undef, $newpath);
     my @results = parsePGFKeys($stomach, $keyvals);
     DefMacroI('\pgfkeysdefaultpath', undef, $savedpath);

--- a/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
@@ -401,44 +401,50 @@ DefMacro('\pgfkeysedefargs{}{}{}', sub {
     DefMacroI(pgfkeyCS($key . '/.@body'), undef, $body); },
   locked => 1);
 
+my $pgf_version_year = 2015;    # default toolchain expected
+if (LookupDefinition(T_CS('\pgfversiondate'))) {
+  if (ToString(Digest('\pgfversiondate')) =~ /^(\d+)/) {
+    $pgf_version_year = int($1); } }
+
 # called by \pgfkeysdefnargs and \pgfkeysedefnargs
-DefMacro('\pgfkeysdefnargs@{}{}{}{}', sub {
-    my ($gullet, $key, $nargs, $body, $def) = @_;
-    # Latest tikz (in texlive 2018) has a fifth argument
-    my $v_pgf_texlive_year = 2015;
-    my ($next1, $next2, $next3);
-    if ($next1 = $gullet->readToken()) {
-      if ($next1->equals(T_BEGIN)) {
-        if ($next2 = $gullet->readToken()) {
-          if ($next2->equals(T_CS("\\pgfkeyssetvalue"))) {
-            if ($next3 = $gullet->readToken()) {
-              if ($next3->equals(T_END)) {
-                # ugly patchy fishing, we found {\pgfkeyssetvalue} , texlive 2018 tikz case
-                $v_pgf_texlive_year = 2018; } } } } } }
-    if ($v_pgf_texlive_year != 2018) {
-      # fishing expedition came back with an empty net, return whichever tokens we scanned over to
-      # the gullet, so that the correct (old?) behavior may take place.
-      $gullet->unread(grep { defined } ($next1, $next2, $next3)); }
-    $key   = ToString(Expand($key));
-    $nargs = ToString($nargs);
-    $nargs =~ s/^#//;
-    my $args = Tokens(map { (T_PARAM, T_OTHER($_)) } 1 .. $nargs);
-    # Define $key/.@args to pretty print the args (?)
-    DefMacroI(pgfkeyCS($key . '/.@args'), undef, $args);
-    # (e-)Define $key/.@@body as if it were the normal macro with $n args
-    DefMacroI(pgfkeyCS($key . '/.@@body'), parseDefParameters("PGF Key $key", $args),
-      (ToString($def) eq '\edef' ? eExpand($body) : $body));
-    # Define $key/.@cmd itself to indirectly call $key/.@@body
-    DefMacroI(pgfkeyCS($key . '/.@cmd'), $PGF_1ARG, sub {
-        (pgfkeyCS($key . '/.@@body'), $_[1]->unlist); });
-    # Store the body
-    if ($v_pgf_texlive_year == 2018) {
+if ($pgf_version_year >= 2018) {    # Latest tikz (in texlive 2018) has a fifth argument
+  DefMacro('\pgfkeysdefnargs@{}{}{}{}{}', sub {
+      my ($gullet, $key, $nargs, $body, $def, $body_macro) = @_;
+      $key   = ToString(Expand($key));
+      $nargs = ToString($nargs);
+      $nargs =~ s/^#//;
+      my $args = Tokens(map { (T_PARAM, T_OTHER($_)) } 1 .. $nargs);
+      # Define $key/.@args to pretty print the args (?)
+      DefMacroI(pgfkeyCS($key . '/.@args'), undef, $args);
+      # (e-)Define $key/.@@body as if it were the normal macro with $n args
+      DefMacroI(pgfkeyCS($key . '/.@@body'), parseDefParameters("PGF Key $key", $args),
+        (ToString($def) eq '\edef' ? eExpand($body) : $body));
+      # Define $key/.@cmd itself to indirectly call $key/.@@body
+      DefMacroI(pgfkeyCS($key . '/.@cmd'), $PGF_1ARG, sub {
+          (pgfkeyCS($key . '/.@@body'), $_[1]->unlist); });
+      # Store the body
       # in texlive 2018, .@body needs to be expanded
       DefMacroI(pgfkeyCS($key . '/.@body'), undef,
-        (ToString($def) eq '\edef' ? eExpand($body) : $body)); }
-    else {
-      DefMacroI(pgfkeyCS($key . '/.@body'), undef, $body); } },
-  locked => 1);
+        (ToString($def) eq '\edef' ? eExpand($body) : $body)); },
+    locked => 1); }
+else {
+  DefMacro('\pgfkeysdefnargs@{}{}{}{}', sub {
+      my ($gullet, $key, $nargs, $body, $def) = @_;
+      $key   = ToString(Expand($key));
+      $nargs = ToString($nargs);
+      $nargs =~ s/^#//;
+      my $args = Tokens(map { (T_PARAM, T_OTHER($_)) } 1 .. $nargs);
+      # Define $key/.@args to pretty print the args (?)
+      DefMacroI(pgfkeyCS($key . '/.@args'), undef, $args);
+      # (e-)Define $key/.@@body as if it were the normal macro with $n args
+      DefMacroI(pgfkeyCS($key . '/.@@body'), parseDefParameters("PGF Key $key", $args),
+        (ToString($def) eq '\edef' ? eExpand($body) : $body));
+      # Define $key/.@cmd itself to indirectly call $key/.@@body
+      DefMacroI(pgfkeyCS($key . '/.@cmd'), $PGF_1ARG, sub {
+          (pgfkeyCS($key . '/.@@body'), $_[1]->unlist); });
+      # Store the body
+      DefMacroI(pgfkeyCS($key . '/.@body'), undef, $body); },
+    locked => 1); }
 
 #DefMacro('\pgfkeys@error{}','PackageWarning{pgfkeys}{#1}{}',
 


### PR DESCRIPTION
Fixes #1143 .

A bit iffy of a fix, but the only "holistic" patch would be to go back to reading the raw tex from the style file. Thanks to @brucemiller  for debugging and binding help.

As always, may need another review, but I can verify that this binding successfully converts the [Tikz Basic](https://latexml.mathweb.org/editor?demo=tikz-basic) example from the showcase, both on a 2018 texlive machine, and on a 2015 texlive machine - I just tested both.

Feedback welcome!