### PR TITLE
remove redundant XMDual lexemes; extra safe end lexeme spacing

### DIFF
--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -737,12 +737,12 @@ sub node_to_lexeme_full {
       # so just ignore the XMDual role attributes
       if ($tag ne 'ltx:XMDual') {
         $mark_start = "$role:start ";
-        $mark_end   = "$role:end";
+        $mark_end   = " $role:end";
       }
     } elsif ($tag =~ '^ltx:XM(Arg|Row|Cell)') {
       my $tag_role = uc($1);
       $mark_start = "$tag_role:start ";
-      $mark_end   = "$tag_role:end";
+      $mark_end   = " $tag_role:end";
     }
   }
   my $lexemes = $mark_start;
@@ -772,7 +772,7 @@ sub node_to_lexeme_full {
       }
     }
   }
-  $lexemes .= ' ' . $mark_end;
+  $lexemes .= $mark_end;
   return $lexemes;
 }
 

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -733,8 +733,12 @@ sub node_to_lexeme_full {
   my ($mark_start, $mark_end) = ('', '');
   if ($tag ne 'ltx:XMath') {
     if ($role) {
-      $mark_start = "$role:start ";
-      $mark_end   = "$role:end";
+      # the dual marks are redundant with the marks on their inner XMWrap or other contents
+      # so just ignore the XMDual role attributes
+      if ($tag ne 'ltx:XMDual') {
+        $mark_start = "$role:start ";
+        $mark_end   = "$role:end";
+      }
     } elsif ($tag =~ '^ltx:XM(Arg|Row|Cell)') {
       my $tag_role = uc($1);
       $mark_start = "$tag_role:start ";
@@ -768,7 +772,7 @@ sub node_to_lexeme_full {
       }
     }
   }
-  $lexemes .= $mark_end;
+  $lexemes .= ' ' . $mark_end;
   return $lexemes;
 }
 


### PR DESCRIPTION
I wish I had arrived at this issue+patch before the full arXiv run, but oh well. I could rerun or guard against it in preprocessing...

I noticed a problem with the end lexeme markers for certain `OPFUNCTION` arguments - by far not all. Upon investigation, a minimal example:

```
latexmlc test.tex  --preload=[mathlexemes]latexml.sty --pmml
```

```tex
\documentclass{article}
\usepackage{amsmath}
\DeclareMathOperator{\dd}    {d\!}     % symbol for integration d
\begin{document}
\begin{equation}
  \dd
\end{equation}
\end{document}
```

Has master branch lexemes:
```
OPFUNCTION:start OPFUNCTION:start d OPFUNCTION:endOPFUNCTION:end
```

this PR upgrades that to:
```
OPFUNCTION:start d OPFUNCTION:end
```

addressing both issues - the wrongly spaced end lexemes, as well as the redundancy of the XMDual role with the inner XMWrap role, for this example. This should remove a wide range of noisy lexemes I am seeing in the arXiv token model. 