### PR TITLE
[deprecated] MathML Accessibility Annotations

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -322,6 +322,7 @@ lib/LaTeXML/Package/PoS.cls.ltxml
 lib/LaTeXML/Package/TeX.pool.ltxml
 lib/LaTeXML/Package/a0poster.cls.ltxml
 lib/LaTeXML/Package/a0size.sty.ltxml
+lib/LaTeXML/Package/a11ymark.sty.ltxml
 lib/LaTeXML/Package/a4.sty.ltxml
 lib/LaTeXML/Package/a4wide.sty.ltxml
 lib/LaTeXML/Package/aa.cls.ltxml

--- a/lib/LaTeXML/Core/Rewrite.pm
+++ b/lib/LaTeXML/Core/Rewrite.pm
@@ -183,7 +183,6 @@ sub applyClause {
 ## EXPERIMENTAL: This is an early experiment and needs to be refactored before it can be considered for serious use
 sub action_insert {
   my ($document, $direction, $extra, $tree) = @_;
-  print STDERR "Tree: ", $tree->toString(1), "\n";
   my $anchor;
   if ($direction eq 'pre') {
     $anchor = $tree->previousSibling; }

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -1530,8 +1530,7 @@ sub NewScript {
     $l++; $bumped = 1 }
   elsif (my $innerl = p_getAttribute($rbase, '_bumplevel')) {
     $l = $innerl; }
-  my $meaning = p_getAttribute($rscript, 'meaning');
-  my $app = Apply(New(undef, undef, role => $y . 'SCRIPTOP', scriptpos => "$x$l", ($meaning ? (meaning => $meaning) : ())),
+  my $app = Apply(New(undef, undef, role => $y . 'SCRIPTOP', scriptpos => "$x$l"),
     $base, Arg($script, 0));
   # Record whether this script was a floating one
   $$app[1]{_wasfloat}  = 1  if $mode eq 'FLOAT';

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -34,7 +34,7 @@ our @EXPORT_OK = (qw(&Lookup &New &Absent &Apply &ApplyNary &recApply &CatSymbol
     &Arg &MaybeFunction
     &SawNotation &IsNotationAllowed
     &isMatchingClose &Fence
-    &p_getAttribute &p_setAttribute));
+    &p_getAttribute &p_setAttribute &p_removeAttribute &p_element_nodes));
 our %EXPORT_TAGS = (constructors
     => [qw(&Lookup &New &Absent &Apply &ApplyNary &recApply &CatSymbols
       &Annotate &InvisibleTimes &InvisibleComma
@@ -1061,6 +1061,14 @@ sub p_setAttribute {
     $$node[1]{$key} = $value; }
   else {
     $node->setAttribute($key => $value); }
+  return; }
+
+sub p_removeAttribute {
+  my ($node, $key) = @_;
+  if (ref $node eq 'ARRAY') {
+    delete $$node[1]{$key}; }
+  else {
+    $node->removeAttribute($key); }
   return; }
 
 sub p_element_nodes {

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -33,7 +33,8 @@ our @EXPORT_OK = (qw(&Lookup &New &Absent &Apply &ApplyNary &recApply &CatSymbol
     &LeftRec
     &Arg &MaybeFunction
     &SawNotation &IsNotationAllowed
-    &isMatchingClose &Fence));
+    &isMatchingClose &Fence
+    &p_getAttribute &p_setAttribute));
 our %EXPORT_TAGS = (constructors
     => [qw(&Lookup &New &Absent &Apply &ApplyNary &recApply &CatSymbols
       &Annotate &InvisibleTimes &InvisibleComma
@@ -1053,6 +1054,14 @@ sub p_getAttribute {
     return $$item[1]{$key}; }
   elsif (ref $item eq 'XML::LibXML::Element') {
     return $item->getAttribute($key); } }
+
+sub p_setAttribute {
+  my ($node, $key, $value) = @_;
+  if (ref $node eq 'ARRAY') {
+    $$node[1]{$key} = $value; }
+  else {
+    $node->setAttribute($key => $value); }
+  return; }
 
 sub p_element_nodes {
   my ($item) = @_;

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -1530,7 +1530,8 @@ sub NewScript {
     $l++; $bumped = 1 }
   elsif (my $innerl = p_getAttribute($rbase, '_bumplevel')) {
     $l = $innerl; }
-  my $app = Apply(New(undef, undef, role => $y . 'SCRIPTOP', scriptpos => "$x$l"),
+  my $meaning = p_getAttribute($rscript, 'meaning');
+  my $app = Apply(New(undef, undef, role => $y . 'SCRIPTOP', scriptpos => "$x$l", ($meaning ? (meaning => $meaning) : ())),
     $base, Arg($script, 0));
   # Record whether this script was a floating one
   $$app[1]{_wasfloat}  = 1  if $mode eq 'FLOAT';

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -18,10 +18,13 @@ use LaTeXML::Package;
 ## 0. Semantic infrastructure
 DefConstructor('\meaning{}{}', '#2', afterConstruct => sub {
     my ($doc, $whatsit) = @_;
-    my $apply = $doc->getNode->lastChild;
-    if ($apply->localName eq 'XMApp') {    # should be an apply, if by design
-      $apply->setAttribute('meaning', ToString($whatsit->getArg(1))); } },
-  bounded => 1, requireMath => 1);
+    my $node  = $doc->getNode;
+    my $apply = $node->lastChild;
+    if ($apply && $apply->localName eq 'XMApp') {    # should be an apply, if by design
+      $apply->setAttribute('meaning', ToString($whatsit->getArg(1))); }
+    else {    # otherwise, add the meaning on the current node, possibly an empty XMArg
+      $node->setAttribute('meaning', ToString($whatsit->getArg(1))); }
+    return; }, bounded => 1, requireMath => 1);
 
 # Embellishment is hard to write, hard to speak, but describes exactly several cases
 # I will abbreviate it "emb", for now, and use it as a prefix
@@ -40,8 +43,13 @@ DefMacro('\emb@base{}{}{}', sub {
     my $id_token  = T_OTHER("id" . int(rand(10000)));
     my $ref_token = Invocation(T_CS('\@XMRef'), $id_token);
     my $arg_token = Invocation(T_CS('\@XMArg'), $id_token, $base);
-    return Invocation(T_CS('\emb@base@build'), $meaning, $ref_token, Tokens($arg_token, $emb))->unlist;
-});
+    return Invocation(T_CS('\emb@base@build'),
+      $meaning, $ref_token, Tokens($arg_token, $emb))->unlist });
+
+DefMacro('\numprimemarks{}', sub {
+    my ($gullet, $numtok) = @_;
+    my $num = int(ToString($numtok));
+    return map { T_CS('\prime') } 1 .. $num; });
 
 DefConstructor('\emb@base@build{}{}{}',
   '<ltx:XMDual>'
@@ -71,6 +79,15 @@ DefMath('\integral{}{}', '\int #1 \diffd #2', meaning => 'integral');
 DefMacro('\power{}{}',   '\meaning{power}{#1^{#2}}');
 DefMacro('\frobulator',  '\emb@atom{frobulator}{x\'}');
 DefMacro('\transpose{}', '\emb@base{transpose}{#1}{^T}');
+DefMacro('\adjoint{}',   '\emb@base{adjoint}{#1}{^\dagger}');
 
-########
+# This looks misleadingly "straightforward". The floating script is hard to convince to bind to #1,
+# so literally writing f'' and trying to annotate failed in pretty much all different configurations I tried.
+# what seems to succeed gracefully is my \meaning-based semantic injections in the constructed tree,
+# *given that* I use the f^{\prime\prime} form.
+#
+DefMacro('\derivenum{}{}', '\meaning{derivative-implicit-variable}{#1^{\meaning{#2}{\numprimemarks{#2}}}}');
+
+################################################################################################################
+
 1;

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -15,6 +15,8 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+RequirePackage('latexml');
+
 DefConstructorI(T_CS('\@request@math@a11y'), undef, "<?latexml a11y='enabled'?>");
 AtBeginDocument(T_CS('\@request@math@a11y'));
 
@@ -65,7 +67,7 @@ DefMacro('\emb@preapply{}{}{}[][]', sub { emb_apply_two(@_, 1); });
 # Example \PrePostArgCrosswise{x}{median}{\overline}{index}{_}{i}
 DefMacro('\PrePostArgCrosswise{}{}{}{}{}{}', sub {
     my ($gullet, $base, $op1_meaning, $op1_pres, $op2_meaning, $op2_pres, $op2_rhs_var) = @_;
-    my ($cargs, $pargs) = dualize_arglist('#1#2', $base, $op2_rhs_var);
+    my ($cargs,    $pargs)       = dualize_arglist('#1#2', $base, $op2_rhs_var);
     my ($ref_base, $ref_rhs_var) = @$cargs;
     my ($arg_base, $arg_rhs_var) = @$pargs;
 
@@ -136,11 +138,11 @@ DefMath('\index{}{}', "{#1_{#2}}", meaning => 'index',
 
 # only mark the script as a dual, so that we can remix it
 DefMacro('\indexArg{}', sub {
-    my ($gullet, $arg) = @_;
-    my ($cargs, $pargs) = dualize_arglist('#1', $arg);
+    my ($gullet, $arg)   = @_;
+    my ($cargs,  $pargs) = dualize_arglist('#1', $arg);
     return Invocation(T_CS('\emb@build@apply'),
       Tokens(Invocation(T_CS('\@CSYMBOL'), 'index'), $$cargs[0]),
-      Tokens(T_SUB, $$pargs[0]))->unlist; });
+      Tokens(T_SUB,                                  $$pargs[0]))->unlist; });
 DefMacro('\supop{}{}{}', '\@sup@apply{#1}{\emb@atom{#2}{#3}}');
 
 DefMacro('\frobulator', '\emb@atom{frobulator}{x\'}');
@@ -203,11 +205,40 @@ DefMath('\norm{}', '|\mathbf{#1}|', meaning => 'norm', role => 'ID',
   reversion => '|\mathbf{#1}|', hide_content_reversion => 1);
 DefMath('\determinant{}', '|\mathbf{#1}|', meaning => 'determinant', role => 'ID',
   reversion => '|\mathbf{#1}|', hide_content_reversion => 1);
-DefMath('\innerp{}{}', '\left<\mathbf{#1},\mathbf{#2}\right>', meaning => 'inner-product', role => 'ID',
-  reversion => '\left<\mathbf{#1},\mathbf{#2}\right>', hide_content_reversion => 1);
-DefMath('\legendre{}{}', '(#1|#2)', meaning => 'Legendre-symbol', role => 'ID',
-  reversion => '(#1|#2)', hide_content_reversion => 1);
-
 ################################################################################################################
+
+# Declare some default common in K12 math when using this package:
+# Also, improve ergonomics of \lxDecalre to my (Deyan's) liking
+DefKeyVal('Declare', 'role',    '', '');
+DefKeyVal('Declare', 'meaning', '', '');
+our %PRAGMA_ROLES = map { $_ => 1 } qw(ID FUNCTION);
+DefMacro('\pragma OptionalMatch:* {}{}', sub { # Limitation: never use commas in the symbol/notation contents
+    my ($gullet, $star, $properties, $notations) = @_;
+    my @declarations       = ();
+    my $notations_expanded = ToString($notations);
+    $notations_expanded =~ s/\?/\\WildCard/g;
+    my @notations  = $star ? $notations_expanded : split(",", $notations_expanded);
+    my @properties = split(",", ToString($properties));
+    for my $notation (@notations) {
+      my $kvprops = LaTeXML::Core::KeyVals->new('KV', 'Declare', assign => T_OTHER('='), punct => T_OTHER(','));
+      for my $p (@properties) {                # extend with more of the lxDeclare capabilities? scopes?
+        if ($PRAGMA_ROLES{$p}) {
+          $kvprops->setValue('role', $p); }
+        else {
+          $kvprops->setValue('meaning', $p); } }
+      push @declarations,
+        Invocation(T_CS('\lxDeclare'), undef, $kvprops,
+        Tokens(T_MATH, Tokenize($notation), T_MATH)); }
+    return @declarations; });
+
+PushValue('@at@begin@document', Tokenize(<<'EOL'));
+\pragma{FUNCTION}{f,g,h}
+\pragma{ID}{a,b,c,d,n,m,x,y,z}
+\pragma{index}{?_?}
+\pragma{power}{?^?}
+\pragma{Pochhamer-symbol}{\left(?\right)_?}
+\pragma{Legendre-symbol}{\left(?|?\right)}
+\pragma*{ID,inner-product}{\left<\mathbf{?},\mathbf{?}\right>}
+EOL
 
 1;

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -18,29 +18,48 @@ use LaTeXML::Package;
 DefConstructorI(T_CS('\@request@math@a11y'), undef, "<?latexml a11y='enabled'?>");
 AtBeginDocument(T_CS('\@request@math@a11y'));
 
+# NOTE: demonstration-oriented binding, all names and definitions subject to change without notice.
+
 # Embellishment is hard to write, hard to speak, but describes exactly several cases
 # I will abbreviate it "emb", for now, and use it as a prefix
-DefMacro('\emb@atom{}{}', '\DUAL{\@CSYMBOL{#1}}{\@WRAP{#2}}');
-DefMacro('\emb@base{}{}{}', sub {
-    my ($gullet, $meaning, $base, $emb) = @_;
-    # Package::dualize_arglist seems to be doing this with more sophistication,
-    # a good bit to read if we ever need to build more infra here.
-    # for now, fast and loose, these don't get saved and are only for local association
-    my $id_token  = T_OTHER("id" . int(rand(10000)));
-    my $ref_token = Invocation(T_CS('\@XMRef'), $id_token);
-    my $arg_token = Invocation(T_CS('\@XMArg'), $id_token, $base);
-    return Invocation(T_CS('\emb@base@build'),
-      $meaning, $ref_token, Tokens($arg_token, $emb))->unlist });
 
-DefConstructor('\emb@base@build{}{}{}',
-  '<ltx:XMDual>'
-    . '<ltx:XMApp>'
-    . '<ltx:XMTok meaning="#1"/>'
-    . '#2'
-    . '</ltx:XMApp>'
-    . '<ltx:XMWrap>#3</ltx:XMWrap>'
-    . '</ltx:XMDual>',
-  bounded => 1, requireMath => 1);
+# \emb@atom{meaning}{presentation}
+DefMacro('\dual',                '\DUAL[hide_content_reversion=true]');
+DefMacro('\emb@atom{}{}',        '\dual{\@CSYMBOL{#1}}{\@WRAP{#2}}');
+DefMacro('\emb@build@apply{}{}', '\dual{\@APPLY{#1}}{\@WRAP{#2}}');
+
+sub emb_apply {
+  my ($gullet, $base, $meaning, $emb, $invert_to_prefix) = @_;
+  my ($cargs, $pargs) = dualize_arglist('#1', $base);
+  my $ref_base     = $$cargs[0];
+  my $arg_base     = $$pargs[0];
+  my $presentation = $invert_to_prefix ? Tokens($emb, $arg_base) : Tokens($arg_base, $emb);
+  return Invocation(T_CS('\emb@build@apply'),
+    Tokens(Invocation(T_CS('\@CSYMBOL'), $meaning), $ref_base),
+    $presentation)->unlist; }
+
+sub emb_apply_two {    # one-or-two operations, can't fully reuse the simple case...
+  my ($gullet, $base, $op1_meaning, $op1_pres, $op2_meaning, $op2_pres, $invert_to_prefix) = @_;
+  if (!$op2_meaning && !$op2_pres) {    # one operation, use the simple apply call
+    return emb_apply(@_); }
+  # Case where we have two consecutive operations
+  my ($cargs, $pargs) = dualize_arglist('#1', $base);
+  my $ref_base = $$cargs[0];
+  my $arg_base = $$pargs[0];
+
+  my $pres_tokens = $invert_to_prefix ? Tokens($op2_pres, $op1_pres, $arg_base) : Tokens($arg_base, $op1_pres, $op2_pres);
+  my $presentation = Invocation(T_CS('\@WRAP'), $pres_tokens);
+  my $content      = Invocation(T_CS('\@APPLY'), Invocation(T_CS('\@CSYMBOL'), $op2_meaning),
+    Invocation(T_CS('\@APPLY'), Invocation(T_CS('\@CSYMBOL'), $op1_meaning), $ref_base));
+  return Invocation(T_CS('\DUAL'), undef, $content, $presentation)->unlist; }
+
+# Two operators acting on base in sequence, commonly alternate scripts ^m_n.
+# \emb@apply{base}{op1 meaning}{op1 pres}[op2 meaning][op2 pres]
+DefMacro('\emb@apply{}{}{}[][]', \&emb_apply_two);
+
+# As with \emb@apply, but the presentation is right-to-left prefix "op2_pres op1_pres base"
+# \emb@preapply{base}{op1 meaning}{op1 pres}[op2 meaning][op2 pres]
+DefMacro('\emb@preapply{}{}{}[][]', sub { emb_apply_two(@_, 1); });
 
 ## I. Calculus
 DefConstructor('\diffd', '<ltx:XMTok meaning="differential" name="diffd" role="DIFFOP">d</ltx:XMTok>');
@@ -57,12 +76,19 @@ DefMath('\deriv[]{}{}',
 DefMath('\integral{}{}', '\int #1 \diffd #2', meaning => 'integral');
 
 ## II. Scripts
+DefMacro('\@sup@apply{}{}', sub {
+    my ($gullet, $base, $script) = @_;
+    my ($cargs, $pargs) = dualize_arglist('#1#2', $base, $script);
+    return Invocation(T_CS('\emb@build@apply'),
+      Tokens($$cargs[1], $$cargs[0]),
+      Invocation(T_CS('\@SUPERSCRIPT'), @$pargs))->unlist; });
+DefMacro('\supop{}{}{}', '\@sup@apply{#1}{\emb@atom{#2}{#3}}');
 DefMath('\power{}{}', "{#1^{#2}}", meaning => 'power',
   reversion              => '#1^{#2}',
   hide_content_reversion => 1);
 DefMacro('\frobulator',  '\emb@atom{frobulator}{x\'}');
-DefMacro('\transpose{}', '\emb@base{transpose}{#1}{^T}');
-DefMacro('\adjoint{}',   '\emb@base{adjoint}{#1}{^\dagger}');
+DefMacro('\transpose{}', '\supop{#1}{transpose}{T}');
+DefMacro('\adjoint{}',   '\supop{#1}{adjoint}{\dagger}');
 
 # What I Really Want to Say here, but can't is likely:
 # DefMath('\derivemark{}', '\derivemark@pres{#1}', meaning=>'#1');

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -81,7 +81,7 @@ DefMacro('\PrePostArgCrosswise{}{}{}{}{}{}', sub {
 # \PostArgsCrosswise{x}{derivative-implicit-variable}{^}{\derivemark{1}}{index}{_}{i}
 DefMacro('\PostArgsCrosswise{}{}{}{}{}{}{}', sub {
     my ($gullet, $base, $op1_meaning, $op1_pres, $op1_rhs_var, $op2_meaning, $op2_pres, $op2_rhs_var) = @_;
-    my ($cargs, $pargs) = dualize_arglist('#1#2', $base, $op1_rhs_var, $op2_rhs_var);
+    my ($cargs, $pargs) = dualize_arglist('#1#2#3', $base, $op1_rhs_var, $op2_rhs_var);
     my ($ref_base, $ref_rhs_var1, $ref_rhs_var2) = @$cargs;
     my ($arg_base, $arg_rhs_var1, $arg_rhs_var2) = @$pargs;
 

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -125,6 +125,14 @@ DefMacro('\subop{}{}{}', '\@sub@apply{#1}{\emb@atom{#2}{#3}}');
 DefMath('\power{}{}', "{#1^{#2}}", meaning => 'power',
   reversion              => '#1^{#2}',
   hide_content_reversion => 1);
+DefMath('\fnpower{}{}', "{#1^{#2}}", meaning => 'functional-power',
+  reversion              => '#1^{#2}',
+  hide_content_reversion => 1);
+DefMath('\fninverse{}', "#1^{-1}", meaning => "inverse", role => 'OPFUNCTION',
+  reversion              => '#1^{-1}',
+  hide_content_reversion => 1);
+DefMath('\laplacian', '\\nabla^2',
+  meaning => 'Laplacian', role => 'OPERATOR', hide_content_reversion => 1);
 
 DefMath('\index{}{}', "{#1_{#2}}", meaning => 'index',
   reversion              => '#1_{#2}',
@@ -138,7 +146,8 @@ DefMacro('\indexArg{}', sub {
       Tokens(T_SUB, $$pargs[0]))->unlist; });
 DefMacro('\supop{}{}{}', '\@sup@apply{#1}{\emb@atom{#2}{#3}}');
 
-DefMacro('\frobulator',  '\emb@atom{frobulator}{x\'}');
+DefMacro('\frobulator', '\emb@atom{frobulator}{x\'}');
+
 DefMacro('\transpose{}', '\supop{#1}{transpose}{T}');
 DefMacro('\adjoint{}',   '\supop{#1}{adjoint}{\dagger}');
 # This works well, but can't be remixed crosswise as \median{x}_i:

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -15,26 +15,9 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
-## 0. Semantic infrastructure
-DefConstructor('\meaning{}{}', '#2', afterConstruct => sub {
-    my ($doc, $whatsit) = @_;
-    my $node  = $doc->getNode;
-    my $apply = $node->lastChild;
-    if ($apply && $apply->localName eq 'XMApp') {    # should be an apply, if by design
-      $apply->setAttribute('meaning', ToString($whatsit->getArg(1))); }
-    else {    # otherwise, add the meaning on the current node, possibly an empty XMArg
-      $node->setAttribute('meaning', ToString($whatsit->getArg(1))); }
-    return; }, bounded => 1, requireMath => 1);
-
 # Embellishment is hard to write, hard to speak, but describes exactly several cases
 # I will abbreviate it "emb", for now, and use it as a prefix
-DefConstructor('\emb@atom{}{}',
-  '<ltx:XMDual>'
-    . '<ltx:XMTok meaning="#1" />'
-    . '<ltx:XMWrap>#2</ltx:XMWrap>'
-    . '</ltx:XMDual>',
-  bounded => 1, requireMath => 1);
-
+DefMacro('\emb@atom{}{}', '\DUAL{\@CSYMBOL{#1}}{\@WRAP{#2}}');
 DefMacro('\emb@base{}{}{}', sub {
     my ($gullet, $meaning, $base, $emb) = @_;
     # Package::dualize_arglist seems to be doing this with more sophistication,
@@ -48,8 +31,10 @@ DefMacro('\emb@base{}{}{}', sub {
 
 DefMacro('\numprimemarks{}', sub {
     my ($gullet, $numtok) = @_;
-    my $num = int(ToString($numtok));
-    return map { T_CS('\prime') } 1 .. $num; });
+    # we need to digest due to \@XMArg being a constructor
+    my $num = int(ToString(Digest($numtok)));
+    return Tokens(map { T_CS('\prime') } 1 .. $num);
+});
 
 DefConstructor('\emb@base@build{}{}{}',
   '<ltx:XMDual>'
@@ -76,17 +61,16 @@ DefMath('\deriv[]{}{}',
 DefMath('\integral{}{}', '\int #1 \diffd #2', meaning => 'integral');
 
 ## II. Scripts
-DefMacro('\power{}{}',   '\meaning{power}{#1^{#2}}');
+DefMath('\power{}{}', "{#1^{#2}}", meaning => 'power',
+  reversion              => '#1^{#2}',
+  hide_content_reversion => 1);
 DefMacro('\frobulator',  '\emb@atom{frobulator}{x\'}');
 DefMacro('\transpose{}', '\emb@base{transpose}{#1}{^T}');
 DefMacro('\adjoint{}',   '\emb@base{adjoint}{#1}{^\dagger}');
 
-# This looks misleadingly "straightforward". The floating script is hard to convince to bind to #1,
-# so literally writing f'' and trying to annotate failed in pretty much all different configurations I tried.
-# what seems to succeed gracefully is my \meaning-based semantic injections in the constructed tree,
-# *given that* I use the f^{\prime\prime} form.
-#
-DefMacro('\derivenum{}{}', '\meaning{derivative-implicit-variable}{#1^{\meaning{#2}{\numprimemarks{#2}}}}');
+DefMacro('\derivemark{}', '\DUAL{#1}{\@WRAP{\numprimemarks{#1}}}');
+DefMath('\fnderive{}{}', '#1^{\derivemark{#2}}',
+  meaning => 'derivative-implicit-variable');
 
 ################################################################################################################
 

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -236,9 +236,11 @@ PushValue('@at@begin@document', Tokenize(<<'EOL'));
 \pragma{ID}{a,b,c,d,n,m,x,y,z}
 \pragma{index}{?_?}
 \pragma{power}{?^?}
-\pragma{Pochhamer-symbol}{\left(?\right)_?}
-\pragma{Legendre-symbol}{\left(?|?\right)}
-\pragma*{ID,inner-product}{\left<\mathbf{?},\mathbf{?}\right>}
+\pragma{Pochhamer-symbol,ID}{\left(?\right)_?}
+\pragma{Legendre-symbol,ID}{\left(?|?\right)}
+\pragma{BesselJ,FUNCTION}{J_?}
+\pragma*{inner-product,ID}{\left<\mathbf{?},\mathbf{?}\right>}
+
 EOL
 
 1;

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -28,5 +28,21 @@ DefMath('\deriv[]{}{}',
 
 DefMath('\integral{}{}', '\int #1 \diffd #2', meaning => 'integral');
 
+DefConstructor('\meaning{}{}', '#2', afterConstruct => sub {
+    my ($doc, $whatsit) = @_;
+    my $apply = $doc->getNode->lastChild;
+    if ($apply->localName eq 'XMApp') {    # should be an apply, if by design
+      $apply->setAttribute('meaning', ToString($whatsit->getArg(1))); } },
+  bounded => 1, requireMath => 1);
+
+DefMacro('\power{}{}', '\meaning{power}{#1^{#2}}');
+
+# These still need work, since currently we get
+# annotations "transpose(#1,#2)" and "frobulator(#1,#2)"
+# instead of the desired "transpose(#1)" and "frobulator"
+# I guess this needs a different type of XMath structural pattern...
+DefMacro('\transpose{}', '\meaning{transpose}{#1^T}');
+DefMacro('\frobulator',  '\meaning{frobulator}{x\'}');
+
 ########
 1;

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -15,6 +15,45 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+## 0. Semantic infrastructure
+DefConstructor('\meaning{}{}', '#2', afterConstruct => sub {
+    my ($doc, $whatsit) = @_;
+    my $apply = $doc->getNode->lastChild;
+    if ($apply->localName eq 'XMApp') {    # should be an apply, if by design
+      $apply->setAttribute('meaning', ToString($whatsit->getArg(1))); } },
+  bounded => 1, requireMath => 1);
+
+# Embellishment is hard to write, hard to speak, but describes exactly several cases
+# I will abbreviate it "emb", for now, and use it as a prefix
+DefConstructor('\emb@atom{}{}',
+  '<ltx:XMDual>'
+    . '<ltx:XMTok meaning="#1" />'
+    . '<ltx:XMWrap>#2</ltx:XMWrap>'
+    . '</ltx:XMDual>',
+  bounded => 1, requireMath => 1);
+
+DefMacro('\emb@base{}{}{}', sub {
+    my ($gullet, $meaning, $base, $emb) = @_;
+    # Package::dualize_arglist seems to be doing this with more sophistication,
+    # a good bit to read if we ever need to build more infra here.
+    # for now, fast and loose, these don't get saved and are only for local association
+    my $id_token  = T_OTHER("id" . int(rand(10000)));
+    my $ref_token = Invocation(T_CS('\@XMRef'), $id_token);
+    my $arg_token = Invocation(T_CS('\@XMArg'), $id_token, $base);
+    return Invocation(T_CS('\emb@base@build'), $meaning, $ref_token, Tokens($arg_token, $emb))->unlist;
+});
+
+DefConstructor('\emb@base@build{}{}{}',
+  '<ltx:XMDual>'
+    . '<ltx:XMApp>'
+    . '<ltx:XMTok meaning="#1"/>'
+    . '#2'
+    . '</ltx:XMApp>'
+    . '<ltx:XMWrap>#3</ltx:XMWrap>'
+    . '</ltx:XMDual>',
+  bounded => 1, requireMath => 1);
+
+## I. Calculus
 DefConstructor('\diffd', '<ltx:XMTok meaning="differential" name="diffd" role="DIFFOP">d</ltx:XMTok>');
 DefMath('\deriv[]{}{}',
   '\frac{\@MAYBEAPPLY{\@SUPERSCRIPT{\diffd}{#1}}{#2}}'
@@ -28,21 +67,10 @@ DefMath('\deriv[]{}{}',
 
 DefMath('\integral{}{}', '\int #1 \diffd #2', meaning => 'integral');
 
-DefConstructor('\meaning{}{}', '#2', afterConstruct => sub {
-    my ($doc, $whatsit) = @_;
-    my $apply = $doc->getNode->lastChild;
-    if ($apply->localName eq 'XMApp') {    # should be an apply, if by design
-      $apply->setAttribute('meaning', ToString($whatsit->getArg(1))); } },
-  bounded => 1, requireMath => 1);
-
-DefMacro('\power{}{}', '\meaning{power}{#1^{#2}}');
-
-# These still need work, since currently we get
-# annotations "transpose(#1,#2)" and "frobulator(#1,#2)"
-# instead of the desired "transpose(#1)" and "frobulator"
-# I guess this needs a different type of XMath structural pattern...
-DefMacro('\transpose{}', '\meaning{transpose}{#1^T}');
-DefMacro('\frobulator',  '\meaning{frobulator}{x\'}');
+## II. Scripts
+DefMacro('\power{}{}',   '\meaning{power}{#1^{#2}}');
+DefMacro('\frobulator',  '\emb@atom{frobulator}{x\'}');
+DefMacro('\transpose{}', '\emb@base{transpose}{#1}{^T}');
 
 ########
 1;

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -24,9 +24,8 @@ AtBeginDocument(T_CS('\@request@math@a11y'));
 # I will abbreviate it "emb", for now, and use it as a prefix
 
 # \emb@atom{meaning}{presentation}
-DefMacro('\dual',                '\DUAL[hide_content_reversion=true]');
-DefMacro('\emb@atom{}{}',        '\dual{\@CSYMBOL{#1}}{\@WRAP{#2}}');
-DefMacro('\emb@build@apply{}{}', '\dual{\@APPLY{#1}}{\@WRAP{#2}}');
+DefMacro('\emb@atom{}{}',        '\DUAL[hide_content_reversion=true]{\@CSYMBOL{#1}}{\@WRAP{#2}}');
+DefMacro('\emb@build@apply{}{}', '\DUAL[hide_content_reversion=true]{\@APPLY{#1}}{\@WRAP{#2}}');
 
 sub emb_apply {
   my ($gullet, $base, $meaning, $emb, $invert_to_prefix) = @_;
@@ -41,7 +40,7 @@ sub emb_apply {
 sub emb_apply_two {    # one-or-two operations, can't fully reuse the simple case...
   my ($gullet, $base, $op1_meaning, $op1_pres, $op2_meaning, $op2_pres, $invert_to_prefix) = @_;
   if (!$op2_meaning && !$op2_pres) {    # one operation, use the simple apply call
-    return emb_apply(@_); }
+    return emb_apply($gullet, $base, $op1_meaning, $op1_pres, $invert_to_prefix); }
   # Case where we have two consecutive operations
   my ($cargs, $pargs) = dualize_arglist('#1', $base);
   my $ref_base = $$cargs[0];
@@ -60,6 +59,38 @@ DefMacro('\emb@apply{}{}{}[][]', \&emb_apply_two);
 # As with \emb@apply, but the presentation is right-to-left prefix "op2_pres op1_pres base"
 # \emb@preapply{base}{op1 meaning}{op1 pres}[op2 meaning][op2 pres]
 DefMacro('\emb@preapply{}{}{}[][]', sub { emb_apply_two(@_, 1); });
+
+# ADHOC for the very awkward example we have so far.
+# and the order of presentation args is inverted, while the semantic one is kept.
+# Example \PrePostArgCrosswise{x}{median}{\overline}{index}{_}{i}
+DefMacro('\PrePostArgCrosswise{}{}{}{}{}{}', sub {
+    my ($gullet, $base, $op1_meaning, $op1_pres, $op2_meaning, $op2_pres, $op2_rhs_var) = @_;
+    my ($cargs, $pargs) = dualize_arglist('#1#2', $base, $op2_rhs_var);
+    my ($ref_base, $ref_rhs_var) = @$cargs;
+    my ($arg_base, $arg_rhs_var) = @$pargs;
+
+    my $presentation = Tokens(Tokens($op1_pres, $arg_base), $op2_pres, $arg_rhs_var);
+    my $content      = Tokens(Invocation(T_CS('\@CSYMBOL'), $op1_meaning),
+      Invocation(T_CS('\@APPLY'), Tokens(
+          Invocation(T_CS('\@CSYMBOL'), $op2_meaning),
+          $ref_base, $ref_rhs_var)));
+    return Invocation(T_CS('\emb@build@apply'), $content, $presentation)->unlist; });
+
+# ADHOC - terrible low-level soup macro with 7 arguments,
+# just an example of things being possible...
+# \PostArgsCrosswise{x}{derivative-implicit-variable}{^}{\derivemark{1}}{index}{_}{i}
+DefMacro('\PostArgsCrosswise{}{}{}{}{}{}{}', sub {
+    my ($gullet, $base, $op1_meaning, $op1_pres, $op1_rhs_var, $op2_meaning, $op2_pres, $op2_rhs_var) = @_;
+    my ($cargs, $pargs) = dualize_arglist('#1#2', $base, $op1_rhs_var, $op2_rhs_var);
+    my ($ref_base, $ref_rhs_var1, $ref_rhs_var2) = @$cargs;
+    my ($arg_base, $arg_rhs_var1, $arg_rhs_var2) = @$pargs;
+
+    my $presentation = Tokens(Tokens($arg_base, $op1_pres, $arg_rhs_var1), $op2_pres, $arg_rhs_var2);
+    my $content      = Tokens(Invocation(T_CS('\@CSYMBOL'), $op1_meaning),
+      Invocation(T_CS('\@APPLY'), Tokens(
+          Invocation(T_CS('\@CSYMBOL'), $op2_meaning), $ref_base, $ref_rhs_var2)),
+      $ref_rhs_var1);
+    return Invocation(T_CS('\emb@build@apply'), $content, $presentation)->unlist; });
 
 ## I. Calculus
 DefConstructor('\diffd', '<ltx:XMTok meaning="differential" name="diffd" role="DIFFOP">d</ltx:XMTok>');
@@ -83,12 +114,35 @@ DefMacro('\@sup@apply{}{}', sub {
       Tokens($$cargs[1], $$cargs[0]),
       Invocation(T_CS('\@SUPERSCRIPT'), @$pargs))->unlist; });
 DefMacro('\supop{}{}{}', '\@sup@apply{#1}{\emb@atom{#2}{#3}}');
+DefMacro('\@sub@apply{}{}', sub {
+    my ($gullet, $base, $script) = @_;
+    my ($cargs, $pargs) = dualize_arglist('#1#2', $base, $script);
+    return Invocation(T_CS('\emb@build@apply'),
+      Tokens($$cargs[1], $$cargs[0]),
+      Invocation(T_CS('\@SUBCRIPT'), @$pargs))->unlist; });
+DefMacro('\subop{}{}{}', '\@sub@apply{#1}{\emb@atom{#2}{#3}}');
+
 DefMath('\power{}{}', "{#1^{#2}}", meaning => 'power',
   reversion              => '#1^{#2}',
   hide_content_reversion => 1);
+
+DefMath('\index{}{}', "{#1_{#2}}", meaning => 'index',
+  reversion              => '#1_{#2}',
+  hide_content_reversion => 1);
+# only mark the script as a dual, so that we can remix it
+DefMacro('\indexArg{}', sub {
+    my ($gullet, $arg) = @_;
+    my ($cargs, $pargs) = dualize_arglist('#1', $arg);
+    return Invocation(T_CS('\emb@build@apply'),
+      Tokens(Invocation(T_CS('\@CSYMBOL'), 'index'), $$cargs[0]),
+      Tokens(T_SUB, $$pargs[0]))->unlist; });
+DefMacro('\supop{}{}{}', '\@sup@apply{#1}{\emb@atom{#2}{#3}}');
+
 DefMacro('\frobulator',  '\emb@atom{frobulator}{x\'}');
 DefMacro('\transpose{}', '\supop{#1}{transpose}{T}');
 DefMacro('\adjoint{}',   '\supop{#1}{adjoint}{\dagger}');
+# This works well, but can't be remixed crosswise as \median{x}_i:
+DefMacro('\median', '\emb@atom{median}{\overline}');
 
 # What I Really Want to Say here, but can't is likely:
 # DefMath('\derivemark{}', '\derivemark@pres{#1}', meaning=>'#1');

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -32,13 +32,6 @@ DefMacro('\emb@base{}{}{}', sub {
     return Invocation(T_CS('\emb@base@build'),
       $meaning, $ref_token, Tokens($arg_token, $emb))->unlist });
 
-DefMacro('\numprimemarks{}', sub {
-    my ($gullet, $numtok) = @_;
-    # we need to digest due to \@XMArg being a constructor
-    my $num = int(ToString(Digest($numtok)));
-    return Tokens(map { T_CS('\prime') } 1 .. $num);
-});
-
 DefConstructor('\emb@base@build{}{}{}',
   '<ltx:XMDual>'
     . '<ltx:XMApp>'
@@ -71,9 +64,53 @@ DefMacro('\frobulator',  '\emb@atom{frobulator}{x\'}');
 DefMacro('\transpose{}', '\emb@base{transpose}{#1}{^T}');
 DefMacro('\adjoint{}',   '\emb@base{adjoint}{#1}{^\dagger}');
 
-DefMacro('\derivemark{}', '\DUAL{#1}{\@WRAP{\numprimemarks{#1}}}');
-DefMath('\fnderive{}{}', '#1^{\derivemark{#2}}',
-  meaning => 'derivative-implicit-variable');
+# What I Really Want to Say here, but can't is likely:
+# DefMath('\derivemark{}', '\derivemark@pres{#1}', meaning=>'#1');
+DefMacro('\derivemark{}', sub {
+    my ($gullet, $token) = @_;
+    # Dualizing the arglist only works if we are going to keep the same token at the end
+    # in the case of 2 --> '' , this fails. So, obtain the presentation right away to figure this out
+
+    # we need to digest due to \@XMArg being a constructor
+    my $mark = ToString(Digest($token));
+    my ($content, $presentation);
+    if ($mark =~ /^\d$/) {    # single digit, add primes
+      $content      = $token;
+      $presentation = Tokens(map { T_CS('\prime') } 1 .. int($mark)) }
+    else {
+      # assume an id, wrap in parens
+      my ($cargs, $pargs) = dualize_arglist('#1', $token);
+      $content      = $$cargs[0];
+      $presentation = Tokens(T_OTHER('('), $$pargs[0], T_OTHER(')')); }
+
+    return Invocation(T_CS('\DUAL'),
+      undef,                  # debugging that I missed this 'undef' argument was not fun.
+      $content,
+      Invocation(T_CS('\@WRAP'), $presentation))->unlist;
+});
+
+# curiously we need an indirection level, so that we point to the dual instead of
+# the content node of the dual. The a11y attribute generation does not support the following markup
+# at the moment:
+#
+# <XMDual>
+#   <XMApp>
+#     <XMTok meaning="derivative-implicit-variable" name="fnderive" role="UNKNOWN"/>
+#     <XMRef idref="p1.m1.1"/>
+#     <XMRef idref="p1.m1.2"/>
+#   </XMApp>
+#   <XMApp>
+#     <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
+#     <XMTok font="italic" role="UNKNOWN" xml:id="p1.m1.1">f</XMTok>
+#     <XMDual>
+#       <XMTok font="italic" fontsize="70%" role="UNKNOWN" xml:id="p1.m1.2">n</XMTok>
+#       <XMWrap> ...
+#
+# We can only deal with 'p1.m1.2' pointing to the inner XMDual, rather than directly to its content "n"
+DefMacro('\fnderive{}{}', '\fnderive@build{#1}{\derivemark{#2}}');
+DefMath('\fnderive@build{}{}', '#1^#2',
+  meaning                => 'derivative-implicit-variable',
+  hide_content_reversion => 1);
 
 ################################################################################################################
 

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -126,17 +126,14 @@ DefMath('\power{}{}', "{#1^{#2}}", meaning => 'power',
   reversion              => '#1^{#2}',
   hide_content_reversion => 1);
 DefMath('\fnpower{}{}', "{#1^{#2}}", meaning => 'functional-power',
-  reversion              => '#1^{#2}',
-  hide_content_reversion => 1);
+  reversion => '#1^{#2}', hide_content_reversion => 1);
 DefMath('\fninverse{}', "#1^{-1}", meaning => "inverse", role => 'OPFUNCTION',
-  reversion              => '#1^{-1}',
+  reversion => '#1^{-1}', hide_content_reversion => 1);
+DefMath('\laplacian', '\nabla^2', meaning => 'Laplacian', role => 'OPERATOR',
   hide_content_reversion => 1);
-DefMath('\laplacian', '\\nabla^2',
-  meaning => 'Laplacian', role => 'OPERATOR', hide_content_reversion => 1);
-
 DefMath('\index{}{}', "{#1_{#2}}", meaning => 'index',
-  reversion              => '#1_{#2}',
-  hide_content_reversion => 1);
+  reversion => '#1_{#2}', hide_content_reversion => 1);
+
 # only mark the script as a dual, so that we can remix it
 DefMacro('\indexArg{}', sub {
     my ($gullet, $arg) = @_;
@@ -200,6 +197,16 @@ DefMacro('\fnderive{}{}', '\fnderive@build{#1}{\derivemark{#2}}');
 DefMath('\fnderive@build{}{}', '#1^#2',
   meaning                => 'derivative-implicit-variable',
   hide_content_reversion => 1);
+
+## Circumfix, applicative:
+DefMath('\norm{}', '|\mathbf{#1}|', meaning => 'norm', role => 'ID',
+  reversion => '|\mathbf{#1}|', hide_content_reversion => 1);
+DefMath('\determinant{}', '|\mathbf{#1}|', meaning => 'determinant', role => 'ID',
+  reversion => '|\mathbf{#1}|', hide_content_reversion => 1);
+DefMath('\innerp{}{}', '\left<\mathbf{#1},\mathbf{#2}\right>', meaning => 'inner-product', role => 'ID',
+  reversion => '\left<\mathbf{#1},\mathbf{#2}\right>', hide_content_reversion => 1);
+DefMath('\legendre{}{}', '(#1|#2)', meaning => 'Legendre-symbol', role => 'ID',
+  reversion => '(#1|#2)', hide_content_reversion => 1);
 
 ################################################################################################################
 

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -1,0 +1,32 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  a11ymark.sty -- demo semantic bindings for accessibility           | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+DefConstructor('\diffd', '<ltx:XMTok meaning="differential" name="diffd" role="DIFFOP">d</ltx:XMTok>');
+DefMath('\deriv[]{}{}',
+  '\frac{\@MAYBEAPPLY{\@SUPERSCRIPT{\diffd}{#1}}{#2}}'
+    . '{\@SUPERSCRIPT{\@APPLY{\diffd #3}}{#1}}',
+  meaning => 'derivative', reorder => [2, 3, 1],
+  # afterDigest => sub {
+  #   # NOTE: arg 2 will be wrapped in XMRef!
+  #   $_[1]->setProperty(role => 'DIFFOP') if checkDiffOp($_[1]);
+  #   return; },
+  hide_content_reversion => 1);
+
+DefMath('\integral{}{}', '\int #1 \diffd #2', meaning => 'integral');
+
+########
+1;

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -236,16 +236,20 @@ DefMacro('\pragma OptionalMatch:* {}{}', sub { # Limitation: never use commas in
         Tokens(T_MATH, Tokenize($notation), T_MATH)); }
     return @declarations; });
 
-PushValue('@at@begin@document', Tokenize(<<'EOL'));
-\pragma{FUNCTION}{f,g,h}
-\pragma{ID}{a,b,c,d,n,m,x,y,z}
-\pragma{index}{?_?}
-\pragma{power}{?^?}
-\pragma{Pochhamer-symbol,ID}{\left(?\right)_?}
-\pragma{Legendre-symbol,ID}{\left(?|?\right)}
-\pragma{BesselJ,FUNCTION}{J_?}
-\pragma*{inner-product,ID}{\left<\mathbf{?},\mathbf{?}\right>}
-\pragma*{pre:\@APPLYFUNCTION}{\left(?,?;?|?\right)}
-EOL
+# Example pragmas, as incldued with the tiny accessibility showcase:
+#
+# disabled by default here, since they may assume too much
+#
+# PushValue('@at@begin@document', Tokenize(<<'EOL'));
+# \pragma{FUNCTION}{f,g,h}
+# \pragma{ID}{a,b,c,d,n,m,x,y,z}
+# \pragma{index}{?_?}
+# \pragma{power}{?^?}
+# \pragma{Pochhamer-symbol,ID}{\left(?\right)_?}
+# \pragma{Legendre-symbol,ID}{\left(?|?\right)}
+# \pragma{BesselJ,FUNCTION}{J_?}
+# \pragma*{inner-product,ID}{\left<\mathbf{?},\mathbf{?}\right>}
+# \pragma*{pre:\@APPLYFUNCTION}{\left(?,?;?|?\right)}
+# EOL
 #
 1;

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -15,6 +15,9 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+DefConstructorI(T_CS('\@request@math@a11y'), undef, "<?latexml a11y='enabled'?>");
+AtBeginDocument(T_CS('\@request@math@a11y'));
+
 # Embellishment is hard to write, hard to speak, but describes exactly several cases
 # I will abbreviate it "emb", for now, and use it as a prefix
 DefMacro('\emb@atom{}{}', '\DUAL{\@CSYMBOL{#1}}{\@WRAP{#2}}');

--- a/lib/LaTeXML/Package/a11ymark.sty.ltxml
+++ b/lib/LaTeXML/Package/a11ymark.sty.ltxml
@@ -209,21 +209,26 @@ DefMath('\determinant{}', '|\mathbf{#1}|', meaning => 'determinant', role => 'ID
 
 # Declare some default common in K12 math when using this package:
 # Also, improve ergonomics of \lxDecalre to my (Deyan's) liking
+# TODO: Can we reuse this keyval from latexml.sty? How?
 DefKeyVal('Declare', 'role',    '', '');
 DefKeyVal('Declare', 'meaning', '', '');
+DefKeyVal('Declare', 'action',  '', '');
+DefKeyVal('Declare', 'replace', '', '');
 our %PRAGMA_ROLES = map { $_ => 1 } qw(ID FUNCTION);
 DefMacro('\pragma OptionalMatch:* {}{}', sub { # Limitation: never use commas in the symbol/notation contents
     my ($gullet, $star, $properties, $notations) = @_;
     my @declarations       = ();
     my $notations_expanded = ToString($notations);
-    $notations_expanded =~ s/\?/\\WildCard/g;
-    my @notations  = $star ? $notations_expanded : split(",", $notations_expanded);
-    my @properties = split(",", ToString($properties));
+    $notations_expanded =~ s/\?/\\WildCard[]/g;
+    my @notations  = $star ? $notations_expanded : split(/\s*,\s*/, $notations_expanded);
+    my @properties = split(/\s*,\s*/, ToString($properties));
     for my $notation (@notations) {
       my $kvprops = LaTeXML::Core::KeyVals->new('KV', 'Declare', assign => T_OTHER('='), punct => T_OTHER(','));
       for my $p (@properties) {                # extend with more of the lxDeclare capabilities? scopes?
         if ($PRAGMA_ROLES{$p}) {
           $kvprops->setValue('role', $p); }
+        elsif ($p =~ /^(pre|post)\:/) {
+          $kvprops->setValue('action', $p); }
         else {
           $kvprops->setValue('meaning', $p); } }
       push @declarations,
@@ -240,7 +245,7 @@ PushValue('@at@begin@document', Tokenize(<<'EOL'));
 \pragma{Legendre-symbol,ID}{\left(?|?\right)}
 \pragma{BesselJ,FUNCTION}{J_?}
 \pragma*{inner-product,ID}{\left<\mathbf{?},\mathbf{?}\right>}
-
+\pragma*{pre:\@APPLYFUNCTION}{\left(?,?;?|?\right)}
 EOL
-
+#
 1;

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -246,7 +246,7 @@ DefPrimitive('\lxDefMath{}[Number][]{} OptionalKeyVals:XMath', sub {
       $params && map { $_ && ToString($_) } map { $params->getValue($_) }
       qw(name meaning cd role alias scope);
     my $needsid = $params && ($params->getValue('tag') || $params->getValue('description'));
-    my $id = ($needsid ? next_declaration_id() : undef);
+    my $id      = ($needsid ? next_declaration_id() : undef);
     DefMathI($cs, convertLaTeXArgs($nargs, $opt), $presentation,
       name  => $name,  meaning => $meaning, omcd => $cd, role => $role, alias => $alias,
       scope => $scope, decl_id => $id,
@@ -294,7 +294,7 @@ sub normalizeDeclareKeys {
   if (my $stuff = $description || $tag) {
     ($term, $desc) = splitDeclareTag($stuff); }
   $short = ($description ? $tag || $desc : undef);
-  $desc = $desc || $description || $tag;
+  $desc  = $desc || $description || $tag;
   $whatsit->setProperties(term => $term, short => $short, description => $desc);
   return; }
 
@@ -340,9 +340,10 @@ sub splitDeclareTag {
 DefKeyVal('Declare', 'nowrap', '{}', 1);
 DefKeyVal('Declare', 'trace',  '{}', 1);
 DefKeyVal('Declare', 'replace', 'UndigestedKey');
+DefKeyVal('Declare', 'action',  'UndigestedKey');
 
 our $declare_keys = { scope => 1, role => 1, tag => 1, description => 1, name => 1, meaning => 1,
-  trace => 1, nowrap => 1, replace => 1, label => 1 };
+  trace => 1, nowrap => 1, replace => 1, action => 1, label => 1 };
 # Most is same as above; merge into one!!!!!
 DefConstructor('\lxDeclare OptionalMatch:* OptionalKeyVals:Declare {}', sub {
     my ($document, $flag, $kv, $pattern, %props) = @_;
@@ -387,7 +388,8 @@ DefConstructor('\lxDeclare OptionalMatch:* OptionalKeyVals:Declare {}', sub {
       nowrap  => defined $kv->getValue('nowrap'),
       id      => $id,
       match   => $pattern,
-      replace => $kv->getValue('replace'));
+      replace => $kv->getValue('replace'),
+      action  => $kv->getValue('action'));
     normalizeDeclareKeys($kv, $whatsit);
 
     if (my $label = ToString($kv->getValue('label'))) {
@@ -436,8 +438,8 @@ sub getDeclarationScope {
 sub createDeclarationRewrite {
   my ($document, $scope, $whatsit) = @_;
   my %props = $whatsit->getProperties;
-  my ($id, $match, $nowrap, $role, $name, $meaning, $ref, $trace, $replace)
-    = map { $props{$_} } qw(id match nowrap role name meaning ref trace replace);
+  my ($id, $match, $nowrap, $role, $name, $meaning, $ref, $trace, $replace, $action)
+    = map { $props{$_} } qw(id match nowrap role name meaning ref trace replace action);
   # Put this rule IN FRONT of other rules!
   UnshiftValue('DOCUMENT_REWRITE_RULES',
     LaTeXML::Core::Rewrite->new('math',
@@ -446,12 +448,14 @@ sub createDeclarationRewrite {
       ($match ? (match => $match) : ()),
       ($replace
         ? (replace => $replace)
-        : attributes => { ($role ? (role => $role) : ()),
-          ($name    ? (name    => $name)    : ()),
-          ($meaning ? (meaning => $meaning) : ()),
-          ($id      ? (decl_id => $id)      : ()),
-          ($nowrap  ? (_nowrap => $nowrap)  : ()),
-        }),
+        : ($action
+          ? (action => $action)
+          : attributes => { ($role ? (role => $role) : ()),
+            ($name    ? (name    => $name)    : ()),
+            ($meaning ? (meaning => $meaning) : ()),
+            ($id      ? (decl_id => $id)      : ()),
+            ($nowrap  ? (_nowrap => $nowrap)  : ()),
+          })),
     ));
   return; }
 

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -546,7 +546,7 @@ sub associateNode {
       else {
         $node->setAttribute('xml:id' => $id); }
       push(@{ $$self{convertedIDs}{$sourceid} }, $id) unless $noxref; } }
-  $self->associateNodeHook($node, $sourcenode, $noxref);
+  $self->associateNodeHook($node, $sourcenode, $noxref, $currentnode);
   if ($isarray) {                                                # Array represented
     map { $self->associateNode($_, $currentnode, $noxref) } @$node[2 .. $#$node]; }
   else {                                                         # LibXML node

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -68,6 +68,10 @@ sub preprocess {
   $$self{nestmath}   = 0 unless $$self{nestmath};
   $doc->adjust_latexml_doctype('MathML');    # Add MathML if LaTeXML dtd.
   $doc->addNamespace($mmlURI, 'm');
+  # flip the accessibility switch on if requested, as it is currently experimental
+  if (my $a11y = $doc->findnode('.//processing-instruction("latexml")[contains(.,"a11y=")]')) {
+    if ($a11y->textContent =~ /a11y=['"]enabled['"]/) {
+      $$self{a11y} = 1; } }
   return; }
 
 # Works for pmml, cmml

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -26,6 +26,7 @@ our @EXPORT = (
     &pmml_infix &pmml_script &pmml_summation),
   qw( &cmml &cmml_share &cmml_shared &cmml_ci
     &cmml_or_compose &cmml_synth_not &cmml_synth_complement),
+  qw(&getQName)
 );
 require LaTeXML::Post::MathML::Presentation;
 require LaTeXML::Post::MathML::Content;

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -105,9 +105,15 @@ sub associateNodeHook {
   my $src_grandparent_name = getQName($src_grandparent);
   # tokens are simplest - if we know of a meaning, use that for accessibility
   if ($source_name eq 'ltx:XMTok') {
-    # avoid token handlers in the constituent subtrees of a dual, handle those top-down
-    if ($src_grandparent_name ne 'ltx:XMDual') {
-      $meaning = $sourcenode->getAttribute('meaning'); } }
+    if (my $token_meaning = $sourcenode->getAttribute('meaning')) {
+      if ($src_grandparent_name eq 'ltx:XMDual') {
+        # often an XMDual contains the participating tokens of a transfix notation
+        # and those tokens carry the same meaning as the top-level dual operation.
+        # in those cases, don't tag the tokens, only tag the top-level dual node
+        my $dual_meaning = $src_grandparent->firstChild->firstChild->getAttribute('meaning');
+        $meaning = $token_meaning if ($token_meaning ne $dual_meaning); }
+      else {    # just copy the meaning in the usual case
+        $meaning = $token_meaning; } } }
   elsif ($source_name eq 'ltx:XMApp') {
     my @src_children = $sourcenode->childNodes;
     my $arg_count    = scalar(@src_children) - 1;

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -83,7 +83,7 @@ sub associateNodeHook {
       p_setAttribute($node, 'href', $href); }
     if (my $title = $sourcenode->getAttribute('title')) {
       p_setAttribute($node, 'title', $title); } }
-  $self->addAccessibilityAnnotations($node, $currentnode);
+  $self->addAccessibilityAnnotations($node, $currentnode) if $$self{a11y};
   return; }
 
 # Experiment: set accessibility attributes on the resulting presentation tree,
@@ -161,7 +161,8 @@ sub addAccessibilityAnnotations {
   if ($dual_pres_node && (my $id = $currentnode->getAttribute('xml:id'))) {
     # We already found the dual
     my $dual_content_node = $dual_pres_node->previousSibling;
-    my @content_args = getQName($dual_content_node) eq 'ltx:XMApp' ? element_nodes($dual_content_node) : ($dual_content_node);
+    my @content_args      = ($dual_content_node && getQName($dual_content_node)) eq 'ltx:XMApp' ?
+      element_nodes($dual_content_node) : ($dual_content_node);
     my $arg_count = scalar(@content_args);
     # if no compound-apply, no need for top-level dual annotation, leave it to the descendants
     my $index = 0;

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -16,7 +16,7 @@ use warnings;
 use base qw(LaTeXML::Post::MathML);
 use LaTeXML::Post::MathML qw(getQName);
 use LaTeXML::MathParser qw(p_getAttribute p_setAttribute);
-use LaTeXML::Common::XML qw(isElementNode);
+use LaTeXML::Common::XML;
 
 sub preprocess {
   my ($self, $doc, @maths) = @_;
@@ -71,8 +71,6 @@ sub convertNode {
 sub rawIDSuffix {
   return '.pmml'; }
 
-use Data::Dumper;
-
 sub associateNodeHook {
   # technical note: $sourcenode is a LibXML element, while $node is that OR the arrayref triple form
   my ($self, $node, $sourcenode, $noxref, $currentnode) = @_;
@@ -88,9 +86,9 @@ sub associateNodeHook {
   $self->addAccessibilityAnnotations($node, $currentnode);
   return; }
 
+# Experiment: set accessibility attributes on the resulting presentation tree,
+# if the XMath source has a claim to the semantics via a "meaning" attribute.
 sub addAccessibilityAnnotations {
-  # Experiment: set accessibility attributes on the resulting presentation tree,
-  # if the XMath source has a claim to the semantics via a "meaning" attribute.
   # Part I: Top-down. Recover the meaning of a subtree as an accessible annotation
   my ($self, $node, $currentnode) = @_;
   my $current_node_name = getQName($currentnode);
@@ -101,117 +99,83 @@ sub addAccessibilityAnnotations {
 # that second call should just immediately terminate, there is nothing to add in such cases.
   return if $currentnode->getAttribute('_a11y_done');
   $currentnode->setAttribute('_a11y_done', '1');
-  my $id = $currentnode->getAttribute('xml:id');
-  my ($meaning, $arg);
-  # FIRST AND FOREMOST, run an exclusion check for pieces that are presentation-only fluff for duals
-  # namely:
+  # --- TOP PRIORITY: run an exclusion check for pieces that are presentation-only fluff for duals
   my @dual_pres_ancestry = $LaTeXML::Post::DOCUMENT->findnodes("ancestor-or-self::*[preceding-sibling::*][parent::ltx:XMDual]", $currentnode);
   my $dual_pres_node = $dual_pres_ancestry[-1]; #  Weirdly ->findnode() is finding the highest ancestor, rather than the tightest ancestor? This [-1] seems to do it.
-  if ($dual_pres_node) {                        # 1) they have a dual ancestor
-                                                # 2) no node on the path to that dual has a "id"
+  if ($dual_pres_node && !$dual_pres_node->isSameNode($currentnode)) { # 1) they have a dual ancestor, but are not the main presentation node
     my $check_node = $currentnode;
+    my $id         = $currentnode->getAttribute('xml:id');
     while (!$id && !$check_node->isSameNode($dual_pres_node)) {
       $id         = $check_node->getAttribute('xml:id');
       $check_node = $check_node->parentNode; }
-    if (!$id) {
-      # 3) they're not "The Main Presentation" node, which is where we want to annotate duals
-      return unless $currentnode->isSameNode($dual_pres_node); } }
-  # All other cases, process the node, it has meaningful annotations to add, handle them first
-  if ($dual_pres_node && $dual_pres_node->isSameNode($currentnode)) { # top-level, annotate with semantic, and potentially arg
-    my $content_child = $dual_pres_node->previousSibling;
-    my $op_literal;
-    if (getQName($content_child) eq 'ltx:XMRef') {
-      $op_literal = '#op'; # important: we have a clear match in the presentation, so the operator will have an arg
-      $content_child = $LaTeXML::Post::DOCUMENT->realizeXMNode($content_child); }
-    if (getQName($content_child) eq 'ltx:XMTok') { # not an else, since this may have just been realized from XMRef
-                                                   # another exception! (x) will have meaning x, so...
-      undef $op_literal;
+    # if no id is found, they are not referenced by the dual
+    return unless $id; }
+  # ---
+  # In the remaining cases, process the node, check if it has meaningful annotations to add
+  my ($meaning, $arg);
+  if ($dual_pres_node && $dual_pres_node->isSameNode($currentnode)) {    # top-level pres of dual
+    my $dual_content_node = $dual_pres_node->previousSibling;
+    my $dual_content_name = getQName($dual_content_node);
+    if ($dual_content_name eq 'ltx:XMRef') {    # single subtree of the presentation, point to it
       $meaning = '#1'; }
-    else {
-      my $op_node = $content_child->firstChild;
-      $op_literal = $op_literal || ($op_node && $op_node->getAttribute('meaning')) || '#op';
-      my @arg_nodes = $content_child->childNodes;
+    elsif ($dual_content_name eq 'ltx:XMTok') {
+      $meaning = $dual_content_node->getAttribute('meaning'); }
+    elsif ($dual_content_name eq 'ltx:XMApp') {
+      my $op_node   = $dual_content_node->firstChild;
+      my $op        = ($op_node && $op_node->getAttribute('meaning')) || '#op';
+      my @arg_nodes = element_nodes($dual_content_node);
       my $arg_count = scalar(@arg_nodes) - 1;
-      $meaning = $op_literal . '(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; }
-# Note that if the carrier ltx:XMDual had a id, it would get lost as we never visit it through this hook.
+      $meaning = $op . '(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; }
+# Note that if the carrier ltx:XMDual had a referenced id, it would get lost as we never visit it through this hook.
 # to correct that, assign it in the top presentation child
-    if (!$id) {
-      my $dual       = $dual_pres_node->parentNode;
-      my $grand_dual = $dual->parentNode;
-      if (my $id = $dual->getAttribute('xml:id')) {
-# But we can't reuse the common logic, since it will comapare the dual with itself rather than its parent, ugh
-        while (getQName($grand_dual) ne 'ltx:XMDual') { $grand_dual = $grand_dual->parentNode; }
-        # this HAS to be an apply child right??
-        my @grand_content_args = $grand_dual->firstChild->childNodes;
-        my $grand_args_count   = scalar(@grand_content_args);
-        my $index              = 0;
-        while (my $grand_content_arg = shift @grand_content_args) {
-          if (($grand_content_arg->getAttribute('idref') || '') eq $id) {
-            $arg = $index ? $index : ($grand_args_count > 1 ? 'op' : '1'); }
-          else { $index++; } } }
-      elsif (getQName($grand_dual) eq 'ltx:XMApp') {
-        # simpler case of the dual being an simple argument, as in x\in(0,1)
-        my $index = 0;
-        my $prev  = $dual->previousSibling;
-        while ($prev) {
-          $index++;
-          $prev = $prev->previousSibling; }
-        $arg = $index ? $index : 'op'; } } }
+    my $dual = $dual_pres_node->parentNode;
+    if (my $id = $dual->getAttribute('xml:id')) {
+      $self->addAccessibilityAnnotations($node, $dual); } }
   # tokens are simplest - if we know of a meaning, use that for accessibility
   elsif ($current_node_name eq 'ltx:XMTok') {
     $meaning = $currentnode->getAttribute('meaning'); }
   elsif ($current_node_name eq 'ltx:XMApp') {
-    my @src_children = $currentnode->childNodes;
-    my $arg_count    = scalar(@src_children) - 1;
+    my @current_children   = element_nodes($currentnode);
+    my $current_op_meaning = $current_children[0]->getAttribute('meaning') || '';
+    my $arg_count          = scalar(@current_children) - 1;
     # Ok, so we need to disentangle the case where the operator XMTok is preserved in pmml,
     # and the case where it isn't. E.g. in \sqrt{x} we get a msqrt wrapper, but no dedicated token
     # so we need to mark the literal "square-root" in msqrt
-    my $op_literal = $src_children[0]->getAttribute('meaning');
-    my $name       = getQName($node);
-    if ($op_literal and $name ne 'm:mrow') { # assume we have phased out the operator node. Are there counter-examples?
-      $meaning = $op_literal . '(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; }
-    elsif ($name eq 'm:mrow') {
-      # usually an mrow keeps the operator token in its children as an <mo> (or such)
-      # when doesn't it? one example is "multirelation", is there a general pattern?
-      if ($op_literal and $op_literal eq 'multirelation') {
-        $meaning = $op_literal . '(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; }
-      else {    # default case, assume we'll find the @op inside
-        $meaning = '#op(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; } } }
+    my $op;
+    my $name = getQName($node);
+    if ($name ne 'm:mrow') {    # not an mrow, prefer the literal semantic
+      $op = $current_op_meaning || $name; }
+    else {    # mrow, prefer #op, except for whitelisted exception cases (which ones??)
+      $op = ($current_op_meaning eq 'multirelation') ? $current_op_meaning : '#op'; }
+    if ($op) {    # Set the meaning, if we found a satisfying $op:
+      $meaning = "$op(" . join(",", map { '#' . $_ } (1 .. $arg_count)) . ")"; } }
 
   # if we found some meaning, attach it as an accessible attribute
   p_setAttribute($node, 'data-semantic', $meaning) if $meaning;
 
   # Part II: Bottom-up. Also check if argument of higher parent notation, mark if so.
-  # best to reset id here
-  $id = $currentnode->getAttribute('xml:id');
-  my $current_parent = $currentnode->parentNode;
-  my $index          = 0;
+  my $index = 0;
   # II.1 id-carrying nodes always point to their referrees.
-  if ($id) {
+  if ($dual_pres_node && (my $id = $currentnode->getAttribute('xml:id'))) {
     # We already found the dual
-    my $content_child = $dual_pres_node->previousSibling;
-    my @content_args = getQName($content_child) eq 'ltx:XMApp' ? ($content_child->childNodes) : ($content_child);
+    my $dual_content_node = $dual_pres_node->previousSibling;
+    my @content_args = getQName($dual_content_node) eq 'ltx:XMApp' ? element_nodes($dual_content_node) : ($dual_content_node);
     my $arg_count = scalar(@content_args);
     # if no compound-apply, no need for top-level dual annotation, leave it to the descendants
-    my $index = 0;
     while (my $c_arg = shift @content_args) {
-      my $idref = $c_arg->getAttribute('idref') || '';
-      if ($idref eq $id) {
+      if ($id eq ($c_arg->getAttribute('idref') || '')) {
         $arg = $index || ($arg_count >= 2 ? 'op' : '1');
-      } else {
+        last;
+      } else {    # note that if we never find the 'idref', arg is never set
         $index++; } } }
   # II.2. applications children are directly pointing to their parents
-  elsif (getQName($current_parent) eq 'ltx:XMApp') {
-    my $op_node = $current_parent->firstChild;
-    if ($op_node->getAttribute('meaning')) {    # only annotated applications we understand
-      my $prev_sibling = $currentnode;
-      while ($prev_sibling = $prev_sibling->previousSibling) {
-        $index++; }
-      if ($index == 0) {
-        $arg = 'op'; }
-      else {
-        $arg = $index; } } }
-  p_setAttribute($node, 'data-arg', $arg) if ($arg);
+  #   also fallback in the dual case, if the XMApp had an id but wasn't an arg
+  if (!$arg && (getQName($currentnode->parentNode) eq 'ltx:XMApp')) {
+    my $prev_sibling = $currentnode;
+    while ($prev_sibling = $prev_sibling->previousSibling) {
+      $index++; }
+    $arg = $index ? $index : 'op'; }
+  p_setAttribute($node, 'data-arg', $arg) if $arg;
   return; }
 
 #================================================================================

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -163,7 +163,7 @@ sub addAccessibilityAnnotations {
     my $dual_content_node = $dual_pres_node->previousSibling;
     # note that if we never find the 'idref', arg is never set
     if (my $xmref = $LaTeXML::Post::DOCUMENT->findnode('//ltx:XMRef[@idref="' . $id . '"]', $dual_content_node)) {
-      p_setAttribute($xmref, '_a11y', 'ref');    # mark as used in ref
+      p_setAttribute($node, '_a11y', 'ref');    # mark as used in ref
       my $index  = 0;
       my $parent = $xmref->parentNode;
       my $c_arg  = $xmref;

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -125,7 +125,7 @@ sub addAccessibilityAnnotations {
       # we could get a deeply nested application tree with a lot of nodes which have no referrents
       # but should be translated into the final data-semantic
       # best to call out into a subroutine?
-      $meaning = get_dual_content_meaning($dual_content_node, 0); }
+      $meaning = dual_content_xmapp_to_semantic_attr($dual_content_node, 0); }
 # Note that the carrier ltx:XMDual is never passed in associateNode, but often requires an "arg". Recurse:
     $self->addAccessibilityAnnotations($node, $dual_pres_node->parentNode); }
   # tokens are simplest - if we know of a meaning, use that for accessibility
@@ -187,18 +187,17 @@ sub addAccessibilityAnnotations {
   p_setAttribute($node, 'data-arg', $arg) if $arg;
   return; }
 
-sub get_dual_content_meaning {
+sub dual_content_xmapp_to_semantic_attr {
   my ($node, $lvl) = @_;
-  my @arg_nodes = element_nodes($node);
-  my $op_node   = shift @arg_nodes;
-  my $op        = $op_node ? $op_node->getAttribute('meaning') :
-    ($lvl ? '#op' . $lvl : '#op');
+  my @arg_nodes   = element_nodes($node);
+  my $op_node     = shift @arg_nodes;
+  my $op          = ($op_node && $op_node->getAttribute('meaning')) || ($lvl ? '#op' . $lvl : '#op');
   my @arg_strings = ();
   my $index       = 0;
   for my $arg_node (@arg_nodes) {
     $index++;
     if (getQName($arg_node) eq 'ltx:XMApp') {
-      push @arg_strings, get_dual_content_meaning($arg_node, $lvl + 1); }
+      push @arg_strings, dual_content_xmapp_to_semantic_attr($arg_node, $lvl + 1); }
     else {
       push @arg_strings, '#' . $index . ($lvl ? "_$lvl" : ""); } }    # will we need level suffixes?
   return $op . '(' . join(",", @arg_strings) . ')'; }

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -119,18 +119,18 @@ sub addAccessibilityAnnotations {
     my $content_child = $dual_pres_node->previousSibling;
     my $op_literal;
     if (getQName($content_child) eq 'ltx:XMRef') {
-      $op_literal = '@op'; # important: we have a clear match in the presentation, so the operator will have an arg
+      $op_literal = '#op'; # important: we have a clear match in the presentation, so the operator will have an arg
       $content_child = $LaTeXML::Post::DOCUMENT->realizeXMNode($content_child); }
     if (getQName($content_child) eq 'ltx:XMTok') { # not an else, since this may have just been realized from XMRef
                                                    # another exception! (x) will have meaning x, so...
       undef $op_literal;
-      $meaning = '@1'; }
+      $meaning = '#1'; }
     else {
       my $op_node = $content_child->firstChild;
-      $op_literal = $op_literal || ($op_node && $op_node->getAttribute('meaning')) || '@op';
+      $op_literal = $op_literal || ($op_node && $op_node->getAttribute('meaning')) || '#op';
       my @arg_nodes = $content_child->childNodes;
       my $arg_count = scalar(@arg_nodes) - 1;
-      $meaning = $op_literal . '(' . join(",", map { '@' . $_ } (1 .. $arg_count)) . ')'; }
+      $meaning = $op_literal . '(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; }
 # Note that if the carrier ltx:XMDual had a id, it would get lost as we never visit it through this hook.
 # to correct that, assign it in the top presentation child
     if (!$id) {
@@ -166,14 +166,14 @@ sub addAccessibilityAnnotations {
     # so we need to mark the literal "square-root" in msqrt
     my $op_literal = $src_children[0]->getAttribute('meaning');
     if ($op_literal and $name ne 'm:mrow') { # assume we have phased out the operator node. Are there counter-examples?
-      $meaning = $op_literal . '(' . join(",", map { '@' . $_ } (1 .. $arg_count)) . ')'; }
+      $meaning = $op_literal . '(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; }
     elsif ($name eq 'm:mrow') {
       # usually an mrow keeps the operator token in its children as an <mo> (or such)
       # when doesn't it? one example is "multirelation", is there a general pattern?
       if ($op_literal and $op_literal eq 'multirelation') {
-        $meaning = $op_literal . '(' . join(",", map { '@' . $_ } (1 .. $arg_count)) . ')'; }
+        $meaning = $op_literal . '(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; }
       else {    # default case, assume we'll find the @op inside
-        $meaning = '@op(' . join(",", map { '@' . $_ } (1 .. $arg_count)) . ')'; } } }
+        $meaning = '#op(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; } } }
 
   # if we found some meaning, attach it as an accessible attribute
   if ($meaning) {

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -134,10 +134,10 @@ sub addAccessibilityAnnotations {
 # Note that if the carrier ltx:XMDual had a id, it would get lost as we never visit it through this hook.
 # to correct that, assign it in the top presentation child
     if (!$id) {
-      my $dual = $dual_pres_node->parentNode;
+      my $dual       = $dual_pres_node->parentNode;
+      my $grand_dual = $dual->parentNode;
       if (my $id = $dual->getAttribute('xml:id')) {
 # But we can't reuse the common logic, since it will comapare the dual with itself rather than its parent, ugh
-        my $grand_dual = $dual->parentNode;
         while (getQName($grand_dual) ne 'ltx:XMDual') { $grand_dual = $grand_dual->parentNode; }
         # this HAS to be an apply child right??
         my @grand_content_args = $grand_dual->firstChild->childNodes;
@@ -146,8 +146,15 @@ sub addAccessibilityAnnotations {
         while (my $grand_content_arg = shift @grand_content_args) {
           if ($grand_content_arg->getAttribute('idref') eq $id) {
             $arg = $index ? $index : ($grand_args_count > 1 ? 'op' : '1'); }
-          else { $index++; } }
-  } } }
+          else { $index++; } } }
+      elsif (getQName($grand_dual) eq 'ltx:XMApp') {
+        # simpler case of the dual being an simple argument, as in x\in(0,1)
+        my $index = 0;
+        my $prev  = $dual->previousSibling;
+        while ($prev) {
+          $index++;
+          $prev = $prev->previousSibling; }
+        $arg = $index ? $index : 'op'; } } }
   # tokens are simplest - if we know of a meaning, use that for accessibility
   elsif ($current_node_name eq 'ltx:XMTok') {
     $meaning = $currentnode->getAttribute('meaning'); }

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -170,11 +170,11 @@ sub addAccessibilityAnnotations {
     # fragid-carrying nodes always  have an arg annotation
     # step 1. find their dual
     my $dual_node = $sourcenode->parentNode;
-    while (getQName($dual_node) ne 'ltx:XMDual') {
+    while ($dual_node && ((getQName($dual_node) || '') ne 'ltx:XMDual')) {
       $dual_node = $dual_node->parentNode; }
-    my $content_child = $dual_node->firstChild;
-    my @content_nodes = getQName($content_child) eq 'ltx:XMApp' ? $content_child->childNodes : ();
-    my $index         = 0;
+    my $content_child = $dual_node && $dual_node->firstChild;
+    my @content_nodes = ($content_child && getQName($content_child) eq 'ltx:XMApp') ? $content_child->childNodes : ();
+    my $index = 0;
     while (my $content_arg = shift @content_nodes) {
       if (getQName($content_arg) eq 'ltx:XMRef' and $content_arg->getAttribute('idref') eq $fragid) {
         if ($index) {

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -163,16 +163,15 @@ sub addAccessibilityAnnotations {
     my $dual_content_node = $dual_pres_node->previousSibling;
     # note that if we never find the 'idref', arg is never set
     if (my $xmref = $LaTeXML::Post::DOCUMENT->findnode('//ltx:XMRef[@idref="' . $id . '"]', $dual_content_node)) {
-      print STDERR "XMREF: ", $xmref->toString(1);
       p_setAttribute($xmref, '_a11y', 'ref');    # mark as used in ref
-      my $index     = 0;
-      my @arg_nodes = element_nodes($xmref->parentNode);
-      my $c_arg     = $xmref;
+      my $index  = 0;
+      my $parent = $xmref->parentNode;
+      my $c_arg  = $xmref;
       while ($c_arg = $c_arg->previousSibling) {
         $index++; }
-      $arg = $index || (scalar(@arg_nodes) >= 2 ? 'op' : '1');
-      my $parent = $xmref->parentNode;
-      my $lvl    = -1;
+      $arg = $index || ((getQName($xmref->parentNode) eq 'ltx:XMDual') ? '1' : ($xmref->nextSibling ? 'op' : '1'));
+      # compute a level suffix if nested within main dual
+      my $lvl = -1;
       while (getQName($parent) eq 'ltx:XMApp') {
         $parent = $parent->parentNode;
         $lvl++; }

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -142,18 +142,18 @@ sub addAccessibilityAnnotations {
 
 # Given the first (content) child of an ltx:XMDual, compute its corresponding a11y "semantic" attribute
 sub dual_content_xmapp_to_semantic_attr {
-  my ($node, $lvl) = @_;
+  my ($node, $prefix) = @_;
   my @arg_nodes   = element_nodes($node);
   my $op_node     = shift @arg_nodes;
-  my $op          = ($op_node && $op_node->getAttribute('meaning')) || ($lvl ? '#op' . $lvl : '#op');
+  my $op          = ($op_node && $op_node->getAttribute('meaning')) || '#op';
   my @arg_strings = ();
   my $index       = 0;
   for my $arg_node (@arg_nodes) {
     $index++;
     if (getQName($arg_node) eq 'ltx:XMApp') {
-      push @arg_strings, dual_content_xmapp_to_semantic_attr($arg_node, $lvl + 1); }
+      push @arg_strings, dual_content_xmapp_to_semantic_attr($arg_node, $prefix ? ($prefix . "_$index") : $index); }
     else {
-      push @arg_strings, '#' . $index . ($lvl ? "_$lvl" : ""); } }    # will we need level suffixes?
+      push @arg_strings, '#' . ($prefix ? ($prefix . "_$index") : $index); } } # will we need level suffixes?
   return $op . '(' . join(",", @arg_strings) . ')'; }
 
 # Given the first (content) child of an ltx:XMDual, and an idref value, compute the corresponding "arg" attribute for that XMRef

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -137,9 +137,9 @@ sub associateNodeHook {
   # if we found some meaning, attach it as an accessible attribute
   if ($meaning) {
     if (ref $node eq 'ARRAY') {
-      $$node[1]{semantic} = $meaning; }
+      $$node[1]{'data-semantic'} = $meaning; }
     else {
-      $node->setAttribute('semantic', $meaning); } }
+      $node->setAttribute('data-semantic', $meaning); } }
 
   # Part II: Bottom-up. Also check if argument of higher parent notation, mark if so.
   my $arg;
@@ -170,9 +170,9 @@ sub associateNodeHook {
 # if we found an indication that this node is an argument of a higher-up content tree, attach the annotation
   if ($arg) {
     if (ref $node eq 'ARRAY') {
-      $$node[1]{arg} = $arg; }
+      $$node[1]{'data-arg'} = $arg; }
     else {
-      $node->setAttribute('arg', $arg); } }
+      $node->setAttribute('data-arg', $arg); } }
   return; }
 
 #================================================================================

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -113,8 +113,6 @@ sub addAccessibilityAnnotations {
     return if $$ancestor == $$container; }
   # 1--end. We reach here only with semantic nodes in hand (or the logic has a Bug).
 
-  print STDERR "semantic node: ", $sourcenode->toString(1), "\n";
-
   # 2. Bookkeep the semantic information.
   my ($meaning, $arg);
   if (my $src_meaning = $sourcenode->getAttribute('meaning')) {

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -119,7 +119,12 @@ sub addAccessibilityAnnotations {
     $meaning = $src_meaning; }
   elsif ($source_node_name eq 'ltx:XMApp') {
     my $op = ($$node[0] eq 'm:mrow') ? '#op' : p_getAttribute($sourcenode->firstChild, 'meaning');
-    $meaning = "$op(" . join(",", map { "#$_" } 1 .. scalar(element_nodes($sourcenode)) - 1) . ')'; }
+    if ($op) {    # annotate only if we knew a 'meaning' attribute, for the special markup scenarios
+      $meaning = "$op(" . join(",", map { "#$_" } 1 .. scalar(element_nodes($sourcenode)) - 1) . ')'; }
+    else {
+      # otherwise, take the liberty to delete all data-arg of direct children
+      for my $pmml_child (@$node[2 .. scalar(@$node) - 1]) {
+        p_removeAttribute($pmml_child, 'data-arg'); } } }
   elsif ($source_node_name eq 'ltx:XMDual') {
     $meaning = dual_content_to_semantic_attr($sourcenode->firstChild); }
 
@@ -175,6 +180,7 @@ sub dual_content_idref_to_data_attr {
     $path     = $path ? ($position . '_' . $path) : $position;
     $ancestor = $ancestor->parentNode; }
   return $path || 'op'; }
+
 #================================================================================
 # Presentation MathML with Line breaking
 # Not at all sure how this will integrate with Parallel markup...

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -126,11 +126,8 @@ sub addAccessibilityAnnotations {
       my @arg_nodes = element_nodes($dual_content_node);
       my $arg_count = scalar(@arg_nodes) - 1;
       $meaning = $op . '(' . join(",", map { '#' . $_ } (1 .. $arg_count)) . ')'; }
-# Note that if the carrier ltx:XMDual had a referenced id, it would get lost as we never visit it through this hook.
-# to correct that, assign it in the top presentation child
-    my $dual = $dual_pres_node->parentNode;
-    if (my $id = $dual->getAttribute('xml:id')) {
-      $self->addAccessibilityAnnotations($node, $dual); } }
+# Note that the carrier ltx:XMDual is never passed in associateNode, but often requires an "arg". Recurse:
+    $self->addAccessibilityAnnotations($node, $dual_pres_node->parentNode); }
   # tokens are simplest - if we know of a meaning, use that for accessibility
   elsif ($current_node_name eq 'ltx:XMTok') {
     # stylistic choice - avoid tagging numbers, even though we could, too obvious

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base qw(LaTeXML::Post::MathML);
 use LaTeXML::Post::MathML qw(getQName);
-use LaTeXML::MathParser qw(p_getAttribute p_setAttribute);
+use LaTeXML::MathParser qw(p_getAttribute p_setAttribute p_removeAttribute p_element_nodes);
 use LaTeXML::Common::XML;
 
 sub preprocess {
@@ -144,11 +144,15 @@ sub addAccessibilityAnnotations {
     my $op;
     my $name = getQName($node);
     if ($name ne 'm:mrow') {    # not an mrow, prefer the literal semantic
-      $op = $current_op_meaning || $name; }
+      $op = $current_op_meaning; }
     else {    # mrow, prefer #op, except for whitelisted exception cases (which ones??)
       $op = ($current_op_meaning eq 'multirelation') ? $current_op_meaning : '#op'; }
     if ($op) {    # Set the meaning, if we found a satisfying $op:
-      $meaning = "$op(" . join(",", map { '#' . $_ } (1 .. $arg_count)) . ")"; } }
+      $meaning = "$op(" . join(",", map { '#' . $_ } (1 .. $arg_count)) . ")"; }
+    else {        # if there is no op, we should undo argument annotations pointing at the application,
+      for my $arg_node (p_element_nodes($node)) {
+        p_removeAttribute($arg_node, 'data-arg');
+  } } }
 
   # if we found some meaning, attach it as an accessible attribute
   p_setAttribute($node, 'data-semantic', $meaning) if $meaning;

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -157,7 +157,6 @@ sub addAccessibilityAnnotations {
   p_setAttribute($node, 'data-semantic', $meaning) if $meaning;
 
   # Part II: Bottom-up. Also check if argument of higher parent notation, mark if so.
-  my $index = 0;
   # II.1 id-carrying nodes always point to their referrees.
   if ($dual_pres_node && (my $id = $currentnode->getAttribute('xml:id'))) {
     # We already found the dual
@@ -165,6 +164,7 @@ sub addAccessibilityAnnotations {
     my @content_args = getQName($dual_content_node) eq 'ltx:XMApp' ? element_nodes($dual_content_node) : ($dual_content_node);
     my $arg_count = scalar(@content_args);
     # if no compound-apply, no need for top-level dual annotation, leave it to the descendants
+    my $index = 0;
     while (my $c_arg = shift @content_args) {
       if ($id eq ($c_arg->getAttribute('idref') || '')) {
         p_setAttribute($node, '_a11y', 'ref');    # mark as used in ref
@@ -175,6 +175,7 @@ sub addAccessibilityAnnotations {
   # II.2. applications children are directly pointing to their parents
   #   also fallback in the dual case, if the XMApp had an id but wasn't an arg
   if (!$arg && (getQName($currentnode->parentNode) eq 'ltx:XMApp')) {
+    my $index        = 0;
     my $prev_sibling = $currentnode;
     while ($prev_sibling = $prev_sibling->previousSibling) {
       $index++; }


### PR DESCRIPTION
Opening a very early pre-alpha pull request, tracking #1303 .

So far I added a minimally working implementation on one example, and will be adapting from there - also taking in feedback and brainstorming. Tests will fail because I haven't added a customization switch yet, so the annotations are always added, hence existing presentation MathML tests don't match up.

Things to note from this naive first stab:
 * when we have an XMApp with an operator token with a known "meaning" attribute, the correspondence is pretty easy/direct
 * when we have an mrow, it's basically rewriting the immediate XMApp tree as an attribute. 
 * when we have another wrapper pmml non-terminal (such as msqrt) for now I assumed the operator token will not be in the presentation, and the meaning should be added as a literal (in this case "square-root").
 * when we have no meaning on the XMApp operator token, I just omit annotating at all. So far this is most (all?) msup/msub variants.
 * We seem to have mrows around integration, which lets me pretend it's just an integral symbol applied on its integrand. Not ideal but easy enough.
 * I have not looked at XMDuals explicitly yet, that's next
 * side-remark: I am thinking of renaming the attributes to `data-semantic` and `data-arg` for a quick demo this week, so that I can use them with the existing browser stack without any turmoil, [staying within the HTML spec](https://www.w3schools.com/tags/att_global_data.asp).

The (somewhat arbitrary) example in question is:
```
latexmlc --whatsin=math --whatsout=math --format=html 'literal:\int \sqrt{x^2+c_i} dx'
```

producing the MathML (at time of opening the PR, definitely subject to change):
```xml
<math id="p1.m1" class="ltx_Math" alttext="\int\sqrt{x^{2}+c_{i}}dx" display="inline">
  <mrow semantic="@op(@1)">
    <mo arg="op" largeop="true" semantic="integral" symmetric="true">∫</mo>
    <mrow arg="1" semantic="@op(@1,@2)">
      <msqrt arg="1" semantic="square-root(@1)">
        <mrow arg="1" semantic="@op(@1,@2)">
          <msup arg="1">
            <mi>x</mi>
            <mn semantic="2">2</mn>
          </msup>
          <mo arg="op" semantic="plus">+</mo>
          <msub arg="2">
            <mi>c</mi>
            <mi>i</mi>
          </msub>
        </mrow>
      </msqrt>
      <mo arg="op" semantic="times">⁢</mo>
      <mrow arg="2" semantic="@op(@1)">
        <mo arg="op" rspace="0pt" semantic="differential-d">𝑑</mo>
        <mi arg="1">x</mi>
      </mrow>
    </mrow>
  </mrow>
</math>
```