### PR TITLE
More robust xpath search for \lxRDFa

### DIFF
--- a/lib/LaTeXML/Package/lxRDFa.sty.ltxml
+++ b/lib/LaTeXML/Package/lxRDFa.sty.ltxml
@@ -149,7 +149,7 @@ sub RDFTriple {
 # You are responsible for how the attributes relate to those
 # in both parent and children nodes, such as establishing
 # of default subject or objects, chaining and so forth.
-DefConstructor('\lxRDFa [] RequiredKeyVals:RDFa', sub {
+DefConstructor('\lxRDFa OptionalSemiverbatim RequiredKeyVals:RDFa', sub {
     my ($document, $xpath, $kv) = @_;
     my ($save, $node);
     if ($xpath) {

--- a/lib/LaTeXML/Package/lxRDFa.sty.ltxml
+++ b/lib/LaTeXML/Package/lxRDFa.sty.ltxml
@@ -149,13 +149,20 @@ sub RDFTriple {
 # You are responsible for how the attributes relate to those
 # in both parent and children nodes, such as establishing
 # of default subject or objects, chaining and so forth.
-DefConstructor('\lxRDFa [Semiverbatim] RequiredKeyVals:RDFa', sub {
+DefConstructor('\lxRDFa [] RequiredKeyVals:RDFa', sub {
     my ($document, $xpath, $kv) = @_;
     my ($save, $node);
     if ($xpath) {
-      $save = $document->getNode;
-      $node = $document->findnode(ToString($xpath), $save); }
-    else {
+      $xpath = ToString($xpath);
+      $save  = $document->getNode;
+      # Try searching up the ancestry,
+      # whenever the node is not local to the current Documnent insertion point
+      my $parent = $save;
+      while (!$node && $parent) {
+        $node   = $document->findnode($xpath, $parent);
+        $parent = $parent->parentNode; }
+      Warn('expected', 'node', $xpath, "Expected to find a node for RDFa attributes at the xpath: $xpath") if !$node; }
+    if (!$node) {
       $save = $document->floatToAttribute('property');    # pic arbitrary rdf attribute
       $node = $document->getElement; }
     my $attr = RDFAttributes($kv);


### PR DESCRIPTION
Fixes #1217 

There are other approaches here, but this seemed simple enough. 

- when the xpath fails to find a node, go up the ancestry tree and retry, as long as there is some document available. It may be slow if the author intended a distant element, but provides predictable markup, as one tends to expect the metadata on the node that is the "closest meaningful match" to the current insertion context

- when a node is not found even after the more thorough search, handle that with a graceful warning, and default to the `floatToAttribute('property')` case. 

One bit I didn't spend time remembering was that the result of ToString on the `[Semiverbatim]` argument returned only the first letter, which is why I switched to the simpler `[]` plain optional argument. 