### PR TITLE
Enable custom LaTeXML::Core options in 'latexml_tests'

### DIFF
--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -118,7 +118,7 @@ sub do_fail {
 # NOTE: This assumes you will have successfully loaded LaTeXML.
 sub latexml_ok {
   my ($texpath, $xmlpath, $name, $core_generator, $compare_kind) = @_;
-  if (my $texstrings = process_texfile($texpath, $name, $core_generator, $compare_kind)) {
+  if (my $texstrings = process_texfile(texpath => $texpath, name => $name, core_generator => $core_generator, compare_kind => $compare_kind)) {
     if (my $xmlstrings = process_xmlfile($xmlpath, $name, $compare_kind)) {
       return is_strings($texstrings, $xmlstrings, $name); } } }
 
@@ -131,7 +131,11 @@ sub latexmlpost_ok {
 # These return the list-of-strings form of whatever was requested, if successful,
 # otherwise undef; and they will have reported the failure
 sub process_texfile {
-  my ($texpath, $name, $core_generator, $compare_kind) = @_;
+  my (%options) = @_;
+  my $texpath = $options{texpath};
+  my $name = $options{name};
+  my $core_generator = $options{core_generator};
+  my $compare_kind = $options{compare_kind};
   my $latexml =
     !$core_generator ?
     eval { LaTeXML::Core->new(preload => [], searchpaths => [], includecomments => 0, verbosity => -2) } :

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -55,7 +55,7 @@ sub latexml_tests {
         SKIP: {
             skip("No file $test.xml", 1) unless (-f "$test.xml");
             next unless check_requirements($test, 1, $$requires{'*'}, $$requires{$name});
-            latexml_ok("$test.tex", "$test.xml", $test, $options{ltxmlhook}, $options{compare}); } }
+            latexml_ok("$test.tex", "$test.xml", $test, $options{core_generator}, $options{compare}); } }
         # Carry out any post-processing tests
         foreach my $name (@post_tests) {
           my $test = "$directory/$name";
@@ -117,8 +117,8 @@ sub do_fail {
 
 # NOTE: This assumes you will have successfully loaded LaTeXML.
 sub latexml_ok {
-  my ($texpath, $xmlpath, $name, $ltxmlhook, $compare_kind) = @_;
-  if (my $texstrings = process_texfile($texpath, $name, $ltxmlhook, $compare_kind)) {
+  my ($texpath, $xmlpath, $name, $core_generator, $compare_kind) = @_;
+  if (my $texstrings = process_texfile($texpath, $name, $core_generator, $compare_kind)) {
     if (my $xmlstrings = process_xmlfile($xmlpath, $name, $compare_kind)) {
       return is_strings($texstrings, $xmlstrings, $name); } } }
 
@@ -131,11 +131,11 @@ sub latexmlpost_ok {
 # These return the list-of-strings form of whatever was requested, if successful,
 # otherwise undef; and they will have reported the failure
 sub process_texfile {
-  my ($texpath, $name, $ltxmlhook, $compare_kind) = @_;
+  my ($texpath, $name, $core_generator, $compare_kind) = @_;
   my $latexml =
-    !$ltxmlhook ?
+    !$core_generator ?
     eval { LaTeXML::Core->new(preload => [], searchpaths => [], includecomments => 0, verbosity => -2) } :
-    eval { &$ltxmlhook() };
+    eval { &$core_generator() };
   if (!$latexml) {
     do_fail($name, "Couldn't instanciate LaTeXML: " . @!); return; }
   else {

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -55,7 +55,7 @@ sub latexml_tests {
         SKIP: {
             skip("No file $test.xml", 1) unless (-f "$test.xml");
             next unless check_requirements($test, 1, $$requires{'*'}, $$requires{$name});
-            latexml_ok("$test.tex", "$test.xml", $test, $options{compare}); } }
+            latexml_ok("$test.tex", "$test.xml", $test, $options{ltxmlhook}, $options{compare}); } }
         # Carry out any post-processing tests
         foreach my $name (@post_tests) {
           my $test = "$directory/$name";
@@ -117,8 +117,8 @@ sub do_fail {
 
 # NOTE: This assumes you will have successfully loaded LaTeXML.
 sub latexml_ok {
-  my ($texpath, $xmlpath, $name, $compare_kind) = @_;
-  if (my $texstrings = process_texfile($texpath, $name, $compare_kind)) {
+  my ($texpath, $xmlpath, $name, $ltxmlhook, $compare_kind) = @_;
+  if (my $texstrings = process_texfile($texpath, $name, $ltxmlhook, $compare_kind)) {
     if (my $xmlstrings = process_xmlfile($xmlpath, $name, $compare_kind)) {
       return is_strings($texstrings, $xmlstrings, $name); } } }
 
@@ -131,9 +131,11 @@ sub latexmlpost_ok {
 # These return the list-of-strings form of whatever was requested, if successful,
 # otherwise undef; and they will have reported the failure
 sub process_texfile {
-  my ($texpath, $name, $compare_kind) = @_;
-  my $latexml = eval { LaTeXML::Core->new(preload => [], searchpaths => [], includecomments => 0,
-      verbosity => -2); };
+  my ($texpath, $name, $ltxmlhook, $compare_kind) = @_;
+  my $latexml =
+    !$ltxmlhook ?
+    eval { LaTeXML::Core->new(preload => [], searchpaths => [], includecomments => 0, verbosity => -2) } :
+    eval { &$ltxmlhook() };
   if (!$latexml) {
     do_fail($name, "Couldn't instanciate LaTeXML: " . @!); return; }
   else {

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -55,7 +55,7 @@ sub latexml_tests {
         SKIP: {
             skip("No file $test.xml", 1) unless (-f "$test.xml");
             next unless check_requirements($test, 1, $$requires{'*'}, $$requires{$name});
-            latexml_ok("$test.tex", "$test.xml", $test, $options{core_generator}, $options{compare}); } }
+            latexml_ok("$test.tex", "$test.xml", $test, $options{compare}, $options{core_generator}); } }
         # Carry out any post-processing tests
         foreach my $name (@post_tests) {
           my $test = "$directory/$name";
@@ -117,7 +117,7 @@ sub do_fail {
 
 # NOTE: This assumes you will have successfully loaded LaTeXML.
 sub latexml_ok {
-  my ($texpath, $xmlpath, $name, $core_generator, $compare_kind) = @_;
+  my ($texpath, $xmlpath, $name, $compare_kind, $core_generator) = @_;
   if (my $texstrings = process_texfile(texpath => $texpath, name => $name, core_generator => $core_generator, compare_kind => $compare_kind)) {
     if (my $xmlstrings = process_xmlfile($xmlpath, $name, $compare_kind)) {
       return is_strings($texstrings, $xmlstrings, $name); } } }

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -55,7 +55,7 @@ sub latexml_tests {
         SKIP: {
             skip("No file $test.xml", 1) unless (-f "$test.xml");
             next unless check_requirements($test, 1, $$requires{'*'}, $$requires{$name});
-            latexml_ok("$test.tex", "$test.xml", $test, $options{compare}, $options{core_generator}); } }
+            latexml_ok("$test.tex", "$test.xml", $test, $options{compare}, $options{core_options}); } }
         # Carry out any post-processing tests
         foreach my $name (@post_tests) {
           my $test = "$directory/$name";
@@ -117,8 +117,8 @@ sub do_fail {
 
 # NOTE: This assumes you will have successfully loaded LaTeXML.
 sub latexml_ok {
-  my ($texpath, $xmlpath, $name, $compare_kind, $core_generator) = @_;
-  if (my $texstrings = process_texfile(texpath => $texpath, name => $name, core_generator => $core_generator, compare_kind => $compare_kind)) {
+  my ($texpath, $xmlpath, $name, $compare_kind, $core_options) = @_;
+  if (my $texstrings = process_texfile(texpath => $texpath, name => $name, core_options => $core_options, compare_kind => $compare_kind)) {
     if (my $xmlstrings = process_xmlfile($xmlpath, $name, $compare_kind)) {
       return is_strings($texstrings, $xmlstrings, $name); } } }
 
@@ -131,15 +131,14 @@ sub latexmlpost_ok {
 # These return the list-of-strings form of whatever was requested, if successful,
 # otherwise undef; and they will have reported the failure
 sub process_texfile {
-  my (%options) = @_;
-  my $texpath = $options{texpath};
-  my $name = $options{name};
-  my $core_generator = $options{core_generator};
+  my (%options)    = @_;
+  my $texpath      = $options{texpath};
+  my $name         = $options{name};
   my $compare_kind = $options{compare_kind};
-  my $latexml =
-    !$core_generator ?
-    eval { LaTeXML::Core->new(preload => [], searchpaths => [], includecomments => 0, verbosity => -2) } :
-    eval { &$core_generator() };
+  my %core_options = $options{core_options} ? %{ $options{core_options} } : (
+    preload => [], searchpaths => [], includecomments => 0, verbosity => -2
+  );
+  my $latexml = eval { LaTeXML::Core->new(%core_options) };
   if (!$latexml) {
     do_fail($name, "Couldn't instanciate LaTeXML: " . @!); return; }
   else {


### PR DESCRIPTION
When using the `latexml_tests` method to create test cases, LaTeXML is instantiated using `LaTeXML::Core->new` with appropriate default options.
This works fine for tests by LaTeXML itself, however it prevents the function from being used in test cases for custom plugins (as none of the profiles, bindings, etc.) can be loaded.

This PR adds a new option `core_options` to `latexml_tests`. When provided, this should be a hash of options passed to `LaTeXML::Core->new`. This allows plugin authors to customize the options used to instantiate LaTeXML for each test case. 