### PR TITLE
[Babel] avoid loading english.sty and default nil.ldf errors-in-name-only

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -425,6 +425,7 @@ lib/LaTeXML/Package/doublespace.sty.ltxml
 lib/LaTeXML/Package/dsfont.sty.ltxml
 lib/LaTeXML/Package/empheq.sty.ltxml
 lib/LaTeXML/Package/endnotes.sty.ltxml
+lib/LaTeXML/Package/english.sty.ltxml
 lib/LaTeXML/Package/eTeX.pool.ltxml
 lib/LaTeXML/Package/ellipsis.sty.ltxml
 lib/LaTeXML/Package/elsart.cls.ltxml

--- a/MANIFEST
+++ b/MANIFEST
@@ -554,6 +554,7 @@ lib/LaTeXML/Package/newtxmath.sty.ltxml
 lib/LaTeXML/Package/newtxtext.sty.ltxml
 lib/LaTeXML/Package/ngerman.sty.ltxml
 lib/LaTeXML/Package/nicefrac.sty.ltxml
+lib/LaTeXML/Package/nil.ldf.ltxml
 lib/LaTeXML/Package/nopageno.sty.ltxml
 lib/LaTeXML/Package/ntheorem.sty.ltxml
 lib/LaTeXML/Package/numprint.sty.ltxml

--- a/lib/LaTeXML/Package/english.sty.ltxml
+++ b/lib/LaTeXML/Package/english.sty.ltxml
@@ -1,0 +1,26 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# | english.sty, legacy implementation for babel                        | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+use LaTeXML::Util::Pathname;
+
+# I think we are finally able to process babel.sty directly
+# and more closely track development of babel.
+# We'll make minimal redefinitions in babel.def.ltxml
+PassOptions('babel', 'sty', 'english');
+RequirePackage('babel');
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+1;

--- a/lib/LaTeXML/Package/english.sty.ltxml
+++ b/lib/LaTeXML/Package/english.sty.ltxml
@@ -16,9 +16,8 @@ use warnings;
 use LaTeXML::Package;
 use LaTeXML::Util::Pathname;
 
-# I think we are finally able to process babel.sty directly
-# and more closely track development of babel.
-# We'll make minimal redefinitions in babel.def.ltxml
+# english.sty advises to do \usepackage[english]{babel} isntead
+# so let's take that advice to heart in this binding:
 PassOptions('babel', 'sty', 'english');
 RequirePackage('babel');
 

--- a/lib/LaTeXML/Package/nil.ldf.ltxml
+++ b/lib/LaTeXML/Package/nil.ldf.ltxml
@@ -1,0 +1,26 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# | english.sty, legacy implementation for babel                        | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+use LaTeXML::Util::Pathname;
+
+# Define an empty stub if the macro is not available, since nil.ldf 2020 expects it defined.
+if (!LookupDefinition(T_CS('\bbl@languages'))) {
+  DefMacro('\bbl@languages', ''); }
+
+InputDefinitions('nil', type => 'ldf', noltxml => 1);
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+1;


### PR DESCRIPTION
1. `\usepackage{english}` creates what is really a deprecation warning ("you should be using babel!") but does it via `\GenericError` so pollutes the cortex reports for arXiv with untrue error cases. I am adding a binding that does what the error suggests -- reroutes to a `\usepackage[english]{babel}`. 
2. There are a number of suspect related mini error reports in loading babel's English on monster, but I'm fixing one that I noticed on my 2019 texlive machine with the default loader (`nil.ldf`) for option-free babel. It turns out the recent `pdflatex` _also_ has babel primitives precompiled in. You can try running pdflatex on a single line of `\show\bbl@languages`, and you'll see it defined. So I read the contents of nil.ldf, saw it is expecting that macro defined, and am adding a specialized binding that just defines it if needed and passes back into the texlive nil.ldf file...

Two arXiv examples to provide here, with a lot of cortex Errors to correspond to each class: `math0006231` for the english.sty case, and `math0209382` for the nil.ldf case. Both can be looked up at the [error:latex:GenericError](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/latex/%5CGenericError?all=false) report page.

I'm considering adding a couple more fixes to this branch that relate to babel, since a couple of the other errors look suspiciously harmless/procedural... 