### PR TITLE
update mathjax url to recommended latest CDN

### DIFF
--- a/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
+++ b/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
@@ -3,7 +3,7 @@
 
 (function() {
     var mathjax_url =
-        "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=MML_HTMLorMML";
+        "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js?config=MML_HTMLorMML";
 
     function refreshMath() {
         // Maybe unnecessary, or overkill, but...


### PR DESCRIPTION
Updates mathjax to latest CDN recommended by mathjax documentation [here](http://docs.mathjax.org/en/latest/web/start.html#using-mathjax-from-a-content-delivery-network-cdn).