### PR TITLE
Restricted inclusion of raw styles to source directory

### DIFF
--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -51,7 +51,9 @@ sub new {
     'global');
   $state->assignValue(GRAPHICSPATHS => [map { pathname_absolute(pathname_canonical($_)) }
         @{ $options{graphicspaths} || [] }], 'global');
-  $state->assignValue(INCLUDE_STYLES => $options{includestyles} || 0, 'global');
+ # For now the "includestyles" option passed from --includestyles will accept both classes and styles?
+  $state->assignValue(INCLUDE_STYLES  => $options{includestyles} || 0, 'global');
+  $state->assignValue(INCLUDE_CLASSES => $options{includestyles} || 0, 'global');
   # Core has to ensure a default input encoding, and we default towards modern utf-8 documents
   # This can be removed when all executables rely on LaTeXML::Common::Config
   $options{inputencoding} = "utf-8" unless $options{inputencoding};

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1859,7 +1859,7 @@ sub pathname_is_raw {
   return ($pathname =~ /\.(tex|pool|sty|cls|clo|cnf|cfg|ldf|def|dfu)$/); }
 
 my $findfile_options = {    # [CONSTANT]
-  type => 1, notex => 1, noltxml => 1 };
+  type => 1, notex => 1, noltxml => 1, restricted => 1 };
 
 sub FindFile {
   my ($file, %options) = @_;
@@ -1927,7 +1927,7 @@ sub FindFile_aux {
     (!$options{notex} ? ($file) : ()));
   local $ENV{TEXINPUTS} = join($Config::Config{'path_sep'},
     @$paths, $ENV{TEXINPUTS} || $Config::Config{'path_sep'});
-  if (my $result = pathname_kpsewhich(@candidates)) {
+  if (my $result = (!$options{restricted}) && pathname_kpsewhich(@candidates)) {
     return (-f $result ? $result : undef); }
   if ($urlbase && ($path = url_find($file, urlbase => $urlbase))) {
     return $path; }
@@ -2250,7 +2250,8 @@ sub AddToMacro {
 #======================================================================
 my $inputdefinitions_options = {    # [CONSTANT]
   options => 1, withoptions => 1, handleoptions => 1,
-  type    => 1, as_class    => 1, noltxml       => 1, notex => 1, noerror => 1, after => 1 };
+  type    => 1, as_class    => 1, noltxml       => 1, notex => 1, noerror => 1, after => 1,
+  restricted => 1 };
 #   options=>[options...]
 #   withoptions=>boolean : pass options from calling class/package
 #   after=>code or tokens or string as $name.$type-h@@k macro. (executed after the package is loaded)
@@ -2287,7 +2288,7 @@ sub InputDefinitions {
         "Option clash for file $filename with options '$curroptions'",
         "previously loaded with '$prevoptions'") unless $curroptions eq $prevoptions; } }
   if (my $file = FindFile($filename, type => $options{type},
-      notex => $options{notex}, noltxml => $options{noltxml})) {
+      notex => $options{notex}, noltxml => $options{noltxml}, restricted => $options{restricted})) {
     if ($options{handleoptions}) {
       Digest(T_CS('\@pushfilename'));
       # For \RequirePackageWithOptions, pass the options from the outer class/style to the inner one.
@@ -2353,7 +2354,7 @@ sub InputDefinitions {
 
 my $require_options = {    # [CONSTANT]
   options => 1, withoptions => 1, type => 1, as_class => 1,
-  noltxml => 1, notex       => 1, raw  => 1, after    => 1 };
+  noltxml => 1, notex       => 1, raw  => 1, after    => 1, restricted => 1 };
 # This (& FindFile) needs to evolve a bit to support reading raw .sty (.def, etc) files from
 # the standard texmf directories.  Maybe even use kpsewhich itself (INSTEAD of pathname_find ???)
 # Another potentially useful option might be that if we are reading a raw file,
@@ -2369,6 +2370,8 @@ sub RequirePackage {
   # We'll usually disallow raw TeX, unless the option explicitly given, or globally set.
   $options{notex} = 1
     if !defined $options{notex} && !LookupValue('INCLUDE_STYLES') && !$options{noltxml};
+  # Top-level requires can be restricted to local sources
+  $options{restricted} //= (!$options{notex}) && LookupValue('INCLUDE_STYLES_NO_KPSEWHICH');
   my $success = InputDefinitions($package, type => $options{type} || 'sty', handleoptions => 1,
     # Pass classes options if we have NONE!
     withoptions => !($options{options} && @{ $options{options} }),
@@ -2377,12 +2380,14 @@ sub RequirePackage {
   return; }
 
 my $loadclass_options = {    # [CONSTANT]
-  options => 1, withoptions => 1, after => 1, notex => 1 };
+  options => 1, withoptions => 1, after => 1, notex => 1, restricted => 1 };
 
 sub LoadClass {
   my ($class, %options) = @_;
   $options{notex} = 1
     if !defined $options{notex} && !LookupValue('INCLUDE_STYLES') && !$options{noltxml};
+  # Top-level requires can be restricted to local sources
+  $options{restricted} //= (!$options{notex}) && LookupValue('INCLUDE_STYLES_NO_KPSEWHICH');
 
   $class = ToString($class) if ref $class;
   CheckOptions("LoadClass ($class)", $loadclass_options, %options);

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1859,7 +1859,7 @@ sub pathname_is_raw {
   return ($pathname =~ /\.(tex|pool|sty|cls|clo|cnf|cfg|ldf|def|dfu)$/); }
 
 my $findfile_options = {    # [CONSTANT]
-  type => 1, notex => 1, noltxml => 1, restricted => 1 };
+  type => 1, notex => 1, noltxml => 1, no_kpsewhich => 1 };
 
 sub FindFile {
   my ($file, %options) = @_;
@@ -1927,7 +1927,7 @@ sub FindFile_aux {
     (!$options{notex} ? ($file) : ()));
   local $ENV{TEXINPUTS} = join($Config::Config{'path_sep'},
     @$paths, $ENV{TEXINPUTS} || $Config::Config{'path_sep'});
-  if (my $result = (!$options{restricted}) && pathname_kpsewhich(@candidates)) {
+  if (my $result = (!$options{no_kpsewhich}) && pathname_kpsewhich(@candidates)) {
     return (-f $result ? $result : undef); }
   if ($urlbase && ($path = url_find($file, urlbase => $urlbase))) {
     return $path; }
@@ -2251,7 +2251,7 @@ sub AddToMacro {
 my $inputdefinitions_options = {    # [CONSTANT]
   options => 1, withoptions => 1, handleoptions => 1,
   type    => 1, as_class    => 1, noltxml       => 1, notex => 1, noerror => 1, after => 1,
-  restricted => 1 };
+  no_kpsewhich => 1 };
 #   options=>[options...]
 #   withoptions=>boolean : pass options from calling class/package
 #   after=>code or tokens or string as $name.$type-h@@k macro. (executed after the package is loaded)
@@ -2288,7 +2288,7 @@ sub InputDefinitions {
         "Option clash for file $filename with options '$curroptions'",
         "previously loaded with '$prevoptions'") unless $curroptions eq $prevoptions; } }
   if (my $file = FindFile($filename, type => $options{type},
-      notex => $options{notex}, noltxml => $options{noltxml}, restricted => $options{restricted})) {
+      notex => $options{notex}, noltxml => $options{noltxml}, no_kpsewhich => $options{no_kpsewhich})) {
     if ($options{handleoptions}) {
       Digest(T_CS('\@pushfilename'));
       # For \RequirePackageWithOptions, pass the options from the outer class/style to the inner one.
@@ -2354,7 +2354,7 @@ sub InputDefinitions {
 
 my $require_options = {    # [CONSTANT]
   options => 1, withoptions => 1, type => 1, as_class => 1,
-  noltxml => 1, notex       => 1, raw  => 1, after    => 1, restricted => 1 };
+  noltxml => 1, notex       => 1, raw  => 1, after    => 1, no_kpsewhich => 1 };
 # This (& FindFile) needs to evolve a bit to support reading raw .sty (.def, etc) files from
 # the standard texmf directories.  Maybe even use kpsewhich itself (INSTEAD of pathname_find ???)
 # Another potentially useful option might be that if we are reading a raw file,
@@ -2370,8 +2370,8 @@ sub RequirePackage {
   # We'll usually disallow raw TeX, unless the option explicitly given, or globally set.
   $options{notex} = 1
     if !defined $options{notex} && !LookupValue('INCLUDE_STYLES') && !$options{noltxml};
-  # Top-level requires can be restricted to local sources
-  $options{restricted} //= (!$options{notex}) && LookupValue('INCLUDE_STYLES_NO_KPSEWHICH');
+  # Top-level requires can be no_kpsewhich to local sources
+  $options{no_kpsewhich} //= (!$options{notex}) && LookupValue('INCLUDE_STYLES_NO_KPSEWHICH');
   my $success = InputDefinitions($package, type => $options{type} || 'sty', handleoptions => 1,
     # Pass classes options if we have NONE!
     withoptions => !($options{options} && @{ $options{options} }),
@@ -2380,14 +2380,14 @@ sub RequirePackage {
   return; }
 
 my $loadclass_options = {    # [CONSTANT]
-  options => 1, withoptions => 1, after => 1, notex => 1, restricted => 1 };
+  options => 1, withoptions => 1, after => 1, notex => 1, no_kpsewhich => 1 };
 
 sub LoadClass {
   my ($class, %options) = @_;
   $options{notex} = 1
     if !defined $options{notex} && !LookupValue('INCLUDE_STYLES') && !$options{noltxml};
-  # Top-level requires can be restricted to local sources
-  $options{restricted} //= (!$options{notex}) && LookupValue('INCLUDE_STYLES_NO_KPSEWHICH');
+  # Top-level requires can be no_kpsewhich to local sources
+  $options{no_kpsewhich} //= (!$options{notex}) && LookupValue('INCLUDE_STYLES_NO_KPSEWHICH');
 
   $class = ToString($class) if ref $class;
   CheckOptions("LoadClass ($class)", $loadclass_options, %options);

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -80,7 +80,7 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
     # So, we'll just try for a .cls, punting to OmniBus if needed.
     # If we start wanting to read style files by default, we'll still need to handle this
     # specially, since class (or sty files pretending to be) cover so much more.
-    if (FindFile($class, type => 'cls', notex => !LookupValue('INCLUDE_STYLES'))) {
+    if (FindFile($class, type => 'cls', notex => !LookupValue('INCLUDE_CLASSES'))) {
       LoadClass($class, options => $options,
         after => Tokens(T_CS('\compat@loadpackages'))); }
     else {

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -53,7 +53,7 @@ DeclareOption('nobibtex', sub { AssignValue('NO_BIBTEX' => 1, 'global'); });
 DeclareOption('mathlexemes', sub { AssignValue('LEXEMATIZE_MATH' => 1, 'global'); });
 
 # Include raw .sty/.cls sources in the source directory of the conversion
-DeclareOption('rawsources', sub {
+DeclareOption('rawsourcestyles', sub {
     AssignValue('INCLUDE_STYLES'              => 1, 'global');
     AssignValue('INCLUDE_STYLES_NO_KPSEWHICH' => 1, 'global'); });
 

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -52,10 +52,13 @@ DeclareOption('nobibtex', sub { AssignValue('NO_BIBTEX' => 1, 'global'); });
 # Lexeme serialization for math formulas
 DeclareOption('mathlexemes', sub { AssignValue('LEXEMATIZE_MATH' => 1, 'global'); });
 
-# Include raw .sty/.cls sources in the source directory of the conversion
-DeclareOption('rawsourcestyles', sub {
-    AssignValue('INCLUDE_STYLES'              => 1, 'global');
-    AssignValue('INCLUDE_STYLES_NO_KPSEWHICH' => 1, 'global'); });
+# Finer control over which (if any) raw .sty/.cls files to include
+DeclareOption('rawstyles',      sub { AssignValue('INCLUDE_STYLES'  => 1,             'global'); });
+DeclareOption('localrawstyles', sub { AssignValue('INCLUDE_STYLES'  => 'searchpaths', 'global'); });
+DeclareOption('norawstyles',    sub { AssignValue('INCLUDE_STYLES'  => 0,             'global'); });
+DeclareOption('rawclasses',     sub { AssignValue('INCLUDE_CLASSES' => 1,             'global'); });
+DeclareOption('localrawclasses', sub { AssignValue('INCLUDE_CLASSES' => 'searchpaths', 'global'); });
+DeclareOption('norawclasses', sub { AssignValue('INCLUDE_CLASSES' => 0, 'global'); });
 
 ProcessOptions();
 #======================================================================

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -52,6 +52,11 @@ DeclareOption('nobibtex', sub { AssignValue('NO_BIBTEX' => 1, 'global'); });
 # Lexeme serialization for math formulas
 DeclareOption('mathlexemes', sub { AssignValue('LEXEMATIZE_MATH' => 1, 'global'); });
 
+# Include raw .sty/.cls sources in the source directory of the conversion
+DeclareOption('rawsources', sub {
+    AssignValue('INCLUDE_STYLES'              => 1, 'global');
+    AssignValue('INCLUDE_STYLES_NO_KPSEWHICH' => 1, 'global'); });
+
 ProcessOptions();
 #======================================================================
 # From latexml.sty


### PR DESCRIPTION
A proposal pull request for the arXiv conversion, motivated by the hope that the recent timeout-resolving PRs buy us more time to do raw interpretation.

A wide range of arXiv articles contain custom `.sty` and at times `.cls` files, which are often easy for latexml to interpret. Until now we have ignored them, under the rightful fear that `--includestyles` will interpret texlive packages that latexml fails badly on, leading to otherwise avoidable Fatals and Errors. We've talked on a number of occasions that it would be informative to do an experiment that only loads raw files from the source directory of a conversion job, which should bring in more positives than negatives (in theory).

So, this PR offers one approach to start such an experiment, via a new experimental latexml.sty option. As a running example, take the minimal:
```tex
\documentclass{memoir}
\usepackage{mysty}
\begin{document}
hello
\end{document}
```

With some trivial/empty `mysty.sty` in the same directory. Running a simple `latexml test.tex` yields, among other messages:
```
Warning:missing_file:memoir Can't find binding for class memoir (using OmniBus)
...
Warning:missing_file:mysty Can't find binding for package mysty
```

Turning on `--includestyles` allows latexml to find both files, and to fail quite badly on memoir, with 40 errors just for reading the `.cls` file. Now, this PR allows to run:
```
latexml test.tex --preload=[rawsourcestyles]latexml.sty
```

Which only yields:
```
Warning:missing_file:memoir Can't find binding for class memoir (using OmniBus)
```

while successfully loading `mysty.sty`.

Definitely open to renaming any/all new bits of code here, it's quite odd to name within the existing scheme, without majorly refactoring other intuitions. For now I intended this option to be used in isolation / apart from `--includestyles`, to avoid the mixed intuitions of using them together. At least good names don't come to me intuitively, I end up with:
```
--includestyles --preload=[toplevelincludesonlyforsourcedir]latexml.sty
```
Similarly for the `restricted` option, maybe it should be `restricted_raw_paths` or some such?

In any case, would love to run this setup over arXiv, and see how the percentages compare, especially after the rest of the upgrade PRs land.