### PR TITLE
add a stub for \matrix@check, avoiding memory leak fatals

### DIFF
--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -799,6 +799,10 @@ DefMacro('\endVmatrix', '\lx@end@ams@matrix');
 DefMacro('\smallmatrix',    '\lx@ams@matrix{name=smallmatrix,atameaning=matrix,style=\scriptsize}');
 DefMacro('\endsmallmatrix', '\lx@end@ams@matrix');
 
+# Some author code defines new matrix environments and uses this check guard.
+# For now just gobble its argument, assuming the check passes (was handled in pdflatex)
+DefMacro('\matrix@check{}', Tokens());
+
 #======================================================================
 # Section 4.2 Math spacing commands
 # \, == \thinspace
@@ -1310,4 +1314,3 @@ DefMacro('\shoveright{}', '#1');
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;
-


### PR DESCRIPTION
I stumbled onto a note by @lab156 that a given arXiv document [did not finish at all](https://github.com/lab156/arxivDownload#problems) under LaTeXML. I checked in CorTeX, and it had my most hated type of fatal - [a memory leak](https://corpora.mathweb.org/preview/arxmliv/tex_to_html/1411.6225).

Inspecting the document, a near-minimal example reproducing the leak is:
```tex
\documentclass{article}
\usepackage{amssymb,amsfonts,amsmath,amsthm,amscd}

\newcommand{\la}{\lambda}
\newcommand{\ph}{\varphi}
\makeatletter
\newenvironment{casks}{%
  \matrix@check\casks\env@casks
}{%
  \endarray\right.%
}
\def\env@casks{%
  \let\@ifnextchar\new@ifnextchar
  \left\lbrack
  \def\arraystretch{1.2}%
  \array{@{}l@{\quad}l@{}}%
}
\makeatother

\begin{document}

\begin{equation*}
\begin{casks}
r\in\{3,4,5,6\},& \la\in\{\ph_1+\ph_r,\ph_2+\ph_r\};\\
r=3,&\la=\ph_1+\ph_2+\ph_3;\\
\end{casks}
\end{equation*}

\end{document}
```

It turned out the leak was a side-effect of not having `\matrix@check` defined, which lead to an infinite waterfall of environment opens. Each open of `{casks}` lead to +1 open due to `\casks` and the actual open payload from `\env@casks`, adding an `\array` at each pass.

Long-story short, simply adding a stub for `\matrix@check` that consumes its argument and assumes the check was successful (due to a main pass through pdflatex), suffices to eliminate the Fatal and produce a good result. 