### PR TITLE
Add support for DockerHub auto-builds (fixes #1178)

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -15,17 +15,24 @@
 # This Dockerfile expects the root directory of LaTeXML as a build context. 
 # To achieve this run the following command from the root directory:
 #
-# > docker build -t latexml -f release/Dockerfile .
+# > docker build -t latexml -f release/docker/Dockerfile .
 
 # This Dockerfile can include a full TeXLive installation. 
 # This is enabled by default however it can be disabled by providing a
 # build argument like so:
 #
-# > docker build -t latexml --build-arg WITH_TEXLIVE=no -f release/Dockerfile .
+# > docker build -t latexml --build-arg WITH_TEXLIVE=no -f release/docker/Dockerfile .
 #
 # Please be aware that including a full TeXLive installation can take a
 # significant amount of time (depending on network connection) and will
 # increase the image size to several Gigabytes. 
+#
+# Futhermore to speed up the build process, it is also possible to
+# tell docker not to run the tests during the build proess. To achieve
+# this, pass --build-arg WITH_TESTS=no to the docker build command, e.g:
+#
+# > docker build -t latexml --build-arg WITH_TESTS=no -f release/docker/Dockerfile .
+
 
 # We start from alpine linux 3.10
 FROM alpine:3.10
@@ -52,6 +59,9 @@ RUN apk add --no-cache \
 # Configure TeXLive Support
 # Set to "no" to disable, "yes" to enable
 ARG WITH_TEXLIVE="yes"
+
+# Configure if we test during the build
+ARG WITH_TESTS="yes"
 
 # Install TeXLive if not disabled
 RUN [ "$WITH_TEXLIVE" == "no" ] || (\
@@ -82,6 +92,7 @@ ADD Makefile.PL     /opt/latexml/Makefile.PL
 #ADD manual.pdf      /opt/latexml/manual.pdf
 #ADD README.pod      /opt/README.pod
 
-# Installing  via cpanm
+# Installing  via cpanm (with or without tests)
 WORKDIR /opt/latexml
-RUN cpanm .
+
+RUN if [ "$WITH_TESTS" == "no" ] ; then cpanm --notest . ; else cpanm . ; fi

--- a/release/docker/hooks/build
+++ b/release/docker/hooks/build
@@ -1,0 +1,19 @@
+#!/bin/bash
+# /=====================================================================\ #
+# | LaTeXML DockerHub Hooks                                             | #
+# | This file is used by DockerHub during the automated build           | #
+# |=====================================================================| #
+# | Thanks to Tom Wiesing <tom.wiesing@gmail.com>                       | #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+
+# cd into the LaTeXML root directory
+cd $(git rev-parse --show-toplevel)
+
+# run the docker build without TeXLive to speed up builds
+docker build --build-arg WITH_TEXLIVE=no --build-arg WITH_TESTS=no -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
I've re-read the DockerHub documentation and figured out that it does support [custom build hooks](https://docs.docker.com/docker-hub/builds/advanced/). As such, I have to revise https://github.com/brucemiller/LaTeXML/issues/1178#issuecomment-517242737. With this PR I would like to merge a branch that has auto-builds (i.e. docker image build on every push) enabled. The generated images can be found at  [tkw01536/latexml](https://hub.docker.com/r/tkw01536/latexml/builds). 

To speed up the build process I made the following two optimizations:
- do not include TeXLive (i.e. `--build-arg WITH_TEXLIVE=no`)
- do not run perl tests during the build (i.e. installing with `cpanm --notest .`)

With these optimizations, building seems to take between 10-20 minutes for each commit.

Please note that deploying DockerHub auto-builds for the main LaTeXML repository will require someone with Owner rights on the GitHub repository to configure them. 