### PR TITLE
add \@ifl@t@r helper to LaTeX.pool

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -907,6 +907,22 @@ Let('\AtEndOfClass', '\AtEndOfPackage');
 
 DefMacro('\AtBeginDvi {}', Tokens());
 
+RawTeX(<<'EoTeX');
+\def\@ifl@t@r#1#2{%
+  \ifnum\expandafter\@parse@version@#1//00\@nil<%
+        \expandafter\@parse@version@#2//00\@nil
+    \expandafter\@secondoftwo
+  \else
+    \expandafter\@firstoftwo
+  \fi}
+\def\@parse@version@#1{\@parse@version0#1}
+\def\@parse@version#1/#2/#3#4#5\@nil{%
+\@parse@version@dash#1-#2-#3#4\@nil
+}
+\def\@parse@version@dash#1-#2-#3#4#5\@nil{%
+  \if\relax#2\relax\else#1\fi#2#3#4 }
+EoTeX
+
 #======================================================================
 # Somewhat related I/O stuff
 DefMacro('\filename@parse{}', sub {


### PR DESCRIPTION
Part of #1214 .

This PR makes the following TeX snippet produce identical output with pdflatex and latexml:
```tex
\documentclass{article}
\makeatletter
\edef\versioned{\@ifl@t@r\fmtversion{2019/10/01}{earlier}{later}}
\begin{document}
\versioned
\end{document}
```

The code is transferred over from a texlive 2019 latex.ltx.