### PR TITLE
paranoid xml:id thawing from XML chunks

### DIFF
--- a/lib/LaTeXML/Common/XML/Parser.pm
+++ b/lib/LaTeXML/Common/XML/Parser.pm
@@ -45,7 +45,7 @@ sub parseChunk {
   # In 1.58, the prefix for the XML_NS, which should be DEFINED to be "xml"
   # is sometimes unbound, leading to mysterious segfaults!!!
 ###  if (($xml_libxml_version < 1.59) && $hasxmlns) {
-  if (($LaTeXML::Common::XML::xml_libxml_version < 1.59) && $hasxmlns) {
+  if ($hasxmlns) {
     #print STDERR "Patchup...\n";
     # Re-create all xml:id entrys, hopefully with correct NS!
     # We assume all id are, in fact, xml:id,


### PR DESCRIPTION
Fixes #1240 .

Turns out, after an afternoon of gradual debugging and tracing (= learning the CrossRef ropes), I tracked the issue for the new arXiv regression down to a problem that was already known and addressed in old versions of libxml.

In fact, the problem is so identical to the "pre 1.59" situation of libxml, that dropping that guard leads to all my test conversions succeeding cleanly. This is quite strange given that I have some of the most recent versions of libxml (C and Perl)... But it is a working fix!

Submitting it as a temporary patch, if desired. I tried to dig around the XML::LibXML documentation for a flag that would allow the chunk parser to understand the `xml:` namespace, but to no avail. The only "correct" idea I have is to add a dedicated namespace declaration to each chunk, but that is quite wasteful in serialization time -- the existing patch is quite adequate in comparison.

I should also mention that this regression was exhibited by the two remote worker servers as well, which run slightly older OS-es and libxml versions, but run close to bleeding edge XML::LibXML versions. Might be a perl wrapper change, if we're to continue digging... 