### PR TITLE
Make epub work under cygwin

### DIFF
--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -185,15 +185,13 @@ sub finalize {
   my @styles        = ();
   my @images        = ();
   find({ no_chdir => 1, wanted => sub {
-        my $OPS_abspath = $_;
-        if (-f $OPS_abspath) {
-          my $OPS_pathname = pathname_relative($OPS_abspath, $OPS_directory);
-          if ($OPS_pathname =~ /\.css$/) {
-            push(@styles, $OPS_pathname); }
-          elsif ($OPS_pathname =~ /\.png$/) {
-            push(@images, $OPS_pathname); }
-          else { }    # skip any other resources
-        }
+        my $OPS_abspath  = $_;
+        my $OPS_pathname = pathname_relative($OPS_abspath, $OPS_directory);
+        if ($OPS_pathname =~ /\.css$/) {
+          push(@styles, $OPS_pathname); }
+        elsif ($OPS_pathname =~ /\.png$/) {
+          push(@images, $OPS_pathname); }
+        else { }    # skip any other resources
   } }, $OPS_directory);
 
   my $manifest = $$self{opf_manifest};


### PR DESCRIPTION
Cpantesters failed for cygwin with the epub test failing to find the CSS assets.

Reading around, I'm suspecting absolute paths don't agree in that setup, as discussed here:
https://www.cs.unc.edu/~jeffay/dirt/FAQ/cygwin-perl.html

As it turns out, the `-f` check was just "extra safety" but wasn't necessary due to the following asset name checks. So, hoping this was indeed the underlying issue, submitting this patch which simply omits the `-f` check for epub asset packing.