### PR TITLE
Mathsvg usability upgrades

### DIFF
--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -18,7 +18,6 @@ use File::Spec;
 use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 use LaTeXML;    # Currently, just for version information.
-use LaTeXML::Common::Error qw(generateMessage colorizeString);
 use LaTeXML::Post;
 use LaTeXML::Post::Writer;
 use LaTeXML::Post::Scan;
@@ -290,9 +289,8 @@ else {
 if ((!defined $destination)
   && ($dographics || $picimages
     || checkMathFormat('images') || checkMathFormat('svg'))) {
-  print STDERR generateMessage(colorizeString("Warning:expected:options", 'warning'), undef,
-    "must supply --destination to support auxilliary files", 0,
-    "  disabling: --nomathimages --nographicimages --nopictureimages");
+  LaTeXML::Post::Warn("expected","options", undef,
+    "must supply --destination to support auxilliary files disabling: --nomathimages --nographicimages --nopictureimages");
   # default resources is sorta ok: we might not copy, but we'll still have the links/script/etc
   $dographics = $picimages = 0;
   removeMathFormat('images');

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -18,6 +18,7 @@ use File::Spec;
 use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 use LaTeXML;    # Currently, just for version information.
+use LaTeXML::Common::Error qw(generateMessage colorizeString);
 use LaTeXML::Post;
 use LaTeXML::Post::Writer;
 use LaTeXML::Post::Scan;
@@ -289,12 +290,14 @@ else {
 if ((!defined $destination)
   && ($dographics || $picimages
     || checkMathFormat('images') || checkMathFormat('svg'))) {
-  print STDERR "WARNING: must supply destination to support auxilliary files;\n"
-    . "  disabling: --nomathimages --nographicimages --nopictureimages\n";
+  print STDERR generateMessage(colorizeString("Warning:expected:options", 'warning'), undef,
+    "must supply --destination to support auxilliary files", 0,
+    "  disabling: --nomathimages --nographicimages --nopictureimages");
   # default resources is sorta ok: we might not copy, but we'll still have the links/script/etc
   $dographics = $picimages = 0;
-  removeMathFormat('images'); removeMathFormat('svg');
-}
+  removeMathFormat('images');
+  removeMathFormat('svg');
+  maybeAddMathFormat('pmml'); }
 
 #======================================================================
 # Do the processing.

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -482,10 +482,11 @@ sub removeMathFormat {
   $removed_math_formats{$fmt} = 1;
   return; }
 
+# Add a default math format, when no math formatter is requested, unless specifically forbidden
 sub maybeAddMathFormat {
   my ($fmt) = @_;
   unshift(@math_formats, $fmt)
-    unless (grep { $_ eq $fmt } @math_formats) || $removed_math_formats{$fmt};
+    unless @math_formats || $removed_math_formats{$fmt};
   return; }
 
 sub checkMathFormat {

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -576,10 +576,11 @@ sub _removeMathFormat {
   $$opts{removed_math_formats}->{$fmt} = 1;
   return; }
 
+# Add a default math format, when no math formatter is requested, unless specifically forbidden
 sub _maybeAddMathFormat {
   my ($opts, $fmt) = @_;
   unshift(@{ $$opts{math_formats} }, $fmt)
-    unless (grep { $_ eq $fmt } @{ $$opts{math_formats} }) || $$opts{removed_math_formats}{$fmt};
+    unless @{ $$opts{math_formats} } || $$opts{removed_math_formats}{$fmt};
   return; }
 
 sub _checkMathFormat {

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -25,6 +25,9 @@ our $PROFILES_DB = {};    # Class-wide, caches all profiles that get used while 
 our $is_bibtex  = qr/(^literal\:\s*\@)|(\.bib$)/;
 our $is_archive = qr/(^literal\:PK)|(\.zip$)/;
 
+use base qw(Exporter);
+our @EXPORT = (qw(addMathFormat removeMathFormat maybeAddMathFormat));
+
 sub new {
   my ($class, %opts) = @_;
   #TODO: How about defaults in the daemon server use case? Should we support those here?
@@ -93,20 +96,20 @@ sub getopt_specification {
     "linelength=i"                => \$$opts{linelength},
     "plane1!"                     => \$$opts{plane1},
     "hackplane1!"                 => \$$opts{hackplane1},
-    "mathimages"                  => sub { _addMathFormat($opts, 'images'); },
-    "nomathimages"                => sub { _removeMathFormat($opts, 'images'); },
-    "mathsvg"                     => sub { _addMathFormat($opts, 'svg'); },
-    "nomathsvg"                   => sub { _removeMathFormat($opts, 'svg'); },
-    "presentationmathml|pmml"     => sub { _addMathFormat($opts, 'pmml'); },
-    "contentmathml|cmml"          => sub { _addMathFormat($opts, 'cmml'); },
-    "openmath|om"                 => sub { _addMathFormat($opts, 'om'); },
-    "keepXMath|xmath"             => sub { _addMathFormat($opts, 'xmath'); },
-    "nopresentationmathml|nopmml" => sub { _removeMathFormat($opts, 'pmml'); },
-    "nocontentmathml|nocmml"      => sub { _removeMathFormat($opts, 'cmml'); },
-    "noopenmath|noom"             => sub { _removeMathFormat($opts, 'om'); },
-    "nokeepXMath|noxmath"         => sub { _removeMathFormat($opts, 'xmath'); },
-    "mathtex"                     => sub { _addMathFormat($opts, 'mathtex'); },
-    "nomathtex"                   => sub { _removeMathFormat($opts, 'mathtex'); },
+    "mathimages"                  => sub { addMathFormat($opts, 'images'); },
+    "nomathimages"                => sub { removeMathFormat($opts, 'images'); },
+    "mathsvg"                     => sub { addMathFormat($opts, 'svg'); },
+    "nomathsvg"                   => sub { removeMathFormat($opts, 'svg'); },
+    "presentationmathml|pmml"     => sub { addMathFormat($opts, 'pmml'); },
+    "contentmathml|cmml"          => sub { addMathFormat($opts, 'cmml'); },
+    "openmath|om"                 => sub { addMathFormat($opts, 'om'); },
+    "keepXMath|xmath"             => sub { addMathFormat($opts, 'xmath'); },
+    "nopresentationmathml|nopmml" => sub { removeMathFormat($opts, 'pmml'); },
+    "nocontentmathml|nocmml"      => sub { removeMathFormat($opts, 'cmml'); },
+    "noopenmath|noom"             => sub { removeMathFormat($opts, 'om'); },
+    "nokeepXMath|noxmath"         => sub { removeMathFormat($opts, 'xmath'); },
+    "mathtex"                     => sub { addMathFormat($opts, 'mathtex'); },
+    "nomathtex"                   => sub { removeMathFormat($opts, 'mathtex'); },
     "parallelmath!"               => \$$opts{parallelmath},
     # Some general XSLT/CSS/JavaScript options.
     "stylesheet=s"      => \$$opts{stylesheet},
@@ -545,7 +548,7 @@ sub _prepare_options {
         && scalar(grep { $_ ne 'images' } @{ $$opts{math_formats} });
       croak("Default html stylesheet does not support svg") if $$opts{svg};
       $$opts{math_formats} = [];
-      _maybeAddMathFormat($opts, 'images');
+      maybeAddMathFormat($opts, 'images');
     }
     $$opts{svg} = 1 unless defined $$opts{svg};      # If we're not making HTML, SVG is on by default
           # PMML default if we're HTMLy and all else fails and no mathimages:
@@ -561,23 +564,23 @@ sub _prepare_options {
   $$self{dirty}  = 0;
   return; }
 
-## Utilities:
+## Public Utilities:
 
-sub _addMathFormat {
+sub addMathFormat {
   my ($opts, $fmt) = @_;
   $$opts{math_formats} = [] unless defined $$opts{math_formats};
   CORE::push(@{ $$opts{math_formats} }, $fmt)
     unless (grep { $_ eq $fmt } @{ $$opts{math_formats} }) || $$opts{removed_math_formats}->{$fmt};
   return; }
 
-sub _removeMathFormat {
+sub removeMathFormat {
   my ($opts, $fmt) = @_;
   @{ $$opts{math_formats} } = grep { $_ ne $fmt } @{ $$opts{math_formats} };
   $$opts{removed_math_formats}->{$fmt} = 1;
   return; }
 
 # Add a default math format, when no math formatter is requested, unless specifically forbidden
-sub _maybeAddMathFormat {
+sub maybeAddMathFormat {
   my ($opts, $fmt) = @_;
   unshift(@{ $$opts{math_formats} }, $fmt)
     unless @{ $$opts{math_formats} } || $$opts{removed_math_formats}{$fmt};
@@ -586,6 +589,8 @@ sub _maybeAddMathFormat {
 sub _checkMathFormat {
   my ($opts, $fmt) = @_;
   return grep { $_ eq $fmt } @{ $$opts{math_formats} }; }
+
+## Utilities:
 
 sub _checkOptionValue {
   my ($option, $value, @choices) = @_;

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -25,6 +25,8 @@ our @EXPORT = (
   qw(&NoteProgress &NoteProgressDetailed &NoteBegin &NoteEnd),
   # Colored-logging related functions
   qw(&colorizeString),
+  # stateless message generation
+  qw(&generateMessage),
   # Status management
   qw(&MergeStatus),
 );


### PR DESCRIPTION
Addresses the usability friction raised in [the discussion](https://github.com/brucemiller/LaTeXML/issues/649#issuecomment-627373957) in #649 .

Namely:
 1. Raise "real" warnings when `--mathsvg` and `--mathimages` are used without `--destination` in both latexmlpost and the LaTeXML.pm API
 2. Change the default single option behavior of `--mathsvg` to *only* provide SVG formulas, rather than implicitly including a presentation MathML base processor
 3. Patch latexmlc to also provide the warning and disable `--mathsvg` without destination, as was always the case in latexmlpost. That features was never thoroughly tested in the latexmlc flow.