### PR TITLE
Unified conversion for multi-bib collections

### DIFF
--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -149,11 +149,11 @@ sub getBibliographies {
   # Lastly, If we found any raw .bib files/literaldata, convert and include them.
   if (@rawbibs) {
     my $raw;
-    if (scalar(@rawbibs) == 1) {    # Multiple, arrange into a single conversion payload
+    if (scalar(@rawbibs) == 1) {    # Single, just convert as-is
       $raw = $rawbibs[0]; }
     else {
       $raw = 'literal:';
-      for my $rawbib (@rawbibs) {
+      for my $rawbib (@rawbibs) { # Multiple, arrange into a single conversion payload
         if ($rawbib =~ s/literal\://) {
           $raw .= $rawbib; }
         else {

--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -108,8 +108,10 @@ sub getBibliographies {
       || $bibnode->parentNode->getAttribute('files')    # !!!!!
     ) {
       @bibnames = map { $_ . '.bib' } split(',', $files); } }
-  my @paths = $doc->getSearchPaths;
-  my @bibs  = ();
+  my @paths   = $doc->getSearchPaths;
+  my @bibs    = ();
+  my @rawbibs = ();
+ # Collect the "ready" bibliographies, while accumulating all raw sources for a single conversion pass
   foreach my $bib (@bibnames) {
     my $ref = ref $bib;
     my $bibdoc;
@@ -121,11 +123,10 @@ sub getBibliographies {
       Error('unexpected', $ref, $self,
         "Don't know how to convert '$bib' (a '$ref') into a Bibliography document"); }
     elsif (pathname_is_literaldata($bib)) {
-      # Assume (for now) that the data is BibTeX text;
-      # [another possibility is serialized xml!]
-      $bibdoc = $self->convertBibliography($doc, $bib); }
-    elsif ($bib =~ /\.xml/) {
-      $bibdoc = $doc->newFromFile($bib); }    # doc will do the searching...
+      push(@rawbibs, $bib);
+      next; }
+    elsif ($bib =~ /\.xml$/) {
+      $bibdoc = $doc->newFromFile($bib); }                 # doc will do the searching...
     elsif ($bib =~ /\.bib(?:\.xml)?$/) {
       my $name = $1;
       # NOTE: We should also use kpsewhich to get the effects of $BIBINPUTS?
@@ -134,7 +135,8 @@ sub getBibliographies {
         $bibdoc = $doc->newFromFile($xmlpath); }    # doc will do the searching...
       elsif (my $bibpath = pathname_find($bib, paths => [@paths], types => ['bib'])
         || pathname_kpsewhich($bib)) {
-        $bibdoc = $self->convertBibliography($doc, $bibpath); }
+        push(@rawbibs, $bibpath);
+        next; }
       else {
         Error('missing_file', $bib, $self,
           "Couldn't find Bibliography '$bib'",
@@ -144,6 +146,26 @@ sub getBibliographies {
     else {
       Info('expected', $bib, $self,
         "Couldn't find usable Bibliography for '$bib'"); } }
+  # Lastly, If we found any raw .bib files/literaldata, convert and include them.
+  if (@rawbibs) {
+    my $raw;
+    if (scalar(@rawbibs) == 1) {    # Multiple, arrange into a single conversion payload
+      $raw = $rawbibs[0]; }
+    else {
+      $raw = 'literal:';
+      for my $rawbib (@rawbibs) {
+        if ($rawbib =~ s/literal\://) {
+          $raw .= $rawbib; }
+        else {
+          # TODO: Is this a memory concern for large bib files?
+          if (open(my $bibfh, '<', $rawbib)) {
+            $raw .= join("", <$bibfh>);
+            close $bibfh; }
+          else {
+            Info("open", $rawbib, $self, "Couldn't open file $rawbib"); } }
+        $raw .= "%\n"; } }
+    my $bibdoc = $self->convertBibliography($doc, $raw);
+    push(@bibs, $bibdoc) if $bibdoc; }
   NoteProgress(" [using bibliographies "
       . join(',', map { (length($_) > 100 ? substr($_, 100) . '...' : $_) } @bibnames)
       . "]");
@@ -178,7 +200,8 @@ sub convertBibliography {
       push(@preload, "[$options]$pkg.sty"); }
     else {
       push(@preload, "$pkg.sty"); } }
-  NoteProgress(" [Converting bibliography $bib ...");
+  my $bibname = pathname_is_literaldata($bib) ? 'Anonymous Bib String' : $bib;
+  NoteProgress(" [Converting bibliography $bibname ...");
   my $bib_config = LaTeXML::Common::Config->new(
     cache_key      => 'BibTeX',
     type           => "BibTeX",

--- a/lib/LaTeXML/Pre/BibTeX.pm
+++ b/lib/LaTeXML/Pre/BibTeX.pm
@@ -62,7 +62,7 @@ sub newFromFile {
   my $self = { source => $bibname, preamble => [], entries => [], macros => {%default_macros} };
   bless $self, $class;
   my $paths = $STATE->lookupValue('SEARCHPATHS');
-  my $file = pathname_find($bibname, types => ['bib'], paths => $paths);
+  my $file  = pathname_find($bibname, types => ['bib'], paths => $paths);
   Fatal('missing_file', $bibname, undef, "Can't find BibTeX file $bibname",
     "SEACHPATHS is " . join(', ', @$paths)) unless $file;
   my $BIB;
@@ -70,7 +70,7 @@ sub newFromFile {
   open($BIB, '<', $file) or Fatal('I/O', $file, undef, "Can't open BibTeX $file for reading", $!);
   $$self{lines} = [<$BIB>];
   close($BIB);
-  $$self{line} = shift(@{ $$self{lines} }) || '';
+  $$self{line}   = shift(@{ $$self{lines} }) || '';
   $$self{lineno} = 1;
   return $self; }
 
@@ -334,6 +334,7 @@ sub skipWhite {
 # So, until an @ is encountered, pretty much skip anything
 sub skipJunk {
   my ($self) = @_;
+  $$self{line} ||= "";
   while (1) {
     $$self{line} =~ s/^[^@%]*//;    # Skip till comment or @
     return '@' if $$self{line} =~ s/^@//;    # Found @
@@ -349,7 +350,7 @@ sub skipJunk {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -436,4 +437,3 @@ Public domain software, produced as part of work done by the
 United States Government & not subject to copyright in the US.
 
 =cut
-


### PR DESCRIPTION
Fixes #980 , but begrudgingly so.

We don't really have a clean API for passing a collection of documents for conversion (so that they reuse the same state), and there is no `\input` opportunity when we are in BibTeX mode. Which leaves me with the sole option of detecting a multi-`.bib` setup in post-processing, and concatenating the content of all of those files together, in order to have a `@preamble` from one bib file visible to all following.

This actually gets Michael's example working smoothly, but makes it annoying to debug cases where you've used several bib files and one of them encounters an error -- since the error message you'll get will be about a literal string that has nothing to do with the original files, even the line numbers are different.

In any case, I'm offering it as a PR, at least as a conversation starter.