### PR TITLE
associateNodeHook with both array and libxml ndoes

### DIFF
--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -70,11 +70,20 @@ sub rawIDSuffix {
 
 sub associateNodeHook {
   my ($self, $node, $sourcenode) = @_;
-  if ($$node[0] =~ /^m:(?:mi|mo|mn)$/) {
+  # TODO: Shouldn't we have a single getQName shared for the entire latexml codebase
+  #  in LaTeXML::Common or LaTeXML::Util ?
+  my $name = LaTeXML::Post::MathML::getQName($node);
+  if ($name =~ /^m:(?:mi|mo|mn)$/) {
     if (my $href = $sourcenode->getAttribute('href')) {
-      $$node[1]{href} = $href; }
+      if (ref $node eq 'ARRAY') {
+        $$node[1]{href} = $href; }
+      else {
+        $node->setAttribute('href', $href); } }
     if (my $title = $sourcenode->getAttribute('title')) {
-      $$node[1]{title} = $title; } }
+      if (ref $node eq 'ARRAY') {
+        $$node[1]{title} = $title; }
+      else {
+        $node->setAttribute('title', $title); } } }
   return; }
 
 #================================================================================


### PR DESCRIPTION
Fixes #1293 

In short, a libxml node snuck its way into a subroutine that only expected the arrayref representation of post nodes. I am also hearing bells go off about having too many `getQName`s in the codebase, but that may be a refactor for another day. Fixes the example in the reported issue, and seems reasonable as a patch.

Ideally, especially if we had a language with fast method dispatch, one could imagine a common internal node class that can dispatch equally well to either arrayref nodes or libxml nodes, but that may be itself a problem for another programming language.