### PR TITLE
Patch infinite loop in some \newtheorem uses

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2707,7 +2707,12 @@ sub defineNewTheorem {
       => { map { ($_ => LookupValue($_)) } keys %parameters }, 'global');
 
   my $thmname = '\\' . $thmset . 'name';
-  DefMacroI($thmname, undef, $type, scope => 'global');
+  # Avoid weird infinite loops, when the $type is already containing a $thmname macro
+  # TODO: What is a better way to stay TeX-near and avoid these issues?
+  my $type_str = ToString($type);
+  if ($type_str !~ /\Q$thmname\E\b/) {
+    DefMacroI($thmname, undef, $type, scope => 'global');
+  }
   my $swap = LookupValue('thm@swap');
 
   DefMacroI('\fnum@' . $thmset, undef,


### PR DESCRIPTION
Once in a blue moon I take a look at the arXiv timeout Fatals, to check if some easy infinite loop case can be spotted. I ended up hitting one at the frist document I checked from the 1905 testbench, a minimal example being:

```tex
\documentclass{article}
\usepackage{amsmath}
\usepackage{amsthm}

\newtheorem{thm}{\theoremname}
\newtheorem{example}[thm]{\protect\examplename}
\providecommand{\examplename}{Example}

\begin{document}
\begin{example}
	test
\end{example}
\end{document}
```

As it turns out, latexml defines `\examplename` at the point of the `\newtheorem` for `example`, while the actual amsthm.sty definitions don't go as far. I would need to study the exact logic in newtheorem for some more time to be able to understand if a general upgrade is possible, but can already contribute a simple patch for now.

It also makes me wonder how many of the arXiv jobs could be sped up by detecting an infinite expansion chain of the same macro... 