### PR TITLE
close text elements when floating to their parent element

### DIFF
--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -998,7 +998,10 @@ sub floatToElement {
   my @candidates = getInsertionCandidates($$self{node});
   my $closeable  = 1;
   if (@candidates && $self->canContain($candidates[0], $qname)) {
-    return $candidates[0]; }    # Fine right here.
+    # Fine right here, just return
+    # -- special case, if current is a text node, float to its parent element and return
+    $self->setNode($candidates[0]) if $$self{node}->getType == XML_TEXT_NODE;
+    return $candidates[0]; }
   while (@candidates && !$self->canContain($candidates[0], $qname)) {
     $closeable &&= $self->canAutoClose($candidates[0]);
     shift(@candidates); }

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -997,9 +997,9 @@ sub floatToElement {
   my ($self, $qname, $closeifpossible) = @_;
   my @candidates = getInsertionCandidates($$self{node});
   my $closeable  = 1;
+  # If the current node can contain already, we're fine right here - just return
   if (@candidates && $self->canContain($candidates[0], $qname)) {
-    # Fine right here, just return
-    # -- special case, if current is a text node, float to its parent element and return
+# Edge case: Don't resume at a text node, if it is current. Don't append more to it after other insertions.
     $self->setNode($candidates[0]) if $$self{node}->getType == XML_TEXT_NODE;
     return $candidates[0]; }
   while (@candidates && !$self->canContain($candidates[0], $qname)) {


### PR DESCRIPTION
Fixes #1271 (see discussion in issue for problem diagnostic)

The Document `floatToElement` method is getting a bit subtle for me, and this PR is just the patch that happened to come to mind when poking around the example. Unsure if it's the right general treatment however.

In short, there is a special case where `floatToElement` is returned almost immediately, when the first candidate is acceptable. The return is direct under the assumption that the first candidate is always the current Document node, which is _almost_ always exactly true. There is an exception in the case where the current node is a text node, rather than a "regular" node, in which case the master `floatToElement` would return the parent element, while leaving the text node as the currently open node.

If this reads a little confusing, you see why I am sensing things feel a little subtle :>

This PR takes the approach of simply recognizing this special case, closing the current Document node when returning its parent element (or equivalently, setting its parent element as the current Document node). Fixes the reported example, tests pass, so thought I'd see how it fairs under @brucemiller review.