### PR TITLE
add \@cite macro from latex.ltx

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3770,6 +3770,7 @@ AssignValue(CITE_YY_SEPARATOR   => T_OTHER(','));
 AssignValue(CITE_NOTE_SEPARATOR => T_OTHER(','));
 AssignValue(CITE_UNIT           => undef);
 
+DefMacro('\@cite{}{}', '[{#1\if@tempswa , #2\fi}]');
 DefConstructor('\@@cite []{}', "<ltx:cite ?#1(class='ltx_citemacro_#1')>#2</ltx:cite>",
   mode => 'text');
 


### PR DESCRIPTION
This is a minimal/piecemeal PR, motivated from an arXiv article (hep-lat0006026) that had Fataled with  >100 errors, but which passes with a single error (undefined `\@cite`) when local .sty files are loaded.

It's piecemeal because the PR doesn't actually provide working TeX-level cite support, it just emulates the macro to the point of depositing placeholders akin to `[?,?]` -- still better than an error, and neat to see a Fatal-to-Warning transition.

We may or may not consider locking certain "core" macros in LaTeX.pool (such as `\cite`) when also interpreting local .sty files... 