### PR TITLE
Cleanup generated svg:g and svg:switch

### DIFF
--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -96,7 +96,7 @@ DefConstructor('\lxSVG@insertpicture{}',
     $document->openElement('svg:g',
       transform => "matrix(1 0 0 -1 0 $props{flipnmove})");
     $document->absorb($content);
-    while ($document->maybeCloseElement('svg:g')) { }
+    while (maybeCloseG($document)) { }
     #                 $document->closeElement('svg:g');
     $document->closeElement('svg:svg');
     $document->closeElement('ltx:picture');
@@ -144,7 +144,15 @@ DefParameterType('SVGMoveableBox', sub {
     $box; });
 
 # Try to avoid errors inserting random boxes (esp. ltx:text)(Is this safe?)
-Tag('svg:switch', autoOpen => 1, autoClose => 1);    # ?
+Tag('svg:switch', autoOpen => 1, autoClose => 1, afterClose => sub {
+    my ($document, $sw) = @_;
+    my @swc = element_nodes($sw);
+    if (!scalar(@swc)) {    # empty? remove.
+      $document->removeNode($sw); }
+    elsif (scalar(@swc) == 1) {    # single child? unwrap
+      $document->replaceNode($sw, $swc[0]); }
+    # otherwise: keep as-is.
+    return; });
 Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
   afterClose => sub {
     my ($document, $node, $whatsit) = @_;
@@ -285,7 +293,7 @@ DefConstructor('\pgfsys@hbox{Number}', sub {
       if ($n->isSameNode($fo)) {
         $doc->closeElement('svg:foreignObject');
         $doc->closeElement('svg:switch');
-        $doc->closeElement('svg:g');
+        maybeCloseG($doc);
         # Check the children of the inserted ltx:p
         # We should at least try to denest svg ?
         # If svg:switch/svg:foreignObject/ltx:p/ltx:picture/svg:svg/svg:g
@@ -298,6 +306,16 @@ DefConstructor('\pgfsys@hbox{Number}', sub {
             $doc->replaceNode($sw, $g);
     } } } }
     # Could conceivably be simplifying ltx:text ???
+
+# What follow are a series of crutch measures that combat inappropriately generated markup.
+#      they are sanitzers that mostly work, but we ought to also work on improving the entire svg:switch-related
+#      machinery.
+# Empty p? Remove, and unwind up the parent hierarchy
+    if (!element_nodes($p)) {
+      my $node_to_remove = $p;
+      while (scalar(element_nodes($node_to_remove->parentNode)) == 1) {
+        $node_to_remove = $node_to_remove->parentNode; }
+      $doc->removeNode($node_to_remove); }
   },
   reversion => sub {
     my $box = $_[0]->getProperty('thebox');
@@ -480,8 +498,21 @@ DefConstructor('\lxSVG@begingroup@ RequiredKeyVals',
 
 DefConstructor('\lxSVG@endgroup@',
 ###  '</svg:g>',
-  sub { $_[0]->maybeCloseElement('svg:g'); },
+  sub { maybeCloseG($_[0]); },
   reversion => '', sizer => 0);
+
+sub maybeCloseG {
+  my ($document) = @_;
+  my $el = $document->getNode;
+  if ($document->getNodeQName($el) eq 'svg:g') {
+    if (!$el->attributes) {    # empty g, unwrap
+      my @el_children = element_nodes($el);
+      if (scalar(@el_children) == 1) {
+        $document->replaceNode($el, $el_children[0]);
+        # return true, since we handled an svg:g
+        return 1; } } }
+  #else: multiple child nodes would be trickier to unwrap, just close in that case (for now)
+  return $document->maybeCloseElement('svg:g'); }
 
 #=====================================================================
 # Implementation


### PR DESCRIPTION
Fixes #1227 with a patch.

I think there are deeper issues with the Tikz->SVG support in a specific subset of cases, but the concrete example could be addressed with some basic mitigation patching.

The key being that there is a `svg:switch` element generated holding (a foreignObject with) an empty `ltx:p` element, which is entirely unnecessary. I added a cleanup step at the end of that bit of construction code, which removes such needless elements, and also modified the Tag for `svg:switch` to unwrap the element if unnecessary (i.e. if only a single child is present).

Similarly, I noticed we generate a whole lot of redundant `svg:g` markup without any attributes, so refactored to use a dedicated subroutine which would unwrap such needless g elements. I'm now wondering whether I did that wrong, and maybe I should have it auto-unwrap also as an `afterClose` Tag rule... 

All that said, I haven't actually addressed the root cause that generates the incorrect markup in the first place, in fact I haven't even understood it yet. Reading the [official switch documentation](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/switch) I don't even think we should be using that element -- rather, we should be throwing Errors and dropping content that was "unexpected" or lead to "malformed" SVG. At least in principle.

An example that also improves with this patch is the [showcase](https://latexml.mathweb.org/editor) "Tikz AC Voltage", which has no text in master, and has all of the text visible after the PR (though the axes legends still have alignment problems). I should mention that I ran all examples under texlive 2019, since it is correctly converting on the showcase server (texlive 2015). The issues are likely all 2019 Tikz regressions.

To contrast, the PR generates this relatively compact snippet for the #1227 tex (texlive 2019):
```xml
<svg id="p1.pic1" class="ltx_picture" style="width:48.6pt;height:20.1pt;" height="27.77" overflow="visible" version="1.1" viewBox="-33.6 -13.88 67.2 27.77" width="67.2">
   <g transform="matrix(1 0 0 -1 0 0.00999999999999801)">
      <g>
         <g stroke="#000000">
            <g fill="#000000">
               <g stroke-width="0.4pt" color="#000000">
                  <g>
                     <g>
                        <path d="M -30.56 -10.84 h 61.11 v 21.68 h -61.11 Z" style="fill:none" />
                        <g>
                           <g transform="matrix(1 0 0 1 -25.94 -3.46)">
                              <g class="ltx_svg_fog" transform="matrix(1 0 0 -1 0 12.45)">
                                 <g stroke="#000000">
                                    <g fill="#000000">
                                       <foreignObject width="7.5pt" height="9.0pt">Text</foreignObject>
                                    </g>
                                 </g>
                              </g>
                           </g>
                        </g>
                     </g>
                  </g>
               </g>
            </g>
         </g>
      </g>
   </g>
</svg>
```

while master generates the longer, and failing to render its text (texlive 2019):
```xml
<svg id="p1.pic1" class="ltx_picture" style="width:48.6pt;height:20.1pt;" height="27.77" overflow="visible" version="1.1" viewBox="-33.6 -13.88 67.2 27.77" width="67.2">
   <g transform="matrix(1 0 0 -1 0 0.00999999999999801)">
      <g>
         <g stroke="#000000">
            <g fill="#000000">
               <g stroke-width="0.4pt" color="#000000">
                  <g>
                     <g>
                        <path d="M -30.56 -10.84 h 61.11 v 21.68 h -61.11 Z" style="fill:none" />
                        <g>
                           <g transform="matrix(1 0 0 1 -25.94 -3.46)">
                              <g class="ltx_svg_fog" transform="matrix(1 0 0 -1 0 12.45)">
                                 <switch>
                                    <foreignObject color="#000000" height="100%" overflow="visible" width="51.89">
                                       <p class="ltx_p" />
                                    </foreignObject>
                                    <g stroke="#000000">
                                       <g fill="#000000">
                                          <switch>
                                             <foreignObject width="7.5pt" height="9.0pt">Text</foreignObject>
                                          </switch>
                                       </g>
                                    </g>
                                 </switch>
                              </g>
                           </g>
                        </g>
                     </g>
                  </g>
               </g>
            </g>
         </g>
      </g>
   </g>
</svg>
```