### PR TITLE
icml_support: load algorithmic only when needed

### DIFF
--- a/lib/LaTeXML/Package/algorithmic.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithmic.sty.ltxml
@@ -15,6 +15,10 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+# Was algorithmicx.sty loaded? If so: BAIL immediately.
+# (deeply incompatible)
+return 1 if IsDefined(T_CS('\algorithmic'));
+
 # Read in the LaTeX definitions and redefine a few things strategically.
 InputDefinitions('algorithmic', type => 'sty', noltxml => 1);
 
@@ -48,7 +52,7 @@ DefConstructor('\lx@algorithmic@item@@ OptionalUndigested',
   "<ltx:listingline xml:id='#id' itemsep='#itemsep'>"
     . "#tags",
   properties => sub {
-    my $id = Digest(T_CS('\theALC@line@ID'));
+    my $id   = Digest(T_CS('\theALC@line@ID'));
     my $tags = Digest(Invocation(T_CS('\lx@make@tags'), T_OTHER('ALC@line')));
     (id => $id, tags => $tags); },
   beforeConstruct => sub { $_[0]->maybeCloseElement('ltx:listingline'); });
@@ -59,4 +63,3 @@ DefMacro('\fnum@ALC@line', '\ALC@lno');
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;
-

--- a/lib/LaTeXML/Package/algorithmic.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithmic.sty.ltxml
@@ -17,7 +17,10 @@ use LaTeXML::Package;
 
 # Was algorithmicx.sty loaded? If so: BAIL immediately.
 # (deeply incompatible)
-return 1 if IsDefined(T_CS('\algorithmic'));
+if (IsDefined(T_CS('\algorithmic'))) {
+  Warn("unexpected", "\\algorithmic",
+    "Another package has already defined \\algorithmic, will not load algorithmic.sty");
+  return 1; }
 
 # Read in the LaTeX definitions and redefine a few things strategically.
 InputDefinitions('algorithmic', type => 'sty', noltxml => 1);

--- a/lib/LaTeXML/Package/algorithmicx.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithmicx.sty.ltxml
@@ -15,6 +15,10 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+# Was algorithmic.sty loaded? If so: BAIL immediately.
+# (deeply incompatible)
+return 1 if IsDefined(T_CS('\algorithmic'));
+
 # Load core, make a few redefinitions
 InputDefinitions('algorithmicx', type => 'sty', noltxml => 1);
 
@@ -71,4 +75,3 @@ DefConstructor('\lx@algorithmicx@hfill',
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;
-

--- a/lib/LaTeXML/Package/algorithmicx.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithmicx.sty.ltxml
@@ -17,7 +17,10 @@ use LaTeXML::Package;
 
 # Was algorithmic.sty loaded? If so: BAIL immediately.
 # (deeply incompatible)
-return 1 if IsDefined(T_CS('\algorithmic'));
+if (IsDefined(T_CS('\algorithmic'))) {
+  Warn("unexpected", "\\algorithmic",
+    "Another package has already defined \\algorithmic, will not load algorithmicx.sty");
+  return 1; }
 
 # Load core, make a few redefinitions
 InputDefinitions('algorithmicx', type => 'sty', noltxml => 1);

--- a/lib/LaTeXML/Package/icml_support.sty.ltxml
+++ b/lib/LaTeXML/Package/icml_support.sty.ltxml
@@ -19,8 +19,13 @@ use LaTeXML::Package;
 RequirePackage('times');
 RequirePackage('fancyhdr');
 RequirePackage('color');
-RequirePackage('algorithm');
-RequirePackage('algorithmic');
+DefPrimitive('\icml@fallback@algorithm', sub {
+    # Load algorithmic, but only if not a version of it has been explicitly loaded already.
+    if (!IsDefined(T_CS('\algorithmic'))) {
+      RequirePackage('algorithm');
+      RequirePackage('algorithmic'); }
+    return; });
+PushValue('@at@begin@document', T_CS('\icml@fallback@algorithm'));
 RequirePackage('natbib');
 # RequirePackage('eso-pic');
 # RequirePackage('forloop');

--- a/lib/LaTeXML/Package/icml_support.sty.ltxml
+++ b/lib/LaTeXML/Package/icml_support.sty.ltxml
@@ -19,13 +19,8 @@ use LaTeXML::Package;
 RequirePackage('times');
 RequirePackage('fancyhdr');
 RequirePackage('color');
-DefPrimitive('\icml@fallback@algorithm', sub {
-    # Load algorithmic, but only if not a version of it has been explicitly loaded already.
-    if (!IsDefined(T_CS('\algorithmic'))) {
-      RequirePackage('algorithm');
-      RequirePackage('algorithmic'); }
-    return; });
-PushValue('@at@begin@document', T_CS('\icml@fallback@algorithm'));
+RequirePackage('algorithm');
+RequirePackage('algorithmic');
 RequirePackage('natbib');
 # RequirePackage('eso-pic');
 # RequirePackage('forloop');


### PR DESCRIPTION
A curve ball infinite loop from arXiv, a minimal snippet is:
```tex
\documentclass{article}
\usepackage{icml2020}
\usepackage{algorithm}
\usepackage[noend]{algpseudocode}

\begin{document}
\begin{algorithmic}[1]
\end{algorithmic}
\end{document}
```

The issue is that icml_support will load algorithmic, while algpseudocode will load algorithmicx. At time of writing, having both of algorithmic and algorithmicx loaded will lead to an infinite loop at `\begin{algorithmic}`, universally, which is the larger issue.

I took two measures, slightly redundant (which is good - extra safe!).

1. Have `icml` load algorithmic only if no package has defined `\algorithmic` by the time of reaching `\begin{document}`, using the hooks. It is the correct application logic upgrade for the specific arXiv paper, which took the trouble of loading `algpseudocode` and get algorithmicx explicitly, not needing any help from the icml support.

2. Fix the general loop threat. I have now required that both `algorithmic.sty.ltxml` and `algorithmicx.sty.ltxml` bail immediately if `\algorithmic` was defined before they started loading. This avoids the entire large landscape of pain and suffering one finds themselves in when both packages are loaded, with a "first wins" pragmatic. Beats a fatal error in my mind (and an infinite loop at that).