### PR TITLE
Avoid windows paths in post-processed graphics

### DIFF
--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -113,7 +113,7 @@ sub findGraphicsPaths {
 
 sub getGraphicsSourceTypes {
   my ($self) = @_;
-  return @{ $$self{graphics_types} }, map {uc($_); } @{ $$self{graphics_types} }; }
+  return @{ $$self{graphics_types} }, map { uc($_); } @{ $$self{graphics_types} }; }
 
 # Return the pathname to an appropriate image.
 sub findGraphicFile {
@@ -165,9 +165,7 @@ sub setGraphicSrc {
   my ($self, $node, $src, $width, $height) = @_;
   # If we are on windows, the $src path will be used for a URI context from the 'imagesrc' attribute,
   # so we can already switch it to the canonical slashified form
-  if ($^O eq 'MSWin32') {
-    $src =~ s/\\/\//g; }
-  $node->setAttribute('imagesrc',    $src);
+  $node->setAttribute('imagesrc',    pathname_to_url($src));
   $node->setAttribute('imagewidth',  $width) if defined $width;
   $node->setAttribute('imageheight', $height) if defined $height;
   return; }

--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -165,7 +165,8 @@ sub setGraphicSrc {
   my ($self, $node, $src, $width, $height) = @_;
   # If we are on windows, the $src path will be used for a URI context from the 'imagesrc' attribute,
   # so we can already switch it to the canonical slashified form
-  $src =~ s/\\/\//g;
+  if ($^O eq 'MSWin32') {
+    $src =~ s/\\/\//g; }
   $node->setAttribute('imagesrc',    $src);
   $node->setAttribute('imagewidth',  $width) if defined $width;
   $node->setAttribute('imageheight', $height) if defined $height;

--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -163,6 +163,9 @@ sub getTypeProperties {
 # width and height.
 sub setGraphicSrc {
   my ($self, $node, $src, $width, $height) = @_;
+  # If we are on windows, the $src path will be used for a URI context from the 'imagesrc' attribute,
+  # so we can already switch it to the canonical slashified form
+  $src =~ s/\\/\//g;
   $node->setAttribute('imagesrc',    $src);
   $node->setAttribute('imagewidth',  $width) if defined $width;
   $node->setAttribute('imageheight', $height) if defined $height;

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -196,7 +196,7 @@ sub pathname_absolute {
 sub pathname_to_url {
   my $relative_pathname = pathname_relative($_[0]);
   if ($SEP ne '/') {
-    $relative_pathname = join('/', split(/$SEP/, $relative_pathname)); }
+    $relative_pathname = join('/', split(/\Q$SEP\E/, $relative_pathname)); }
   return $relative_pathname; }
 
 #======================================================================

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -38,7 +38,7 @@ our @EXPORT = qw( &pathname_find &pathname_findall &pathname_kpsewhich
   &pathname_split &pathname_directory &pathname_name &pathname_type
   &pathname_timestamp
   &pathname_concat
-  &pathname_relative &pathname_absolute
+  &pathname_relative &pathname_absolute &pathname_to_url
   &pathname_is_absolute &pathname_is_contained
   &pathname_is_url &pathname_is_literaldata
   &pathname_protocol
@@ -192,6 +192,12 @@ sub pathname_absolute {
   return (!pathname_is_absolute($pathname) && !pathname_is_url($pathname)
     ? File::Spec->rel2abs($pathname, ($base ? pathname_canonical($base) : pathname_cwd()))
     : $pathname); }
+
+sub pathname_to_url {
+  my $relative_pathname = pathname_relative($_[0]);
+  if ($SEP ne '/') {
+    $relative_pathname = join('/', split(/$SEP/, $relative_pathname)); }
+  return $relative_pathname; }
 
 #======================================================================
 # Actual file system operations.
@@ -418,7 +424,7 @@ sub build_kpse_cache {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -492,6 +498,11 @@ Returns the absolute pathname resulting from interpretting
 C<$path> relative to the directory C<$base>.  If C<$path>
 is already absolute, it is returned unchanged.
 
+=item C<< $relative_url = pathname_to_url($path); >>
+
+Creates a local, relative URL for a given pathname,
+also ensuring proper path separators on non-Unix systems.
+
 =back
 
 =head2 File System Operations
@@ -520,9 +531,9 @@ It preserves the timestamp of C<$source>.
 
 =item C<< $path = pathname_find($name,%options); >>
 
-Finds the first file named C<$name> that exists 
+Finds the first file named C<$name> that exists
 and that matches the specification
-in the keywords C<%options>.  
+in the keywords C<%options>.
 An absolute pathname is returned.
 
 If C<$name> is not already an absolute pathname, then
@@ -545,6 +556,13 @@ The type C<*> matches any extension.
 Like C<pathname_find>,
 but returns I<all> matching (absolute) paths that exist.
 
+=item C<< $path = pathname_kpsewhich(@names); >>
+
+Attempt to find a candidate name via the external C<kpsewhich>
+capability of the system's TeX toolchain. If C<kpsewhich> is
+not available, or the file is not found, returns a
+Perl undefined value.
+
 =back
 
 =head1 AUTHOR
@@ -557,4 +575,3 @@ Public domain software, produced as part of work done by the
 United States Government & not subject to copyright in the US.
 
 =cut
-


### PR DESCRIPTION
Fixes #1187 in the simplest possible way.

Greetings from my Windows OS. This PR is overly simplistic, but workable in standard cases where people don't use backslashes in Unix filenames. I am opening mostly to state that if the path is sanitized just before it is set as an `imagesrc` attribute, the change is nicely propagated to the result of post-processing, and I happily created an HTML that rendered as expected on a Windows Firefox. So a successful patch attempt over here. 

Happy to test alternatives too. The other bit of good news is that the latest latexml master still has all tests passing on my Windows machine, though that is with the expl3 tests skipped, as we're still avoiding them on Windows.