### PR TITLE
[WIP] TeX-faitfhul errors on undefined command sequence expansion

### DIFF
--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -244,7 +244,7 @@ sub unread {
 #  will step to the next input stream (Mouth) if one is available,
 # If $commentsok is true, will also pass comments.
 sub readXToken {
-  my ($self, $toplevel, $commentsok) = @_;
+  my ($self, $toplevel, $commentsok, $undefined_allowed) = @_;
   $toplevel = 1 unless defined $toplevel;
   return shift(@{ $$self{pending_comments} }) if $commentsok && @{ $$self{pending_comments} };
   my ($token, $cc, $defn);
@@ -272,7 +272,7 @@ sub readXToken {
                 : ($r eq 'LaTeXML::Core::Tokens' ? @$_
                   : Fatal('misdefined', $r, undef, "Expected a Token, got " . Stringify($_))))) }
             @{$r}); } }
-    elsif ($cc == CC_CS && !(LaTeXML::Core::State::lookupMeaning($STATE, $token))) {
+    elsif ($cc == CC_CS && !$undefined_allowed && !(LaTeXML::Core::State::lookupMeaning($STATE, $token))) {
       Error('undefined', $token, $self, "The token " . Stringify($token) . " is not defined during expansion. Consuming it and proceeding, expect trouble...");
       return; }
     else {

--- a/lib/LaTeXML/Core/Parameter.pm
+++ b/lib/LaTeXML/Core/Parameter.pm
@@ -152,7 +152,7 @@ sub revert {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 

--- a/lib/LaTeXML/Package/IEEEtran.cls.ltxml
+++ b/lib/LaTeXML/Package/IEEEtran.cls.ltxml
@@ -72,14 +72,14 @@ RawTeX(<<'EoTeX');
 \DeclareOption{onecolumn}{\CLASSOPTIONonecolumntrue\CLASSOPTIONtwocolumnfalse}
 \DeclareOption{twocolumn}{\CLASSOPTIONtwocolumntrue\CLASSOPTIONonecolumnfalse}
 \DeclareOption{draft}{\CLASSOPTIONdrafttrue\CLASSOPTIONdraftclstrue
-                      \CLASSOPTIONdraftclsnofootfalse} 
+                      \CLASSOPTIONdraftclsnofootfalse}
 % draftcls is for a draft mode which will not affect any packages
 % used by the document.
 \DeclareOption{draftcls}{\CLASSOPTIONdraftfalse\CLASSOPTIONdraftclstrue
-                         \CLASSOPTIONdraftclsnofootfalse} 
+                         \CLASSOPTIONdraftclsnofootfalse}
 % draftclsnofoot is like draftcls, but without the footer.
 \DeclareOption{draftclsnofoot}{\CLASSOPTIONdraftfalse\CLASSOPTIONdraftclstrue
-                               \CLASSOPTIONdraftclsnofoottrue} 
+                               \CLASSOPTIONdraftclsnofoottrue}
 \DeclareOption{final}{\CLASSOPTIONdraftfalse\CLASSOPTIONdraftclsfalse
                       \CLASSOPTIONdraftclsnofootfalse}
 
@@ -148,8 +148,9 @@ DefMacro('\IEEEauthorblockN{}', '#1');        # author
 DefConstructor('\@@@affiliation{}', "^ <ltx:contact role='affiliation'>#1</ltx:contact>");
 DefMacro('\IEEEauthorblockA{}', '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
 
-DefMacro(T_CS('\begin{IEEEkeywords}'),              '\@IEEEkeywords');
-DefMacro(T_CS('\end{IEEEkeywords}'),                '\@endIEEEkeywords');
+DefMacro(T_CS('\begin{IEEEkeywords}'), '\@IEEEkeywords');
+DefMacro(T_CS('\end{IEEEkeywords}'),   '\@endIEEEkeywords');
+Let('\@endIEEEkeywords', '\relax');           # stub
 DefMacro('\@IEEEkeywords XUntil:\@endIEEEkeywords', '\@add@frontmatter{ltx:keywords}{#1}');
 DefMacro('\IEEEraisesectionheading{}',              '#1');
 DefMacro('\IEEEPARstart{}{}', '#1#2');        # Eventually, dropcap?
@@ -171,7 +172,7 @@ RawTeX(<<'EoTeX');
 \def\theparagraph{\thesubsubsection.\arabic{paragraph}}
 \else
 \def\thesection{\Roman{section}}                             % I
-% V1.7, \mbox prevents breaks around - 
+% V1.7, \mbox prevents breaks around -
 \def\thesubsection{\mbox{\thesection-\Alph{subsection}}}     % I-A
 % V1.7 use I-A1 format used by the IEEE rather than I-A.1
 \def\thesubsubsection{\thesubsection\arabic{subsubsection}}  % I-A1

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -3168,8 +3168,9 @@ DefPrimitive('\unhcopy Number', sub {
     my $stuff = LookupValue($box);
     (defined $stuff ? $stuff->unlist : ()); });
 
-# \vrule
-# \valign ???
+# Implement ???
+# DefMacro('\vrule','\relax');
+DefMacro('\valign', '');
 
 DefMacro('\vspace{}', '\vskip#1\relax');
 # \indent, \noindent, \par; see above.

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -885,6 +885,11 @@ DefMacro('\expandafter Token Token', sub {
       local $LaTeXML::NOEXPAND_THE = undef;
       my $x = $defn->invoke($gullet);
       ($tok, ($x ? @{$x} : ())); }    # Expand $xtok ONCE ONLY!
+    elsif (!defined($STATE->lookupMeaning($xtok))) {
+      # Undefined token is an error, as expansion is expected. The unknown token is consumed.
+      # see TeX B book, item 367.
+      Error('undefined', $xtok, $gullet, "The token " . Stringify($xtok) . " is not defined");
+      ($tok); }
     else {
       ($tok, $xtok); } });
 

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2804,8 +2804,11 @@ DefPrimitiveI('\@@open@inner@column', undef, sub {
     my @savedtokens = ();
     $$colspec{empty} = 0;           # Assume the column isn't empty
                                     # Scan for leading \omit, skipping over (& saving) \hline.
+         # TODO: This loop of expansions actually allows for undefined command sequences to be present
+      #      as its timing is a little artificial. E.g. it would read locally scoped macros before they are
+      #      activated by the before=> templates of columns.
 
-    while (my $tok = $gullet->readXToken(0)) {
+    while (my $tok = $gullet->readXToken(0, 0, 1)) {
       if ($tok->equals(T_SPACE)) { }    # Skip leading space
       elsif (grep { $tok->equals($_) } @line_tokens) {    # Save line commands
         push(@lines, $stomach->invokeToken($tok)); }

--- a/lib/LaTeXML/Package/calc.sty.ltxml
+++ b/lib/LaTeXML/Package/calc.sty.ltxml
@@ -20,10 +20,12 @@ use LaTeXML::Package;
 ## (e.g. \ratio, \minOf, etc)
 ## and are instead consumed incrementally. However, for that to succeed with the correct implementation
 ## of readXToken, we would need to define them explicitly, or we get "undefined cs was expanded" errors.
-##
-## Hence, for now I am  leaving the reads as shallow readToken calls. If there is a need to extend this binding
-## to expand its arguments, we could define each macro to expand into its name, and have chekcs on
-## "ToString($op) eq 'ratio' ", etc.
+DefMacro('\minof',    '\noexpand\minof');
+DefMacro('\maxof',    '\noexpand\maxof');
+DefMacro('\widthof',  '\noexpand\widthof');
+DefMacro('\heightof', '\noexpand\heightof');
+DefMacro('\ratio',    '\noexpand\ratio');
+DefMacro('\real',     '\noexpand\real');
 
 # \setcounter{<ctr>}{<integer expression>}
 DefPrimitive('\setcounter{}{}', sub {
@@ -147,7 +149,7 @@ sub readTerm {
 sub readValue {
   my ($gullet, $type) = @_;
   $gullet->skipSpaces;
-  my $peek = $gullet->readToken();
+  my $peek = $gullet->readXToken();
   # Evaluate <Text Dimen Factors>
   if (Equals($peek, T_CS('\widthof'))) {
     my $box = Digest($gullet->readArg);
@@ -203,7 +205,7 @@ sub readValue {
 sub readMinMax {
   my ($gullet, $type) = @_;
   $gullet->skipSpaces;
-  my $peek = $gullet->readToken();
+  my $peek = $gullet->readXToken();
   if (Equals($peek, T_CS('\minof'))) {
     my $x = readExpression($gullet, $type, $gullet->readArg);
     my $y = readExpression($gullet, $type, $gullet->readArg);
@@ -219,7 +221,7 @@ sub readMinMax {
 sub readTextDimenFactor {
   my ($gullet) = @_;
   $gullet->skipSpaces;
-  my $peek = $gullet->readToken();
+  my $peek = $gullet->readXToken();
   if (Equals($peek, T_CS('\widthof'))) {
     my $box = Digest($gullet->readArg);
     return Dimension(0); }
@@ -247,7 +249,7 @@ sub readParenthesized {
 sub readReal {
   my ($gullet) = @_;
   $gullet->skipSpaces;
-  my $peek = $gullet->readToken();
+  my $peek = $gullet->readXToken();
   if (Equals($peek, T_CS('\real'))) {
     my $arg = $gullet->readArg;
     return $gullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {

--- a/lib/LaTeXML/Package/calc.sty.ltxml
+++ b/lib/LaTeXML/Package/calc.sty.ltxml
@@ -15,6 +15,16 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+## TODO: Refactor goals.
+## There is a choice made in this binding, where the core macros of calc.sty are left undefined
+## (e.g. \ratio, \minOf, etc)
+## and are instead consumed incrementally. However, for that to succeed with the correct implementation
+## of readXToken, we would need to define them explicitly, or we get "undefined cs was expanded" errors.
+##
+## Hence, for now I am  leaving the reads as shallow readToken calls. If there is a need to extend this binding
+## to expand its arguments, we could define each macro to expand into its name, and have chekcs on
+## "ToString($op) eq 'ratio' ", etc.
+
 # \setcounter{<ctr>}{<integer expression>}
 DefPrimitive('\setcounter{}{}', sub {
     my ($stomach, $ctr, $arg) = @_;
@@ -137,7 +147,7 @@ sub readTerm {
 sub readValue {
   my ($gullet, $type) = @_;
   $gullet->skipSpaces;
-  my $peek = $gullet->readXToken();
+  my $peek = $gullet->readToken();
   # Evaluate <Text Dimen Factors>
   if (Equals($peek, T_CS('\widthof'))) {
     my $box = Digest($gullet->readArg);
@@ -193,7 +203,7 @@ sub readValue {
 sub readMinMax {
   my ($gullet, $type) = @_;
   $gullet->skipSpaces;
-  my $peek = $gullet->readXToken();
+  my $peek = $gullet->readToken();
   if (Equals($peek, T_CS('\minof'))) {
     my $x = readExpression($gullet, $type, $gullet->readArg);
     my $y = readExpression($gullet, $type, $gullet->readArg);
@@ -209,7 +219,7 @@ sub readMinMax {
 sub readTextDimenFactor {
   my ($gullet) = @_;
   $gullet->skipSpaces;
-  my $peek = $gullet->readXToken();
+  my $peek = $gullet->readToken();
   if (Equals($peek, T_CS('\widthof'))) {
     my $box = Digest($gullet->readArg);
     return Dimension(0); }
@@ -237,7 +247,7 @@ sub readParenthesized {
 sub readReal {
   my ($gullet) = @_;
   $gullet->skipSpaces;
-  my $peek = $gullet->readXToken();
+  my $peek = $gullet->readToken();
   if (Equals($peek, T_CS('\real'))) {
     my $arg = $gullet->readArg;
     return $gullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
@@ -251,9 +261,6 @@ sub readReal {
   else {
     $gullet->unread($peek);
     return; } }
-
-Let('\real',  '\relax');
-Let('\ratio', '\relax');
 
 #**********************************************************************
 1;

--- a/lib/LaTeXML/Package/calc.sty.ltxml
+++ b/lib/LaTeXML/Package/calc.sty.ltxml
@@ -252,5 +252,8 @@ sub readReal {
     $gullet->unread($peek);
     return; } }
 
+Let('\real',  '\relax');
+Let('\ratio', '\relax');
+
 #**********************************************************************
 1;

--- a/lib/LaTeXML/Package/siunitx.sty.ltxml
+++ b/lib/LaTeXML/Package/siunitx.sty.ltxml
@@ -102,8 +102,8 @@ DefPrimitiveI('\lx@six@initialize', undef, sub {
       InputDefinitions('siunitx-abbreviations', type => 'cfg', noltxml => 1); }
     if (six_getBool('binary-units')) {
       InputDefinitions('siunitx-binary', type => 'cfg', noltxml => 1); }
-    # if (six_getBool('free-standing-units')) { # ??
-    six_enableUnitMacros(six_getBool('overwrite-functions'));    # }
+    if (six_getBool('free-standing-units')) {
+      six_enableUnitMacros(six_getBool('overwrite-functions')); }
     return; });
 
 AtBeginDocument('\lx@six@initialize');
@@ -503,7 +503,9 @@ sub six_parse_begin {
   my $stomach = $STATE->getStomach;
   $stomach->bgroup;
   six_setup($kv) if $kv;
-  map { Let($_, T_CS('\relax')); } six_get('input-protect-tokens')->unlist;
+  for my $token (six_get('input-protect-tokens')->unlist) {
+    my $name = $token->getCSName;
+    Let($token, T_OTHER($name)); }
   return; }
 
 sub six_parse_end {
@@ -1161,7 +1163,7 @@ DefMacro('\lx@six@highlight{}', '\lx@six@unitobject@arg{highlight}{#1}');
 DefColumnType('s Optional', sub {
     my ($gullet, $kv) = @_;
     $LaTeXML::BUILD_TEMPLATE->addColumn(
-      before => Tokens(T_CS('\lx@si@column@begin'), ($kv ? (T_OTHER('['), $kv, T_OTHER(']')) : ())),
+      before => Tokens(T_CS('\lx@sicolumn@begin'), ($kv ? (T_OTHER('['), $kv, T_OTHER(']')) : ()), T_LETTER("sismall")),
       #      after => Tokens(T_CS('\lx@si@column@end')),
       #      align => 'char:' . ToString(Digest(T_CS('\nprt@decimal')))
     );
@@ -1170,25 +1172,30 @@ DefColumnType('s Optional', sub {
 DefColumnType('S Optional', sub {
     my ($gullet, $kv) = @_;
     $LaTeXML::BUILD_TEMPLATE->addColumn(
-      before => Tokens(T_CS('\lx@SI@column@begin'), ($kv ? (T_OTHER('['), $kv, T_OTHER(']')) : ())),
+      before => Tokens(T_CS('\lx@sicolumn@begin'), ($kv ? (T_OTHER('['), $kv, T_OTHER(']')) : ()), T_LETTER("SILARGE")),
       #      after => Tokens(T_CS('\lx@SI@column@end')),
       #      align => 'char:' . ToString(Digest(T_CS('\nprt@decimal'))));
     );
     return; });
 
-DefMacro('\lx@si@column@begin Optional XUntil:\@@close@inner@column',
-  '\def\@@eat@space{}\lx@table@si[#1]{#2}\@@close@inner@column');
-DefMacro('\lx@SI@column@begin Optional XUntil:\@@close@inner@column',
-  '\def\@@eat@space{}\lx@table@num[#1]{#2}\@@close@inner@column');
+DefMacro('\lx@sicolumn@begin OptionalKeyVals:SIX Token', sub {
+    my ($gullet, $kv, $type) = @_;
+    six_parse_begin($gullet, $kv);
+    if (ToString($type) eq 'sismall') {
+      six_enableUnitMacros(1);
+      return (T_CS('\lx@column@next'), T_CS('\lx@table@si')); }
+    else {
+      return (T_CS('\lx@column@next'), T_CS('\lx@table@num')); }
+});
+DefMacro('\lx@column@next Token XUntil:\@@close@inner@column', '\def\@@eat@space{}#1{#2}\@@close@inner@column');
 
 # TODO: These two need to deal better with unrecognized arguments.
 # Generally they should NOT be in math mode... (but sometimes, still?)
 
 # Similar to \num, no error...
 # color treated a bit differently?
-DefMacro('\lx@table@num OptionalKeyVals:SIX {}', sub {
-    my ($gullet, $kv, $number) = @_;
-    six_parse_begin($gullet, $kv);
+DefMacro('\lx@table@num {}', sub {
+    my ($gullet, $number) = @_;
     my @tokens  = Expand($number)->unlist;
     my $doparse = six_getBool('parse-numbers');
     # Deal with recognizing "surrounding material"
@@ -1226,10 +1233,8 @@ DefMacro('\lx@table@num OptionalKeyVals:SIX {}', sub {
       @post); });
 
 # similar to \si
-DefMacro('\lx@table@si OptionalKeyVals:SIX {}', sub {
-    my ($gullet, $kv, $units) = @_;
-    six_parse_begin($gullet, $kv);
-    six_enableUnitMacros(1);
+DefMacro('\lx@table@si {}', sub {
+    my ($gullet, $units) = @_;
     my @tokens = Expand($units)->unlist;
     my @pre    = ();
     my @post   = ();

--- a/lib/LaTeXML/Package/siunitx.sty.ltxml
+++ b/lib/LaTeXML/Package/siunitx.sty.ltxml
@@ -89,7 +89,7 @@ DefPrimitive('\sisetup RequiredKeyVals:SIX', sub { six_setup($_[1]); });
 DefMacro('\ProvidesExplFile{}{}{}{}', '');
 DefPrimitiveI('\lx@six@initialize', undef, sub {
     my $pkgoptions = LookupValue('opt@siunitx.sty');
-    my $setup = $pkgoptions && Tokenize('\sisetup{' . join(',', map { $_ } @$pkgoptions) . '}');
+    my $setup      = $pkgoptions && Tokenize('\sisetup{' . join(',', map { $_ } @$pkgoptions) . '}');
     Digest($setup) if $setup;
     if (six_getBool('version-1-compatibility') || six_get('alsoload')) {
       # At present time (siunitx 2.6q) compatibility file is deeply expl3-ish.
@@ -102,8 +102,8 @@ DefPrimitiveI('\lx@six@initialize', undef, sub {
       InputDefinitions('siunitx-abbreviations', type => 'cfg', noltxml => 1); }
     if (six_getBool('binary-units')) {
       InputDefinitions('siunitx-binary', type => 'cfg', noltxml => 1); }
-    if (six_getBool('free-standing-units')) {
-      six_enableUnitMacros(six_getBool('overwrite-functions')); }
+    # if (six_getBool('free-standing-units')) { # ??
+    six_enableUnitMacros(six_getBool('overwrite-functions'));    # }
     return; });
 
 AtBeginDocument('\lx@six@initialize');
@@ -222,7 +222,7 @@ sub six_parse_cenumber {
   my ($expmark, $expsign, $exp);
   if ($expmark = six_match($tokens, 'input-exponent-markers')) {
     $expsign = six_match($tokens, 'input-signs');
-    $exp = six_match($tokens, 'input-digits', 'input-symbols');
+    $exp     = six_match($tokens, 'input-digits', 'input-symbols');
     $number = { operator => 'exponent', arg1 => $number,
       arg2 => { sign => $expsign, integer => $exp } }; }
   return $number; }
@@ -295,14 +295,14 @@ sub six_adjust_uncertainty {
       for (my $i = $n ; $i < $ndigits ; $i++) {
         unshift(@dig, T_OTHER('0')); }
       $$number{uncertainty} = { sign => T_CS('\pm'),
-        integer => T_OTHER('0'), decimal => six_get('output-decimal-marker'),
+        integer  => T_OTHER('0'), decimal => six_get('output-decimal-marker'),
         fraction => Tokens(@dig) }; }
     else {
       my @man = ();
       for (my $i = $n ; $i > $ndigits ; $i--) {
         push(@man, shift(@dig)); }
       $$number{uncertainty} = { sign => T_CS('\pm'),
-        integer => Tokens(@man), decimal => six_get('output-decimal-marker'),
+        integer  => Tokens(@man), decimal => six_get('output-decimal-marker'),
         fraction => Tokens(@dig) }; } }
   else {    # Need bracketted, but have separate uncertainty.
     my @dig = ();
@@ -318,7 +318,7 @@ sub six_adjust_uncertainty {
       for (my $i = $ndigits ; $i < $nuf ; $i++) {
         push(@frac, T_OTHER('0')); }
       $$number{fraction} = Tokens(@frac);
-      $$number{decimal} = six_get('output-decimal-marker') unless $$number{decimal}; }
+      $$number{decimal}  = six_get('output-decimal-marker') unless $$number{decimal}; }
     $$number{uncertainty} = { integer => Tokens(@dig) }; }
   return; }
 
@@ -503,7 +503,7 @@ sub six_parse_begin {
   my $stomach = $STATE->getStomach;
   $stomach->bgroup;
   six_setup($kv) if $kv;
-  map { Let($_, T_CS('\nothing')); } six_get('input-protect-tokens')->unlist;
+  map { Let($_, T_CS('\relax')); } six_get('input-protect-tokens')->unlist;
   return; }
 
 sub six_parse_end {
@@ -1037,7 +1037,7 @@ DefMacro('\lx@six@unitobject@collapsible{}{}', sub {
 #   \__siunitx_declare_prefix : Nnnn    #1 {#2} { 2 } {#3} }
 DefPrimitive('\DeclareBinaryPrefix OptionalKeyVals:SIX SkipSpaces DefToken {}{}', sub {
     my ($stomach, $kv, $cs, $presentation, $power) = @_;
-    my $name = $cs->getCSName; $name =~ s/^\\//;
+    my $name  = $cs->getCSName; $name =~ s/^\\//;
     my $newcs = T_CS('\lx@six@' . $name);
     AssignMapping('siunitx_macros',
       $name => { name => $name, cs => $cs, implementation => $newcs, keyvals => $kv, type => 'prefix',
@@ -1051,7 +1051,7 @@ DefPrimitive('\DeclareBinaryPrefix OptionalKeyVals:SIX SkipSpaces DefToken {}{}'
 # Prefix operator, applies a power
 DefPrimitive('\DeclareSIPrefix OptionalKeyVals:SIX SkipSpaces DefToken {}{}', sub {
     my ($stomach, $kv, $cs, $presentation, $power) = @_;
-    my $name = $cs->getCSName; $name =~ s/^\\//;
+    my $name  = $cs->getCSName; $name =~ s/^\\//;
     my $newcs = T_CS('\lx@six@' . $name);
     AssignMapping('siunitx_macros',
       $name => { name => $name, cs => $cs, implementation => $newcs, keyvals => $kv, type => 'prefix',
@@ -1064,7 +1064,7 @@ DefPrimitive('\DeclareSIPrefix OptionalKeyVals:SIX SkipSpaces DefToken {}{}', su
 # Prefix operator, applies a power
 DefPrimitive('\DeclareSIPrePower OptionalKeyVals:SIX SkipSpaces DefToken {}', sub {
     my ($stomach, $kv, $cs, $power) = @_;
-    my $name = $cs->getCSName; $name =~ s/^\\//;
+    my $name  = $cs->getCSName; $name =~ s/^\\//;
     my $newcs = T_CS('\lx@six@' . $name);
     AssignMapping('siunitx_macros',
       $name => { name => $name, cs => $cs, implementation => $newcs,
@@ -1078,7 +1078,7 @@ DefPrimitive('\DeclareSIPrePower OptionalKeyVals:SIX SkipSpaces DefToken {}', su
 # Postfix operator, applies a power
 DefPrimitive('\DeclareSIPostPower OptionalKeyVals:SIX SkipSpaces DefToken {}', sub {
     my ($stomach, $kv, $cs, $power) = @_;
-    my $name = $cs->getCSName; $name =~ s/^\\//;
+    my $name  = $cs->getCSName; $name =~ s/^\\//;
     my $newcs = T_CS('\lx@six@' . $name);
     AssignMapping('siunitx_macros',
       $name => { name => $name, cs => $cs, implementation => $newcs,
@@ -1103,7 +1103,7 @@ DefMacro('\lx@six@raiseto{}', '\lx@six@unitobject@arg{raiseto}{#1}');
 # Postfix operator, qualifies the meaning, applies a subscript
 DefPrimitive('\DeclareSIQualifier OptionalKeyVals:SIX SkipSpaces DefToken {}', sub {
     my ($stomach, $kv, $cs, $qualifier) = @_;
-    my $name = $cs->getCSName; $name =~ s/^\\//;
+    my $name  = $cs->getCSName; $name =~ s/^\\//;
     my $newcs = T_CS('\lx@six@' . $name);
     AssignMapping('siunitx_macros',
       $name => { name => $name, cs => $cs, implementation => $newcs,
@@ -1124,7 +1124,7 @@ DefMacro('\lx@six@of{}', '\lx@six@unitobject@arg{of}{#1}');
 # Or a macro (or Unit) that expands into... (and it may not even be defined yet)
 DefPrimitive('\DeclareSIUnit OptionalKeyVals:SIX SkipSpaces DefToken {}', sub {
     my ($stomach, $kv, $cs, $presentation) = @_;
-    my $name = $cs->getCSName; $name =~ s/^\\//;
+    my $name  = $cs->getCSName; $name =~ s/^\\//;
     my $newcs = T_CS('\lx@six@' . $name);
     AssignMapping('siunitx_macros',
       $name => { name => $name, cs => $cs, implementation => $newcs,
@@ -1585,5 +1585,6 @@ sub six_load_compat1 {
 \DeclareSIUnit \yb        { \yocto \barn }
 EoTeX
   return; }
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;


### PR DESCRIPTION
Fixes #1180 . 

And likely breaks a range of hard-to-foresee arXiv jobs, and third party raw TeX uses. I think my fixes definitely need some review and discussion/thought, as I touched bindings I am not closely familiar with.

The general concept is simple enough - expansion must *always* have defined command sequence arguments. And all *good* uses of expansion already do. The breakage in latexml happens at the fringes -- e.g. bindings that take very Perl-y approaches and leave certain command sequences undefined, or raw interpretation that silently ends up accepting invalid inputs where it should alert us with an error that latexml needs further improvement. I gave two examples in the issue of error cases, which now work just the same as in pdflatex with this PR. And tests pass with my modifications.
