### PR TITLE
Add {planotable} alias for {deluxetable} in aaspp4

### DIFF
--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -293,6 +293,8 @@ DefMacro('\figcaption', sub {
 #======================================================================
 # 2.15 Tables
 RequirePackage('deluxetable');
+Let(T_CS('\begin{planotable}'), T_CS('\begin{deluxetable}'));
+Let(T_CS('\end{planotable}'),   T_CS('\end{deluxetable}'));
 
 DefMacro('\phn',   '\phantom{0}');
 DefMacro('\phd',   '\phantom{.}');


### PR DESCRIPTION
Resolves the Errors in `astro-ph/0003429`, rooted in the [classic planotable construct](https://cds.cern.ch/record/304372/files/9605457.pdf) in AAS. Likely only helps with some handful of old AAS articles, but at least the resolution is simple - planotable seems to be largely identical to deluxetable, and aliasing them works wonders for the reference arXiv article - the three tables typeset well and error-free using the deluxetable internals.