### PR TITLE
neurips binding and reliable preloads for bib conversion

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -548,6 +548,7 @@ lib/LaTeXML/Package/multido.sty.ltxml
 lib/LaTeXML/Package/multirow.sty.ltxml
 lib/LaTeXML/Package/nameref.sty.ltxml
 lib/LaTeXML/Package/natbib.sty.ltxml
+lib/LaTeXML/Package/neurips.sty.ltxml
 lib/LaTeXML/Package/newcent.sty.ltxml
 lib/LaTeXML/Package/newfloat.sty.ltxml
 lib/LaTeXML/Package/newlfont.sty.ltxml

--- a/lib/LaTeXML/Package/neurips.sty.ltxml
+++ b/lib/LaTeXML/Package/neurips.sty.ltxml
@@ -1,0 +1,34 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# | neurips_2019.sty                                                    | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#======================================================================
+RequirePackage('natbib');
+RequirePackage('geometry');
+RequirePackage('lineno');
+#  /--------------------------------------------------------------------\
+# | Drafted by texscan --stub neurips_2019.sty                           |
+#  \--------------------------------------------------------------------/
+DefMacro('\AND',                                   Tokens());
+DefMacro('\And',                                   Tokens());
+DefMacro('\bottomfraction',                        Tokens());
+DefMacro('\patchAmsMathEnvironmentForLineno',      Tokens());
+DefMacro('\patchBothAmsMathEnvironmentsForLineno', Tokens());
+DefMacroI('\subsubsubsection', undef, '\@startsection{subsubsubsection}{4}{}{}{}{}', locked => 1);
+DefMacro('\textfraction', Tokens());
+DefMacro('\topfraction',  Tokens());
+#======================================================================
+1;

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -203,8 +203,13 @@ sub generateResourcePathname {
   $doc->cacheStore($counter, $n);
   return pathname_make(dir => $subdir, name => $name, type => $type); }
 
-# Get a list [class,classoptions, oldstyle],[package,packageoptions],...]
-# The options are strings
+# Returns a two-part list of the form:
+#
+# [class, classoptions, oldstyle], [package1,package1options], [package2,package2options], ...
+#
+# Where there first element is always the *class* (if none, "article" returned as a default)
+# And all following elements are *packages*
+#
 sub find_documentclass_and_packages {
   my ($self, $doc) = @_;
   my ($class, $classoptions, $oldstyle, @packages);

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -218,12 +218,10 @@ sub find_documentclass_and_packages {
       $classoptions = $$entry{options} || 'onecolumn';
       $oldstyle     = $$entry{oldstyle}; }
     elsif ($$entry{package}) {
-      push(@packages, [$$entry{package} . ".sty", $$entry{options} || '']); } }
+      push(@packages, [$$entry{package}, $$entry{options} || '']); } }
   if (!$class) {
     Warn('expected', 'class', undef, "No document class found; using article");
     $class = 'article'; }
-  if ($class !~ /\.cls$/) {
-    $class = $class . ".cls"; }
   return ([$class, $classoptions, $oldstyle], @packages); }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -56,7 +56,7 @@ sub ProcessChain_internal {
     foreach my $doc (@docs) {
       local $LaTeXML::Post::DOCUMENT = $doc;
       if (my @nodes = grep { $_ } $processor->toProcess($doc)) {    # If there are nodes to process
-        my $n = scalar(@nodes);
+        my $n   = scalar(@nodes);
         my $msg = join(' ', $processor->getName || '',
           $doc->siteRelativeDestination || '',
           ($n > 1 ? "$n to process" : 'processing'));
@@ -198,7 +198,7 @@ sub generateResourcePathname {
   my $subdir = $$self{resource_directory} || '';
   my $prefix = $$self{resource_prefix}    || "x";
   my $counter = join('_', "_max", $subdir, $prefix, "counter_");
-  my $n = $doc->cacheLookup($counter) || 0;
+  my $n    = $doc->cacheLookup($counter) || 0;
   my $name = $prefix . ++$n;
   $doc->cacheStore($counter, $n);
   return pathname_make(dir => $subdir, name => $name, type => $type); }
@@ -218,11 +218,12 @@ sub find_documentclass_and_packages {
       $classoptions = $$entry{options} || 'onecolumn';
       $oldstyle     = $$entry{oldstyle}; }
     elsif ($$entry{package}) {
-      push(@packages, [$$entry{package}, $$entry{options} || '']); }
-  }
+      push(@packages, [$$entry{package} . ".sty", $$entry{options} || '']); } }
   if (!$class) {
     Warn('expected', 'class', undef, "No document class found; using article");
     $class = 'article'; }
+  if ($class !~ /\.cls$/) {
+    $class = $class . ".cls"; }
   return ([$class, $classoptions, $oldstyle], @packages); }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -336,7 +337,7 @@ sub processNode {
   # XMath will be removed (LATER!), but mark its ids as reusable.
   $doc->preremoveNodes($xmath);
   if ($$self{parallel}) {
-    my $primary = $self->convertNode($doc, $xmath);
+    my $primary     = $self->convertNode($doc, $xmath);
     my @secondaries = ();
     foreach my $proc (@{ $$self{secondary_processors} }) {
       local $LaTeXML::Post::MATHPROCESSOR = $proc;
@@ -425,7 +426,7 @@ sub convertXMTextContent {
       my $tag = $doc->getQName($node);
       if ($tag eq 'ltx:XMath') {
         my $conversion = $self->convertNode($doc, $node);
-        my $xml = $$conversion{xml};
+        my $xml        = $$conversion{xml};
         # And if no xml ????
         push(@result, $self->outerWrapper($doc, $node, $xml)); }
       else {
@@ -516,7 +517,7 @@ sub associateNode {
       $document->generateNodeID($sourcenode, '', 1); }         # but the ID is reusable
     if (my $sourceid = $sourcenode->getAttribute('fragid')) {    # If source has ID
       my $nodeid = $currentnode->getAttribute('fragid') || $sourceid;
-      my $id = $document->uniquifyID($nodeid, $self->IDSuffix);
+      my $id     = $document->uniquifyID($nodeid, $self->IDSuffix);
       if ($isarray) {
         $$node[1]{'xml:id'} = $id; }
       else {
@@ -775,7 +776,7 @@ sub setDocument_internal {
     my ($tag, $attributes, @children) = @$root;
     my ($prefix, $localname) = $tag =~ /^(.*):(.*)$/;
     my $nsuri = $$self{namespaces}{$prefix};
-    my $node = $$self{document}->createElementNS($nsuri, $localname);
+    my $node  = $$self{document}->createElementNS($nsuri, $localname);
     $$self{document}->setDocumentElement($node);
     map { $$attributes{$_} && $node->setAttribute($_ => $$attributes{$_}) } keys %$attributes
       if $attributes;
@@ -927,7 +928,7 @@ sub idcheck {
   my %missing = ();
   foreach my $node ($self->findnodes("//*[\@xml:id]")) {
     my $id = $node->getAttribute('xml:id');
-    $dups{$id} = 1 if $idcache{$id};
+    $dups{$id}    = 1 if $idcache{$id};
     $idcache{$id} = 1; }
   foreach my $id (keys %{ $$self{idcache} }) {
     $missing{$id} = 1 unless $idcache{$id}; }
@@ -1181,13 +1182,14 @@ sub prependNodes {
 sub cloneNode {
   my ($self, $node, $idsuffix, %options) = @_;
   return $node unless ref $node;
+  return $node if ref $node eq 'ARRAY'; # Should we deep clone if we get an array? Just return for now
   my $copy    = $node->cloneNode(1);
   my $nocache = $options{nocache};
 ####  $idsuffix = '' unless defined $idsuffix;
   # Find all id's defined in the copy and change the id.
   my %idmap = ();
   foreach my $n ($self->findnodes('descendant-or-self::*[@xml:id]', $copy)) {
-    my $id = $n->getAttribute('xml:id');
+    my $id    = $n->getAttribute('xml:id');
     my $newid = $self->uniquifyID($id, $idsuffix);
     $idmap{$id} = $newid;
     $self->recordID($newid => $n) unless $nocache;

--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -162,13 +162,14 @@ sub convertBibliography {
   my ($self, $doc, $bib) = @_;
   require LaTeXML;
   require LaTeXML::Common::Config;
-  my @packages =
-    my @preload = ();
-  # Might want/need to preload more (all?) packages, but at least do inputenc!
+  my @preload = ();    # custom macros often used in e.g. howpublished field
+                       # need to preload all packages used by the main article
   foreach my $po ($self->find_documentclass_and_packages($doc)) {
     my ($pkg, $options) = @$po;
-    if ($pkg eq 'inputenc') {
-      push(@preload, "[$options]$pkg"); } }
+    if ($options) {
+      push(@preload, "[$options]$pkg"); }
+    else {
+      push(@preload, "$pkg"); } }
   NoteProgress(" [Converting bibliography $bib ...");
   my $bib_config = LaTeXML::Common::Config->new(
     cache_key      => 'BibTeX',

--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -164,12 +164,20 @@ sub convertBibliography {
   require LaTeXML::Common::Config;
   my @preload = ();    # custom macros often used in e.g. howpublished field
                        # need to preload all packages used by the main article
-  foreach my $po ($self->find_documentclass_and_packages($doc)) {
+  my ($classdata, @packages)     = $self->find_documentclass_and_packages($doc);
+  my ($class,     $classoptions) = @$classdata;
+  if ($class) {
+
+    if ($classoptions) {
+      push(@preload, "[$classoptions]$class.cls"); }
+    else {
+      push(@preload, "$class.cls"); } }
+  foreach my $po (@packages) {
     my ($pkg, $options) = @$po;
     if ($options) {
-      push(@preload, "[$options]$pkg"); }
+      push(@preload, "[$options]$pkg.sty"); }
     else {
-      push(@preload, "$pkg"); } }
+      push(@preload, "$pkg.sty"); } }
   NoteProgress(" [Converting bibliography $bib ...");
   my $bib_config = LaTeXML::Common::Config->new(
     cache_key      => 'BibTeX',


### PR DESCRIPTION
Starting to take the "make sure your own arXiv submissions convert well!" mantra seriously.

This PR adds a simple binding for a base `neurips.sty` package, which has several variations in use in arXiv (the one I used is `neurips_2019.sty`).

More interestingly, I used `\url` consistently in my bibtex entries this time, so preloading the right macros was crucial to get the right output. Luckily the code was already there it was just being shy(?) and only letting inputenc through. I now made it possible to preload the full dependency tree, which gets a full "no problem" post-processing on my article!

I don't think this PR will have significant impact on arXiv, but it does get my paper error-free and looking good!