### PR TITLE
[infinite loop patch] wrapped beginBibliography in omnibus

### DIFF
--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -129,7 +129,10 @@ DefConstructor('\references',
     . "bibstyle='#bibstyle' citestyle='#citestyle' sort='#sort'>"
     . "<ltx:title font='#titlefont' _force_font='true'>#title</ltx:title>"
     . "<ltx:biblist>",
-  afterDigest => sub { beginBibliography($_[1]); });
+  afterDigest => sub {
+    $_[0]->begingroup;    # wrapped so redefns don't take effect!
+    beginBibliography($_[1]);
+    $_[0]->endgroup; });
 
 DefConstructor('\endreferences',
   "</ltx:biblist></ltx:bibliography>");


### PR DESCRIPTION
Maybe not the highest-impact timeout, but since I've spotted it... The minimal example is:
```tex
\documentstyle[aas2pp4]{article}
\begin{document}
\begin{references}

\reference{key} A

\end{references}

\end{document}
```

Which leads to:
 - `Info:note:OmniBus Loading OmniBus class to attempt to cover missing options`
 - `PATCHING with \begin{thebibliography}`
 - `Error:undefined:\reference The token T_CS[\reference] is not defined.`

at which point an infinite loop takes place at `\end{references}`. I don't exactly follow, but there seems to be some unfortunate ladder of re-leting macros to values that form a cycle. I read around and noticed that `\lx@bibliography` in LaTeX.pool has a special begingroup/endgroup wrapped around its `beginBibliography`, so that "redefinitions don't take effect", which sounded very topical. Adding that guard to OmniBus eliminates the loop, hence this PR.

Would be great if Bruce could double-check whether this is sensible given the (admittedly Error-level) example, and maybe even whether `beginBibliography` should have the groups enforced internally (and always).