### PR TITLE
Add Perl 5.14 Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - PERL=5.26.2 TEX=none
   - PERL=5.24.4 TEX=none
   - PERL=5.20.3 TEX=none
-##  - PERL=5.12.5 TEX=none
+  - PERL=5.14.4 TEX=none
   ## Testing with texlive 2018 -- perl 5.28
   - PERL=5.28.0 TEX=texlive-2018
   ## Testing with texlive 2016 -- perl 5.26

--- a/tools/travis/README.md
+++ b/tools/travis/README.md
@@ -35,11 +35,11 @@ The travis tests not using any TeX take around 5 minutes to run, whereas the tes
 Usually, a Dockerfile is built using a `Dockerfile` and an appropriate `build context` (i.e. a set of files that might be included into the docker image). 
 Since the travis tests need a set of docker images (one for each combination of perl and tex to be tested), these `Dockerfile`s are created using an automated script. 
 
-The `src/build-test-image.sh` takes two arguments (the `TEX` and `PERL` versions to be used), generates a `Dockerfile` into the `dist/$PERL_$TEX` directory, and then builds the docker image. 
+The `scripts/build-test-image.sh` takes two arguments (the `TEX` and `PERL` versions to be used), generates a `Dockerfile` into the `dist/$PERL_$TEX` directory, and then builds the docker image. 
 
 For example, to generate a test image for perl `5.22.4` and `texlive-2015` it can be invoked like so:
 
-    src/build-test-image.sh 5.22.4 texlive-2015
+    bash scripts/build-test-image.sh 5.22.4 texlive-2015
 
 This will build the image `latexml/latexml-test-runtime:5.22.4_texlive-2015`. 
 

--- a/tools/travis/scripts/build-all.sh
+++ b/tools/travis/scripts/build-all.sh
@@ -19,7 +19,7 @@ build_image 5.28.0 none
 build_image 5.26.2 none
 build_image 5.24.4 none
 build_image 5.20.3 none
-build_image 5.10.1 none
+build_image 5.14.4 none
 build_image 5.28.0 texlive-2018
 build_image 5.26.2 texlive-2016
 build_image 5.22.4 texlive-2015


### PR DESCRIPTION
The tests for perl 5.12 were removed in https://github.com/brucemiller/LaTeXML/commit/4217f4c862062c53bbc17293d11774ffa65c0f4e. In https://github.com/brucemiller/LaTeXML/pull/1169#issuecomment-509509520 @brucemiller suggested adding tests for perl 5.14. 

This PR adds tests for version 5.14.4. For this purpose I added a new Docker Image. An example test run can be found at https://travis-ci.org/brucemiller/LaTeXML/jobs/556303915. 