### PR TITLE
Silence side-effect warnings for math lexemes (otherwise harmless)

### DIFF
--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -708,6 +708,7 @@ sub node_to_lexeme {
           push @to_add, $value; } }
       if (@to_add) {
         $lexeme = join("-", sort(@to_add)) . "-" . $lexeme; } } }
+  local $LaTeXML::MathParser::STRICT = 0;
   if (my $role = $self->getGrammaticalRole($node)) {
     if ($role ne 'UNKNOWN') {
       $lexeme = $role . ":" . $lexeme; } }


### PR DESCRIPTION
I spotted some cosmetic bugs in reporting the unknown tokens in math parsing, when the math lexeme serialization is turned on. It did not affect any of the processing or output, just the (info-level) messages printed out - an unintended side-effect from reusing the `getGrammaticalRole` method.

Example in master:
```
 latexmlc --whatsin=math --preload=llamapun.sty 'literal:\sqrt{x}'
```

![image](https://user-images.githubusercontent.com/348975/62745654-065a2d80-ba1a-11e9-9f8d-74a7d5749c96.png)

with PR:

![image](https://user-images.githubusercontent.com/348975/62745723-49b49c00-ba1a-11e9-8514-7d77b740fd8e.png)


