### PR TITLE
Fatal-avoiding patches for a handful of arXiv cases

### DIFF
--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -236,12 +236,21 @@ sub computeSize {
 #**********************************************************************
 # What about Kern, Glue, Penalty ...
 
+# stubs to avoid "shallow" Fatal errors on broken documents
+sub multiply { my ($self) = @_; return $self; }
+sub subtract { my ($self) = @_; return $self; }
+sub add      { my ($self) = @_; return $self; }
+sub negate   { my ($self) = @_; return $self; }
+sub divide   { my ($self) = @_; return $self; }
+sub getX     { my ($self) = @_; return $self; }
+sub getY     { my ($self) = @_; return $self; }
+sub ptValue  { return; }
 #======================================================================
 1;
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 

--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -13,6 +13,7 @@ package LaTeXML::Core::Box;
 use strict;
 use warnings;
 use LaTeXML::Global;
+use LaTeXML::Common::Dimension qw(Dimension);
 use LaTeXML::Common::Object;
 use base qw(LaTeXML::Common::Object);
 use base qw(Exporter);
@@ -237,13 +238,13 @@ sub computeSize {
 # What about Kern, Glue, Penalty ...
 
 # stubs to avoid "shallow" Fatal errors on broken documents
-sub multiply { my ($self) = @_; return $self; }
-sub subtract { my ($self) = @_; return $self; }
-sub add      { my ($self) = @_; return $self; }
-sub negate   { my ($self) = @_; return $self; }
-sub divide   { my ($self) = @_; return $self; }
-sub getX     { my ($self) = @_; return $self; }
-sub getY     { my ($self) = @_; return $self; }
+sub multiply { return Dimension(0); }
+sub subtract { return Dimension(0); }
+sub add      { return Dimension(0); }
+sub negate   { return Dimension(0); }
+sub divide   { return Dimension(0); }
+sub getX     { return Dimension(0); }
+sub getY     { return Dimension(0); }
 sub ptValue  { return; }
 #======================================================================
 1;

--- a/lib/LaTeXML/Core/List.pm
+++ b/lib/LaTeXML/Core/List.pm
@@ -110,7 +110,7 @@ sub computeSize {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -14,6 +14,7 @@ package LaTeXML::Package;
 use strict;
 use warnings;
 use Exporter;
+use Scalar::Util qw(blessed);
 use LaTeXML::Global;
 use LaTeXML::Common::Object;
 use LaTeXML::Common::Error;
@@ -2222,8 +2223,8 @@ sub AddToMacro {
     Warn('unexpected', $cs, $STATE->getStomach->getGullet,
       ToString($cs) . " is not an expandable control sequence", "Ignoring addition"); }
   else {
-    DefMacroI($cs, undef, Tokens($defn->getExpansion->unlist,
-        map { $_->unlist } map { (ref $_ ? $_ : TokenizeInternal($_)) } @tokens),
+    DefMacroI($cs, undef, Tokens(map { $_->unlist }
+          map { (blessed $_ ? $_ : TokenizeInternal($_)) } ($defn->getExpansion, @tokens)),
       scope => 'global'); }
   return; }
 

--- a/lib/LaTeXML/Package/etoolbox.sty.ltxml
+++ b/lib/LaTeXML/Package/etoolbox.sty.ltxml
@@ -1298,7 +1298,8 @@ DefMacro('\patchcmd [] DefToken {}{}{}{}', sub {
       }
       my $string        = ToString($expansion);
       my $search_string = ToString($search);
-      my $search_regex  = qr/$search_string/;
+      $search_string =~ s/\\/\\\\/g;    # ensure macro backslashes are escaped?
+      my $search_regex = qr/$search_string/;
       if ($string =~ $search_regex) {
         # Should the token substitution happen on the actual data structure?
         # string replacement is a quick&dirty way out...


### PR DESCRIPTION
The only purpose of this PR is to "plug" needless Fatals, and allow the processing to proceed further. I tested ~10 papers from the latest arXiv run, and ~5 of them switched to Error status, the others switching to `100 error` Fatals. 

I claim both are better outcomes, as the `Perl:die` fatal category is rather opaque to comb through, and we might as well gain some robustness for odd cases.

Changes:
 - Adding stubs for Number/Pair methods to Box, so that cases where the arguments are misinterpreted can fail more gracefully. No need to Fatal a document because a List snuck into the number arithmetic. Though of course no sensible content will come out for that particular piece of the document.

 - Be a little more careful with unblessed refs sneaking into `AddToMacro`, which is something I've seen in the examples. Checking for `blessed` instead of `ref` does the trick.

- Lastly, escape the search string provided to `\patchcmd`, one arXiv example had used `\par` as the input there, and the regex was failing with "`\pa` is an unrecognized Unicode class".

We've had the discussion about whether reducing Fatals is a good thing on its own, for now I will keep rooting on team "extra robustness is good, especially for arXiv jobs".