### PR TITLE
Use parse_string for XML chunks with xml:id

### DIFF
--- a/lib/LaTeXML/Common/XML/Parser.pm
+++ b/lib/LaTeXML/Common/XML/Parser.pm
@@ -34,7 +34,13 @@ sub parseChunk {
   my ($self, $string) = @_;
   my $hasxmlns = $string =~ /\Wxml:id\W/;
   # print STDERR "\nFISHY!!\n" if $hasxmlns;
-  my $xml = $$self{parser}->parse_xml_chunk($string);
+  my $xml;
+  if ($hasxmlns) {
+    local $XML::LibXML::skipXMLDeclaration = 1;
+    $xml = $$self{parser}->parse_string($string);
+  } else {
+    $xml = $$self{parser}->parse_xml_chunk($string);
+  }
   # Simplify, if we get a single node Document Fragment.
   #[which we, apparently, always do]
   if ($xml && (ref $xml eq 'XML::LibXML::DocumentFragment')) {


### PR DESCRIPTION
Fixes #1240 , as a better approach to #1242 .

In essence, I noticed that `parse_string` has a reliably correct behaviour over `xml:id`-carrying XML chunks. While it can not handle all chunk cases, it appears that our use case for CrossRef in particular is to store a single XML node, which `parse_string` handles correctly.

Thus this PR, which should be a targeted improvement. I tested two of the arXiv Fatals and the issue is resolved entirely also with this changeset. 

I have also tested the `parse_string` approach on 3 separate machines - my desktop, the mercury and monster servers, on the minimal example Bruce prepared. Looks consistently solid.