### PR TITLE
raw interpretation of blindtext.sty

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -391,6 +391,7 @@ lib/LaTeXML/Package/bbm.sty.ltxml
 lib/LaTeXML/Package/bbold.sty.ltxml
 lib/LaTeXML/Package/beton.sty.ltxml
 lib/LaTeXML/Package/bibunits.sty.ltxml
+lib/LaTeXML/Package/blindtext.sty.ltxml
 lib/LaTeXML/Package/bm.sty.ltxml
 lib/LaTeXML/Package/book.cls.ltxml
 lib/LaTeXML/Package/bookman.sty.ltxml

--- a/lib/LaTeXML/Package/blindtext.sty.ltxml
+++ b/lib/LaTeXML/Package/blindtext.sty.ltxml
@@ -1,0 +1,25 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# | blindtext.sty                                                       | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#======================================================================
+# Note: \languagename is assumed as defined by blindtext, and it so happens that
+#       pdflatex has parts of babel defined by default. For now, just request babel loaded
+RequirePackage('babel', options => ['english']);
+
+InputDefinitions('blindtext', type => 'sty', noltxml => 1);
+
+1;


### PR DESCRIPTION
Interesting stumble on a lipsum-like package that latexml can interpret directly (even in texlive 2018!).

A minimal example looks like:
```tex
\documentclass{article}
\usepackage{blindtext}
\begin{document}
\Blindtext{4}
\end{document}
```

which generates 4 lipsum paragraphs. Works identically in pdflatex and latexml's raw sty interpretation. The one interesting catch is that blindtext assumes the modern pdflatex behavior -- which I just learned about -- of preloading parts of the babel support. In particular, it expects the macro `\languagename` to be available, and to my surprise it is. This minimal latex documents works great under pdflatex:

```tex
\documentclass{minimal}
\begin{document}
test \languagename
\end{document}
```

I grep-ed around, but it looks like the availability of that macro happens somewhat "secretely" in the pdflatex bootup.

In any case, this could be an easy merge/win for arXiv coverage, 1.4% of tasks in the 1905 testbench:
https://corpora.mathweb.org/corpus/arxiv_1905/tex_to_html/warning/missing_file?all=true