### PR TITLE
End lexeme marker always preceded by space

### DIFF
--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -731,11 +731,11 @@ sub node_to_lexeme_full {
   if ($tag ne 'ltx:XMath') {
     if ($role) {
       $mark_start = "$role:start ";
-      $mark_end   = "$role:end";
+      $mark_end   = " $role:end";
     } elsif ($tag =~ '^ltx:XM(Arg|Row|Cell)') {
       my $tag_role = uc($1);
       $mark_start = "$tag_role:start ";
-      $mark_end   = "$tag_role:end";
+      $mark_end   = " $tag_role:end";
     }
   }
   my $lexemes = $mark_start;


### PR DESCRIPTION
As reported in #723 , the XMDual markup  being addressed, the lexeme serialization still need extra guarantees for spacing out the end-lexemes. So this fix is really needed.