### PR TITLE
Handle dual-mode content for {d} coulmns in dcolumn.sty

### DIFF
--- a/lib/LaTeXML/Package/dcolumn.sty.ltxml
+++ b/lib/LaTeXML/Package/dcolumn.sty.ltxml
@@ -38,15 +38,18 @@ DefMacro('\DC@{}{}{}', sub {
       $STATE->assignMathcode($delim => 0x8000);
       DefMacroI(T_CS($delim), undef, '\@hidden@bgroup\lx@unactivate{' . $delim . '}\ROLE{PERIOD}{' . UnTeX($todelim) . '}\@hidden@egroup');
     }
-    if (LookupValue('IN_MATH') || $gullet->ifNext(T_MATH)) {    # Not really good enough, but...
-      (); }
-    else {
-      Let('\DC@end', T_MATH);
-      (T_MATH); } });
+    # We need to temporarily deactivate '$'
+    Let(T_CS('\DC@saved@dollar'), T_MATH);
+    Let(T_MATH,                   T_CS('\relax'));
+    return Tokens(LookupValue('IN_MATH') ? () : T_CS('\@@BEGININLINEMATH'));
+});
 # NOTE: We should be making arrangements for this funny thing to still
 # be considered a number!
 
-DefMacro('\DC@end', '');
+DefMacro('\DC@end', sub {
+    Let(T_MATH, T_CS('\DC@saved@dollar'));
+    return (T_CS('\@@ENDINLINEMATH'));
+});
 
 DefColumnType('D{}{}{}', sub {
     my ($gullet, $delim, $todelim, $ndec) = @_;


### PR DESCRIPTION
An Error-level patch for the latest arXiv run. I was looking at the `Error:malformed:XMApp` category:
https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/malformed/ltx%3AXMApp?all=false

In particular, `cond-mat0001181`. The problem is that the authors treated the `d` column, which has an intent for numeric literal content, as "advisory" rather than "mandatory". In particular, this gorgeous table (PDF):
![image](https://user-images.githubusercontent.com/348975/76694758-5bfc5580-664d-11ea-9034-289440720465.png)

was typeset using a d-column with content:
```tex
($ 1 0 \frac{1}{2} $) 
```

Note that the parentheses are in text mode, while the fraction + other numeric literals are in math mode. This was breaking the current support in dcolumn.sty.ltxml.

I found a satisfying upgrade that seems to follow closer the "intent" of d-columns. Namely, I deactivated `T_MATH` (as `\relax`) for the duration of ingesting content for that column, re-activating it at the column end. And I added mandatory open/close of inline math mode. In effect this will treat the entire content of d-columns as a single math expression, but more importantly will produce valid XMath even in mixed-mode inputs.

Could be a nice entry point into finding more upgrades for avoiding `malformed` errors in arXiv I think.