### PR TITLE
Improve on svg:g scaffolding bindings

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -4034,7 +4034,7 @@ are added.
 
 C<afterOpen:early> or C<afterOpen:late> can be used in
 place of C<afterOpen>; these will be run as a group
-bfore, or after (respectively) the unmodified blocks.
+before, or after (respectively) the unmodified blocks.
 
 =item C<afterClose=E<gt>I<code>($document,$box)>
 

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -474,8 +474,28 @@ DefMacro('\lxSVG@endgroup',
 DefMacro('\lxSVG@endgroups', sub {
     map { T_CS('\lxSVG@endgroup') } 1 .. LookupValue('pgf_scopecount'); });
 
-DefConstructor('\lxSVG@begingroup@ RequiredKeyVals',
-  '<svg:g %&GetKeyVals(#1)>',
+DefConstructor('\lxSVG@begingroup@ RequiredKeyVals', sub {
+    my ($doc, $kv) = @_;
+    my $g_attrs        = $kv->getKeyVals;
+    my @keys           = keys %$g_attrs;
+    my $this           = $doc->getElement;
+    my $orig_this_name = $doc->getNodeQName($this);
+    # Special case check: if we are in a latexml context, the parent svg:g is acceptable
+    if ($orig_this_name =~ /^ltx:/ && (my $g_ancestor = $doc->findnode("ancestor::svg:g", $this))) {
+      # Sometimes even when we have a parent g, there is an attribute conflict
+      #    and we need to open a new one. AND make it the current insertion point OR?!
+      my @needs_wrap = grep { $g_ancestor->hasAttribute($_) } @keys;
+      if (@needs_wrap) {    # incompatible, wrap with new g
+        $this = $doc->wrapNodes('svg:g', $g_ancestor->lastChild); }
+      else {                # compatible, reuse
+        $this = $g_ancestor; } }
+    else {                  # all other cases, just open a g.
+                            # TODO: Redundant g's get made, we can merge them on afterClose?
+      $this = $doc->openElement('svg:g'); }
+    # We have the _correct_ svg:g here, let's assign the attributes
+    foreach my $key (@keys) {
+      my $value = $kv->getValue($key);
+      $doc->setAttribute($this, $key, $value); } },
   reversion => '', sizer => 0);
 
 DefConstructor('\lxSVG@endgroup@',


### PR DESCRIPTION
Fixes #1227 , and improves towards also fixing #1196 .

Second attempt after the previous #1255  PR hit a dead end. This time I decided to approach things a little closer to the TeX machinery. In particular, by making the `\lxSVG@begingroup@` , which is a constructor solely focused on the output XML markup, a little smarter.

To reiterate my previous realization, since TeX makes no inherent distinction between "drawing" and outputting "content", the pgf/tikz machinery intertwines the two at will without any negative consequences. Meanwhile, at least in the cases of `\hbox` generating `svg:foreignObject` we hit cases where the current open element in the document is in the `ltx:` namespace, but the insertion coming in is for an `svg:` construct. There are a wide range of configurations that could trigger different edge cases of this interplay, _unless_ we can provide for the general situation of "incoming SVG while inside a foreignObject's LTX".

This is what this PR attempts -- when a new `svg:g` attempts to open, it checks if the current insertion context is an `ltx:`, and if so, it "floats up" to its previous `svg:g` ancestor. I have so far only seen a need to do this with the `g` element, as it is a mostly "transparent envelope", hosting an attribute payload.

It would of course be a big problem if the ancestor g had actual drawn content, such as an `svg:path`, which is why the code explicitly targets the g's "last child" which is bound to host the current insertion context, where the foreignObject would be. Works in the #1227 example, and keeps the showcase examples in tact - in fact it _improves_ significantly on some previous regressions, including the one behind [missing diagram text](https://github.com/brucemiller/LaTeXML/issues/1196#issuecomment-527942852) for #1196. 

To wrap up, a reminder that all of these issues have only been observed (and debugged against) in texlive 2019. Older texlives seemed to get by without all of this caution, and it may be worth double-checking they still work with the PR. I assume @brucemiller could verify/contradict that :+1: