### PR TITLE
[regression] guard xml:id NCName for leading digit

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -855,6 +855,8 @@ sub GenerateID {
       else {
         # Or base the id on the id'd ancestor's id.
         $id = generateID_nextid($p[-1] || $document->documentElement, $prefix, $id); } }
+    # We may still be in a case where we got a raw numeric id. If so, guard with a prefix:
+    $id = "id$id" if $id =~ /^\d/;
     $document->setAttribute($node, 'xml:id' => $id); }
   return; }
 
@@ -1074,10 +1076,10 @@ sub DefConditionalI {
         conditional_type => 'unless', %options),
       $options{scope}); }
   elsif ($csname =~ /^\\(..)(.*)$/) {
-    my($prefix, $name) = ($1,$2);
-    if($prefix ne 'if'){
+    my ($prefix, $name) = ($1, $2);
+    if ($prefix ne 'if') {
       Warn('misdefined', $cs, $STATE->getStomach,
-      "The conditional " . Stringify($cs) . " is being defined but doesn't start with \\if"); }
+        "The conditional " . Stringify($cs) . " is being defined but doesn't start with \\if"); }
     if ((defined $name) && ($name ne 'case')
       && (!defined $test)) {    # user-defined conditional, like with \newif
       DefMacroI(T_CS('\\' . $name . 'true'),  undef, Tokens(T_CS('\let'), $cs, T_CS('\iftrue')));


### PR DESCRIPTION
From the latest and greatest GenerateID speedups ( #1248 ) we have a regression, in some torture cases of documents with actual Errors.

You can explore the full list from the testbench here:
https://corpora.mathweb.org/corpus/arxiv%5Ftestbench/tex%5Fto%5Fhtml/fatal/perl/die?all=false

The one I tested with was `0704.2285`. The problem is that some `xml:id`s with the new mechanism get generated with a leading digit, and are hence no longer NCNames, breaking post-processing with a Fatal. You could find a better patch than mine, but it's probably workable just as well -- the `$prefix` setting and passing machinery has gotten a bit convoluted / hard to track. I think in certain cases it is possible to end up with the pregenerated numerical id while no prefix is set.