### PR TITLE
argument number oversight in \format@title@

### DIFF
--- a/lib/LaTeXML/Package/float.sty.ltxml
+++ b/lib/LaTeXML/Package/float.sty.ltxml
@@ -49,7 +49,7 @@ DefPrimitive('\newfloat{}{}{}[]', sub {
     DefMacro('\fnum@font@' . $type, ($isplain ? '\rmfamily' : '\bfseries'));
     DefMacro('\format@title@' . $type . '{}',
       ($isplain
-        ? '\lx@tag[][: ]{\lx@fnum@@{' . $type . '}} #2'
+        ? '\lx@tag[][: ]{\lx@fnum@@{' . $type . '}} #1'
         : '\lx@tag[][ ]{\lx@fnum@@{' . $type . '}} #1'));
     DefMacro('\ext@' . $type, $auxext);
     DefEnvironment("{$type}[]",


### PR DESCRIPTION
Theoretically smallest PR possible - just 1 character.

This is simply adding the perfectly diagnozed and patched fix at #1161 , I have reproduced the correct behaviour and can confirm the `#2` looks like an argument number typo. Full credit to @evoludolab for diagnosing and reporting this.