### PR TITLE
exitval 0 for intended quick invocations such as --help and --VERSION

### DIFF
--- a/bin/latexml
+++ b/bin/latexml
@@ -54,9 +54,9 @@ GetOptions("destination=s" => \$destination,
   "help"            => \$help,
 ) or pod2usage(-message => $LaTeXML::IDENTITY,
   -exitval => 1, -verbose => 0, -output => \*STDERR);
-pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 2, -output => \*STDOUT)
+pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 2, -output => \*STDOUT)
   if $help;
-if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(1); }
+if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(0); }
 pod2usage(-message => "$LaTeXML::IDENTITY\nMissing input TeX file",
   -exitval => 1, -verbose => 0, -output => \*STDERR) unless @ARGV;
 my $source = $ARGV[0];

--- a/bin/latexmlfind
+++ b/bin/latexmlfind
@@ -38,9 +38,9 @@ GetOptions("symbol=s" => \@symbols,,
   "help"               => \$help,
 ) or pod2usage(-message => $LaTeXML::IDENTITY,
   -exitval => 1, -verbose => 0, -output => \*STDERR);
-pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 2, -output => \*STDOUT)
+pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 2, -output => \*STDOUT)
   if $help;
-if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(1); }
+if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(0); }
 pod2usage(-message => "$LaTeXML::IDENTITY\nMissing input TeX file",
   -exitval => 1, -verbose => 0, -output => \*STDERR) unless @ARGV;
 my $source = $ARGV[0];
@@ -50,12 +50,12 @@ my $source = $ARGV[0];
 print STDERR "$LaTeXML::IDENTITY\n" if $verbosity > -1;
 binmode(STDOUT, ":encoding(UTF-8)");    # Make sure output can handle UTF8
 
-my $DOC = LaTeXML::Common::XML::Parser->new()->parseFile($source);
+my $DOC   = LaTeXML::Common::XML::Parser->new()->parseFile($source);
 my $XPATH = LaTeXML::Common::XML::XPath->new(ltx => "http://dlmf.nist.gov/LaTeXML");
 $XPATH->registerFunction('match-font', \&LaTeXML::Common::Font::match_font);
 
 # Objects being labelled sections, equations, etc.
-our %OBJECTS = ();
+our %OBJECTS     = ();
 our $ROOT_OBJECT = { type => 'Document',
   subobjects => [], items => [] };
 

--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -69,9 +69,9 @@ GetOptions(
   "help"            => \$help,
 ) or pod2usage(-message => $LaTeXML::IDENTITY,
   -exitval => 1, -verbose => 0, -output => \*STDERR);
-pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 2, -output => \*STDOUT)
+pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 2, -output => \*STDOUT)
   if $help;
-if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(1); }
+if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(0); }
 pod2usage(-message => "$LaTeXML::IDENTITY\nMissing input TeX file",
   -exitval => 1, -verbose => 0, -output => \*STDERR) unless @ARGV;
 
@@ -129,7 +129,7 @@ if (my @baddirs = grep { !-d $_ } @paths) {
   warn "$LaTeXML::IDENTITY: these path directories do not exist: " . join(', ', @baddirs) . "\n"; }
 
 my $latexml = LaTeXML::Core->new(preload => ['LaTeX.pool', @preload], searchpaths => [@paths],
-  verbosity => $verbosity, strict => $strict,
+  verbosity       => $verbosity, strict => $strict,
   includecomments => 0,
   includestyles   => $includestyles,
   inputencoding   => $inputencoding,
@@ -149,7 +149,7 @@ $$model{tagprop}{'ltx:Math'}{afterClose}
     @{ $$model{tagprop}{'ltx:Math'}{afterClose} }];
 
 my $converted = $digested && $latexml->convertDocument($digested);
-my $document = $digested && LaTeXML::Post::Document->new($converted, nocache => 1);
+my $document  = $digested && LaTeXML::Post::Document->new($converted, nocache => 1);
 
 #======================================================================
 # Postprocess to convert the math to whatever desired forms.
@@ -168,7 +168,7 @@ our %OPTIONS = ();
 
 # I wonder if this stuff even will be needed,
 # once fragid is sorted out?
-my $DB = LaTeXML::Util::ObjectDB->new(%OPTIONS);
+my $DB   = LaTeXML::Util::ObjectDB->new(%OPTIONS);
 my $post = LaTeXML::Post->new(verbosity => $verbosity || 0);
 ($document) = $post->ProcessChain($document,
   LaTeXML::Post::Scan->new(db => $DB, %OPTIONS),

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -161,8 +161,8 @@ GetOptions("quiet" => sub { $verbosity--; },
 
 ) or pod2usage(-message => $LaTeXML::IDENTITY,
   -exitval => 1, -verbose => 0, -output => \*STDERR);
-pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 2, -output => \*STDOUT) if $help;
-if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(1); }
+pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 2, -output => \*STDOUT) if $help;
+if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(0); }
 
 # Get the requested XML file
 xError("Missing input xmlfile") unless @ARGV;

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -188,7 +188,7 @@ sub read {
       -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   if (!$silent && $$opts{help}) {
-    pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
+    pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 99,
       -input    => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', output => \*STDOUT);
   }
@@ -202,7 +202,7 @@ sub read {
   # Removed math formats are irrelevant for conversion:
   delete $$opts{removed_math_formats};
 
-  if ($$opts{showversion}) { print STDERR "$LaTeXML::IDENTITY\n"; exit(1); }
+  if ($$opts{showversion}) { print STDERR "$LaTeXML::IDENTITY\n"; exit(0); }
 
   $$opts{source} = $ARGV[0] unless $$opts{source};
   # Special source-based guessing needs to happen here,


### PR DESCRIPTION
Fixes #1208 

Simple enough, just exit with 0 for `--help` and `--VERSION`.