### PR TITLE
Elevate fallback interface to all LaTeXML::Common::Object

### DIFF
--- a/lib/LaTeXML/Common/Object.pm
+++ b/lib/LaTeXML/Common/Object.pm
@@ -165,11 +165,25 @@ sub unlist {
   return $self; }
 
 #**********************************************************************
+# What about Kern, Glue, Penalty ...
+
+# stubs to avoid "shallow" Fatal errors on broken documents
+sub multiply { return Dimension(0); }
+sub subtract { return Dimension(0); }
+sub add      { return Dimension(0); }
+sub negate   { return Dimension(0); }
+sub divide   { return Dimension(0); }
+sub getX     { return Dimension(0); }
+sub getY     { return Dimension(0); }
+sub ptValue  { return 0.0; }
+sub valueOf  { return 0.0; }
+#**********************************************************************
+
 1;
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -189,7 +203,7 @@ to beautify error reporting.
 =item C<< $string = Stringify($object); >>
 
 Returns a string identifying C<$object>, for debugging.
-Works on any values and objects, but invokes the stringify method on 
+Works on any values and objects, but invokes the stringify method on
 blessed objects.
 More informative than the default perl conversion to a string.
 
@@ -207,7 +221,7 @@ the toString method on blessed objects.
 
 =item C<< $boolean = Equals($x,$y); >>
 
-Compares the two objects for equality.  Works on any values and objects, 
+Compares the two objects for equality.  Works on any values and objects,
 but invokes the equals method on blessed objects, which does a
 deep comparison of the two objects.
 
@@ -279,4 +293,3 @@ Public domain software, produced as part of work done by the
 United States Government & not subject to copyright in the US.
 
 =cut
-

--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -234,18 +234,6 @@ sub computeSize {
   $$props{cdepth}  = $d unless defined $$props{depth};
   return; }
 
-#**********************************************************************
-# What about Kern, Glue, Penalty ...
-
-# stubs to avoid "shallow" Fatal errors on broken documents
-sub multiply { return Dimension(0); }
-sub subtract { return Dimension(0); }
-sub add      { return Dimension(0); }
-sub negate   { return Dimension(0); }
-sub divide   { return Dimension(0); }
-sub getX     { return Dimension(0); }
-sub getY     { return Dimension(0); }
-sub ptValue  { return; }
 #======================================================================
 1;
 


### PR DESCRIPTION
A follow-up to my great line of "robustness at all cost" reasoning that we explored in #1241 .

It turns out in the arXiv Fatals we also see cases of `getX`, `ptValue` or `valueOf` getting called on `Token` and `Tokens` objects, not just boxes. Luckily, there is a common thread -- all of these inherit from `Common::Object`!

Hence, this PR elevates the "fallback interface" up to Object, and I'm also throwing in `valueOf` which I noticed breaking one doc. Clawing my way to less Fatals, one fix at a time...