### PR TITLE
Simplify storage of XML in ObjectDB to only be single nodes

### DIFF
--- a/lib/LaTeXML/Common/XML/Parser.pm
+++ b/lib/LaTeXML/Common/XML/Parser.pm
@@ -30,35 +30,11 @@ sub parseString {
   my ($self, $string) = @_;
   return $$self{parser}->parse_string($string); }
 
+# Note: This expects only a single node, not a document fragment.
 sub parseChunk {
   my ($self, $string) = @_;
-  my $hasxmlns = $string =~ /\Wxml:id\W/;
-  # print STDERR "\nFISHY!!\n" if $hasxmlns;
-  my $xml = $$self{parser}->parse_xml_chunk($string);
-  # Simplify, if we get a single node Document Fragment.
-  #[which we, apparently, always do]
-  if ($xml && (ref $xml eq 'XML::LibXML::DocumentFragment')) {
-    my @k = $xml->childNodes;
-    $xml = $k[0] if (scalar(@k) == 1); }
-  #  $xml = $xml->cloneNode(1);
-  ####
-  # In 1.58, the prefix for the XML_NS, which should be DEFINED to be "xml"
-  # is sometimes unbound, leading to mysterious segfaults!!!
-###  if (($xml_libxml_version < 1.59) && $hasxmlns) {
-  if (($LaTeXML::Common::XML::xml_libxml_version < 1.59) && $hasxmlns) {
-    #print STDERR "Patchup...\n";
-    # Re-create all xml:id entrys, hopefully with correct NS!
-    # We assume all id are, in fact, xml:id,
-    # because we seemingly can't probe the namespace!
-    foreach my $attr ($xml->findnodes("descendant-or-self::*/attribute::*[local-name()='id']")) {
-      my $element = $attr->parentNode;
-      my $id      = $attr->getValue();
-      #print STDERR "RESET ID: $id\n";
-      $attr->unbindNode();
-      $element->setAttributeNS($LaTeXML::Common::XML::XML_NS, 'id', $id); }
-    #    print STDERR "\nXML: ".$xml->toString."\n";
-  }
-  return $xml; }
+  my $xml = $$self{parser}->parse_string($string);
+  return $xml && $xml->documentElement; }
 
 #======================================================================
 1;

--- a/lib/LaTeXML/Util/ObjectDB/Entry.pm
+++ b/lib/LaTeXML/Util/ObjectDB/Entry.pm
@@ -118,6 +118,11 @@ sub encodeValue {
     return $value; }
   # The node is cloned so as to copy any inherited namespace nodes.
   elsif ($ref =~ /^XML::/) {
+    if ($ref eq 'XML::LibXML::DocumentFragment') {
+      my @c = $value->childNodes;
+      if (scalar(@c) > 1) {
+        warn "Encoding XML Document fragment; dropping all except 1st node!"; }
+      $value = $c[0]; }
     return "XML::" . $value->cloneNode(1)->toString; }
   elsif ($ref eq 'ARRAY') {
     return [map { encodeValue($_) } @$value]; }


### PR DESCRIPTION
Simplify storage of XML in ObjectDB to only be single nodes (not DocumentFragment); this avoids the buggy parse_xml_chunk method of XML::LibXML which fails (sometimes) to bind the xml prefix to the namespace