### PR TITLE
Patch finalize_rec for stex ltx:text elements

### DIFF
--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -415,10 +415,9 @@ sub finalize_rec {
     elsif ($type == XML_TEXT_NODE) {
       # Remove any pending declarations that can't be on $FONT_ELEMENT_NAME
       my $elementname = $pending_declaration{element}{value} || $FONT_ELEMENT_NAME;
+      delete $pending_declaration{element};    # If any...
       foreach my $key (keys %pending_declaration) {
-        # make sure we also delete the element key we just used, or one can infinitely recurse on ltx:text
-        if (($key eq 'element') || !$self->canHaveAttribute($elementname, $key)) {
-          delete $pending_declaration{$key}; } }
+        delete $pending_declaration{$key} unless $self->canHaveAttribute($elementname, $key); }
       if ($self->canContain($qname, $elementname)
         && scalar(keys %pending_declaration)) {
         # Too late to do wrapNodes?
@@ -426,11 +425,11 @@ sub finalize_rec {
         # Add (or combine) attributes
         foreach my $attr (keys %pending_declaration) {
           my $value = $pending_declaration{$attr}{value};
-          if ($attr eq 'class') {    # Generalize?
+          if ($attr eq 'class') {              # Generalize?
             if (my $ovalue = $text->getAttribute('class')) {
               $value .= ' ' . $ovalue; } }
           $self->setAttribute($text, $attr => $value); }
-        $self->finalize_rec($text);    # Now have to clean up the new node!
+        $self->finalize_rec($text);            # Now have to clean up the new node!
       }
   } }
 

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -416,7 +416,9 @@ sub finalize_rec {
       # Remove any pending declarations that can't be on $FONT_ELEMENT_NAME
       my $elementname = $pending_declaration{element}{value} || $FONT_ELEMENT_NAME;
       foreach my $key (keys %pending_declaration) {
-        delete $pending_declaration{$key} unless $self->canHaveAttribute($elementname, $key); }
+        # make sure we also delete the element key we just used, or one can infinitely recurse on ltx:text
+        if (($key eq 'element') || !$self->canHaveAttribute($elementname, $key)) {
+          delete $pending_declaration{$key}; } }
       if ($self->canContain($qname, $elementname)
         && scalar(keys %pending_declaration)) {
         # Too late to do wrapNodes?
@@ -2275,4 +2277,3 @@ Public domain software, produced as part of work done by the
 United States Government & not subject to copyright in the US.
 
 =cut
-


### PR DESCRIPTION
This is another one of those "too many moving parts" debugging streams, as sTeX usually is.

I localized a snippet that experienced a deep recursion on `Document::finalize_rec` when serializing, see `deep_rec.xml` at:
https://gist.github.com/dginev/4a1eaa48ca26b662a0f217da288642ad

It turned out it was looping on a trivial `ltx:text` element containing `foo`, as the `%pending_declarations` were never emptied. They contained a very artificial `{ element => {} }`, and thus the recursive call kept happening, until it bottomed out.

I am not really certain as to why/how sTeX got itself into that position, but here is a trace of what finalize_rec was seeing as arguments when it went into the loop:
```xml
finalize_rec on :
 <omdoc:rendering _box="LaTeXML::Core::Whatsit=HASH(0x55bb206a2290)" _font="Font[serif,medium,upright,10,black,white,1,OT1,*,*,0]">
  <ltx:text _font="Font[serif,medium,upright,10,black,white,1,OT1,*,*,0]" _box="LaTeXML::Core::Whatsit=HASH(0x55bb206af3d0)" class="ltx_markedasmath">foo</ltx:text>
</omdoc:rendering>
finalize_rec on : <ltx:text _font="Font[serif,medium,upright,10,black,white,1,OT1,*,*,0]" _box="LaTeXML::Core::Whatsit=HASH(0x55bb206af3d0)" class="ltx_markedasmath">foo</ltx:text>
finalize_rec on : <ltx:text _font="Font[serif,medium,upright,10,black,white,1,OT1,*,*,0]" _box="LaTeXML::Core::Whatsit=HASH(0x55bb206af3d0)">foo</ltx:text>
finalize_rec on : <ltx:text _font="Font[serif,medium,upright,10,black,white,1,OT1,*,*,0]" _box="LaTeXML::Core::Whatsit=HASH(0x55bb206af3d0)">foo</ltx:text>
finalize_rec on : <ltx:text _font="Font[serif,medium,upright,10,black,white,1,OT1,*,*,0]" _box="LaTeXML::Core::Whatsit=HASH(0x55bb206af3d0)">foo</ltx:text>
...
```

The fix in this PR escapes the loop and terminates with reasonable output. Just hoping it's not even subtler.