### PR TITLE
prune XMDuals with mirrored single tokens

### DIFF
--- a/t/complex/physics.xml
+++ b/t/complex/physics.xml
@@ -1117,10 +1117,7 @@
                   <XMApp>
                     <XMTok name="rightarrow" role="ARROW">→</XMTok>
                     <XMTok meaning="absent"/>
-                    <XMDual>
-                      <XMTok meaning="gradient"/>
-                      <XMTok name="nabla" role="OPERATOR">∇</XMTok>
-                    </XMDual>
+                    <XMTok font="italic" meaning="gradient" name="nabla" role="OPERATOR">∇</XMTok>
                   </XMApp>
                 </XMath>
               </Math></td>
@@ -1719,10 +1716,7 @@
                       <XMTok name="rightarrow" role="ARROW">→</XMTok>
                       <XMTok meaning="absent"/>
                       <XMApp>
-                        <XMDual>
-                          <XMTok meaning="sine"/>
-                          <XMTok role="OPFUNCTION" scriptpos="post">sin</XMTok>
-                        </XMDual>
+                        <XMTok font="italic" meaning="sine" role="OPFUNCTION" scriptpos="post">sin</XMTok>
                         <XMTok font="italic" role="UNKNOWN">x</XMTok>
                       </XMApp>
                     </XMApp>
@@ -1754,10 +1748,7 @@
                       <XMRef idref="S1.Ex1.m1.5"/>
                     </XMApp>
                     <XMApp>
-                      <XMDual xml:id="S1.Ex1.m1.4">
-                        <XMTok meaning="sine"/>
-                        <XMTok role="OPFUNCTION" scriptpos="post">sin</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="sine" role="OPFUNCTION" scriptpos="post" xml:id="S1.Ex1.m1.4">sin</XMTok>
                       <XMWrap>
                         <XMTok role="OPEN" stretchy="false">[</XMTok>
                         <XMApp backgroundcolor="#00FFFF" xml:id="S1.Ex1.m1.5">
@@ -1782,10 +1773,7 @@
                         <XMRef idref="S1.Ex1.m1.7"/>
                       </XMApp>
                       <XMApp>
-                        <XMDual xml:id="S1.Ex1.m1.6">
-                          <XMTok meaning="sine"/>
-                          <XMTok role="OPFUNCTION" scriptpos="post">sin</XMTok>
-                        </XMDual>
+                        <XMTok font="italic" meaning="sine" role="OPFUNCTION" scriptpos="post" xml:id="S1.Ex1.m1.6">sin</XMTok>
                         <XMWrap>
                           <XMTok role="OPEN" stretchy="false">[</XMTok>
                           <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex1.m1.7">x</XMTok>
@@ -1851,10 +1839,7 @@
                       <XMRef idref="S1.Ex1.m1.10"/>
                     </XMApp>
                     <XMApp>
-                      <XMDual xml:id="S1.Ex1.m1.9">
-                        <XMTok meaning="sine"/>
-                        <XMTok role="OPFUNCTION" scriptpos="post">sin</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="sine" role="OPFUNCTION" scriptpos="post" xml:id="S1.Ex1.m1.9">sin</XMTok>
                       <XMWrap>
                         <XMTok role="OPEN" stretchy="false">{</XMTok>
                         <XMApp backgroundcolor="#00FFFF" xml:id="S1.Ex1.m1.10">
@@ -1879,10 +1864,7 @@
                         <XMRef idref="S1.Ex1.m1.12"/>
                       </XMApp>
                       <XMApp>
-                        <XMDual xml:id="S1.Ex1.m1.11">
-                          <XMTok meaning="sine"/>
-                          <XMTok role="OPFUNCTION" scriptpos="post">sin</XMTok>
-                        </XMDual>
+                        <XMTok font="italic" meaning="sine" role="OPFUNCTION" scriptpos="post" xml:id="S1.Ex1.m1.11">sin</XMTok>
                         <XMWrap>
                           <XMTok role="OPEN" stretchy="false">[</XMTok>
                           <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex1.m1.12">x</XMTok>
@@ -2657,10 +2639,7 @@
                     <XMTok name="rightarrow" role="ARROW">→</XMTok>
                     <XMTok meaning="absent"/>
                     <XMApp>
-                      <XMDual>
-                        <XMTok meaning="trace"/>
-                        <XMTok role="OPFUNCTION" scriptpos="post">tr</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="trace" role="OPFUNCTION" scriptpos="post">tr</XMTok>
                       <XMTok font="italic" name="rho" role="UNKNOWN">ρ</XMTok>
                     </XMApp>
                   </XMApp>
@@ -2709,10 +2688,7 @@
                     <XMTok name="rightarrow" role="ARROW">→</XMTok>
                     <XMTok meaning="absent"/>
                     <XMApp>
-                      <XMDual>
-                        <XMTok meaning="trace"/>
-                        <XMTok role="OPFUNCTION" scriptpos="post">Tr</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="trace" role="OPFUNCTION" scriptpos="post">Tr</XMTok>
                       <XMTok font="italic" name="rho" role="UNKNOWN">ρ</XMTok>
                     </XMApp>
                   </XMApp>
@@ -2728,10 +2704,7 @@
                     <XMTok name="rightarrow" role="ARROW">→</XMTok>
                     <XMTok meaning="absent"/>
                     <XMApp>
-                      <XMDual>
-                        <XMTok meaning="rank"/>
-                        <XMTok role="OPFUNCTION" scriptpos="post">rank</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="rank" role="OPFUNCTION" scriptpos="post">rank</XMTok>
                       <XMTok font="italic" role="UNKNOWN">M</XMTok>
                     </XMApp>
                   </XMApp>
@@ -2778,10 +2751,7 @@
                         <XMRef idref="S1.T3.m6.3"/>
                       </XMApp>
                       <XMApp>
-                        <XMDual xml:id="S1.T3.m6.2">
-                          <XMTok meaning="residue"/>
-                          <XMTok role="OPFUNCTION" scriptpos="post">Res</XMTok>
-                        </XMDual>
+                        <XMTok font="italic" meaning="residue" role="OPFUNCTION" scriptpos="post" xml:id="S1.T3.m6.2">Res</XMTok>
                         <XMWrap>
                           <XMTok role="OPEN" stretchy="false">[</XMTok>
                           <XMApp xml:id="S1.T3.m6.3">
@@ -2988,10 +2958,7 @@
                       <XMRef idref="S1.Ex2.m1.2"/>
                     </XMApp>
                     <XMApp>
-                      <XMDual xml:id="S1.Ex2.m1.1">
-                        <XMTok meaning="realport"/>
-                        <XMTok role="OPFUNCTION" scriptpos="post">Re</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="realport" role="OPFUNCTION" scriptpos="post" xml:id="S1.Ex2.m1.1">Re</XMTok>
                       <XMWrap>
                         <XMTok role="OPEN" stretchy="false">(</XMTok>
                         <XMApp backgroundcolor="#00FFFF" xml:id="S1.Ex2.m1.2">
@@ -3014,10 +2981,7 @@
                       <XMRef idref="S1.Ex2.m1.4"/>
                     </XMApp>
                     <XMApp>
-                      <XMDual xml:id="S1.Ex2.m1.3">
-                        <XMTok meaning="realport"/>
-                        <XMTok role="OPFUNCTION" scriptpos="post">Re</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="realport" role="OPFUNCTION" scriptpos="post" xml:id="S1.Ex2.m1.3">Re</XMTok>
                       <XMWrap>
                         <XMTok role="OPEN" stretchy="false">[</XMTok>
                         <XMApp backgroundcolor="#00FFFF" xml:id="S1.Ex2.m1.4">
@@ -3040,10 +3004,7 @@
                       <XMRef idref="S1.Ex2.m1.6"/>
                     </XMApp>
                     <XMApp>
-                      <XMDual xml:id="S1.Ex2.m1.5">
-                        <XMTok meaning="imagport"/>
-                        <XMTok role="OPFUNCTION" scriptpos="post">Im</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="imagport" role="OPFUNCTION" scriptpos="post" xml:id="S1.Ex2.m1.5">Im</XMTok>
                       <XMWrap>
                         <XMTok role="OPEN" stretchy="false">(</XMTok>
                         <XMApp backgroundcolor="#00FFFF" xml:id="S1.Ex2.m1.6">
@@ -3066,10 +3027,7 @@
                       <XMRef idref="S1.Ex2.m1.8"/>
                     </XMApp>
                     <XMApp>
-                      <XMDual xml:id="S1.Ex2.m1.7">
-                        <XMTok meaning="imagport"/>
-                        <XMTok role="OPFUNCTION" scriptpos="post">Im</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="imagport" role="OPFUNCTION" scriptpos="post" xml:id="S1.Ex2.m1.7">Im</XMTok>
                       <XMWrap>
                         <XMTok role="OPEN" stretchy="false">[</XMTok>
                         <XMApp backgroundcolor="#00FFFF" xml:id="S1.Ex2.m1.8">
@@ -3307,10 +3265,7 @@
                   <XMApp>
                     <XMTok name="rightarrow" role="ARROW">→</XMTok>
                     <XMTok meaning="absent"/>
-                    <XMDual>
-                      <XMTok meaning="differential"/>
-                      <XMTok role="UNKNOWN">d</XMTok>
-                    </XMDual>
+                    <XMTok font="italic" meaning="differential" role="UNKNOWN">d</XMTok>
                   </XMApp>
                 </XMath>
               </Math></td>
@@ -3325,10 +3280,7 @@
                     <XMTok meaning="absent"/>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                      <XMDual>
-                        <XMTok meaning="differential"/>
-                        <XMTok role="UNKNOWN">d</XMTok>
-                      </XMDual>
+                      <XMTok font="italic" meaning="differential" role="UNKNOWN">d</XMTok>
                       <XMTok font="italic" role="UNKNOWN">x</XMTok>
                     </XMApp>
                   </XMApp>
@@ -3399,10 +3351,7 @@
                         <XMWrap>
                           <XMTok role="OPEN" stretchy="true">(</XMTok>
                           <XMApp xml:id="S1.T6.m6.1">
-                            <XMDual>
-                              <XMTok meaning="cosine"/>
-                              <XMTok role="OPFUNCTION" scriptpos="post">cos</XMTok>
-                            </XMDual>
+                            <XMTok font="italic" meaning="cosine" role="OPFUNCTION" scriptpos="post">cos</XMTok>
                             <XMTok font="italic" name="theta" role="UNKNOWN">θ</XMTok>
                           </XMApp>
                           <XMTok role="CLOSE" stretchy="true">)</XMTok>
@@ -6616,19 +6565,13 @@
                             <XMCell align="center">
                               <XMApp>
                                 <XMTok fontsize="70%" meaning="minus" role="ADDOP">-</XMTok>
-                                <XMDual role="UNKNOWN">
-                                  <XMTok meaning="imaginary-unit" name="lx@physics@iunit" role="UNKNOWN"/>
-                                  <XMTok font="italic" fontsize="70%" role="UNKNOWN">i</XMTok>
-                                </XMDual>
+                                <XMTok font="italic" fontsize="70%" meaning="imaginary-unit" name="lx@physics@iunit" role="UNKNOWN">i</XMTok>
                               </XMApp>
                             </XMCell>
                           </XMRow>
                           <XMRow>
                             <XMCell align="center">
-                              <XMDual role="UNKNOWN">
-                                <XMTok meaning="imaginary-unit" name="lx@physics@iunit" role="UNKNOWN"/>
-                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">i</XMTok>
-                              </XMDual>
+                              <XMTok font="italic" fontsize="70%" meaning="imaginary-unit" name="lx@physics@iunit" role="UNKNOWN">i</XMTok>
                             </XMCell>
                             <XMCell align="center">
                               <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>

--- a/t/fonts/mathbbol.xml
+++ b/t/fonts/mathbbol.xml
@@ -10,48 +10,21 @@
       <Math mode="display" tex="\Langle\Eins\Rangle,\qquad\Lbrack\Eins\Rbrack,\qquad\Lparen\Eins\Rparen," xml:id="S0.Ex1.m1">
         <XMath>
           <XMWrap>
-            <XMDual role="OPEN">
-              <XMTok name="Langle" role="OPEN"/>
-              <XMTok font="blackboard" meaning="less-than" role="RELOP">&lt;</XMTok>
-            </XMDual>
-            <XMDual role="UNKNOWN" xml:id="S0.Ex1.m1.1">
-              <XMTok name="Eins" role="UNKNOWN"/>
-              <XMTok font="blackboard" meaning="1" role="NUMBER">1</XMTok>
-            </XMDual>
-            <XMDual role="CLOSE">
-              <XMTok name="Rangle" role="CLOSE"/>
-              <XMTok font="blackboard" meaning="greater-than" role="RELOP">&gt;</XMTok>
-            </XMDual>
+            <XMTok font="italic" meaning="less-than" name="Langle" role="OPEN">&lt;</XMTok>
+            <XMTok font="italic" meaning="1" name="Eins" role="UNKNOWN" xml:id="S0.Ex1.m1.1">1</XMTok>
+            <XMTok font="italic" meaning="greater-than" name="Rangle" role="CLOSE">&gt;</XMTok>
           </XMWrap>
           <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
           <XMWrap>
-            <XMDual role="OPEN">
-              <XMTok name="Lbrack" role="OPEN"/>
-              <XMTok font="blackboard" role="OPEN" stretchy="false">[</XMTok>
-            </XMDual>
-            <XMDual role="UNKNOWN">
-              <XMTok name="Eins" role="UNKNOWN"/>
-              <XMTok font="blackboard" meaning="1" role="NUMBER">1</XMTok>
-            </XMDual>
-            <XMDual role="CLOSE">
-              <XMTok name="Rbrack" role="CLOSE"/>
-              <XMTok font="blackboard" role="CLOSE" stretchy="false">]</XMTok>
-            </XMDual>
+            <XMTok font="italic" name="Lbrack" role="OPEN" stretchy="false">[</XMTok>
+            <XMTok font="italic" meaning="1" name="Eins" role="UNKNOWN">1</XMTok>
+            <XMTok font="italic" name="Rbrack" role="CLOSE" stretchy="false">]</XMTok>
           </XMWrap>
           <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
           <XMWrap>
-            <XMDual role="OPEN">
-              <XMTok name="Lparen" role="OPEN"/>
-              <XMTok font="blackboard" role="OPEN" stretchy="false">(</XMTok>
-            </XMDual>
-            <XMDual role="UNKNOWN">
-              <XMTok name="Eins" role="UNKNOWN"/>
-              <XMTok font="blackboard" meaning="1" role="NUMBER">1</XMTok>
-            </XMDual>
-            <XMDual role="CLOSE">
-              <XMTok name="Rparen" role="CLOSE"/>
-              <XMTok font="blackboard" role="CLOSE" stretchy="false">)</XMTok>
-            </XMDual>
+            <XMTok font="italic" name="Lparen" role="OPEN" stretchy="false">(</XMTok>
+            <XMTok font="italic" meaning="1" name="Eins" role="UNKNOWN">1</XMTok>
+            <XMTok font="italic" name="Rparen" role="CLOSE" stretchy="false">)</XMTok>
           </XMWrap>
           <XMTok role="PUNCT">,</XMTok>
         </XMath>
@@ -89,122 +62,53 @@
               <XMRef idref="S0.Ex2.m1.21"/>
             </XMApp>
             <XMWrap>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.1">
-                <XMTok name="bbalpha" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="alpha" role="UNKNOWN">α</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbalpha" role="UNKNOWN" xml:id="S0.Ex2.m1.1">α</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.2">
-                <XMTok name="bbbeta" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="beta" role="UNKNOWN">β</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbbeta" role="UNKNOWN" xml:id="S0.Ex2.m1.2">β</XMTok>
               <XMTok role="PUNCT">,</XMTok>
               <XMApp xml:id="S0.Ex2.m1.22">
                 <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                <XMDual role="UNKNOWN">
-                  <XMTok name="bbeta" role="UNKNOWN"/>
-                  <XMTok font="blackboard" name="beta" role="UNKNOWN">β</XMTok>
-                </XMDual>
-                <XMDual role="UNKNOWN">
-                  <XMTok name="bbchi" role="UNKNOWN"/>
-                  <XMTok font="blackboard" name="chi" role="UNKNOWN">χ</XMTok>
-                </XMDual>
+                <XMTok font="italic" name="bbeta" role="UNKNOWN">β</XMTok>
+                <XMTok font="italic" name="bbchi" role="UNKNOWN">χ</XMTok>
               </XMApp>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.3">
-                <XMTok name="bbdelta" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="delta" role="UNKNOWN">δ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbdelta" role="UNKNOWN" xml:id="S0.Ex2.m1.3">δ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.4">
-                <XMTok name="bbespilon" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="epsilon" role="UNKNOWN">ϵ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbespilon" role="UNKNOWN" xml:id="S0.Ex2.m1.4">ϵ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.5">
-                <XMTok name="bbgamma" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="gamma" role="UNKNOWN">γ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbgamma" role="UNKNOWN" xml:id="S0.Ex2.m1.5">γ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.6">
-                <XMTok name="bbiota" role="UNKNOWN"/>
-                <XMTok font="blackboard" role="UNKNOWN">i</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbiota" role="UNKNOWN" xml:id="S0.Ex2.m1.6">i</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.7">
-                <XMTok name="bbkappa" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="kappa" role="UNKNOWN">κ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbkappa" role="UNKNOWN" xml:id="S0.Ex2.m1.7">κ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.8">
-                <XMTok name="bblambda" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="lambda" role="UNKNOWN">λ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bblambda" role="UNKNOWN" xml:id="S0.Ex2.m1.8">λ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.9">
-                <XMTok name="bbmu" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="mu" role="UNKNOWN">μ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbmu" role="UNKNOWN" xml:id="S0.Ex2.m1.9">μ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.10">
-                <XMTok name="bbnu" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="nu" role="UNKNOWN">ν</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbnu" role="UNKNOWN" xml:id="S0.Ex2.m1.10">ν</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.11">
-                <XMTok name="bbomega" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="omega" role="UNKNOWN">ω</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbomega" role="UNKNOWN" xml:id="S0.Ex2.m1.11">ω</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.12">
-                <XMTok name="bbphi" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="phi" role="UNKNOWN">ϕ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbphi" role="UNKNOWN" xml:id="S0.Ex2.m1.12">ϕ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.13">
-                <XMTok name="bbpi" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="pi" role="UNKNOWN">π</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbpi" role="UNKNOWN" xml:id="S0.Ex2.m1.13">π</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.14">
-                <XMTok name="bbpsi" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="psi" role="UNKNOWN">ψ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbpsi" role="UNKNOWN" xml:id="S0.Ex2.m1.14">ψ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.15">
-                <XMTok name="bbrho" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="rho" role="UNKNOWN">ρ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbrho" role="UNKNOWN" xml:id="S0.Ex2.m1.15">ρ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.16">
-                <XMTok name="bbsigma" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="sigma" role="UNKNOWN">σ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbsigma" role="UNKNOWN" xml:id="S0.Ex2.m1.16">σ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.17">
-                <XMTok name="bbtau" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="tau" role="UNKNOWN">τ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbtau" role="UNKNOWN" xml:id="S0.Ex2.m1.17">τ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.18">
-                <XMTok name="bbtheta" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="theta" role="UNKNOWN">θ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbtheta" role="UNKNOWN" xml:id="S0.Ex2.m1.18">θ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.19">
-                <XMTok name="bbupsilon" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="upsilon" role="UNKNOWN">υ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbupsilon" role="UNKNOWN" xml:id="S0.Ex2.m1.19">υ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.20">
-                <XMTok name="bbxi" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="xi" role="UNKNOWN">ξ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbxi" role="UNKNOWN" xml:id="S0.Ex2.m1.20">ξ</XMTok>
               <XMTok role="PUNCT">,</XMTok>
-              <XMDual role="UNKNOWN" xml:id="S0.Ex2.m1.21">
-                <XMTok name="bbzeta" role="UNKNOWN"/>
-                <XMTok font="blackboard" name="zeta" role="UNKNOWN">ζ</XMTok>
-              </XMDual>
+              <XMTok font="italic" name="bbzeta" role="UNKNOWN" xml:id="S0.Ex2.m1.21">ζ</XMTok>
             </XMWrap>
           </XMDual>
         </XMath>

--- a/t/fonts/stmaryrd.xml
+++ b/t/fonts/stmaryrd.xml
@@ -17,10 +17,7 @@
             </XMApp>
             <XMWrap>
               <XMApp xml:id="S0.Ex1.m1.1">
-                <XMDual role="RELOP">
-                  <XMTok name="Ydown" role="RELOP"/>
-                  <XMTok class="ltx_nounicode" role="UNKNOWN">\Ydown</XMTok>
-                </XMDual>
+                <XMTok class="ltx_nounicode" font="italic" name="Ydown" role="RELOP">\Ydown</XMTok>
                 <XMTok font="italic" role="UNKNOWN">a</XMTok>
                 <XMTok font="italic" role="UNKNOWN">b</XMTok>
               </XMApp>
@@ -33,10 +30,7 @@
                 </XMApp>
                 <XMWrap>
                   <XMApp xml:id="S0.Ex1.m1.2.1">
-                    <XMDual role="RELOP">
-                      <XMTok name="Yleft" role="RELOP"/>
-                      <XMTok class="ltx_nounicode" role="UNKNOWN">\Yleft</XMTok>
-                    </XMDual>
+                    <XMTok class="ltx_nounicode" font="italic" name="Yleft" role="RELOP">\Yleft</XMTok>
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
                     <XMTok font="italic" role="UNKNOWN">b</XMTok>
                   </XMApp>
@@ -49,10 +43,7 @@
                     </XMApp>
                     <XMWrap>
                       <XMApp xml:id="S0.Ex1.m1.2.2.1">
-                        <XMDual role="RELOP">
-                          <XMTok name="Yright" role="RELOP"/>
-                          <XMTok class="ltx_nounicode" role="UNKNOWN">\Yright</XMTok>
-                        </XMDual>
+                        <XMTok class="ltx_nounicode" font="italic" name="Yright" role="RELOP">\Yright</XMTok>
                         <XMTok font="italic" role="UNKNOWN">a</XMTok>
                         <XMTok font="italic" role="UNKNOWN">b</XMTok>
                       </XMApp>
@@ -222,10 +213,7 @@
             </XMApp>
             <XMWrap>
               <XMApp xml:id="S0.Ex4.m1.1">
-                <XMDual role="ARROW">
-                  <XMTok name="curlyveedownarrow" role="ARROW"/>
-                  <XMTok class="ltx_nounicode" role="UNKNOWN">\curlyveedownarrow</XMTok>
-                </XMDual>
+                <XMTok class="ltx_nounicode" font="italic" name="curlyveedownarrow" role="ARROW">\curlyveedownarrow</XMTok>
                 <XMTok font="italic" role="UNKNOWN">a</XMTok>
                 <XMTok font="italic" role="UNKNOWN">b</XMTok>
               </XMApp>
@@ -238,10 +226,7 @@
                 </XMApp>
                 <XMWrap>
                   <XMApp xml:id="S0.Ex4.m1.2.1">
-                    <XMDual role="ARROW">
-                      <XMTok name="curlyveeuparrow" role="ARROW"/>
-                      <XMTok class="ltx_nounicode" role="UNKNOWN">\curlyveeuparrow</XMTok>
-                    </XMDual>
+                    <XMTok class="ltx_nounicode" font="italic" name="curlyveeuparrow" role="ARROW">\curlyveeuparrow</XMTok>
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
                     <XMTok font="italic" role="UNKNOWN">b</XMTok>
                   </XMApp>
@@ -254,19 +239,13 @@
                     </XMApp>
                     <XMWrap>
                       <XMApp xml:id="S0.Ex4.m1.2.2.1">
-                        <XMDual role="ARROW">
-                          <XMTok name="curlywedgedownarrow" role="ARROW"/>
-                          <XMTok class="ltx_nounicode" role="UNKNOWN">\curlywedgedownarrow</XMTok>
-                        </XMDual>
+                        <XMTok class="ltx_nounicode" font="italic" name="curlywedgedownarrow" role="ARROW">\curlywedgedownarrow</XMTok>
                         <XMTok font="italic" role="UNKNOWN">a</XMTok>
                         <XMTok font="italic" role="UNKNOWN">b</XMTok>
                       </XMApp>
                       <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
                       <XMApp xml:id="S0.Ex4.m1.2.2.2">
-                        <XMDual role="ARROW">
-                          <XMTok name="curlywedgeuparrow" role="ARROW"/>
-                          <XMTok class="ltx_nounicode" role="UNKNOWN">\curlywedgeuparrow</XMTok>
-                        </XMDual>
+                        <XMTok class="ltx_nounicode" font="italic" name="curlywedgeuparrow" role="ARROW">\curlywedgeuparrow</XMTok>
                         <XMTok font="italic" role="UNKNOWN">a</XMTok>
                         <XMTok font="italic" role="UNKNOWN">b</XMTok>
                       </XMApp>
@@ -290,10 +269,7 @@
             </XMApp>
             <XMWrap>
               <XMApp xml:id="S0.Ex5.m1.1">
-                <XMDual role="ARROW">
-                  <XMTok name="fatbslash" role="ARROW"/>
-                  <XMTok class="ltx_nounicode" role="UNKNOWN">\fatbslash</XMTok>
-                </XMDual>
+                <XMTok class="ltx_nounicode" font="italic" name="fatbslash" role="ARROW">\fatbslash</XMTok>
                 <XMTok font="italic" role="UNKNOWN">a</XMTok>
                 <XMTok font="italic" role="UNKNOWN">b</XMTok>
               </XMApp>
@@ -319,10 +295,7 @@
                     </XMApp>
                     <XMWrap>
                       <XMApp xml:id="S0.Ex5.m1.2.2.1">
-                        <XMDual role="ARROW">
-                          <XMTok name="fatslash" role="ARROW"/>
-                          <XMTok class="ltx_nounicode" role="UNKNOWN">\fatslash</XMTok>
-                        </XMDual>
+                        <XMTok class="ltx_nounicode" font="italic" name="fatslash" role="ARROW">\fatslash</XMTok>
                         <XMTok font="italic" role="UNKNOWN">a</XMTok>
                         <XMTok font="italic" role="UNKNOWN">b</XMTok>
                       </XMApp>
@@ -386,10 +359,7 @@
                         <XMApp xml:id="S0.Ex6.m1.3.2.1">
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
                           <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                          <XMDual role="UNKNOWN">
-                            <XMTok name="moo" role="UNKNOWN"/>
-                            <XMTok class="ltx_nounicode" role="UNKNOWN">\moo</XMTok>
-                          </XMDual>
+                          <XMTok class="ltx_nounicode" font="italic" name="moo" role="UNKNOWN">\moo</XMTok>
                           <XMTok font="italic" role="UNKNOWN">b</XMTok>
                         </XMApp>
                         <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
@@ -1169,10 +1139,7 @@
             </XMApp>
             <XMWrap>
               <XMApp xml:id="S0.Ex18.m1.1">
-                <XMDual role="ARROW">
-                  <XMTok name="nnearrow" role="ARROW"/>
-                  <XMTok class="ltx_nounicode" role="UNKNOWN">\nnearrow</XMTok>
-                </XMDual>
+                <XMTok class="ltx_nounicode" font="italic" name="nnearrow" role="ARROW">\nnearrow</XMTok>
                 <XMTok font="italic" role="UNKNOWN">a</XMTok>
                 <XMTok font="italic" role="UNKNOWN">b</XMTok>
               </XMApp>
@@ -1185,10 +1152,7 @@
                 </XMApp>
                 <XMWrap>
                   <XMApp xml:id="S0.Ex18.m1.2.1">
-                    <XMDual role="ARROW">
-                      <XMTok name="nnwarrow" role="ARROW"/>
-                      <XMTok class="ltx_nounicode" role="UNKNOWN">\nnwarrow</XMTok>
-                    </XMDual>
+                    <XMTok class="ltx_nounicode" font="italic" name="nnwarrow" role="ARROW">\nnwarrow</XMTok>
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
                     <XMTok font="italic" role="UNKNOWN">b</XMTok>
                   </XMApp>
@@ -1201,19 +1165,13 @@
                     </XMApp>
                     <XMWrap>
                       <XMApp xml:id="S0.Ex18.m1.2.2.1">
-                        <XMDual role="ARROW">
-                          <XMTok name="ssearrow" role="ARROW"/>
-                          <XMTok class="ltx_nounicode" role="UNKNOWN">\ssearrow</XMTok>
-                        </XMDual>
+                        <XMTok class="ltx_nounicode" font="italic" name="ssearrow" role="ARROW">\ssearrow</XMTok>
                         <XMTok font="italic" role="UNKNOWN">a</XMTok>
                         <XMTok font="italic" role="UNKNOWN">b</XMTok>
                       </XMApp>
                       <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
                       <XMApp xml:id="S0.Ex18.m1.2.2.2">
-                        <XMDual role="ARROW">
-                          <XMTok name="sswarrow" role="ARROW"/>
-                          <XMTok class="ltx_nounicode" role="UNKNOWN">\sswarrow</XMTok>
-                        </XMDual>
+                        <XMTok class="ltx_nounicode" font="italic" name="sswarrow" role="ARROW">\sswarrow</XMTok>
                         <XMTok font="italic" role="UNKNOWN">a</XMTok>
                         <XMTok font="italic" role="UNKNOWN">b</XMTok>
                       </XMApp>
@@ -1375,10 +1333,7 @@
             </XMApp>
             <XMWrap>
               <XMApp xml:id="S0.Ex21.m1.1">
-                <XMDual role="RELOP">
-                  <XMTok name="arrownot" role="RELOP"/>
-                  <XMTok meaning="divide" role="MULOP" width="0pt">/</XMTok>
-                </XMDual>
+                <XMTok font="italic" meaning="divide" name="arrownot" role="RELOP" width="0pt">/</XMTok>
                 <XMTok font="italic" role="UNKNOWN">a</XMTok>
                 <XMTok font="italic" role="UNKNOWN">b</XMTok>
               </XMApp>
@@ -1391,10 +1346,7 @@
                 </XMApp>
                 <XMWrap>
                   <XMApp xml:id="S0.Ex21.m1.2.1">
-                    <XMDual role="RELOP">
-                      <XMTok name="longarrownot" role="RELOP"/>
-                      <XMTok meaning="divide" role="MULOP" width="0pt">/</XMTok>
-                    </XMDual>
+                    <XMTok font="italic" meaning="divide" name="longarrownot" role="RELOP" width="0pt">/</XMTok>
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
                     <XMTok font="italic" role="UNKNOWN">b</XMTok>
                   </XMApp>
@@ -1407,19 +1359,13 @@
                     </XMApp>
                     <XMWrap>
                       <XMApp xml:id="S0.Ex21.m1.2.2.1">
-                        <XMDual role="RELOP">
-                          <XMTok name="Arrownot" role="RELOP"/>
-                          <XMTok meaning="divide" role="MULOP" width="0pt">/</XMTok>
-                        </XMDual>
+                        <XMTok font="italic" meaning="divide" name="Arrownot" role="RELOP" width="0pt">/</XMTok>
                         <XMTok font="italic" role="UNKNOWN">a</XMTok>
                         <XMTok font="italic" role="UNKNOWN">b</XMTok>
                       </XMApp>
                       <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
                       <XMApp xml:id="S0.Ex21.m1.2.2.2">
-                        <XMDual role="RELOP">
-                          <XMTok name="Longarrownot" role="RELOP"/>
-                          <XMTok meaning="divide" role="MULOP" width="0pt">/</XMTok>
-                        </XMDual>
+                        <XMTok font="italic" meaning="divide" name="Longarrownot" role="RELOP" width="0pt">/</XMTok>
                         <XMTok font="italic" role="UNKNOWN">a</XMTok>
                         <XMTok font="italic" role="UNKNOWN">b</XMTok>
                       </XMApp>


### PR DESCRIPTION
Continues the work of #1309 to now also compress duals with single mirrored tokens. 
The changes to the test suite are a very good illustration of the exact effect here.

I stumbled on this while working on the a11y PR #1305 , and wanted to detach it into a standalone PR, to make merging the various pieces easier.