### PR TITLE
\documentstyle for .sty targets

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -80,7 +80,13 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
     # So, we'll just try for a .cls, punting to OmniBus if needed.
     # If we start wanting to read style files by default, we'll still need to handle this
     # specially, since class (or sty files pretending to be) cover so much more.
-    LoadClass($class, options => $options, after => Tokens(T_CS('\compat@loadpackages')));
+    if (FindFile($class, type => 'cls', notex => !LookupValue('INCLUDE_STYLES'))) {
+      LoadClass($class, options => $options,
+        after => Tokens(T_CS('\compat@loadpackages'))); }
+    else {
+      InputDefinitions('OmniBus', type => 'cls', noerror => 1, handleoptions => 1);
+      RequirePackage($class, options => $options,
+        after => Tokens(T_CS('\compat@loadpackages'))); }
     return; });
 
 DefPrimitiveI('\compat@loadpackages', undef, sub {
@@ -868,6 +874,7 @@ DefPrimitive('\ExecuteOptions{}', sub {
 DefPrimitive('\ProcessOptions OptionalMatch:*', sub {
     my ($stomach, $star) = @_;
     ProcessOptions(($star ? (inorder => 1) : ())); });
+DefMacro('\@options', '\ProcessOptions*');
 
 DefMacro('\AtEndOfPackage{}', sub {
     my ($gullet, $code) = @_;

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -85,7 +85,7 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
         after => Tokens(T_CS('\compat@loadpackages'))); }
     else {
       InputDefinitions('OmniBus', type => 'cls', noerror => 1, handleoptions => 1);
-      RequirePackage($class, options => $options,
+      RequirePackage($class, options => $options, as_class => 1,
         after => Tokens(T_CS('\compat@loadpackages'))); }
     return; });
 


### PR DESCRIPTION
Motivated by [this arxiv paper](https://arxiv.org/abs/cond-mat/0003484), while looking for what turned out to be an incidental [ltx:XMTok in ltx:p](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/malformed/ltx%3AXMTok?all=false) malformed error.

The main issue with the document is an old use of `\documentstyle` that really targets a `.sty` file, and one that is distributed together with the paper sources - a custom `jpsj.sty`.

I added a check for a finding `.cls` file, which when OK proceeds, but when failed tries to load a `.sty` file of the same name, with a preloaded OmniBus.cls. It improved the status of the document substantially (even threw in a `\@options` helper definition for it, but since alignments were involved it still failed flat after a certain point. I thought I would pass the work along as a PR, whether or not it's deemed impactful in the long run.