### PR TITLE
aipproc.sty and extensions to OmniBus

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -342,6 +342,7 @@ lib/LaTeXML/Package/algc.sty.ltxml
 lib/LaTeXML/Package/algcompatible.sty.ltxml
 lib/LaTeXML/Package/aipcheck.tex.ltxml
 lib/LaTeXML/Package/aipproc.cls.ltxml
+lib/LaTeXML/Package/aipproc.sty.ltxml
 lib/LaTeXML/Package/algmatlab.sty.ltxml
 lib/LaTeXML/Package/algorithm.sty.ltxml
 lib/LaTeXML/Package/algorithm2e.sty.ltxml

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -83,8 +83,10 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
 #
 # EXCEPTION: of course there is an exception. Older arXiv articles use \documentstyle{aipproc}
 # to load a different aipproc.sty than the later evolved aipproc.cls. And of course we need to support that.
-    if ($class eq 'aipproc') {
-      RequirePackage('aipproc', options => $options); }
+    if (FindFile($class, type => 'sty')) {
+      InputDefinitions('article', type => 'cls', noerror => 1, handleoptions => 1);
+      RequirePackage($class, options => $options, as_class => 1,
+        after => Tokens(T_CS('\compat@loadpackages'))); }
     elsif (FindFile($class, type => 'cls', notex => !LookupValue('INCLUDE_CLASSES'))) {
       LoadClass($class, options => $options,
         after => Tokens(T_CS('\compat@loadpackages'))); }
@@ -577,7 +579,7 @@ DefMath('\mathring{}', "\x{030A}", operator_role => 'OVERACCENT');
 # casual user redefinitions work, too.
 DefMacroI('\chapter', undef, '\@startsection{chapter}{0}{}{}{}{}', locked => 1);
 DefMacroI('\part', undef, '\@startsection{part}{-1}{}{}{}{}'); # not locked since sometimes redefined as partition?
-DefMacroI('\section', undef, '\@startsection{section}{1}{}{}{}{}', locked => 1);
+DefMacroI('\section',       undef, '\@startsection{section}{1}{}{}{}{}',       locked => 1);
 DefMacroI('\subsection',    undef, '\@startsection{subsection}{2}{}{}{}{}',    locked => 1);
 DefMacroI('\subsubsection', undef, '\@startsection{subsubsection}{3}{}{}{}{}', locked => 1);
 DefMacroI('\paragraph',     undef, '\@startsection{paragraph}{4}{}{}{}{}',     locked => 1);
@@ -629,7 +631,7 @@ DefConstructor('\@@numbered@section{} Undigested OptionalUndigested Undigested',
     MaybePeekLabel();
     $type = ToString($type);
     my %props     = RefStepCounter($type);
-    my $xtitle    = Digest(Invocation(T_CS('\lx@format@title@@'), $type, $title));
+    my $xtitle    = Digest(Invocation(T_CS('\lx@format@title@@'),    $type, $title));
     my $xtoctitle = Digest(Invocation(T_CS('\lx@format@toctitle@@'), $type, $toctitle || $title));
     if ($type eq 'appendix') {
       $props{backmatterelement} = LookupMapping('BACKMATTER_ELEMENT', 'ltx:' . $type); }
@@ -1019,7 +1021,7 @@ DefConstructor('\person@thanks{}', "^ <ltx:contact role='thanks'>#1</ltx:contact
   alias => '\thanks', mode => 'text');
 DefConstructor('\@personname{}', "<ltx:personname>#1</ltx:personname>",
   beforeDigest => sub { Let('\thanks', '\person@thanks'); },
-  bounded      => 1, mode => 'text');
+  bounded => 1, mode => 'text');
 
 DefConstructorI('\and', undef, " and ");
 
@@ -1041,7 +1043,7 @@ DefConstructor('\lx@author@prefix', sub {
     my $node       = $document->getElement;
     my $nauthors   = LookupValue('NUMBER_OF_AUTHORS');
     my $i          = scalar(@{ $document->findnodes('//ltx:creator[@role="author"]') });
-    if ($i <= 1) { }
+    if    ($i <= 1) { }
     elsif ($i == $nauthors) {
       $document->setAttribute($node, before => ToString(Digest(T_CS('\lx@author@conj')))); }
     else {
@@ -1162,7 +1164,7 @@ DefEnvironment('{titlepage}', '<ltx:titlepage>#body',
       "When using titlepage, Frontmatter will not be well-structured");
     return; },
   beforeDigestEnd => sub { Digest(T_CS('\maybe@end@title')); },
-  locked          => 1, mode => 'text');
+  locked => 1, mode => 'text');
 
 Tag('ltx:titlepage', autoClose => 1);
 DefConstructorI('\maybe@end@title', undef, sub {
@@ -1193,13 +1195,13 @@ DefMacroI('\center',    undef, '\centering');
 DefMacroI('\endcenter', undef, '');
 
 DefEnvironment('{flushleft}', sub {
-    $_[0]->maybeCloseElement('ltx:p');                        # this starts a new vertical block
+    $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
     aligningEnvironment('left', 'ltx_align_left', @_); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par'); });
 DefEnvironment('{flushright}', sub {
-    $_[0]->maybeCloseElement('ltx:p');                        # this starts a new vertical block
+    $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
     aligningEnvironment('right', 'ltx_align_right', @_); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
@@ -1340,7 +1342,7 @@ sub RefStepItemCounter {
       my $typename  = (IsDefined(T_CS('\\' . $counter . 'name'))
         ? T_CS('\\' . $counter . 'name') : T_CS('\itemtyperefname'));
       my $tags = Digest(T_BEGIN,
-        T_CS('\let'), T_CS('\the' . $counter), T_CS('\@empty'),
+        T_CS('\let'), T_CS('\the' . $counter),   T_CS('\@empty'),
         T_CS('\def'), T_CS('\fnum@' . $counter), T_BEGIN, $formatter, T_BEGIN, Revert($tag), T_END, T_END,
         T_CS('\def'), T_CS('\typerefnum@' . $counter),
         T_BEGIN, $typename, T_SPACE, Revert($tag), T_END,
@@ -2228,9 +2230,9 @@ sub rearrangeEqnarray {
   foreach my $rownode ($document->findnodes('ltx:equation', $equationgroup)) {
     my @cells = $document->findnodes('ltx:_Capture_', $rownode);    # representing each column.
     push(@rows, { node => $rownode, cols => [@cells],
-        L => ($cells[0] && $cells[0]->hasChildNodes),
-        M => ($cells[1] && $cells[1]->hasChildNodes),
-        R => ($cells[2] && $cells[2]->hasChildNodes),
+        L        => ($cells[0] && $cells[0]->hasChildNodes),
+        M        => ($cells[1] && $cells[1]->hasChildNodes),
+        R        => ($cells[2] && $cells[2]->hasChildNodes),
         numbered => ($document->findnode('ltx:tags', $rownode) ? 1 : 0),
         labelled => $rownode->hasAttribute('label') }); }
   my $nL = scalar(grep { $$_{L} } @rows);
@@ -2577,11 +2579,11 @@ DefPrimitive('\DeclareFontFamily{}{}{}',      undef);
 DefPrimitive('\DeclareSizeFunction{}{}',      undef);
 
 my $symboltype_roles = {
-  '\mathord'  => 'ID',   '\mathop'    => 'BIGOP', '\mathbin'   => 'BINOP', '\mathrel' => 'RELOP',
+  '\mathord' => 'ID', '\mathop' => 'BIGOP', '\mathbin' => 'BINOP', '\mathrel' => 'RELOP',
   '\mathopen' => 'OPEN', '\mathclose' => 'CLOSE', '\mathpunct' => 'PUNCT' };
 DefPrimitive('\DeclareMathSymbol DefToken SkipSpaces DefToken {}{Number}', sub {
     my ($stomach, $cs, $type, $font, $code) = @_;
-    my $encoding = ToString($font);              # Or maybe just a font name or class?
+    my $encoding = ToString($font);    # Or maybe just a font name or class?
     if (my $decl = LookupValue('fontdeclaration@' . $encoding)) {
       $encoding = $$decl{encoding} if $$decl{encoding}; }
     my $glyph = FontDecode($code->valueOf, $encoding);
@@ -2876,8 +2878,8 @@ DefPrimitive('\newcounter{}[]', sub {
     return; });
 DefPrimitive('\setcounter{}{Number}',   sub { SetCounter(ToString(Expand($_[1])), $_[2]); });
 DefPrimitive('\addtocounter{}{Number}', sub { AddToCounter(ToString(Expand($_[1])), $_[2]); });
-DefPrimitive('\stepcounter{}',    sub { StepCounter(ToString(Expand($_[1])));    return; });
-DefPrimitive('\refstepcounter{}', sub { RefStepCounter(ToString(Expand($_[1]))); return; });
+DefPrimitive('\stepcounter{}',          sub { StepCounter(ToString(Expand($_[1])));    return; });
+DefPrimitive('\refstepcounter{}',       sub { RefStepCounter(ToString(Expand($_[1]))); return; });
 
 sub addtoCounterReset {
   my ($ctr, $within) = @_;
@@ -3964,13 +3966,13 @@ sub process_index_phrases {
       if ($string eq '|') {
         pop(@tokens);    # Remove the extra "!" stopbit.
         my $extra = ToString(Tokens(@tokens));
-        if ($extra =~ /^see\s*{/) { push(@expansion, T_CS('\@indexsee'), @tokens[3 .. $#tokens]); }
+        if    ($extra =~ /^see\s*{/)      { push(@expansion, T_CS('\@indexsee'), @tokens[3 .. $#tokens]); }
         elsif ($extra =~ /^seealso\s*\{/) { push(@expansion, T_CS('\@indexseealso'), @tokens[7 .. $#tokens]); }
-        elsif ($extra eq '(') { $style = 'rangestart'; }                     # ?
-        elsif ($extra eq ')') { $style = 'rangeend'; }                       # ?
-        else                  { $style = $index_style{$extra} || $extra; }
+        elsif ($extra eq '(')             { $style = 'rangestart'; }                     # ?
+        elsif ($extra eq ')')             { $style = 'rangeend'; }                       # ?
+        else                              { $style = $index_style{$extra} || $extra; }
         @tokens = (); } }
-    elsif (!@phrase && ($string =~ /\s/)) { }                                # Skip leading whitespace
+    elsif (!@phrase && ($string =~ /\s/)) { }    # Skip leading whitespace
     else {
       push(@phrase, $tok); } }
   @expansion = (T_CS('\@index'),
@@ -4041,8 +4043,8 @@ sub indexify_tex {
   $string =~ s/(\\mathrm|\\mathit|\\mathbf|\\mathsf|\\mathtt|\\mathcal|\\mathscr|\\mbox|\\rm|\\it|\\bf|\\tt|\\small|\\tiny)//g;
   $string =~ s/\\left\b//g; $string =~ s/\\right\b//g;
   $string =~ s/(\\|\{|\})//g;
-  $string =~ s/\W//g;                                    # to be safe (if perhaps non-unique?)
-  $string =~ s/\s//g;    # Or remove entirely? Eventually worry about many=>1 mapping???
+  $string =~ s/\W//g;           # to be safe (if perhaps non-unique?)
+  $string =~ s/\s//g;           # Or remove entirely? Eventually worry about many=>1 mapping???
   return $string; }
 
 # ---- Creating the index itself
@@ -4137,9 +4139,9 @@ DefMacro('\endsloppypar', '\par');
 DefMacroI('\nobreakdashes', undef, T_OTHER('-'));
 
 DefMacro('\showhyphens{}', '#1');     # ?
-     #======================================================================
-     # C.12.2 Page Breaking
-     #======================================================================
+    #======================================================================
+    # C.12.2 Page Breaking
+    #======================================================================
 DefMacro('\pagebreak[]', '\vadjust{\clearpage}');
 DefPrimitive('\nopagebreak[]', undef);
 DefPrimitiveI('\columnbreak', undef, undef);    # latex? or multicol?
@@ -4260,7 +4262,7 @@ DefConstructor('\@framebox[Dimension][]{}',
     . "(<ltx:text ?#width(width='#width') ?#align(align='#align')"
     . " framed='rectangle' framecolor='#framecolor'"
     . " _noautoclose='1'>#3</ltx:text>)",
-  alias        => '\framebox', sizer => '#3',
+  alias => '\framebox', sizer => '#3',
   beforeDigest => sub {
     my ($stomach) = @_;
     my $wasmath = LookupValue('IN_MATH');
@@ -4365,7 +4367,7 @@ DefConstructor('\parbox[][Dimension][]{Dimension}{}', sub {
     (width => $_[4],
       vattach => translateAttachment($_[1]),
       height  => $_[2]); },
-  mode         => 'text', bounded => 1,
+  mode => 'text', bounded => 1,
   beforeDigest => sub {
     AssignValue('\hsize' => $_[4]);
     Let('\\\\', '\lx@parboxnewline'); });
@@ -4781,32 +4783,32 @@ DefMacro('\usefont{}{}{}{}',
 
 # If these series or shapes appear in math, they revert it to roman, medium, upright (?)
 DefConstructor('\textmd@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded      => 1, font => { series => 'medium' }, alias => '\textmd',
+  bounded => 1, font => { series => 'medium' }, alias => '\textmd',
   beforeDigest => sub { DefMacro('\f@series', 'm'); });
 DefConstructor('\textbf@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded      => 1, font => { series => 'bold' }, alias => '\textbf',
+  bounded => 1, font => { series => 'bold' }, alias => '\textbf',
   beforeDigest => sub { DefMacro('\f@series', 'b'); });
 DefConstructor('\textrm@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded      => 1, font => { family => 'serif' }, alias => '\textrm',
+  bounded => 1, font => { family => 'serif' }, alias => '\textrm',
   beforeDigest => sub { DefMacro('\f@family', 'cm'); });
 DefConstructor('\textsf@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded      => 1, font => { family => 'sansserif' }, alias => '\textsf',
+  bounded => 1, font => { family => 'sansserif' }, alias => '\textsf',
   beforeDigest => sub { DefMacro('\f@family', 'cmss'); });
 DefConstructor('\texttt@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded      => 1, font => { family => 'typewriter' }, alias => '\texttt',
+  bounded => 1, font => { family => 'typewriter' }, alias => '\texttt',
   beforeDigest => sub { DefMacro('\f@family', 'cmtt'); });
 
 DefConstructor('\textup@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded      => 1, font => { shape => 'upright' }, alias => '\textup',
+  bounded => 1, font => { shape => 'upright' }, alias => '\textup',
   beforeDigest => sub { DefMacro('\f@shape', ''); });
 DefConstructor('\textit@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded      => 1, font => { shape => 'italic' }, alias => '\textit',
+  bounded => 1, font => { shape => 'italic' }, alias => '\textit',
   beforeDigest => sub { DefMacro('\f@shape', 'i'); });
 DefConstructor('\textsl@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded      => 1, font => { shape => 'slanted' }, alias => '\textsl',
+  bounded => 1, font => { shape => 'slanted' }, alias => '\textsl',
   beforeDigest => sub { DefMacro('\f@shape', 'sl'); });
 DefConstructor('\textsc@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded      => 1, font => { shape => 'smallcaps' }, alias => '\textsc',
+  bounded => 1, font => { shape => 'smallcaps' }, alias => '\textsc',
   beforeDigest => sub { DefMacro('\f@shape', 'sc'); });
 DefConstructor('\textnormal@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
   bounded => 1, font => { family => 'serif', series => 'medium', shape => 'upright' }, alias => '\textnormal',
@@ -4829,7 +4831,7 @@ DefPrimitive('\DeclareTextFontCommand{}{}', sub {
     my ($stomach, $cmd, $font) = @_;
     DefConstructorI($cmd, "{}",
       "?#isMath(<ltx:text _noautoclose='1'>#1</ltx:text>)(#1)",
-      mode         => 'text', bounded => 1,
+      mode => 'text', bounded => 1,
       beforeDigest => sub { Digest($font); (); });
     return; });
 
@@ -4895,9 +4897,9 @@ DefPrimitiveI('\textasciitilde',   undef, "~");
 DefPrimitiveI('\textcompwordmark', undef, "");                # ???
 DefPrimitiveI('\textunderscore',   undef, "_");
 DefPrimitiveI('\textvisiblespace', undef, "\x{2423}"); # SYMBOL FOR SPACE;  Not really the right symbol!
-DefPrimitiveI('\textellipsis',   undef, "\x{2026}");   # HORIZONTAL ELLIPSIS
-DefPrimitiveI('\textregistered', undef, UTF(0xAE));    # REGISTERED SIGN
-DefPrimitiveI('\texttrademark',  undef, "\x{2122}");   # TRADE MARK SIGN
+DefPrimitiveI('\textellipsis',   undef, "\x{2026}");    # HORIZONTAL ELLIPSIS
+DefPrimitiveI('\textregistered', undef, UTF(0xAE));     # REGISTERED SIGN
+DefPrimitiveI('\texttrademark',  undef, "\x{2122}");    # TRADE MARK SIGN
 DefConstructor('\textsuperscript{}', "<ltx:sup>#1</ltx:sup>",
   mode => 'text');
 # This is something coming from xetex/xelatex ? Why define this way?

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -74,13 +74,18 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
     my $class   = ToString($whatsit->getArg(2));
     my $options = $whatsit->getArg(1);
     $options = [($options ? split(/\s*,\s*/, ToString($options)) : ())];
-    # Watch out; In principle, compatibility mode wants a .sty, not a .cls!!!
-    # But, we'd prefer .cls, since we'll have better bindings.
-    # And in fact, nobody's likely to write a binding for a .sty that wants to be a class anyway.
-    # So, we'll just try for a .cls, punting to OmniBus if needed.
-    # If we start wanting to read style files by default, we'll still need to handle this
-    # specially, since class (or sty files pretending to be) cover so much more.
-    if (FindFile($class, type => 'cls', notex => !LookupValue('INCLUDE_CLASSES'))) {
+# Watch out; In principle, compatibility mode wants a .sty, not a .cls!!!
+# But, we'd prefer .cls, since we'll have better bindings.
+# And in fact, nobody's likely to write a binding for a .sty that wants to be a class anyway.
+# So, we'll just try for a .cls, punting to OmniBus if needed.
+# If we start wanting to read style files by default, we'll still need to handle this
+# specially, since class (or sty files pretending to be) cover so much more.
+#
+# EXCEPTION: of course there is an exception. Older arXiv articles use \documentstyle{aipproc}
+# to load a different aipproc.sty than the later evolved aipproc.cls. And of course we need to support that.
+    if ($class eq 'aipproc') {
+      RequirePackage('aipproc', options => $options); }
+    elsif (FindFile($class, type => 'cls', notex => !LookupValue('INCLUDE_CLASSES'))) {
       LoadClass($class, options => $options,
         after => Tokens(T_CS('\compat@loadpackages'))); }
     else {

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -57,6 +57,7 @@ DefMacro('\bibitem',
 DefEnvironment('{frontmatter}', '#body');
 DefEnvironment('{mainmatter}',  '#body');
 DefEnvironment('{backmatter}',  '#body');
+
 DefMacro('\shorttitle{}',  '\@add@frontmatter{ltx:toctitle}{#1}');
 DefMacro('\shortauthor{}', '');
 DefRegister('\titlerunning',  Tokens());
@@ -97,9 +98,37 @@ DefMacro('\keyword{}',  '\@add@frontmatter{ltx:keywords}{#1}');
 DefMacro('\keywords{}', '\@add@frontmatter{ltx:keywords}{#1}');
 DefMacro('\kword{}',    '\@add@frontmatter{ltx:keywords}{#1}');
 # {keyword}, {keywords}
+DefEnvironment('{keywords}', '',
+  afterDigest => sub {
+    my $frontmatter = LookupValue('frontmatter');
+    push(@{ $$frontmatter{'ltx:classification'} },
+      ['ltx:classification', { scheme => 'keywords' }, @LaTeXML::LIST]);
+    return; });
 
 DefMacro('\classification{}', '\@add@frontmatter{ltx:classification}{#1}');
 DefMacro('\pacs{}',           '\@add@frontmatter{ltx:classification}[scheme=pacs]{#1}');
+DefMacro('\doi{}',            '\@add@frontmatter{ltx:classification}[scheme=doi]{#1}');
+
+sub bootstrapAmsThm {
+  my ($token) = @_;
+  RequirePackage('amsthm');
+  return Tokenize("\\newtheorem{theorem}{Theorem}[section]
+\\newtheorem{conjecture}[theorem]{Conjecture}
+\\newtheorem{proposition}[theorem]{Proposition}
+\\newtheorem{lemma}[theorem]{Lemma}
+\\newtheorem{corollary}[theorem]{Corollary}
+\\newtheorem{example}[theorem]{Example}
+\\newtheorem{definition}[theorem]{Definition}
+$token")->unlist; }
+
+DefMacroI(T_CS('\begin{proof}'), undef, sub {
+    return bootstrapAmsThm('\\begin{proof}'); });
+DefMacroI(T_CS('\begin{theorem}'), undef, sub {
+    return bootstrapAmsThm('\\begin{theorem}'); });
+DefMacroI(T_CS('\begin{lemma}'), undef, sub {
+    return bootstrapAmsThm('\\begin{lemma}'); });
+DefMacroI(T_CS('\begin{proposition}'), undef, sub {
+    return bootstrapAmsThm('\\begin{proposition}'); });
 
 # \abstracts
 Let('\abst', '\abstract');

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -117,11 +117,19 @@ Let('\endacknowledgements',   '\endacknowledgments');
 Let('\theacknowledgments',    '\acknowledgments');
 Let('\endtheacknowledgments', '\endacknowledgments');
 
-DefMacro('\received{}', '\@add@frontmatter{ltx:date}[role=received]{#1}');
-DefMacro('\revised{}',  '\@add@frontmatter{ltx:date}[role=revised]{#1}');
-DefMacro('\accepted{}', '\@add@frontmatter{ltx:date}[role=accepted]{#1}');
-DefMacro('\pubyear',    '\@add@frontmatter{ltx:date}[role=publication]{#1}');
-DefMacro('\preprint{}', '\@add@frontmatter{ltx:note}[role=preprint]{#1}');
+DefMacro('\received{}',     '\@add@frontmatter{ltx:date}[role=received]{#1}');
+DefMacro('\revised{}',      '\@add@frontmatter{ltx:date}[role=revised]{#1}');
+DefMacro('\accepted{}',     '\@add@frontmatter{ltx:date}[role=accepted]{#1}');
+DefMacro('\pubyear',        '\@add@frontmatter{ltx:date}[role=publication]{#1}');
+DefMacro('\preprint{}',     '\@add@frontmatter{ltx:note}[role=preprint]{#1}');
+DefMacro('\communicated{}', '\@add@frontmatter{ltx:date}[role=communicated]{#1}');
+DefMacro('\dedicated{}',    '\@add@frontmatter{ltx:note}[role=dedicated]{#1}');
+DefMacro('\presented{}',    '\@add@frontmatter{ltx:date}[role=presented]{#1}');
+DefMacro('\articletype{}',  '\@add@frontmatter{ltx:note}[role=articletype]{#1}');
+DefMacro('\issue{}',        '\@add@frontmatter{ltx:note}[role=issue]{#1}');
+DefMacro('\journal{}',      '\@add@frontmatter{ltx:note}[role=journal]{#1}');
+DefMacro('\volume',         '\@add@frontmatter{ltx:note}[role=volume]{#1}');
+DefMacro('\pubyear',        '\@add@frontmatter{ltx:date}[role=publication]{#1}');
 
 # work as environment or not...
 DefConstructor('\references',
@@ -130,7 +138,7 @@ DefConstructor('\references',
     . "<ltx:title font='#titlefont' _force_font='true'>#title</ltx:title>"
     . "<ltx:biblist>",
   beforeDigest => sub { beforeDigestBibliography(); },
-  afterDigest => sub { beginBibliography($_[1]); }
+  afterDigest  => sub { beginBibliography($_[1]); }
 );
 
 DefConstructor('\endreferences',

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -109,26 +109,18 @@ DefMacro('\classification{}', '\@add@frontmatter{ltx:classification}{#1}');
 DefMacro('\pacs{}',           '\@add@frontmatter{ltx:classification}[scheme=pacs]{#1}');
 DefMacro('\doi{}',            '\@add@frontmatter{ltx:classification}[scheme=doi]{#1}');
 
-sub bootstrapAmsThm {
-  my ($token) = @_;
-  RequirePackage('amsthm');
-  return Tokenize("\\newtheorem{theorem}{Theorem}[section]
-\\newtheorem{conjecture}[theorem]{Conjecture}
-\\newtheorem{proposition}[theorem]{Proposition}
-\\newtheorem{lemma}[theorem]{Lemma}
-\\newtheorem{corollary}[theorem]{Corollary}
-\\newtheorem{example}[theorem]{Example}
-\\newtheorem{definition}[theorem]{Definition}
-$token")->unlist; }
-
-DefMacroI(T_CS('\begin{proof}'), undef, sub {
-    return bootstrapAmsThm('\\begin{proof}'); });
-DefMacroI(T_CS('\begin{theorem}'), undef, sub {
-    return bootstrapAmsThm('\\begin{theorem}'); });
-DefMacroI(T_CS('\begin{lemma}'), undef, sub {
-    return bootstrapAmsThm('\\begin{lemma}'); });
-DefMacroI(T_CS('\begin{proposition}'), undef, sub {
-    return bootstrapAmsThm('\\begin{proposition}'); });
+for my $env (qw(conjecture proposition lemma corollary example definition)) {
+  my $beginenv = "\\begin{$env}";
+  DefMacroI(T_CS($beginenv), undef, sub {
+      RequirePackage('amsthm');
+      return Tokenize("\\newtheorem{theorem}{Theorem}[section]
+  \\newtheorem{conjecture}[theorem]{Conjecture}
+  \\newtheorem{proposition}[theorem]{Proposition}
+  \\newtheorem{lemma}[theorem]{Lemma}
+  \\newtheorem{corollary}[theorem]{Corollary}
+  \\newtheorem{example}[theorem]{Example}
+  \\newtheorem{definition}[theorem]{Definition}
+  $beginenv")->unlist; }); }
 
 # \abstracts
 Let('\abst', '\abstract');

--- a/lib/LaTeXML/Package/aipproc.sty.ltxml
+++ b/lib/LaTeXML/Package/aipproc.sty.ltxml
@@ -21,9 +21,7 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
-PassOptions('revtex', 'cls', 'amssymb', 'amsfonts');
-LoadClass('revtex');
-
+RequirePackage('revtex3_support');
 RequirePackage('longtable');
 RequirePackage('psfig');
 

--- a/lib/LaTeXML/Package/aipproc.sty.ltxml
+++ b/lib/LaTeXML/Package/aipproc.sty.ltxml
@@ -1,0 +1,33 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  aipproc.sty                                                        | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Released to the Public Domain                                       | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+#
+# Source: https://arxiv.org/ftp/physics/papers/macros/aipproc.sty
+# aipproc.sty, v1.0 <11 May 95>
+# tested against arXiv:cond-mat/0003014
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+PassOptions('revtex', 'cls', 'amssymb', 'amsfonts');
+LoadClass('revtex');
+
+RequirePackage('longtable');
+RequirePackage('psfig');
+
+DefMacro('\lefthead{}',  '');    # Obsolete form
+DefMacro('\righthead{}', '');    # Obsolete form
+
+1;


### PR DESCRIPTION
Examining some arXiv errors, I am suggesting:
 - add `\volume` and some sibling metadata macros to OmniBus.cls, since they seemed needed in cases where a custom `.cls` file was ignored by latexml when processing arXiv articles
 - add [the arXiv artifact aipproc.sty](https://arxiv.org/list/physics/macros) with a specialized binding. 

The second point is a pain, because we also have a `aipproc.cls.ltxml`, from the arXMLiv Jacobs work, which seems to be developed for the later [aipproc.cls](http://dark.ft.uam.es/dsu2006/proc/AIPPROC/aipguide-6s.pdf), which is more evolved, e.g. expects key=vals for the `\author` macro rather than a simple strict.

It seems like a good default behaviour is to load the essentially revtex3-equivalent `aipproc.sty` when encountering `\documentstyle{aipproc}`, while only loading `aipproc.cls` with `\documentclass{aipproc}`. A case we once never expected to be possible :> But of course it is.

These fixes upgrade two arXiv articles from the latest cortex run, the aipproc one can be e.g. tested against `cond-mat0003014` from the [Error:undefined:\address report](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/undefined/%5Caddress?all=false). (indeed `\address` is another difference between the revtex3 base vs the custom aipproc.cls)