### PR TITLE
Add missing xcolor primitive for basic Tikz load in texlive 2019

### DIFF
--- a/lib/LaTeXML/Package/xcolor.sty.ltxml
+++ b/lib/LaTeXML/Package/xcolor.sty.ltxml
@@ -355,6 +355,7 @@ sub LookupXColor {
 # \selectcolormodel{model}
 # Sets the target model to model
 DefMacro('\selectcolormodel{}', '');
+DefMacro('\XC@tgt@mod {}',      '#1');
 
 # \substitutecolormodel{sourcemodel}{targetmodellist}
 # makes xcolor use (one of) target model whenever source model was specified


### PR DESCRIPTION
All tikz-related examples on texlive 2019 currently lead to an Error status under the latexml master, as the latest pgf kernel also invokes `\XC@tgt@mod` from xcolor.sty, which is not yet added to that binding.

I've added the basic version of the macro, which gets my basic showcase Tikz examples working. There is a separate regression to address with #1227 , which is unrelated to this basic fix.