### PR TITLE
Allow for raw definitions in bibliography post-processing

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2251,7 +2251,12 @@ sub InputDefinitions {
     && grep { $prevname eq $_ } @{ LookupValue('@masquerading@as@class') || [] };
 
   $options{raw} = 1 if $options{noltxml};    # so it will be read as raw by Gullet.!L!
-  my $astype = ($options{as_class} ? 'cls' : $options{type});
+  my $astype = ($options{as_class} ? 'cls' : $options{type} || 'sty');
+
+  if ($astype eq 'cls' and $options{options}) {
+    PushValue(class_options => @{ $options{options} });
+    # ? Expand {\zap@space#2 \@empty}%
+    DefMacroI('\@classoptionslist', undef, join(',', @{ $options{options} })); }
 
   my $filename = $name;
   $filename .= '.' . $options{type} if $options{type};
@@ -2361,11 +2366,6 @@ sub LoadClass {
 
   $class = ToString($class) if ref $class;
   CheckOptions("LoadClass ($class)", $loadclass_options, %options);
-  #  AssignValue(class_options => [$options{options} ? @{ $options{options} } : ()]);
-  PushValue(class_options => ($options{options} ? @{ $options{options} } : ()));
-  if (my $op = $options{options}) {
-    # ? Expand {\zap@space#2 \@empty}%
-    DefMacroI('\@classoptionslist', undef, join(',', @$op)); }
   # Note that we'll handle errors specifically for this case.
   if (my $success = InputDefinitions($class, type => 'cls', notex => $options{notex}, handleoptions => 1, noerror => 1,
       %options)) {

--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -153,7 +153,7 @@ sub getBibliographies {
       $raw = $rawbibs[0]; }
     else {
       $raw = 'literal:';
-      for my $rawbib (@rawbibs) { # Multiple, arrange into a single conversion payload
+      for my $rawbib (@rawbibs) {    # Multiple, arrange into a single conversion payload
         if ($rawbib =~ s/literal\://) {
           $raw .= $rawbib; }
         else {
@@ -209,6 +209,7 @@ sub convertBibliography {
     format         => 'dom',
     whatsin        => 'document',
     whatsout       => 'document',
+    includestyles  => 1,
     bibliographies => [],
     (@preload ? (preload => [@preload]) : ()));
   my $bib_converter = LaTeXML->get_converter($bib_config);


### PR DESCRIPTION
Today @stamer alerted me by email about another weakness in our attempt to faithfully convert bibliographies in the MakeBibliography post-processor.

Namely, he had an example which interpreted `some.cls` raw via `--includestyles` in the main processing, which then failed miserably when its `some.bib` file was being converted in post-processing. The failure is easy to explain - `--includestyles` is never made visible to the post-processor, so the search for the `.cls.ltxml` file fails and the entire conversion of the bib file surrenders.

Now, I had a very happy thought while understanding the error trace. During post-processing, all packages and classes that have been copied over from the Core processing have essentially been "vetted". Namely, if the core conversion managed to "succeed" with them, we should assume the post-processor could be less cautious with re-vetting them. In particular, I could have the includestyles switch **always on** in MakeBibliography, as:
 - sty/cls files in the XML PIs with bindings will still have the bindings read first
 - sty/cls files in the XML PIs files without bindings, must have been (~successfully) interpreted raw by Core, so they can be interpreted raw by MakeBibliography.

Thus, I am offering a minimal change that flips `includestyles` to on for the MakeBibliography `->convert` calls.

While testing that I also realized a side flaw that also could be easily improved (thanks to babel.sty, as usual). When a class is preloaded via `--preload=some.cls --includestyles`, it does not get loaded by LoadClass, but via InputDefinitions. This leads to `\@classoptionslist` not being set for the preloaded class, and could result in additional trouble - which it does when that class loads babel internally. To fix that, I moved the logic introducing that macro into `InputDefinitions`, while still checking for the `cls` type, so that using that API call is sufficient.