### PR TITLE
Additional alertness for zero width/height values in image scaling

### DIFF
--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -321,8 +321,10 @@ sub image_graphicx_complex {
   my $notes = '';
   foreach my $trans (@transform) {
     my ($op, $a1, $a2, $a3, $a4) = @$trans;
+    return unless $w && $h;
     if ($op eq 'scale') {                                                            # $a1 => scale
       ($w, $h) = (ceil($w * $a1), ceil($h * ($a2 || $a1)));
+      return unless $w && $h;
       $notes .= " scale to $w x $h";
       image_internalop($image, 'Scale', width => $w, height => $h) or return; }
     elsif ($op eq 'scale-to') {


### PR DESCRIPTION
Another rare Fatal from arxiv in image scaling:

```
Warning:imageprocessing:Crop Image processing operation Crop (x, 0, width, 0, y, 1123, height, 0) returned Exception 310: geometry does not contain image `/tmp/material.jpg' @ warning/transform.c/CropImage/717
	In Post::Graphics[@0x557cb4a47300] ->transformGraphic

Fatal:perl:die Perl died
	Illegal division by zero at /home/deyan/perl5/lib/perl5/LaTeXML/Util/Image.pm line 331.
	In Post::Graphics[@0x557cb4a47300] ->transformGraphic
```

We can avoid the division and short-circuit the scaling calls, leaving the document only with the warning, and retaining the otherwise good conversion. The Fatal example I am looking at (`0903.2803`) upgraded to a good-looking Warning doc with this PR.