### PR TITLE
Use algorithmic instead of algorithmicx in icml*.sty

### DIFF
--- a/lib/LaTeXML/Package/icml_support.sty.ltxml
+++ b/lib/LaTeXML/Package/icml_support.sty.ltxml
@@ -20,7 +20,7 @@ RequirePackage('times');
 RequirePackage('fancyhdr');
 RequirePackage('color');
 RequirePackage('algorithm');
-RequirePackage('algorithmicx');
+RequirePackage('algorithmic');
 RequirePackage('natbib');
 # RequirePackage('eso-pic');
 # RequirePackage('forloop');


### PR DESCRIPTION
All icml style files I've tested (2013-2019) require `algorithmic` package, but `algorithmicx` doesn’t define any `algorithmic` commands. [Here's](https://arxiv.org/pdf/1402.5766v1.pdf) an example of paper (using icml2014.sty) on which LaTeXML hangs during processing when `algorithmicx` is used.