### PR TITLE
faster GenerateID for [ids]latexml.sty workflows (arXiv)

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -829,13 +829,8 @@ sub ResetCounter {
 sub GenerateID {
   my ($document, $node, $whatsit, $prefix) = @_;
   # Nothing to do if xml:id already set, or not allowable by schema
-  if ($node->hasAttribute('xml:id') || !$document->canHaveAttribute($node, 'xml:id')) {
-    return; }
   # Also, we want to be avoid adding ids to otherwise valid elements, which are not inherently content
-  # e.g. ltx:document which only gets an id from an EXPLICIT \thedocument@id.
-  # e.g. isn't a _Capture_ node, or XMWrap (which ultimately should disappear)
-  my $name = $node->nodeName || '';
-  if ($name =~ /^(?:_Capture_|document|XM(?:Wrap|Arg))$/) {
+  if ($node->hasAttribute('xml:id') || ($node->nodeName =~ /^_/) || !$document->canHaveAttribute($node, 'xml:id')) {
     return; }
   ## Old versions don't like ->getAttribute('xml:id');
   # This is hot code when [ids]latexml.sty is active, optimized for performance

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -39,20 +39,6 @@ else {
   Let('\thedocument@ID', '\@empty'); }
 NewCounter('@XMARG', 'document', idprefix => 'XM');
 
-# Optionally, add ID's to ALL nodes.
-# By default, this is OFF;
-# Set to 1 (or \usepackage[ids]{latexml}) to enable.
-# Set to 0 (or \usepackage[noids]{latexml}) to disable.
-#### AssignValue(GENERATE_IDS=>1,'global');
-Tag('ltx:*', afterOpen => sub {
-    # If GENERATE_IDS is true, we'll assign an ID to EVERY element,
-    # EXCEPT ltx:document which only gets an id from an EXPLICIT \thedocument@id.
-    my $tag = $_[0]->getNodeQName($_[1]);
-    if (($tag ne 'ltx:document')
-      && ($tag ne 'ltx:XMWrap')    # No auto-generated id on wrap???
-      && LookupValue('GENERATE_IDS')) {
-      GenerateID(@_); } });
-
 #======================================================================
 
 Tag('ltx:document', afterOpen => \&ProcessPendingResources);

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -32,8 +32,11 @@ DefPrimitive('\latexmlfalse', sub {
 
 #======================================================================
 # Package Options
-DeclareOption('ids',   sub { AssignValue('GENERATE_IDS' => 1, 'global'); });
-DeclareOption('noids', sub { AssignValue('GENERATE_IDS' => 0, 'global'); });
+# Set to 1 (or \usepackage[ids]{latexml}) to enable.
+# Set to 0 (or \usepackage[noids]{latexml}) to disable.
+DeclareOption('ids', sub { Tag('ltx:*', afterOpen => \&LaTeXML::Package::Pool::GenerateID); });
+# Currently disabling is a no-op, may be useful if we switch defaults some day
+DeclareOption('noids', sub { return; });
 
 DeclareOption('comments',   sub { AssignValue('INCLUDE_COMMENTS' => 1, 'global'); });
 DeclareOption('nocomments', sub { AssignValue('INCLUDE_COMMENTS' => 0, 'global'); });

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -34,7 +34,14 @@ DefPrimitive('\latexmlfalse', sub {
 # Package Options
 # Set to 1 (or \usepackage[ids]{latexml}) to enable.
 # Set to 0 (or \usepackage[noids]{latexml}) to disable.
-DeclareOption('ids', sub { Tag('ltx:*', afterOpen => \&LaTeXML::Package::Pool::GenerateID); });
+DeclareOption('ids', sub { Tag('ltx:*', afterOpen => sub {
+        # Almost all, but some exceptions
+        # e.g. ltx:document which only gets an id from an EXPLICIT \thedocument@id.
+        # e.g. isn't a _Capture_ node, or XMWrap (which ultimately should disappear)
+        my $tag = $_[0]->getNodeQName($_[1]);
+        return if $tag =~ /^ltx:(?:document|XMWrap|XMArg)$/;
+        GenerateID(@_);
+        return; }) });
 # Currently disabling is a no-op, may be useful if we switch defaults some day
 DeclareOption('noids', sub { return; });
 


### PR DESCRIPTION
Working on reducing the rate of arXiv timeouts. One of them, a document with 1600 formulas, is the stress test behind the PR. Converting it with latexml-master, took **37min**. Here's the local command to get that:

```
 time latexmlc 2002.10839.tex --dest=test.html --preload=[ids]latexml.sty \
                              --pmml --cmml --timeout=600000
```

Time in master:
```
real	37m0.826s
user	36m57.642s
sys	0m0.907s
```

I ran the conversion with a huge timeout setting, while making dinner. Meanwhile,

Time with this PR is **10min**:
```
real	10m16.427s
user	10m15.048s
sys	0m0.807s
```

The main workload reduction is from now also ignoring `XMArg` when running GenerateID. I was inspired by the rule to ignore XMWrap and tried adding arg in, and the improvement was geometric (to my surprise).

A smaller speedup is from using the `->parentNode` loop instead of running the XPath, motivated by the observation that the parent node almost always has an id, and most calls execute in constant time, rather than having to setup an xpath context.

With this PR, The first expansion/building phase takes 3 minutes, the math parsing (with associated GenerateIDs) is now 2 min and 40 seconds. Post-processing spends 1min 30sec on Scan and 2 min 40sec on the MathML post-processing. The rest of the phases take smaller amounts of 10 or less seconds. (In master, 28 mins were in math parsing,  the post-proc times were comparably the same).

I took the liberty of moving the `Tag('ltx:*',..` rule for id generation out of the sizeable TeX.pool and relocated it to the only piece of code that required it - `latexml.sty.ltxml`. I also tried to straighten out some bits of logic in GenerateID, given that it is a very hot path for the arXiv runs, which have thousands of formulas, each with hundreds of xml:id attributes.