### PR TITLE
Update users of beginBibliography

### DIFF
--- a/lib/LaTeXML/Package/BibTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/BibTeX.pool.ltxml
@@ -179,7 +179,7 @@ DefEnvironment('{bibtex@bibliography}',
     . "<ltx:biblist>#body</ltx:biblist>"
     . "</ltx:bibliography>",
   beforeDigest => sub {
-    AssignValue(inPreamble => 0); },
+    beforeDigestBibliography(); },
   afterDigestBegin => sub { beginBibliography($_[1]); });
 
 DefEnvironment('{bib@entry} Semiverbatim Semiverbatim',

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3459,6 +3459,14 @@ DefConstructor('\pageref OptionalMatch:* Semiverbatim', "<ltx:ref labelref='#lab
 
 DefMacroI('\thebibliography@ID', undef, Tokens());
 
+# Do this before digesting the body of a bibliography
+sub beforeDigestBibliography {
+  AssignValue(inPreamble => 0); Digest('\@lx@inbibliographytrue');
+  DefMacro('\bibliographystyle{}', '');
+  DefMacro('\bibliography {}',     '');
+  ResetCounter('@bibitem');
+  return; }
+
 # This sub does things that would commonly be needed when starting a bibliography
 # setting the ID, etc...
 sub beginBibliography {
@@ -3604,10 +3612,7 @@ DefConstructorI('\thebibliography', undef,
     . "<ltx:title font='#titlefont' _force_font='true'>#title</ltx:title>"
     . "<ltx:biblist>",
   beforeDigest => sub {
-    AssignValue(inPreamble => 0); Digest('\@lx@inbibliographytrue');
-    DefMacro('\bibliographystyle{}', '');
-    DefMacro('\bibliography {}',     '');
-    ResetCounter('@bibitem'); },
+    beforeDigestBibliography(); },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     # NOTE that in some perverse situations (revtex?)

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -129,9 +129,13 @@ DefConstructor('\references',
     . "bibstyle='#bibstyle' citestyle='#citestyle' sort='#sort'>"
     . "<ltx:title font='#titlefont' _force_font='true'>#title</ltx:title>"
     . "<ltx:biblist>",
-  afterDigest => sub { beginBibliography($_[1]); });
+  beforeDigest => sub { beforeDigestBibliography(); },
+  afterDigest => sub { beginBibliography($_[1]); }
+);
 
 DefConstructor('\endreferences',
   "</ltx:biblist></ltx:bibliography>");
+
+Let('\reference', '\bibitem');
 
 1;

--- a/lib/LaTeXML/Package/amsrefs.sty.ltxml
+++ b/lib/LaTeXML/Package/amsrefs.sty.ltxml
@@ -63,6 +63,8 @@ DefEnvironment('{bibdiv}',
     . "<ltx:title font='#titlefont' _force_font='true'>#title</ltx:title>"
     . "#body"
     . "</ltx:bibliography>",
+  beforeDigest => sub {
+    beforeDigestBibliography(); },
   afterDigestBegin => sub { beginBibliography_clean($_[1]); Let('\par', '\relax'); });
 
 DefEnvironment('{biblist}', "<ltx:biblist>#body</ltx:biblist>");

--- a/lib/LaTeXML/Package/revtex4_support.sty.ltxml
+++ b/lib/LaTeXML/Package/revtex4_support.sty.ltxml
@@ -189,6 +189,8 @@ DefConstructor('\references',
     . "bibstyle='#bibstyle' citestyle='#citestyle' sort='#sort'>"
     . "<ltx:title font='#titlefont' _force_font='true'>#title</ltx:title>"
     . "<ltx:biblist>",
+  beforeDigest => sub {
+    beforeDigestBibliography(); },
   afterDigest => sub { beginBibliography($_[1]); });
 
 DefConstructor('\endreferences',


### PR DESCRIPTION
Update users of beginBibliography to call beforeDigestBibliography when actually digesting bibitems so appropriate switches get set.  Particularly offensive was potential uses of ```\if@lx@inbibliography```.