### PR TITLE
upgrades to \meaning, \show-like macros, writableTokens

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2164,7 +2164,7 @@ DefPrimitive('\endgroup',   sub { $_[0]->endgroup; });
 # Debugging aids; Ignored!
 DefPrimitive('\show Token', sub {
     my $stuff = Invocation(T_CS('\meaning'), $_[1]);
-    print STDERR "\n> " . ($_[1][1] == CC_CS ? ToString($_[1]) . '=' : '') . writableTokens(Expand($stuff), 1) . ".\n";
+    print STDERR "\n> " . ($_[1][1] == CC_CS ? ToString($_[1]) . '=' : '') . writableTokens(Expand($stuff)) . ".\n";
     print STDERR $_[0]->getLocator->toString() . "\n\n";
     return; });
 DefPrimitive('\showbox Number', undef);
@@ -2215,19 +2215,23 @@ DefPrimitive('\lowercase GeneralText', sub {
 # doubles #, converts to string; optionally adds spaces after control sequences
 # in the spirit of the B Book, "show_token_list" routine, in 292.
 sub writableTokens {
-  my ($tokens, $addspaces) = @_;
+  my ($tokens) = @_;
   my @tokens = $tokens->unlist;
-# unwrap a \noexpand-created \relax to its actual content, to avoid confusing users with a \relax dontexpand
-  @tokens = map { $$_[2] || $_ } @tokens;
-  if ($addspaces) {
-    @tokens = map { $_->getCatcode == CC_CS ? ($_, T_SPACE) : $_ } @tokens; }
-  @tokens = map { $_->getCatcode == CC_PARAM ? ($_, $_) : $_ } @tokens;
+  # unwrap a \noexpand-created \relax to its actual content,
+  # to avoid confusing users with a \relax dontexpand
+  @tokens = map {
+    my $t  = ($$_[2] || $_);
+    my $cc = $$t[1];
+    if    ($cc == CC_CS)    { ($t, T_SPACE); }
+    elsif ($cc == CC_PARAM) { ($t, $t); }
+    else                    { $t; }
+  } @tokens;
   return UnTeX(Tokens(@tokens)); }
 
 DefPrimitive('\message{}', sub {
     my ($stomach, $stuff) = @_;
     return if LookupValue('VERBOSITY') <= -1;
-    print STDERR writableTokens(Expand($stuff), 1);
+    print STDERR writableTokens(Expand($stuff));
     return; });
 
 DefRegister('\errhelp' => Tokens());

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -311,8 +311,8 @@ DefRegisterI('\lx@DUMMY@REGISTER', undef, Tokens());
 # Read a variable, ie. a token (after expansion) that is a writable register.
 DefParameterType('Variable', sub {
     my ($gullet) = @_;
-    my $token = $gullet->readXToken;
-    my $defn = $token && LookupDefinition($token);
+    my $token    = $gullet->readXToken;
+    my $defn     = $token && LookupDefinition($token);
     if ((defined $defn) && $defn->isRegister && !$defn->isReadonly) {
       [$defn, $defn->readArguments($gullet)]; }
     else {
@@ -337,8 +337,8 @@ DefParameterType('Variable', sub {
 # Same, but not necessarily writable
 DefParameterType('Register', sub {
     my ($gullet) = @_;
-    my $token = $gullet->readXToken;
-    my $defn = $token && LookupDefinition($token);
+    my $token    = $gullet->readXToken;
+    my $defn     = $token && LookupDefinition($token);
     if ((defined $defn) && $defn->isRegister) {
       [$defn, $defn->readArguments($gullet)]; }
     else {
@@ -831,9 +831,11 @@ DefMacro('\meaning Token', sub {
         $type =~ s/^LaTeXML:://; }
       # The actual tests start here
       if ($type =~ /token$/i) {
-        my $cc   = $definition->getCatcode;
-        my $char = $definition->getString;
-        $meaning = ($CATCODE_MEANING[$cc] || '') . ' ' . ($cc == CC_SPACE ? ' ' : $char); }
+        my $cc         = $definition->getCatcode;
+        my $char       = $definition->getString;
+        my $meaning_cc = $CATCODE_MEANING[$cc] || '';
+        $meaning_cc .= ' ' if $meaning_cc;    # append space separator if defined
+        $meaning = $meaning_cc . $char; }
       elsif ($type =~ /register$/i) {
         my $value         = $definition->valueOf;
         my $register_type = lc(ref $value);
@@ -846,22 +848,29 @@ DefMacro('\meaning Token', sub {
         # Should we be more careful to distinguish between latex and tex counters?
         $meaning = $prefix . $literal_value; }
       elsif ($type =~ /expandable$/i) {
-        my $expansion = $definition->getExpansion;
-        my $ltxps     = $definition->getParameters;
-        my @params;
-        my $argcount = 0;
-        if (defined $ltxps) {
-          @params   = $ltxps->getParameters;
-          $argcount = $ltxps->getNumArgs;
-        }
-        my $sp;
-        my @specparts = map { (($sp = $_->{spec}) =~ s/^(\w+):// ? $sp : $sp) } @params;
-        my $arg       = 1;
-        foreach (@specparts) {
-          last if ($arg > $argcount);
-          $_ .= "#$arg";
-          $arg++; }
-        my $spec = join("", @specparts);
+        my $expansion  = $definition->getExpansion;
+        my $ltxps      = $definition->getParameters;
+        my $arg_index  = 0;
+        my @spec_parts = ();
+        my @params     = $ltxps ? $ltxps->getParameters : ();
+        my $p_trailer  = '';
+        for my $param (@params) {
+          my $p_spec = $$param{spec};
+          if ($p_spec eq 'RequireBrace') {
+            # tex's \meaning prints out the required braces for "\def\a#{}" variants
+            $p_trailer = '{';
+            $p_spec    = '{'; }
+          elsif ($p_spec eq 'UntilBrace') {    # should only ever be used in the last argument?
+            $p_trailer = '{';
+            $p_spec    = "#" . (++$arg_index) . '{'; }
+          elsif ($p_spec =~ s/^Match://) { }          # just match, don't increment arg index
+          elsif ($p_spec =~ s/^\w?Until(\w*)://) {    # implied argument at this slot
+            $p_spec = "#" . (++$arg_index) . $p_spec; }
+          else {                                      # regular parameter, increment
+            next if $$param{novalue}; # skip the latexml-only requirement params, but only here, since Match also have "novalue" set.
+            $p_spec = "#" . (++$arg_index); }
+          push @spec_parts, $p_spec; }
+        my $spec = join("", @spec_parts);
         $spec =~ s/\{\}//g;
         $spec =~ s/Token//g;
         my $prefixes = join('',
@@ -869,16 +878,24 @@ DefMacro('\meaning Token', sub {
           ($definition->isLong      ? '\long'      : ()),
           ($definition->isOuter     ? '\outer'     : ()),
         );
-        $meaning = ($prefixes ? $prefixes . ' ' : '') . "macro:" . ToString($spec) . "->" . ToString($expansion); }
+        my $expansion_str = '';
+        if (ref $expansion eq 'LaTeXML::Core::Tokens') {
+          for my $t (@$expansion) {
+            $expansion_str .= $$t[0];
+            if (@$expansion && $$t[1] == CC_CS) {
+              $expansion_str .= ' '; } } }
+        else {
+          $expansion_str = ToString($expansion); }
+        $meaning = ($prefixes ? $prefixes . ' ' : '') .
+          "macro:$spec->$expansion_str$p_trailer"; }
       elsif ($type =~ /chardef$/i) {    # from \mathchardef and the like.
         my $prefix = '\char';
         if ($$definition{internalcs} && $$definition{internalcs}->getCSName =~ /^\\\@mathchardef/) {
           $prefix = '\mathchar'; }
-        $meaning = $prefix . '"' . $definition->valueOf->valueOf; }
-      Explode($meaning); }
-    else {
-      Explode('undefined'); } });
-
+        $meaning = $prefix . '"' . $definition->valueOf->valueOf; } }
+    # One catch: make sure all \s in the meaning string are normalized to a simple space ' '
+    $meaning =~ s/\s/ /g;
+    return Explode($meaning); });
 DefParameterType('CSName', sub {
     my ($gullet) = @_;
     my $token;
@@ -1000,10 +1017,10 @@ DefRegister('\tracingcommands', Number(0),
 
 {
   my %iparms = (
-    pretolerance => 100, tolerance     => 200, hbadness            => 1000, vbadness => 1000,
-    linepenalty  => 10,  hyphenpenalty => 50,  exhyphenpenalty     => 50,
-    binoppenalty => 700, relpenalty    => 500,
-    clubpenalty  => 150, widowpenalty  => 150, displaywidowpenalty => 50,
+    pretolerance => 100, tolerance     => 200, hbadness        => 1000, vbadness => 1000,
+    linepenalty  => 10,  hyphenpenalty => 50,  exhyphenpenalty => 50,
+    binoppenalty         => 700,   relpenalty          => 500,
+    clubpenalty          => 150,   widowpenalty        => 150, displaywidowpenalty => 50,
     brokenpenalty        => 100,   predisplaypenalty   => 10000,
     postdisplaypenalty   => 0,     interlinepenalty    => 0,
     floatingpenalty      => 0,     outputpenalty       => 0,
@@ -1500,10 +1517,10 @@ DefParameterType('FontToken', sub {
     $token; });    #?
 DefRegister('\fontdimen Number FontToken' => Dimension(0),
   getter => sub { my $p = ToString($_[0]);
-    if    ($p == 2) { Dimension('0.5em'); }    # interword space
+    if ($p == 2)    { Dimension('0.5em'); }    # interword space
     elsif ($p == 5) { Dimension('1ex'); }      # x-height
     elsif ($p == 6) { Dimension('1em'); }      # quad width
-    else { Dimension(0); } });
+    else            { Dimension(0); } });
 
 #   Could be handled by setting dimensions whenever the box itself is set?
 
@@ -1787,8 +1804,8 @@ DefConstructor('\mathaccent Number Digested',
     my ($stomach, $whatsit) = @_;
     my $n = $whatsit->getArg(1)->valueOf;
     my ($role, $glyph) = decodeMathChar($n);
-    $whatsit->setProperty(glyph => $glyph) if $glyph;
-    $whatsit->setProperty(font => LookupValue('font')->specialize($glyph)) if $glyph;
+    $whatsit->setProperty(glyph => $glyph)                                  if $glyph;
+    $whatsit->setProperty(font  => LookupValue('font')->specialize($glyph)) if $glyph;
     return; });
 
 # <box> = \box <8bit> | \copy <8bit> | \lastbox | \vsplit <8bit> to <dimen>
@@ -1845,7 +1862,7 @@ sub readBoxContents {
   my ($gullet, $everybox) = @_;
   my $t;
   while (($t = $gullet->readToken) && !Equals($t, T_BEGIN)) { }    # Skip till { or \bgroup
-          # Now, insert some extra tokens, if any, possibly from \afterassignment
+      # Now, insert some extra tokens, if any, possibly from \afterassignment
   if (my $token = LookupValue('BeforeNextBox')) {
     AssignValue(BeforeNextBox => undef, 'global');
     $gullet->unread($token); }
@@ -1902,7 +1919,7 @@ DefConstructor('\hbox BoxSpecification HBoxContents', sub {
     my $issvg = $current && $document->getNodeQName($current) =~ /^svg:/;
     my $vmode = $current && $current->getAttribute('_vertical_mode_');
     my $newtag = ($issvg ? 'svg:g' : ($vmode ? 'ltx:p' : 'ltx:text'));
-    my $node = $document->openElement($newtag, _noautoclose => 1,
+    my $node   = $document->openElement($newtag, _noautoclose => 1,
       width => $props{width});
 
     $document->absorb($contents);
@@ -2145,7 +2162,11 @@ DefPrimitive('\begingroup', sub { $_[0]->begingroup; });
 DefPrimitive('\endgroup',   sub { $_[0]->endgroup; });
 
 # Debugging aids; Ignored!
-DefPrimitive('\show Token',     undef);
+DefPrimitive('\show Token', sub {
+    my $stuff = Invocation(T_CS('\meaning'), $_[1]);
+    print STDERR "\n> " . ($_[1][1] == CC_CS ? ToString($_[1]) . '=' : '') . writableTokens(Expand($stuff), 1) . ".\n";
+    print STDERR $_[0]->getLocator->toString() . "\n\n";
+    return; });
 DefPrimitive('\showbox Number', undef);
 DefPrimitive('\showlists',      undef);
 DefPrimitive('\showthe Token',  undef);
@@ -2192,9 +2213,12 @@ DefPrimitive('\lowercase GeneralText', sub {
 
 # Converts $tokens to a string in the fashion of \message and others:
 # doubles #, converts to string; optionally adds spaces after control sequences
+# in the spirit of the B Book, "show_token_list" routine, in 292.
 sub writableTokens {
   my ($tokens, $addspaces) = @_;
   my @tokens = $tokens->unlist;
+# unwrap a \noexpand-created \relax to its actual content, to avoid confusing users with a \relax dontexpand
+  @tokens = map { $$_[2] || $_ } @tokens;
   if ($addspaces) {
     @tokens = map { $_->getCatcode == CC_CS ? ($_, T_SPACE) : $_ } @tokens; }
   @tokens = map { $_->getCatcode == CC_PARAM ? ($_, $_) : $_ } @tokens;
@@ -2202,7 +2226,7 @@ sub writableTokens {
 
 DefPrimitive('\message{}', sub {
     my ($stomach, $stuff) = @_;
-    return unless LookupValue('VERBOSITY') > -1;
+    return if LookupValue('VERBOSITY') <= -1;
     print STDERR writableTokens(Expand($stuff), 1);
     return; });
 
@@ -2248,7 +2272,7 @@ DefPrimitive('\read Number SkipKeyword:to SkipSpaces Token', sub {
         push(@tokens, $t);
         $level++ if $cc == CC_BEGIN;
         $level-- if $cc == CC_END;
-        last if !$level && $mouth->isEOL; }
+        last     if !$level && $mouth->isEOL; }
       $stomach->egroup;
       @tokens = (T_CS('\par')) unless @tokens;    # trailing blank line
       DefMacroI($token, undef, Tokens(@tokens)); }
@@ -2848,7 +2872,7 @@ DefPrimitiveI('\@@open@inner@column', undef, sub {
                                     # Scan for leading \omit, skipping over (& saving) \hline.
 
     while (my $tok = $gullet->readXToken(0, 0)) {
-      if ($tok->equals(T_SPACE)) { }    # Skip leading space
+      if ($tok->equals(T_SPACE)) { }                      # Skip leading space
       elsif (grep { $tok->equals($_) } @line_tokens) {    # Save line commands
         push(@lines, $stomach->invokeToken($tok)); }
       elsif (Equals($tok, T_BEGIN)) {                     # Crazy... seems { doesn't "block" \omit!
@@ -3300,7 +3324,7 @@ sub add_TeX {
     my $tex = UnTeX($thing);
     $LaTeXML::DUAL_BRANCH = 'content';
     my $ctex = UnTeX($thing);
-    $document->setAttribute($node, tex => $tex);
+    $document->setAttribute($node, tex           => $tex);
     $document->setAttribute($node, 'content-tex' => $ctex) if $ctex ne $tex; }
   return; }
 
@@ -3313,7 +3337,7 @@ sub add_body_TeX {
       my $tex = UnTeX($body);
       $LaTeXML::DUAL_BRANCH = 'content';
       my $ctex = UnTeX($body);
-      $document->setAttribute($node, tex => $tex);
+      $document->setAttribute($node, tex           => $tex);
       $document->setAttribute($node, 'content-tex' => $ctex) if $ctex ne $tex; } }
   return; }
 
@@ -3648,7 +3672,7 @@ sub equationgroupJoinRows {
 # which contain several columns, each pair of which represent a semantic equation.
 sub equationgroupJoinCols {
   my ($document, $ncols, $equation) = @_;
-  my ($col, $main, $branch) = (0, undef, undef);
+  my ($col,      $main,  $branch)   = (0, undef, undef);
   foreach my $cell ($document->findnodes('ltx:_Capture_', $equation)) {
     next unless $document->getNodeQName($cell) =~ /(.*?:)?_Capture_$/;
     if (($col++ % $ncols) == 0) {    # Create new MathFork every $ncols cells.
@@ -3678,7 +3702,7 @@ DefMacroI('\eqno', undef, sub {
         push(@stuff, $t, $gullet->readBalanced); }
       # What do I need to explicitly list here!?!?!? UGGH!
       elsif (Equals($t, T_MATH) || Equals($t, T_CS('\]')) || Equals($t, T_CS('\@@ENDDISPLAYMATH'))
-        || Equals($t, T_CS('\begingroup'))    # Totally wrong, but to catch expanded environments
+        || Equals($t, T_CS('\begingroup'))           # Totally wrong, but to catch expanded environments
         || (ToString($t) =~ /^\\(?:begin|end)\{/)    # any sort of environ begin or end???
                                                      # This seems needed within AmSTeX environs
         || Equals($t, T_CS('\@@close@inner@column'))
@@ -3786,7 +3810,7 @@ sub scriptHandler {
     # Parsing is too late!
     while (my $prev = pop(@LaTeXML::LIST)) {
       if ((ref $prev eq 'LaTeXML::Core::Whatsit') && $prev->getProperty('isSpace')) {
-        $prevspace = 1;    # a space avoids double-scripts
+        $prevspace = 1;              # a space avoids double-scripts
         unshift(@putback, $prev);    # put back? assuming it will add rpadding to previous???
         next; }
       elsif (IsEmpty($prev)) {       # If empty, the script floats, can't conflict, but don't put back
@@ -3879,7 +3903,7 @@ sub scriptSizer {
   # Fishing for the scriptpos on the base (if any)
   my $attr;
   $pos = $base->getProperty('scriptpos') if !defined $pos && defined $base;
-  $pos = 'post' if !defined $pos;
+  $pos = 'post'                          if !defined $pos;
   if ($pos eq 'mid') {
     $w = max(0, $ws - $wb);              # as if max width of base & script
     if ($op eq 'SUPERSCRIPT') {
@@ -4080,7 +4104,7 @@ DefConstructor('\lx@generalized@over Undigested RequiredKeyVals',
     my $role      = ToString($kv->getValue('role'));
     my $meaning   = ToString($kv->getValue('meaning'));
     my $thickness = ToString($kv->getValue('thickness'));
-    $role = 'FRACOP' unless $role;
+    $role    = 'FRACOP' unless $role;
     $meaning = 'divide' if (!$meaning) && ($thickness ne '0pt');
     # Unfortunately, the numerator's already digested! We have to adjust it's mathstyle
     my @top = $stomach->regurgitate;
@@ -4104,7 +4128,7 @@ DefConstructor('\lx@generalized@over Undigested RequiredKeyVals',
     return $closing; },    # and leave the closing bit, whatever it is.
   properties => sub { %{ $_[2]->getKeyVals }; },
   sizer      => sub { fracSizer($_[0]->getProperty('top'), $_[0]->getProperty('bottom')); },
-  reversion => sub {
+  reversion  => sub {
     my ($whatsit) = @_;
     (Revert($whatsit->getProperty('top')),
       $whatsit->getArg(1)->unlist,
@@ -4296,7 +4320,7 @@ DefMathLigature(matcher => sub { my ($document, $node) = @_;
         # if thousands separator (but NOT simultaneously PUNCT!!!! Be paranoid about lists)
         elsif (($text eq $thou) && ($r ne 'PUNCT')) {
           $string = $text . $string; }    # Add to string, but omit from number
-                                          # if decimal separator, turn it into "standard" "."
+                                                         # if decimal separator, turn it into "standard" "."
         elsif (($text eq $dec) || ($r eq $decrole)) {    # was $r eq 'PERIOD'
           $string = $node->textContent . $string;
           $number = '.' . $number; }
@@ -4403,7 +4427,7 @@ DefPrimitive('\newbox    Token', sub {
     AssignValue("box$n", List());
     DefRegisterI($_[1], undef, Number($n), readonly => 1); });
 DefPrimitive('\newhelp Token {}', sub { AssignValue(ToString($_[1]) => $_[2]); });
-DefPrimitive('\newtoks Token', sub { DefRegisterI($_[1], undef, Tokens()); });
+DefPrimitive('\newtoks Token',    sub { DefRegisterI($_[1], undef, Tokens()); });
 # the next 4 actually work by doing a \chardef instead of \countdef, etc.
 # which means they actually work quite differently
 DefRegister('\allocationnumber' => Number(0));
@@ -5133,7 +5157,7 @@ DefAccent('\t', "\x{0361}", "-");    # COMBINING DOUBLE INVERTED BREVE & ???? Wh
       # this one's actually defined in mathscinet.sty, but just stick it here!
 DefAccent('\lfhook', "\x{0326}", ",", below => 1);   # COMBINING COMMA BELOW
                                                      # I doubt that latter covers multiple chars...?
-        #DefAccent('\bar',"\x{0304}", ?);  # COMBINING MACRON or is this the longer overbar?
+       #DefAccent('\bar',"\x{0304}", ?);  # COMBINING MACRON or is this the longer overbar?
 
 # This will fail if there really are "assignments" after the number!
 # We're given a number pointing into the font, from which we can derive the standalone char.
@@ -5316,10 +5340,10 @@ DefMathI('\hbar',  undef, "\x{210F}", role => 'ID', meaning => 'Planck-constant-
 DefMathI('\imath', undef, "\x{0131}");
 DefMathI('\jmath', undef, "\x{0237}");
 DefMathI('\ell',   undef, "\x{2113}");
-DefMathI('\wp', undef, "\x{2118}", meaning => 'Weierstrass-p');
-DefMathI('\Re', undef, "\x{211C}", role    => 'OPFUNCTION', meaning => 'real-part');
-DefMathI('\Im', undef, "\x{2111}", role    => 'OPFUNCTION', meaning => 'imaginary-part');
-DefMathI('\mho', undef, "\x{2127}");
+DefMathI('\wp',    undef, "\x{2118}", meaning => 'Weierstrass-p');
+DefMathI('\Re',    undef, "\x{211C}", role => 'OPFUNCTION', meaning => 'real-part');
+DefMathI('\Im',    undef, "\x{2111}", role => 'OPFUNCTION', meaning => 'imaginary-part');
+DefMathI('\mho',   undef, "\x{2127}");
 
 DefMathI('\prime',    undef, "\x{2032}", role => 'SUPOP',    locked  => 1);
 DefMathI('\emptyset', undef, "\x{2205}", role => 'ID',       meaning => 'empty-set');
@@ -5343,7 +5367,7 @@ DefMathI('\backslash', undef, UTF(0x5C), role => 'MULOP');
 DefMathI('\partial',   undef, "\x{2202}", role => 'OPERATOR', meaning => 'partial-differential');
 
 DefMathI('\infty', undef, "\x{221E}", role => 'ID', meaning => 'infinity');
-DefMathI('\Box', undef, "\x{25A1}");
+DefMathI('\Box',         undef, "\x{25A1}");
 DefMathI('\Diamond',     undef, "\x{25C7}");
 DefMathI('\triangle',    undef, "\x{25B3}");
 DefMathI('\clubsuit',    undef, "\x{2663}");
@@ -5465,7 +5489,7 @@ DefMathI('\times', undef, UTF(0xD7),  role => 'MULOP', meaning => 'times');
 DefMathI('\div',   undef, UTF(0xF7),  role => 'MULOP', meaning => 'divide');
 DefMathI('\ast',   undef, "\x{2217}", role => 'MULOP');
 DefMathI('\star',  undef, "\x{22C6}", role => 'MULOP');
-DefMathI('\circ',  undef, "\x{2218}", role => 'MULOP', meaning => 'compose');
+DefMathI('\circ', undef, "\x{2218}", role => 'MULOP', meaning => 'compose');
 DefMathI('\bullet', undef, "\x{2219}", role => 'MULOP');
 DefMathI('\cdot',   undef, "\x{22C5}", role => 'MULOP');
 ##  , meaning=>'inner-product');  that's pushing it a bit far...
@@ -5498,7 +5522,7 @@ DefMathI('\oplus',  undef, "\x{2295}", role => 'ADDOP', meaning => 'direct-sum')
 DefMathI('\ominus', undef, "\x{2296}", role => 'ADDOP', meaning => 'symmetric-difference');
 DefMathI('\otimes', undef, "\x{2297}", role => 'MULOP', meaning => 'tensor-product');
 DefMathI('\oslash', undef, "\x{2298}", role => 'MULOP');
-DefMathI('\odot',   undef, "\x{2299}", role => 'MULOP', meaning => 'direct-product');
+DefMathI('\odot', undef, "\x{2299}", role => 'MULOP', meaning => 'direct-product');
 DefMathI('\bigcirc', undef, "\x{25CB}", role => 'MULOP');
 DefMathI('\dagger',  undef, "\x{2020}", role => 'MULOP');
 DefMathI('\ddagger', undef, "\x{2021}", role => 'MULOP');
@@ -5727,13 +5751,13 @@ DefConstructorI('\vdots', undef,
       ? (font => LookupValue('font')->merge(family => 'serif',
           series => 'medium', shape => 'upright')->specialize("\x{22EE}"))
       : ()); });    # Since not DefMath!
-                    # But not these!
+                                                        # But not these!
 DefMathI('\cdots', undef, "\x{22EF}", role => 'ID');    # MIDLINE HORIZONTAL ELLIPSIS
 
 DefMathI('\ddots', undef, "\x{22F1}", role => 'ID');           # DOWN RIGHT DIAGONAL ELLIPSIS
 DefMathI('\colon', undef, ':',        role => 'METARELOP');    # Seems like good default role
-        # Note that amsmath redefines \dots to be `smart'.
-        # Aha, also can be in text...
+    # Note that amsmath redefines \dots to be `smart'.
+    # Aha, also can be in text...
 DefConstructorI('\dots', undef,
   "?#isMath(<ltx:XMTok name='dots' font='#font' role='ID'>\x{2026}</ltx:XMTok>)(\x{2026})",
   properties => sub {
@@ -6165,7 +6189,7 @@ DefKeyVal('lx@GEN', 'style', 'UndigestedKey');
 DefPrimitive('\lx@gen@matrix@bindings RequiredKeyVals:lx@GEN', sub {
     my ($stomach, $kv) = @_;
     $stomach->bgroup;
-    my $style = $kv->getValue('style') || T_CS('\textstyle');
+    my $style = $kv->getValue('style')               || T_CS('\textstyle');
     my $align = ToString($kv->getValue('alignment')) || 'c';
     # We really should be using ReadAlignmentTemplate (LaTeXML::Core::Alignment)
     # but we'd have to convert it to a repeating spec somehow.
@@ -6604,7 +6628,7 @@ Let('\@currext',  '\@empty');
 # Returning a call to this utility from Primitives will add a preamble Processing Instruction
 sub AddToPreamble {
   my ($cs, @args) = @_;
-  Digest(Invocation(T_CS('\lx@add@Preamble@PI'), Invocation((ref $cs ? $cs : T_CS($cs)), @args))); }
+  return Digest(Invocation(T_CS('\lx@add@Preamble@PI'), Invocation((ref $cs ? $cs : T_CS($cs)), @args))); }
 
 DefConstructor('\lx@add@Preamble@PI Undigested',
   "<?latexml preamble='#1'?>");
@@ -6855,7 +6879,7 @@ sub setAlignOrClass {
   my ($document, $node, $align, $class) = @_;
   my $model = $document->getModel;
   my $qname = $model->getNodeQName($node);
-  if ($qname eq 'ltx:tag') { }    # HACK
+  if ($qname eq 'ltx:tag') { }                                       # HACK
   elsif ($align && $document->canHaveAttribute($qname, 'align')) {
     $node->setAttribute(align => $align); }
   elsif ($class && $document->canHaveAttribute($qname, 'class')) {

--- a/lib/LaTeXML/Package/eTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/eTeX.pool.ltxml
@@ -26,7 +26,7 @@ DefPrimitiveI('\protected', undef, sub {
     $STATE->setPrefix('protected'); return; }, isPrefix => 1);
 
 # \detokenize
-DefMacro('\detokenize GeneralText', sub { Explode(writableTokens($_[1])); });
+DefMacro('\detokenize GeneralText', sub { Explode(writableTokens($_[1], 1)); });
 
 # \unexpanded
 # This is like \noexpand, but acts on <general text>
@@ -116,8 +116,10 @@ DefRegister('\interactionmode' => Number(0));
 DefPrimitive('\showgroups', undef);
 
 # \showtokens <generaltext>
-# NOTE Debugging aids are currently IGNORED!
-DefPrimitive('\showtokens GeneralText', undef);
+DefPrimitive('\showtokens GeneralText', sub {
+    print STDERR "\n> " . writableTokens($_[1], 1) . ".\n";
+    print STDERR $_[0]->getLocator->toString() . "\n\n";
+    return; });
 
 DefRegister('\tracingassigns'    => Number(0));    # ???
 DefRegister('\tracinggroups'     => Number(0));
@@ -134,8 +136,8 @@ DefRegister('\everyeof', Tokens());
 DefConstructor('\middle Token', '#1',
   afterConstruct => sub {
     my ($document) = @_;
-    my $current = $document->getNode;
-    my $delim = $document->getLastChildElement($current) || $current;
+    my $current    = $document->getNode;
+    my $delim      = $document->getLastChildElement($current) || $current;
     $document->setAttribute($delim, role     => 'MIDDLE');
     $document->setAttribute($delim, stretchy => 'true');
     return; });

--- a/lib/LaTeXML/Package/eTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/eTeX.pool.ltxml
@@ -26,7 +26,7 @@ DefPrimitiveI('\protected', undef, sub {
     $STATE->setPrefix('protected'); return; }, isPrefix => 1);
 
 # \detokenize
-DefMacro('\detokenize GeneralText', sub { Explode(writableTokens($_[1], 1)); });
+DefMacro('\detokenize GeneralText', sub { Explode(writableTokens($_[1])); });
 
 # \unexpanded
 # This is like \noexpand, but acts on <general text>
@@ -45,6 +45,11 @@ DefMacro('\readline Number SkipKeyword:to SkipSpaces Token', sub {
       DefMacroI($token, undef, Tokens(Explode(($mouth->readRawLine || '') . "\r"))); }
     return; });
 
+# https://tex.loria.fr/moteurs/etex_ref.html#scantokens
+# TODO: "Parentheses and a single space representing the pseudo-file will be displayed
+#        if \tracingscantokens (q.v.) is positive and non-zero."
+#       We are currently missing a final trailing space in some uses
+#           c.f. t/tokenize/hashes.tex
 DefMacro('\scantokens GeneralText', sub {
     LaTeXML::Core::Mouth->new(writableTokens($_[1]))->readTokens; });
 
@@ -117,7 +122,7 @@ DefPrimitive('\showgroups', undef);
 
 # \showtokens <generaltext>
 DefPrimitive('\showtokens GeneralText', sub {
-    print STDERR "\n> " . writableTokens($_[1], 1) . ".\n";
+    print STDERR "\n> " . writableTokens($_[1]) . ".\n";
     print STDERR $_[0]->getLocator->toString() . "\n\n";
     return; });
 

--- a/lib/LaTeXML/Package/etoolbox.sty.ltxml
+++ b/lib/LaTeXML/Package/etoolbox.sty.ltxml
@@ -43,18 +43,18 @@ DefMacro('\newrobustcmd OptionalMatch:* DefToken [Number][]{}', sub {
         "Ignoring redefinition (\\newcommand) of '" . Stringify($cs) . "'")
         unless LookupValue(ToString($cs) . ':locked'); }
     else {
-      DefMacroI($cs, convertLaTeXArgs($nargs, $opt), $body, protected => 1); }
+      DefMacroI($cs, convertLaTeXArgs($nargs, $opt), $body, protected => 1, long => 1); }
     return Tokens(); });
 
 DefMacro('\renewrobustcmd OptionalMatch:* DefToken [Number][]{}', sub {
     my ($stomach, $star, $cs, $nargs, $opt, $body) = @_;
-    DefMacroI($cs, convertLaTeXArgs($nargs, $opt), $body, protected => 1);
+    DefMacroI($cs, convertLaTeXArgs($nargs, $opt), $body, protected => 1, long => 1);
     return Tokens(); });
 
 DefMacro('\providerobustcmd OptionalMatch:* DefToken [Number][]{}', sub {
     my ($stomach, $star, $cs, $nargs, $opt, $body) = @_;
     if (isDefinable($cs)) {
-      DefMacroI($cs, convertLaTeXArgs($nargs, $opt), $body, protected => 1); }
+      DefMacroI($cs, convertLaTeXArgs($nargs, $opt), $body, protected => 1, long => 1); }
     return Tokens(); });
 
 RawTeX(<<'EoTeX');

--- a/t/expansion/definedness.xml
+++ b/t/expansion/definedness.xml
@@ -39,7 +39,7 @@ it is NOT relax,
 and it is NOT @defined.</p>
   </para>
   <para xml:id="p7">
-    <p>After the @ifundefined, however:  “relax.
+    <p>After the @ifundefined, however: “relax.
 IS defined,
 it IS cs-defined,
 it IS relax,
@@ -60,13 +60,13 @@ and it is still NOT relax.</p>
   </para>
   <para xml:id="p10">
     <p>[test1 ],
-After ifx csname concoction:  “relax.
+After ifx csname concoction: “relax.
 IS defined,
 it IS cs-defined,
 and it IS relax.</p>
   </para>
   <para xml:id="p11">
-    <p>Let zonk to relax:  “relax.
+    <p>Let zonk to relax: “relax.
 IS defined,
 it IS cs-defined,
 it IS relax,

--- a/t/expansion/meaning.xml
+++ b/t/expansion/meaning.xml
@@ -15,7 +15,7 @@
     <p>\par</p>
   </para>
   <para xml:id="p4">
-    <p>macro:-&gt;\nobreakspace{}</p>
+    <p>macro:-&gt;\nobreakspace {}</p>
   </para>
   <para xml:id="p5">
     <p>superscript character ^</p>

--- a/t/expansion/noexpand_conditional.xml
+++ b/t/expansion/noexpand_conditional.xml
@@ -15,63 +15,63 @@
     </tags>
     <title><tag close=" ">1</tag>Definitions</title>
     <para class="ltx_noindent" xml:id="S1.p1">
-      <p>1.1 “foo vs “foo
+      <p>1.1 “foo  vs “foo 
 (ifx) T F F T;
 (if) F F F T;
 (ifcat) OFOOT F OT T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p2">
-      <p>1.2 “foo vs “footoo
+      <p>1.2 “foo  vs “footoo 
 (ifx) T F F T;
 (if) F F F T;
 (ifcat) OFOOT F OT T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p3">
-      <p>1.3 “foo vs “letfoo
+      <p>1.3 “foo  vs “letfoo 
 (ifx) T F F T;
 (if) F F F T;
 (ifcat) OFOOT F OT T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p4">
-      <p>1.4 “foo vs “usefoo
+      <p>1.4 “foo  vs “usefoo 
 (ifx) F F F T;
 (if) F F F T;
 (ifcat) OFOOT F OT T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p5">
-      <p>1.5 “foo vs “letnxfoo
+      <p>1.5 “foo  vs “letnxfoo 
 (ifx) F T F T;
 (if) F T F T;
 (ifcat) OT T OT T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p6">
-      <p>1.6 “foo vs “eafoo
+      <p>1.6 “foo  vs “eafoo 
 (ifx) F F F T;
 (if) F F F T;
 (ifcat) OFOOT F OT T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p7">
-      <p>1.7 “relax vs “letnxfoo
+      <p>1.7 “relax  vs “letnxfoo 
 (ifx) F F F F;
 (if) T T T T;
 (ifcat) T T T T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p8">
-      <p>1.8 “relax vs “eafoo
+      <p>1.8 “relax  vs “eafoo 
 (ifx) F F F F;
 (if) F F T T;
 (ifcat) F F T T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p9">
-      <p>1.9 “isnotdefined vs “isnotdefined
+      <p>1.9 “isnotdefined  vs “isnotdefined 
 (ifx) T F F T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p10">
-      <p>1.10 “isnotdefinedA vs “isnotdefinedB
+      <p>1.10 “isnotdefinedA  vs “isnotdefinedB 
 (ifx) T F F T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S1.p11">
-      <p>1.11 “foo vs “isnotdefinedC
+      <p>1.11 “foo  vs “isnotdefinedC 
 (ifx) F F F T.</p>
     </para>
   </section>
@@ -83,31 +83,31 @@
     </tags>
     <title><tag close=" ">2</tag>Counters</title>
     <para class="ltx_noindent" xml:id="S2.p1">
-      <p>2.1 “ctr vs “ctr
+      <p>2.1 “ctr  vs “ctr 
 (ifx) T T T T;
 (if) T T T T;
 (ifcat) T T T T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S2.p2">
-      <p>2.2 “ctr vs “four
+      <p>2.2 “ctr  vs “four 
 (ifx) F F F F;
 (if) T T T T;
 (ifcat) T T T T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S2.p3">
-      <p>2.3 “four vs “fourtoo
+      <p>2.3 “four  vs “fourtoo 
 (ifx) F F F F;
 (if) T T T T;
 (ifcat) T T T T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S2.p4">
-      <p>2.4 “ctr vs “ctrx
+      <p>2.4 “ctr  vs “ctrx 
 (ifx) F F F F;
 (if) T T T T;
 (ifcat) T T T T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S2.p5">
-      <p>2.5 “ctrx vs “ctry
+      <p>2.5 “ctrx  vs “ctry 
 (ifx) T T T T;
 (if) T T T T;
 (ifcat) T T T T.</p>
@@ -127,7 +127,7 @@
 (ifcat) T T T T.</p>
     </para>
     <para class="ltx_noindent" xml:id="S3.p2">
-      <p>3.2 “foo vs x
+      <p>3.2 “foo  vs x
 (ifx) F F F F;
 (if) F F F F;
 (ifcat) OxT F OxT F.</p>
@@ -139,7 +139,7 @@
 (ifcat) F F F F.</p>
     </para>
     <para class="ltx_noindent" xml:id="S3.p4">
-      <p>3.4 “foo vs *
+      <p>3.4 “foo  vs *
 (ifx) F F F F;
 (if) F F F F;
 (ifcat) O*T F O*T F.</p>

--- a/t/tokenize/hashes.xml
+++ b/t/tokenize/hashes.xml
@@ -12,7 +12,7 @@
     </tags>
     <title><tag close=" ">1</tag>Testing duplication of #</title>
     <para xml:id="S1.p1">
-      <p>detokenize: Two hashes: ##, not one; “a.</p>
+      <p>detokenize: Two hashes: ##, not one; “a .</p>
     </para>
     <para xml:id="S1.p2">
       <p>scantokens: two hashes: ##, not one; [expanded a].</p>


### PR DESCRIPTION
Detaching more of the (hopefully) independently reasonable upgrades that set the stage for the core upgrades needed for expl3 in texlive2020. Focus is on `\meaning`, `writableTokens` and some of the `\show`-like macros, which I think can be upgraded in isolation.

Curious to see if the Travis expl3 tests will pass.

(This PR was originally opened at [#5](https://github.com/dginev/LaTeXML/pull/5) and I am migrating it by hand, now that the main fork's master has moved)