### PR TITLE
\bezier and \dashbox argument patches

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4476,7 +4476,7 @@ DefConstructor('\qbezier [Number] Pair Pair Pair',
   alias      => '\qbezier',
   properties => sub {
     picProperties(pt => PairList(picScale($_[2]), picScale($_[3]), picScale($_[4]))); });
-DefConstructor('\bezier Number Pair Pair Pair',
+DefConstructor('\bezier {Number} Pair Pair Pair',
   "<ltx:bezier ?#1(displayedpoints='#1') points='&ptValue(#pt)' stroke-width='#thick' />",
   alias      => '\bezier',
   properties => sub {
@@ -4504,7 +4504,7 @@ DefConstructor('\pic@framebox Pair []{}',
   properties   => sub { picProperties(size => picScale($_[1])); });
 
 #DefConstructor('\pic@dashbox {Float} Pair [] {}',
-DefConstructor('\dashbox {Float} Pair [] {}',
+DefConstructor('\dashbox [Float] Pair [] []',
   "<ltx:rect x='0' y='0' %&PairAttr(#size,width,height)"
     . " stroke-width='#thick' stroke-dasharray='&ptValue(#dash)' fill='none'/>" .
     "<ltx:g %&PairAttr(#size,width,height) pos='#3'>#4</ltx:g>",

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4504,10 +4504,19 @@ DefConstructor('\pic@framebox Pair []{}',
   properties   => sub { picProperties(size => picScale($_[1])); });
 
 #DefConstructor('\pic@dashbox {Float} Pair [] {}',
-DefConstructor('\dashbox [Float] Pair [] []',
+DefMacro('\dashbox', sub {
+    my ($gullet) = @_;
+    if ($gullet->ifNext(T_OTHER("("))) {
+      return (T_CS('\ltx@dashbox'), T_BEGIN, T_OTHER('0'), T_END); }
+    if ($gullet->ifNext(T_BEGIN)) {
+      return T_CS('\ltx@dashbox'); }
+    else {
+      my $float_arg = $gullet->readUntil(T_OTHER("("));
+      return (T_CS('\ltx@dashbox'), T_BEGIN, $float_arg->unlist(), T_END, T_OTHER("(")); } });
+DefConstructor('\ltx@dashbox {Float} Pair [] OptionalPlain',
   "<ltx:rect x='0' y='0' %&PairAttr(#size,width,height)"
-    . " stroke-width='#thick' stroke-dasharray='&ptValue(#dash)' fill='none'/>" .
-    "<ltx:g %&PairAttr(#size,width,height) pos='#3'>#4</ltx:g>",
+    . " stroke-width='#thick' stroke-dasharray='&ptValue(#dash)' fill='none'/>"
+    . "<ltx:g %&PairAttr(#size,width,height) pos='#3'>#4</ltx:g>",
   alias      => '\dashbox',
   properties => sub { picProperties(dash => picScale($_[1]), size => picScale($_[2])); });
 


### PR DESCRIPTION
I was just quickly skimming another Fatal-status doc, and it encountered problems related to:

```tex
\bezier{200}(30,30)(40,25)(50,30)
```
and
```tex
\put(10,10){\dashbox(40,0)}
```

So, just as a test, I patched the signatures of those two macros to be more lenient and... well, the document converted with just Warnings? So this may be a fix? I don't know enough about the `{picture}` environment to be certain this is a robust patch, but in both cases all "mandatory" argument cases should still work, while also allowing the new "optional"/"flexible" patterns.

arXiv document was `quant-ph0506026`