### PR TITLE
PGF processing on a tighter compute budget

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -570,6 +570,7 @@ lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
 lib/LaTeXML/Package/pgfmath.code.tex.ltxml
 lib/LaTeXML/Package/pgfplots.sty.ltxml
 lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+lib/LaTeXML/Package/pgfutil-common.tex.ltxml
 lib/LaTeXML/Package/pifont.sty.ltxml
 lib/LaTeXML/Package/placeins.sty.ltxml
 lib/LaTeXML/Package/preview.sty.ltxml

--- a/MANIFEST
+++ b/MANIFEST
@@ -568,6 +568,7 @@ lib/LaTeXML/Package/pdfsync.sty.ltxml
 lib/LaTeXML/Package/pgf.sty.ltxml
 lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
 lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+lib/LaTeXML/Package/pgfmathcalc.code.tex.ltxml
 lib/LaTeXML/Package/pgfplots.sty.ltxml
 lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
 lib/LaTeXML/Package/pgfutil-common.tex.ltxml

--- a/lib/LaTeXML/Common/Object.pm
+++ b/lib/LaTeXML/Common/Object.pm
@@ -39,7 +39,7 @@ sub Stringify {
     elsif ($object->isa('XML::LibXML::Node')) {
       if ($object->nodeType == XML_ELEMENT_NODE) {
         my $model = $STATE && $STATE->getModel;
-        my $tag = ($model ? $model->getNodeQName($object)
+        my $tag   = ($model ? $model->getNodeQName($object)
           : $object->nodeName);
         my $attributes = '';
         foreach my $attr ($object->attributes) {
@@ -71,8 +71,8 @@ sub ToString {
 # Just how deep of an equality test should this be?
 sub Equals {
   my ($x, $y) = @_;
-  return 1 if !(defined $x) && !(defined $y);    # both undefined, equal, I guess
-  return 0 unless (defined $x) && (defined $y);  # else both must be defined
+  return 1 if !(defined $x)    && !(defined $y);    # both undefined, equal, I guess
+  return 0 unless (defined $x) && (defined $y);     # else both must be defined
   my $refx = (ref $x) || '_notype_';
   my $refy = (ref $y) || '_notype_';
 
@@ -94,12 +94,12 @@ sub Equals {
     else { return 0; } }
 
   return $x eq $y if ($refx eq '_notype_') || $NOBLESS{$refx};    # Deep comparison of builtins?
-        # Special cases? (should be methods, but that embeds State knowledge too low)
+      # Special cases? (should be methods, but that embeds State knowledge too low)
 
   if ($refx eq 'LaTeXML::Core::Token') {    # Check if they've been \let to the same defn.
-    my $defx = $STATE->lookupMeaning($x) || $x;
-    my $defy = $STATE->lookupMeaning($y) || $y;
-    return $defx->equals($defy); }
+    $x = $STATE->lookupMeaning($x) || $x;
+    $y = $STATE->lookupMeaning($y) || $y;
+  }
   return $x->equals($y); }                  # semi-shallow comparison?
 
 # Reverts an object into TeX code, as a Tokens list, that would create it.

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -35,10 +35,11 @@ use base qw(LaTeXML::Common::Object);
 
 sub new {
   my ($class, %options) = @_;
+  my $verbosity = defined $options{verbosity} ? $options{verbosity} : 0;
   my $state = LaTeXML::Core::State->new(catcodes => 'standard',
-    stomach => LaTeXML::Core::Stomach->new(),
+    stomach => LaTeXML::Core::Stomach->new(verbosity => $verbosity),
     model   => $options{model} || LaTeXML::Common::Model->new());
-  $state->assignValue(VERBOSITY => (defined $options{verbosity} ? $options{verbosity} : 0),
+  $state->assignValue(VERBOSITY => $verbosity,
     'global');
   $state->assignValue(STRICT => (defined $options{strict} ? $options{strict} : 0),
     'global');

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -29,9 +29,10 @@ use LaTeXML::Core::MuGlue;
 use base qw(LaTeXML::Common::Object);
 #**********************************************************************
 sub new {
-  my ($class) = @_;
+  my ($class, %options) = @_;
   return bless {
-    mouth => undef, mouthstack => [], pushback => [], autoclose => 1, pending_comments => []
+    mouth     => undef, mouthstack => [], pushback => [], autoclose => 1, pending_comments => [],
+    verbosity => $options{verbosity} || 0
   }, $class; }
 
 #**********************************************************************
@@ -367,6 +368,7 @@ sub readBalanced {
   my ($self, $expanded) = @_;
   my @tokens = ();
   my ($token, $level) = (undef, 1);
+  my $startloc = ($$self{verbosity} > 0) && $self->getLocator;
   # Inlined readToken (we'll keep comments in the result)
   while ($token = ($expanded ? $self->readXToken(0, 1) : $self->readToken())) {
     my $cc = $$token[1];
@@ -384,9 +386,9 @@ sub readBalanced {
   if ($level > 0) {
  # TODO: The current implementation has a limitation where if the balancing end is in a different mouth,
  #       it will not be recognized.
+    my $loc_message = $startloc ? ("Started at " . ToString($startloc)) : ("Ended at " . ToString($self->getLocator));
     Error('expected', "}", $self, "Gullet->readBalanced ran out of input in an unbalanced state.",
-      "Ended at " . ToString($self->getLocator));
-  }
+      $loc_message); }
   return (wantarray ? (Tokens(@tokens), $token) : Tokens(@tokens)); }
 
 sub ifNext {

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -367,7 +367,6 @@ sub readBalanced {
   my ($self, $expanded) = @_;
   my @tokens = ();
   my ($token, $level) = (undef, 1);
-  my $startloc = $self->getLocator;
   # Inlined readToken (we'll keep comments in the result)
   while ($token = ($expanded ? $self->readXToken(0, 1) : $self->readToken())) {
     my $cc = $$token[1];
@@ -386,7 +385,7 @@ sub readBalanced {
  # TODO: The current implementation has a limitation where if the balancing end is in a different mouth,
  #       it will not be recognized.
     Error('expected', "}", $self, "Gullet->readBalanced ran out of input in an unbalanced state.",
-      "started at " . ToString($startloc));
+      "Ended at " . ToString($self->getLocator));
   }
   return (wantarray ? (Tokens(@tokens), $token) : Tokens(@tokens)); }
 

--- a/lib/LaTeXML/Core/Parameter.pm
+++ b/lib/LaTeXML/Core/Parameter.pm
@@ -82,7 +82,6 @@ sub read {
   # (eg. \caption(...\label{badchars}}) where you really need to
   # cleanup after the fact!
   # Hmmm, seem to still need it...
-  my $startloc = $gullet->getLocator;
   $self->setupCatcodes;
   my $value = &{ $$self{reader} }($gullet, @{ $$self{extra} || [] });
   $value = $value->neutralize(@{ $$self{semiverbatim} }) if $$self{semiverbatim} && (ref $value)
@@ -91,7 +90,7 @@ sub read {
   if ((!defined $value) && !$$self{optional}) {
     Error('expected', $self, $gullet,
       "Missing argument " . Stringify($self) . " for " . Stringify($fordefn),
-      "Started at " . ToString($startloc));
+      "Ended at " . ToString($gullet->getLocator));
     $value = T_OTHER('missing'); }
   return $value; }
 

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -32,7 +32,7 @@ use base qw(LaTeXML::Common::Object);
 #**********************************************************************
 sub new {
   my ($class, %options) = @_;
-  return bless { gullet => LaTeXML::Core::Gullet->new(),
+  return bless { gullet => LaTeXML::Core::Gullet->new(%options),
     boxing => [], token_stack => [] }, $class; }
 
 #**********************************************************************

--- a/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
@@ -266,7 +266,7 @@ sub pgfAssignKey {
   DefMacroI(T_CS('\pgfkeyscurrentvalue'), undef,
     ($value ? Tokens(map { ($_->getCatcode == CC_PARAM ? ($_, $_) : $_) } @value_toks)
       : ()));    # (or \pgfkeysnovalue ????
-  if (defined $value) { }    # Got value? ok.
+  if (defined $value) { }                              # Got value? ok.
   elsif (my $def = pgfkeyLookup($key . '/.@def')) {    # else if a default, let to it
     Let(T_CS('\pgfkeyscurrentvalue'), pgfkeyCS($key . '/.@def')); }
 
@@ -361,14 +361,14 @@ sub pgfReSplitPath {
   if ($key =~ m|^(.*?)/([^/]*)/([^/]*)$|) {
     ($path, $sub, $name) = ($1, $2, $3);
     if ($path) { $name = $sub . '/' . $name; }
-    else { $path = $path . '/' . $sub; } }
+    else       { $path = $path . '/' . $sub; } }
   DefMacroI(T_CS('\pgfkeyscurrentpath'), undef, TokenizeInternal($path));
   DefMacroI(T_CS('\pgfkeyscurrentname'), undef, TokenizeInternal($name));
   return ($path, $name); }
 
 sub pgfHandleValue {
   my ($stomach, $key) = @_;
-  Let(T_CS('\pgfkeys@code'), pgfkeyCS(ToString($key)));
+  Let(T_CS('\pgfkeys@code'), pgfkeyCS($key));
   return $stomach->digest(Tokens(T_CS('\expandafter'), T_CS('\pgfkeys@code'),
       T_CS('\pgfkeyscurrentvalue'), T_CS('\pgfeov'))); }
 

--- a/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
@@ -201,12 +201,12 @@ sub parsePGFKeys {
       # Note that this isn't consistently described in pgfkeys.code.tex
       my @k = $key->unlist;
       if (@k && !Equals($k[0], T_OTHER('/'))) {    # If doesn't start with /, add default path
-        Digest(T_CS('\pgfkeysaddeddefaultpathtrue'));
+        $stomach->digest(T_CS('\pgfkeysaddeddefaultpathtrue'));
         my $oldkey = Tokens(@k);
         unshift(@k, Expand(T_CS('\pgfkeysdefaultpath'))->unlist);
         $key = Tokens(@k); }
       else {
-        Digest(T_CS('\pgfkeysaddeddefaultpathfalse')); }
+        $stomach->digest(T_CS('\pgfkeysaddeddefaultpathfalse')); }
       DefMacroI(T_CS('\pgfkeyscurrentkey'), undef, $key);
       #----------------------------------------
       # Finally, start working with the value
@@ -255,8 +255,16 @@ sub pgfAssignKey {
   my $cmdkey;
   my $filtered = IfCondition(T_CS('\ifpgfkeysfilteringisactive'));
   # Double # to simulate what \pgfkeys@spdef does
+  my @value_toks = $value ? $value->unlist : ();
+  # Undef {} case
+  if ((scalar(@value_toks) == 2) &&
+    ($value_toks[0]->getCatcode() == CC_BEGIN) &&
+    ($value_toks[1]->getCatcode() == CC_END)) {
+    @value_toks = ();
+    undef $value;
+  }
   DefMacroI(T_CS('\pgfkeyscurrentvalue'), undef,
-    ($value ? Tokens(map { ($_->getCatcode == CC_PARAM ? ($_, $_) : $_) } $value->unlist)
+    ($value ? Tokens(map { ($_->getCatcode == CC_PARAM ? ($_, $_) : $_) } @value_toks)
       : ()));    # (or \pgfkeysnovalue ????
   if (defined $value) { }    # Got value? ok.
   elsif (my $def = pgfkeyLookup($key . '/.@def')) {    # else if a default, let to it
@@ -264,7 +272,7 @@ sub pgfAssignKey {
 
   # Deal with cases where value is required
   if (XEquals(T_CS('\pgfkeyscurrentvalue'), T_CS('\pgfkeysvaluerequired'))) {    # value REQUIRED!
-    Digest(Tokens(pgfkeyCS('/errors/value required/.@def'), T_CS('\pgfcurrentkey'),
+    $stomach->digest(Tokens(pgfkeyCS('/errors/value required/.@def'), T_CS('\pgfcurrentkey'),
         T_CS('\pgfkeyscurrentkey'), T_CS('\pgfkeyscurrentvalue'))); }
   else {
     # Case 1: a command defined for the key
@@ -277,16 +285,16 @@ sub pgfAssignKey {
         $filtered = 0; } }
     if ($filtered) { SetCondition(T_CS('\ifpgfkeysfiltercontinue'), 1); }
     if (pgfkeyLookup($cmdkey = $key . '/.@cmd')) {    # Case 1
-      return if $filtered && testFilterPredicate($key, 1);
+      return if $filtered && testFilterPredicate($stomach, $key, 1);
       print STDERR "PROCESSING KEY $key (" . ($filtered ? 'filtered ' : '') . "case 1)\n" if $PGFKEYS_DEBUG;
-      pgfHandleValue($cmdkey, $value); }
+      pgfHandleValue($stomach, $cmdkey); }
     # Case 2: a normal value assignment.
     elsif (my $cs = pgfkeyLookup($key)) {
-      return if $filtered && testFilterPredicate($key, 2);
+      return if $filtered && testFilterPredicate($stomach, $key, 2);
       print STDERR "PROCESSING KEY $key (" . ($filtered ? 'filtered ' : '') . "case 2)\n" if $PGFKEYS_DEBUG;
       # Case 2: "extern"
       if (XEquals(T_CS('\pgfkeyscurrentvalue'), T_CS('\pgfkeysnovalue@text'))) {    # value empty?
-        Digest(pgfkeyCS($key)); }    # Just execute the STORED value!
+        $stomach->digest(pgfkeyCS($key)); }    # Just execute the STORED value!
       else {
         Let(pgfkeyCS($key), T_CS('\pgfkeyscurrentvalue')); } }
     # Case 3: Find a handler
@@ -310,31 +318,31 @@ sub pgfAssignKey {
           || (($handle eq 'full') && !IfCondition(T_CS('\ifpgfkeysaddeddefaultpath')))
           || LookupDefinition(T_CS('\pgfkey@excpt@' . $name))
           || pgfkeyLookup($path) || pgfkeyLookup($path . '/.@cmd'))) {
-        return if $filtered && testFilterPredicate($key, 3);
+        return if $filtered && testFilterPredicate($stomach, $key, 3);
         print STDERR "PROCESSING KEY $key (" . ($filtered ? 'filtered ' : '') . "case 3)\n" if $PGFKEYS_DEBUG;
-        pgfHandleValue($cmdkey, $value); }
+        pgfHandleValue($stomach, $cmdkey); }
       else {                                                         # Handle unknown
         if ($restricted) {
           ($path, $name) = pgfReSplitPath($key);
           print STDERR "RESPLIT '$key' => '$path' / '$name'\n" if $PGFKEYS_DEBUG; }
-        return if $filtered && testFilterPredicate($key, 0);
+        return if $filtered && testFilterPredicate($stomach, $key, 0);
         # Else various handlers for unknown
         if (pgfkeyLookup($cmdkey = $path . '/.unknown/.@cmd')) {
           print STDERR "PROCESSING KEY $key (case 0) for $cmdkey\n" if $PGFKEYS_DEBUG;
-          pgfHandleValue($cmdkey, $value); }
+          pgfHandleValue($stomach, $cmdkey); }
         elsif ($cmdkey = '/handlers/.unknown/.@cmd') {
           print STDERR "PROCESSING KEY $key (case 0) for $cmdkey\n" if $PGFKEYS_DEBUG;
-          pgfHandleValue($cmdkey, $value); } }
+          pgfHandleValue($stomach, $cmdkey); } }
   } }
   return; }
 
 sub testFilterPredicate {
-  my ($key, $case) = @_;
+  my ($stomach, $key, $case) = @_;
   DefMacroI('\pgfkeyscasenumber', undef, $case);
-  Digest(T_CS('\pgfkeys@key@predicate'));
+  $stomach->digest(T_CS('\pgfkeys@key@predicate'));
   if (!IfCondition(T_CS('\ifpgfkeysfiltercontinue'))) {
     print STDERR "FILTERED OUT KEY $key (case $case)\n" if $PGFKEYS_DEBUG;
-    Digest(T_CS('\pgfkeys@filtered@handler'));
+    $stomach->digest(T_CS('\pgfkeys@filtered@handler'));
     return 1; }
   return; }
 
@@ -359,9 +367,9 @@ sub pgfReSplitPath {
   return ($path, $name); }
 
 sub pgfHandleValue {
-  my ($key, $value) = @_;
+  my ($stomach, $key) = @_;
   Let(T_CS('\pgfkeys@code'), pgfkeyCS(ToString($key)));
-  return Digest(Tokens(T_CS('\expandafter'), T_CS('\pgfkeys@code'),
+  return $stomach->digest(Tokens(T_CS('\expandafter'), T_CS('\pgfkeys@code'),
       T_CS('\pgfkeyscurrentvalue'), T_CS('\pgfeov'))); }
 
 #======================================================================

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -297,8 +297,18 @@ sub pgfmathparse {
   my $input = $string;
 ###    if ($string =~/^+/){        # Don't parse as expression, just as glue. ???
   #    print STDERR "\nPGF Math Parse: $string\n";
-  $PGFMATHGrammar = Parse::RecDescent->new($PGFMATHGrammarSpec) unless $PGFMATHGrammar;
-  my $result = $PGFMATHGrammar->expr(\$string) || 0.0;
+  my $result;
+  {
+    local $@;
+    $result = eval $string;
+    if (!$@) {
+      # need to erase string when perl eval works, to keep it consistent with recdescent
+      $string = ''; }
+    else {    # failed to eval, use tikz grammar
+      $PGFMATHGrammar = Parse::RecDescent->new($PGFMATHGrammarSpec) unless $PGFMATHGrammar;
+      $result         = $PGFMATHGrammar->expr(\$string); }
+  }
+  $result = $result || 0.0;
   #  $result = "0.0" if $result eq "0";
   #    print STDERR "  GOT " . (defined $result ? $result : '<fail>') . "\n";
   if ($string) {

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -300,6 +300,7 @@ sub pgfmathparse {
   my $result;
   {
     local $@;
+    no warnings;
     $result = eval $string;
     if (!$@) {
       # need to erase string when perl eval works, to keep it consistent with recdescent

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -288,6 +288,8 @@ RawTeX(<<'EoTeX');
 \@ifundefined{pgfmathmathunitsdeclaredtrue}{\newif\ifpgfmathmathunitsdeclared}{}
 EoTeX
 
+our $PGMATH_UNITS_REGEXP = undef;
+
 sub pgfmathparse {
   my ($gullet, $tokens) = @_;
   SetCondition(T_CS('\ifpgfmathunitsdeclared'),     0, 'global');
@@ -295,20 +297,29 @@ sub pgfmathparse {
   my $string = (ref $tokens ? ToString(Expand($tokens)->stripBraces) : $tokens);
   $string =~ s/^\s+//; $string =~ s/\s+$//;
   my $input = $string;
-###    if ($string =~/^+/){        # Don't parse as expression, just as glue. ???
-  #    print STDERR "\nPGF Math Parse: $string\n";
   my $result;
-  {
-    local $@;
-    no warnings;
-    $result = eval $string;
-    if (!$@) {
-      # need to erase string when perl eval works, to keep it consistent with recdescent
-      $string = ''; }
-    else {    # failed to eval, use tikz grammar
-      $PGFMATHGrammar = Parse::RecDescent->new($PGFMATHGrammarSpec) unless $PGFMATHGrammar;
-      $result         = $PGFMATHGrammar->expr(\$string); }
-  }
+  $PGMATH_UNITS_REGEXP
+    = join('|', qw(em ex mu), keys %{ $STATE->lookupValue('UNITS') })
+
+    unless $PGMATH_UNITS_REGEXP;
+  # Also common would be unit=\pgflinewidth (height?)
+  if ($string =~ /^([+-]?[\d\.]+)($PGMATH_UNITS_REGEXP)$/) {
+    $result = pgfmath_convert($1, $2);
+    $string = ''; }
+  if ($string && !$result
+    && ($string !~ /\W(?:sin|cos|tan|cot|sec|cosec)\W/)) { {
+      local $LaTeXML::IGNORE_ERRORS = 1;
+      local $@;
+      no warnings;
+      $result = eval $string;
+      if (!$@) {
+        # need to erase string when perl eval works, to keep it consistent with recdescent
+        $string = ''; }
+    } }
+  if ($string && !$result) {
+    $PGFMATHGrammar = Parse::RecDescent->new($PGFMATHGrammarSpec) unless $PGFMATHGrammar;
+    $result         = $PGFMATHGrammar->expr(\$string); }
+
   $result = $result || 0.0;
   #  $result = "0.0" if $result eq "0";
   #    print STDERR "  GOT " . (defined $result ? $result : '<fail>') . "\n";

--- a/lib/LaTeXML/Package/pgfmathcalc.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmathcalc.code.tex.ltxml
@@ -1,0 +1,36 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  pgfmathcalc.code.tex                                               | #
+# | Implementation for LaTeXML                                          | #
+# |---------------------------------------------------------------------| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#======================================================================
+# Load pgf's TeX code for math, first
+InputDefinitions('pgfmathcalc.code', type => 'tex', noltxml => 1)
+  || Warn(":missing:pgfmathcalc.code.tex Couldn't find pgfmath.code.tex");
+
+# \pgfmathsetmacro
+# \edef#1 as the result of evaluating #2.
+DefPrimitive('\pgfmathsetmacro{}{}', sub {
+    my ($stomach, $cs, $expression) = @_;
+    $stomach->begingroup;
+    my $parse_result = Tokens(Explode(pgfmathparse($stomach->getGullet, $expression)));
+    $stomach->endgroup;
+    # We can simply endgroup immediately,
+    # Perl can jump around the trick of \pgfmath@smuggleone{#1}
+    DefMacroI($cs, undef, $parse_result, scope => 'local');
+    return; });
+
+1;
+

--- a/lib/LaTeXML/Package/pgfutil-common.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfutil-common.tex.ltxml
@@ -1,0 +1,39 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  pgfutils latexml driver                                            | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Released to the Public Domain                                       | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+
+#======================================================================
+# Load pgf's TeX code for util-common, first
+InputDefinitions('pgfutil-common', type => 'tex', noltxml => 1)
+  || Warn(":missing:pgfutil-common.tex Couldn't find pgfutil-common.tex");
+
+# Overwrite macros of interest
+
+DefMacro('\pgfutil@in@{}{}', sub {
+    AssignValue('pgfutilin_args', [ToString($_[1]), ToString($_[2])]);
+    return; });
+
+DefConditional('\ifpgfutil@in@', sub {
+    my $args    = LookupValue('pgfutilin_args') || ['', ''];
+    my $element = $$args[0];
+    my $list    = $$args[1];
+    my $test    = (index($list, $element) != -1);
+    # print STDERR "-- Is $element in $list ? Answer: $test\n";
+    return $test; });
+
+1;

--- a/lib/LaTeXML/Package/xcolor.sty.ltxml
+++ b/lib/LaTeXML/Package/xcolor.sty.ltxml
@@ -550,7 +550,7 @@ DefPrimitive('\color[]{}', sub {
     (Box(undef, undef, undef,
         Invocation(T_CS('\color'), T_OTHER('rgb'),    # Revert to ACTUAL color, not user's name
           T_OTHER(join(',', $color->rgb->components)))),
-      Digest(T_CS('\XC@mcolor'))); });
+      $stomach->digest(T_CS('\XC@mcolor'))); });
 
 DefPrimitive('\set@color', sub {
     my $color = LookupValue('color_.');


### PR DESCRIPTION
Another mini-project motivated by arXiv conversion Fatal:timeouts. The minimal snippet was:
```tex
% source: arXiv 1002.3757
\documentclass{article}
\usepackage{tikz}

\newcommand\dw[2]{\draw[#1!#2,fill=#1!#2]}

\begin{document}
\begin{tikzpicture}
\def\LL{10}
\pgfmathsetmacro{\LLQ}{200/(\LL*\LL)}
\def\list{0,.2,...,\LL}
\foreach \x in \list {
    \foreach \y in \list {
        \pgfmathsetmacro{\d}{(\LLQ*(\LL*(\x + \y) - \x*\x - \y*\y))}
        \dw{black}{\d} (\x, \y) +(-.1, -.1) rectangle ++(.1, .1);
    }   
}
\end{tikzpicture}
\end{document}
```

In order to keep things fast I developed my speedups with `\def\LL{2}`. The times in question are on my x230 thinkpad laptop, so a little slower than usual:

| LL | converter | time sec |
|----:|----------:|-----------:|
| 2   | master | 95 |
| 10 | master | 1860|
| 2   | PR       |    30 | 
| 10 | PR       |  420 |   
|   2| pdflatex | 0.7   |
| 10 | pdflatex| 5.6   |

Here is the PDF with LL 10 for intuition's sake:
[itertikz.pdf](https://github.com/brucemiller/LaTeXML/files/4332266/itertikz.pdf)
And the zip-ed HTML+SVG
[testpr.zip](https://github.com/brucemiller/LaTeXML/files/4332306/testpr.zip)



The intuition is the usual -- nothing is _particularly_ slow about Tikz, there is just a lot of it getting processed due to running the full TeX machinery. I spent more time that I'd like to admit hunting for easy wins, and I found one big one and a couple of smaller ones.

1. The big winner is actually a cheat in `pgfmathparse`. It turns out even in the cases where the expression is simple arithmetic, the RecDescent machinery takes quite some time. And an advanced drawing would have thousands of expressions. In this example the nested loops samples a total of 2500 (x,y) coordinates, and computes an expression for each of them, only then proceeding to draw. Turns out parsing 2500 expressions with RecDescent just takes too long for a 30 min timeout. However, it is near-instant when we let `perl` give them a go -- just an `eval $string` call is a geometric speedup, even if most of the expressions end up failing (which I doubt). I also tried some improvements with regexes, but didn't see as noticeable a speedup over the grammar approach. One could even take it further and have a quick pre-scan turning all units into perl floats, and then passing the resulting expression into an "eval" call.

2. 10% speedup. Error-only uses of locators were calling getLocator in tens of thousands of instances where there was no error. In fact NYTProf reported `getLocator` as a top 15 subroutine in my tikz tests, which was surprising -- especially since the locators were never preserved in the two cases I refactored. The changes here only call the subroutine when it is actually used, losing some accuracy as it now reports on the end rather than the start position of the error. Something to consider, maybe the old behavior could be kept when a debug flag is on.

3. Opted in for `$stomach->digest` over `Digest` to save on overhead in pgf "hot paths" that get visited frequently.

4. Added perl bindings for `\pgfmathsetmacro` and `\pgfutil@in@`, which were both simple and often used enough to try. It had marginal success, a second or two shaved here or there, but seems reasonable enough to keep.

Still quite far from pdflatex, but promising in terms of eliminating arXiv fatals, at least to an extent.