### PR TITLE
Explicit warnings on zero divisions in calc

### DIFF
--- a/lib/LaTeXML/Package/calc.sty.ltxml
+++ b/lib/LaTeXML/Package/calc.sty.ltxml
@@ -181,7 +181,11 @@ sub readValue {
   elsif (Equals($peek, T_CS('\ratio'))) {
     my $x = readExpression($gullet, 'Glue', $gullet->readArg);
     my $y = readExpression($gullet, 'Glue', $gullet->readArg);
-    return Float($x->ptValue / $y->ptValue); }
+    my $y_pt = $y->ptValue;
+    if ($y_pt == 0) {
+      Warn("unexpected", "<number>", "calc: divisor should never be zero!");
+      $y_pt = 1; }
+    return Float($x->ptValue / $y_pt); }
   # Evaluate MinMax values
   elsif (Equals($peek, T_CS('\minof'))) {
     my $x = readExpression($gullet, $type, $gullet->readArg);
@@ -259,7 +263,11 @@ sub readReal {
   elsif (Equals($peek, T_CS('\ratio'))) {
     my $x = readExpression($gullet, 'Glue', $gullet->readArg);
     my $y = readExpression($gullet, 'Glue', $gullet->readArg);
-    return Float($x->ptValue / $y->ptValue); }
+    my $y_pt = $y->ptValue;
+    if ($y_pt == 0) {
+      Warn("unexpected", "<number>", "calc: divisor should never be zero!");
+      $y_pt = 1; }
+    return Float($x->ptValue / $y_pt); }
   else {
     $gullet->unread($peek);
     return; } }


### PR DESCRIPTION
The next rare error comes from calc.sty, e.g. in arxiv `0907.3632`, and is again a case of division by zero.

I added a Warn and a fallback which improves that document to an Error-level with some HTML. Message example:
```
Warning:unexpected:<number> 
	at calc: divisor should never be zero!
	In Core::Gullet[@0x5632617bb6c0] /tmp/BFCA-INS.tex; from line 232 col 0 to line 232 col 75
```

Sadly, what comes out is quite broken, but it's a step in the right direction.