### PR TITLE
use latex.ltx definition of \@makeother to properly neutralize \^

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1639,7 +1639,11 @@ DefRegister('\@itemdepth' => Number(0));
 # NOTE: how's the best way to get verbatim material through?
 DefEnvironment('{verbatim}',  '<ltx:verbatim>#body</ltx:verbatim>');
 DefEnvironment('{verbatim*}', '<ltx:verbatim>#body</ltx:verbatim>');
-Let('\@verbatim', '\verbatim');    # Close enough?
+# Let('\@verbatim', '\verbatim');    # Close enough?
+DefMacro('\@verbatim', <<'EOL');
+\let\do\@makeother \dospecials
+\obeylines \verbatim@font \@noligs
+EOL
 # verbatim is a bit of special case;
 # It looks like an environment, but it only ends with an explicit "\end{verbatim}" on it's own line.
 # So, we'll end up doing things more manually.
@@ -4981,7 +4985,9 @@ DefMacro('\@secondoftwo{}{}',    sub { $_[2]; });
 DefMacro('\@thirdofthree{}{}{}', sub { $_[3]; });
 DefMacro('\@expandtwoargs{}{}{}', sub {
     ($_[1]->unlist, T_BEGIN, Expand($_[2])->unlist, T_END, T_BEGIN, Expand($_[3])->unlist, T_END); });
-DefMacro('\@makeother{}', sub { AssignCatcode($_[1] => CC_OTHER, 'local'); });
+# The perl approach to \@makeother failed to capture the nuance needed when doing \@makeother\^
+# DefMacro('\@makeother{}', sub { AssignCatcode($_[1] => CC_OTHER, 'local');});
+DefMacro('\@makeother{}', '\catcode`#1=12\relax');
 
 RawTeX(<<'EoTeX');
 {\catcode`\^^M=13 \gdef\obeycr{\catcode`\^^M13 \def^^M{\\\relax}%


### PR DESCRIPTION
Debugging an arXiv doc error, here is a minimal example:
```tex
\documentclass{article}
\makeatletter
% verbatimlisting for computer code
\def\verbatimlisting#1{%
  \begingroup \@verbatim
    \input#1
    \endgroup}
\makeatother

\begin{document}
\verbatimlisting{snippet}
\end{document}
```

where the snippet file is just a single line:
```tex
test ^ here
```

pdflatex happily neutralizes and provides a verbatim snippet, while latexml chokes on the `^` sign. It turned out there were two bits needed for this paper to work:
1. Switch to a `\@verbatim` definition closer to the one in latex.ltx, in particular one that uses `\@makeother` internally.

2. More importantly, switch to using the direct latex.ltx macro definition of `\@makeother`, as the perl code for it was missing on subtle trickery that makes it work in raw tex. Namely, the difference between `^` and `\^` is significant, but when one uses `\catcode`, the `\^` form is a stand-in for the bare hat. 

I won't claim I've mastered the nuance in the interpretation, but I will rely on the fact that I copy-pasted the relevant bits from latex.ltx directly, and they seem to be producing the exact right output in XML.