### PR TITLE
Ensure we always match patchcmd patterns as literal chars

### DIFF
--- a/lib/LaTeXML/Package/etoolbox.sty.ltxml
+++ b/lib/LaTeXML/Package/etoolbox.sty.ltxml
@@ -1298,7 +1298,8 @@ DefMacro('\patchcmd [] DefToken {}{}{}{}', sub {
       }
       my $string        = ToString($expansion);
       my $search_string = ToString($search);
-      $search_string =~ s/\\/\\\\/g;    # ensure macro backslashes are escaped?
+      # All characters are meant to be matched as literal, avoid regex interpretation
+      $search_string = quotemeta($search_string);
       my $search_regex = qr/$search_string/;
       if ($string =~ $search_regex) {
         # Should the token substitution happen on the actual data structure?


### PR DESCRIPTION
Paying for my own carelessness the previous time I improved the `\patchcmd` binding -- the tex example I looked at now matched on `\left(` , where the parenthesis remained unescaped, leading to a Fatal regex error.

I finally reached for the "official" way to escape all active regex characters in a string, and switched to using `quotemeta`. Improved the Fatal article in question `1604.01056` to warning status.

Fatal read:
```
Perl died at IS_FB_Capacity_MC_May_2015_FINAL_Part_2_V12.tex; line 53 col 0 - line 53 col 45 
Unmatched ( in regex; marked by <-- HERE in m/\\left( <-- HERE / 
at /home/deginev/perl5/lib/perl5/LaTeXML/Package/etoolbox.sty.ltxml line 1302, <$IN> line 53. 
In Core::Definition::Expandable[\patchcm... /home/deginev/perl5/lib/perl5/LaTeXML/Package/etoolbox.sty.ltxml; line 1317 <= Core::Gullet[@0x3f25e08] <= Core::Stomach[@0x3f26408]
```