### PR TITLE
[Suggestion] elevate perl's deep recursion to Fatal level

### DIFF
--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -243,6 +243,8 @@ sub perl_warn_handler {
   if ($line[0] =~ /^Use of uninitialized value (.*?)(\s?+in .*?)\s+(at\s+.*?\s+line\s+\d+)\.$/) {
     my ($what, $how, $where) = ($1 || 'value', $2, $3);
     Warn('uninitialized', $what, $where, "Use of uninitialized value $what $how", @line[1 .. $#line]); }
+  elsif ($line[0] =~ /^Deep recursion on/) {
+    Fatal('perl', 'deep_recursion', undef, $line[0]); }
   elsif ($line[0] =~ /^(.*?)\s+(at\s+.*?\s+line\s+\d+)\.$/) {
     my ($warning, $where) = ($1, $2);
     Warn('perl', 'warn', undef, $warning, $where, @line[1 .. $#line]); }
@@ -629,4 +631,3 @@ Public domain software, produced as part of work done by the
 United States Government & not subject to copyright in the US.
 
 =cut
-


### PR DESCRIPTION
This PR may be more about the discussion than the change. I was inspecting an interesting selection of out-of-memory/timeout examples from the arXiv run, and noticed a few cases with a "deep recursion", which later lead to errors and uncontrollable behaviour.

Now that we have a "recursion error" category, I am wondering if we may also want to continue down that path and get a "recursion fatal" category, for cases where it isn't clear how to escape back into the main document processing. A perl deep recursion is such a case - it should almost never occur naturally, and most of the times it is seen it leads to uncontrollable errors following. I recall there are occasional exceptions, where a binding could trigger a deep recursion and remain functional, but it's usually a sign that it can be optimized differently and avoid the recursion calls (performancy-costly in perl).

One very clean example was the use of alignments `&` outside of environments in an old latex document, which used low-level markup for aligned pieces in equations.

Making such examples work properly is a different topic, but we likely have a variety of interpretation limitations that are subtly spinning off into deep recursions, and then circling until they hit a timeout or out-of-memory Fatal. It's a great speedup for arxiv whenever we manage to mark a Fatal in several seconds, instead of consuming the CPU for 30 minutes.

```tex
\documentclass[11pt]{article}
\newtheorem{example}{Example}%[section]
\newdimen\Squaresize \Squaresize=14pt
\newdimen\Thickness \Thickness=0.5pt
\def\Square#1{\hbox{\vrule width \Thickness
   \vbox to \Squaresize{\hrule height \Thickness\vss
      \hbox to \Squaresize{\hss#1\hss}
   \vss\hrule height\Thickness}
\unskip\vrule width \Thickness}
\kern-\Thickness}

\def\Vsquare#1{\vbox{\Square{$#1$}}\kern-\Thickness}

\def\young#1{
\vbox{\smallskip\offinterlineskip
\halign{&\Vsquare{##}\cr #1}}}

% *****************************************************************

\begin{document}
\begin{example}{
\[
P(w_\pi) =
\matrix{\young{4\cr 3 & 5 \cr  1 & 2\cr}}\,.
\]
(Here and in what follows we choose the French orientation for
drawing Young tableaux.)
}\end{example}\end{document}
```
![image](https://user-images.githubusercontent.com/348975/62299921-e3d97a80-b443-11e9-9331-00b23d99145f.png)

