### PR TITLE
Fixes to catcode tables and minor lints

### DIFF
--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -155,7 +155,7 @@ sub getSource {
 
 sub getSourceMouth {
   my ($self) = @_;
-  my $mouth = $$self{mouth};
+  my $mouth  = $$self{mouth};
   my $source = defined $mouth && $mouth->getSource;
   if (!defined($source)) {
     foreach my $frame (@{ $$self{mouthstack} }) {
@@ -212,7 +212,7 @@ our @hold_token = (
   0, 0, 0, 0,
   0, 0, 0, 0,
   0, 0, 1, 0,
-  0, 0, 1);
+  0, 1);
 
 sub readToken {
   my ($self) = @_;
@@ -295,7 +295,7 @@ sub readRawLine {
   my @tokens  = @{ $$self{pushback} };
   my @markers = grep { $_->getCatcode == CC_MARKER } @tokens;
   if (@markers) {    # Whoops, profiling markers!
-    @tokens = grep { $_->getCatcode != CC_MARKER } @tokens;    # Remove
+    @tokens = grep { $_->getCatcode != CC_MARKER } @tokens;                      # Remove
     map { LaTeXML::Core::Definition::stopProfiling($_, 'expand') } @markers; }
   $$self{pushback} = [];
   # If we still have peeked tokens, we ONLY want to combine it with the remainder
@@ -362,7 +362,7 @@ our @balanced_interesting_cc = (
   0, 0, 0, 0,
   0, 0, 0, 0,
   0, 0, 0, 0,
-  0, 0, 1);
+  0, 1);
 
 sub readBalanced {
   my ($self, $expanded) = @_;
@@ -432,7 +432,7 @@ sub readKeyword {
     while (@tomatch && defined($tok = $self->readXToken(0)) && push(@matched, $tok)
       && (uc($tok->getString) eq $tomatch[0])) {
       shift(@tomatch); }
-    return $keyword unless @tomatch;    # All matched!!!
+    return $keyword unless @tomatch;             # All matched!!!
     unshift(@{ $$self{pushback} }, @matched);    # Put 'em back and try next!
   }
   return; }
@@ -610,7 +610,7 @@ sub readFactor {
 sub readNumber {
   my ($self) = @_;
   my $s = $self->readOptionalSigns;
-  if (defined(my $n = $self->readNormalInteger)) { return ($s < 0 ? $n->negate : $n); }
+  if    (defined(my $n = $self->readNormalInteger))  { return ($s < 0 ? $n->negate : $n); }
   elsif (defined($n = $self->readInternalDimension)) { return Number($s * $n->valueOf); }
   elsif (defined($n = $self->readInternalGlue))      { return Number($s * $n->valueOf); }
   else {
@@ -633,11 +633,11 @@ sub readNormalInteger {
     return; }
   elsif (($$token[1] == CC_OTHER) && ($token->getString =~ /^[0-9]$/)) {    # Read decimal literal
     return Number(int($token->getString . $self->readDigits('0-9', 1))); }
-  elsif ($token->equals(T_OTHER("\'"))) {                                   # Read Octal literal
+  elsif ($token->equals(T_OTHER("'"))) {                                    # Read Octal literal
     return Number(oct($self->readDigits('0-7', 1))); }
   elsif ($token->equals(T_OTHER("\""))) {                                   # Read Hex literal
     return Number(hex($self->readDigits('0-9A-F', 1))); }
-  elsif ($token->equals(T_OTHER("\`"))) {                                   # Read Charcode
+  elsif ($token->equals(T_OTHER("`"))) {                                    # Read Charcode
     my $next = $self->readToken;
     my $s    = ($next && $next->getString) || '';
     $s =~ s/^\\//;

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -90,8 +90,8 @@ sub new {
   my $self = bless {    # table => {},
     value   => {}, meaning  => {}, stash  => {}, stash_active => {},
     catcode => {}, mathcode => {}, sfcode => {}, lccode       => {}, uccode => {}, delcode => {},
-    undo => [{ _FRAME_LOCK_ => 1 }], prefixes => {}, status => {},
-    stomach => $options{stomach}, model => $options{model} }, $class;
+    undo    => [{ _FRAME_LOCK_ => 1 }], prefixes => {}, status => {},
+    stomach => $options{stomach},       model    => $options{model} }, $class;
   # Note that "100" is hardwired into TeX, The Program!!!
   $$self{value}{MAX_ERRORS} = [100];
   $$self{value}{VERBOSITY}  = [0];
@@ -107,9 +107,9 @@ sub new {
   if ($options{catcodes} =~ /^(standard|style)/) {
     # Setup default catcodes.
     my %std = ("\\" => CC_ESCAPE, "{" => CC_BEGIN, "}" => CC_END, "\$" => CC_MATH,
-      "\&" => CC_ALIGN, "\r" => CC_EOL,   "#"  => CC_PARAM, "^" => CC_SUPER,
-      "_"  => CC_SUB,   " "  => CC_SPACE, "\t" => CC_SPACE, "%" => CC_COMMENT,
-      "~" => CC_ACTIVE, chr(0) => CC_IGNORE, "\f" => CC_ACTIVE);
+      "&" => CC_ALIGN, "\r" => CC_EOL,   "#"  => CC_PARAM, "^" => CC_SUPER,
+      "_" => CC_SUB,   " "  => CC_SPACE, "\t" => CC_SPACE, "%" => CC_COMMENT,
+      "~" => CC_ACTIVE, chr(0) => CC_ESCAPE, "\f" => CC_ACTIVE);
     map { $$self{catcode}{$_} = [$std{$_}] } keys %std;
     for (my $c = ord('A') ; $c <= ord('Z') ; $c++) {
       $$self{catcode}{ chr($c) } = [CC_LETTER];
@@ -453,7 +453,7 @@ sub lookupDigestableDefinition {
     if (((ref $defn) eq 'LaTeXML::Core::Token')
       # If we're digesting an unexpanded, act like \relax
       && ($lookupname = ($$defn[2] ? '\relax' : $executable_primitive_name[$$defn[1]]))
-      && ($entry = $$self{meaning}{$lookupname})) {
+      && ($entry      = $$self{meaning}{$lookupname})) {
       $defn = $$entry[0]; }
     return $defn; }
   return $token; }
@@ -577,7 +577,7 @@ sub pushDaemonFrame {
         my $type  = ref $value;
         if (($type eq 'HASH') || ($type eq 'ARRAY')) {    # Only concerned with mutable perl data?
                                                           # Local assignment
-          $$frame{$table}{$key} = 1;                      # Note new value in this frame.
+          $$frame{$table}{$key} = 1;                                  # Note new value in this frame.
           unshift(@{ $$hash{$key} }, daemon_copy($value)); } } } }    # And push new binding.
       # Record the contents of LaTeXML::Package::Pool as preloaded
   my $pool_preloaded_hash = { map { $_ => 1 } keys %LaTeXML::Package::Pool:: };
@@ -647,7 +647,7 @@ sub activateScope {
         # Here we ALWAYS push the stashed values into the table
         # since they may be popped off by deactivateScope
         my ($table, $key, $value) = @$entry;
-        $$frame{$table}{$key}++;    # Note that this many values must be undone
+        $$frame{$table}{$key}++;                             # Note that this many values must be undone
         unshift(@{ $$self{$table}{$key} }, $value); } } }    # And push new binding.
   return; }
 

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -137,7 +137,11 @@ my $MAXSTACK = 200;    # [CONSTANT]
 
 # Overly complex, but want to avoid recursion/stack
 my @absorbable_cc = (    # [CONSTANT]
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0);
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+  0, 0, 1, 1,
+  1, 0, 1, 0,
+  0, 0);
 
 sub invokeToken {
   my ($self, $token) = @_;

--- a/lib/LaTeXML/Core/Token.pm
+++ b/lib/LaTeXML/Core/Token.pm
@@ -64,22 +64,22 @@ use constant CC_MARKER => 17;    # non TeX extension!
 # [The documentation for constant is a bit confusing about subs,
 # but these apparently DO generate constants; you always get the same one]
 # These are immutable
-use constant T_BEGIN => bless ['{',  1],  'LaTeXML::Core::Token';
-use constant T_END   => bless ['}',  2],  'LaTeXML::Core::Token';
-use constant T_MATH  => bless ['$',  3],  'LaTeXML::Core::Token';
-use constant T_ALIGN => bless ['&',  4],  'LaTeXML::Core::Token';
-use constant T_PARAM => bless ['#',  6],  'LaTeXML::Core::Token';
-use constant T_SUPER => bless ['^',  7],  'LaTeXML::Core::Token';
-use constant T_SUB   => bless ['_',  8],  'LaTeXML::Core::Token';
-use constant T_SPACE => bless [' ',  10], 'LaTeXML::Core::Token';
-use constant T_CR    => bless ["\n", 10], 'LaTeXML::Core::Token';
-sub T_LETTER { my ($c) = @_; return bless [$c, 11], 'LaTeXML::Core::Token'; }
-sub T_OTHER  { my ($c) = @_; return bless [$c, 12], 'LaTeXML::Core::Token'; }
-sub T_ACTIVE { my ($c) = @_; return bless [$c, 13], 'LaTeXML::Core::Token'; }
-sub T_COMMENT { my ($c) = @_; return bless ['%' . ($c || ''), 14], 'LaTeXML::Core::Token'; }
-sub T_CS { my ($c) = @_; return bless [$c, 16], 'LaTeXML::Core::Token'; }
+use constant T_BEGIN => bless ['{',  CC_BEGIN], 'LaTeXML::Core::Token';
+use constant T_END   => bless ['}',  CC_END],   'LaTeXML::Core::Token';
+use constant T_MATH  => bless ['$',  CC_MATH],  'LaTeXML::Core::Token';
+use constant T_ALIGN => bless ['&',  CC_ALIGN], 'LaTeXML::Core::Token';
+use constant T_PARAM => bless ['#',  CC_PARAM], 'LaTeXML::Core::Token';
+use constant T_SUPER => bless ['^',  CC_SUPER], 'LaTeXML::Core::Token';
+use constant T_SUB   => bless ['_',  CC_SUB],   'LaTeXML::Core::Token';
+use constant T_SPACE => bless [' ',  CC_SPACE], 'LaTeXML::Core::Token';
+use constant T_CR    => bless ["\n", CC_SPACE], 'LaTeXML::Core::Token';
+sub T_LETTER { my ($c) = @_; return bless [$c, CC_LETTER], 'LaTeXML::Core::Token'; }
+sub T_OTHER  { my ($c) = @_; return bless [$c, CC_OTHER],  'LaTeXML::Core::Token'; }
+sub T_ACTIVE { my ($c) = @_; return bless [$c, CC_ACTIVE], 'LaTeXML::Core::Token'; }
+sub T_COMMENT { my ($c) = @_; return bless ['%' . ($c || ''), CC_COMMENT], 'LaTeXML::Core::Token'; }
+sub T_CS { my ($c) = @_; return bless [$c, CC_CS], 'LaTeXML::Core::Token'; }
 # Illegal: don't use unless you know...
-sub T_MARKER { my ($t) = @_; return bless [$t, 17], 'LaTeXML::Core::Token'; }
+sub T_MARKER { my ($t) = @_; return bless [$t, CC_MARKER], 'LaTeXML::Core::Token'; }
 
 sub Token {
   my ($string, $cc) = @_;
@@ -143,7 +143,7 @@ sub UnTeX {
     if ($cc == CC_END) { $level--; }
     $prevs = $s; $prevcc = $cc; }
   # Patch up nesting for valid TeX !!!
-  if ($level > 0) { $string = $string . ('}' x $level); }
+  if    ($level > 0) { $string = $string . ('}' x $level); }
   elsif ($level < 0) { $string = ('{' x -$level) . $string; }
   return $string; }
 
@@ -156,32 +156,33 @@ our @primitive_catcode = (    # [CONSTANT]
   1, 1, 1, 1,
   1, 0, 1, 0,
   0, 0, 0, 0,
-  0);
+  0, 0);
 our @executable_catcode = (    # [CONSTANT]
   0, 1, 1, 1,
   1, 0, 0, 1,
   1, 0, 0, 0,
   0, 1, 0, 0,
-  1);
+  1, 0);
 
 our @standardchar = (          # [CONSTANT]
   "\\",  '{',   '}',   q{$},
   q{&},  "\n",  q{#},  q{^},
   q{_},  undef, undef, undef,
-  undef, undef, q{%},  undef);
+  undef, undef, q{%},  undef,
+  undef, undef);
 
 our @CC_NAME =                 #[CONSTANT]
   qw(Escape Begin End Math
   Align EOL Parameter Superscript
   Subscript Ignore Space Letter
   Other Active Comment Invalid
-  ControlSequence);
+  ControlSequence Marker);
 our @PRIMITIVE_NAME = (        # [CONSTANT]
   'Escape',    'Begin', 'End',       'Math',
   'Align',     'EOL',   'Parameter', 'Superscript',
   'Subscript', undef,   'Space',     undef,
   undef,       undef,   undef,       undef,
-  undef);
+  undef,       undef);
 our @CC_SHORT_NAME =           #[CONSTANT]
   qw(T_ESCAPE T_BEGIN T_END T_MATH
   T_ALIGN T_EOL T_PARAM T_SUPER
@@ -240,7 +241,7 @@ my @NEUTRALIZABLE = (    # [CONSTANT]
   1, 0, 1, 1,
   1, 0, 0, 0,
   0, 1, 0, 0,
-  0);
+  0, 0);
 
 # neutralize really should only retroactively imitate what Semiverbatim would have done.
 # So, it needs to neutralize those in SPECIALS


### PR DESCRIPTION
Starting to put small piecemeal PRs to disentangle my expl3 work into acceptable chunks...

The first bit is correcting the catcode tables - we currently have 18 catcodes in Token.pm, indexed 0 through 17, and any catcode table should have exactly 18 elements, ideally chunked 4 per line, with a last line of 2 elements. I believe two of the Gullet tables had typos, as they trated Marker as array element 18 instead of 17, which spurred this. It became painfully clear when I added a new catcode and things were breaking. 

I also eliminated the use of raw integers in Token.pm for the `T_` constructors and relied on the `CC_` constants instead, to protect from possible typos.

Lastly, the linter warned me that the escapes `\'` and ``` \` ``` do not exist, so I dropped those backslashes from Gullet.pm