### PR TITLE
Adding even more consistent names in physics.sty

### DIFF
--- a/lib/LaTeXML/Package/physics.sty.ltxml
+++ b/lib/LaTeXML/Package/physics.sty.ltxml
@@ -300,10 +300,10 @@ DefMacro('\lx@physics@operatorP{}{}{}', sub {
 
 my @operators = (qw(
     sin sine cos cosine tan tangent csc cosecant sec secand cot cotangent
-    hsin hypsine cosh hypcosine tanh hyptangent csch hypcosecant sech hypsecand coth hypcotangent
+    hsin hyperbolic-sine cosh hyperbolic-cosine tanh hyperbolic-tangent csch hyperbolic-cosecant sech hyperbolic-secand coth hyperbolic-cotangent
     arcsin arcsine arccos arccosine arctan arctangent arccsc arccosecant arcsec arcsecand arccot arccotangent
-    asin asine acos acosine atan atangent acsc acosecant asec asecand acot acotangent
-    exp exponential log logarithm ln naturallogarithm det determinant Pr Probability
+    asin arcsine acos arccosine atan arctangent acsc arccosecant asec arcsecand acot arccotangent
+    exp exponential log logarithm ln natural-logarithm det determinant Pr probability
     ));
 
 while (@operators) {

--- a/lib/LaTeXML/Package/physics.sty.ltxml
+++ b/lib/LaTeXML/Package/physics.sty.ltxml
@@ -87,7 +87,7 @@ sub phys_close {
 sub phys_readArg {
   my ($gullet, $required, %delimiters) = @_;
   my ($arg, $open, $close);
-  my $next = $gullet->readToken();    # or XToken ?
+  my $next = $gullet->readToken();          # or XToken ?
   if ($next && $next->equals(T_BEGIN)) {    # Read regular arg, use default delimiters
     $gullet->unread($next);
     $arg = $gullet->readArg(); }
@@ -298,19 +298,21 @@ DefMacro('\lx@physics@operatorP{}{}{}', sub {
           phys_open($size, $open || T_OTHER('(')), I_arg(1), phys_close($size, $close || T_OTHER(')'))),
         $arg, ($power ? $power : ())); } });
 
-my @operators = (qw(
-    sin sine cos cosine tan tangent csc cosecant sec secand cot cotangent
-    hsin hyperbolic-sine cosh hyperbolic-cosine tanh hyperbolic-tangent csch hyperbolic-cosecant sech hyperbolic-secand coth hyperbolic-cotangent
-    arcsin arcsine arccos arccosine arctan arctangent arccsc arccosecant arcsec arcsecand arccot arccotangent
-    asin arcsine acos arccosine atan arctangent acsc arccosecant asec arcsecand acot arccotangent
-    exp exponential log logarithm ln natural-logarithm det determinant Pr probability
-    ));
+my @operators = (
+  ['sin', 'sine'], ['cos', 'cosine'], ['tan', 'tangent'], ['csc', 'cosecant'], ['sec', 'secand'], ['cot', 'cotangent'], ['hsin', 'hypsine', 'hyperbolic-sine'],
+  ['cosh', 'hypcosine', 'hyperbolic-cosine'], ['tanh', 'hyptangent', 'hyperbolic-tangent'], ['csch', 'hypcosecant', 'hyperbolic-cosecant'],
+  ['sech', 'hypsecand', 'hyperbolic-secand'], ['coth', 'hypcotangent', 'hyperbolic-cotangent'], ['arcsin', 'arcsine'], ['arccos', 'arccosine'],
+  ['arctan', 'arctangent'], ['arccsc', 'arccosecant'], ['arcsec', 'arcsecand'], ['arccot', 'arccotangent'], ['asin', 'asine', 'arcsine'],
+  ['acos', 'acosine', 'arccosine'], ['atan', 'atangent', 'arctangent'], ['acsc', 'acosecant', 'arccosecant'], ['asec', 'asecand', 'arcsecand'],
+  ['acot', 'acotangent', 'arccotangent'], ['exp', 'exponential'], ['log', 'logarithm'], ['ln', 'naturallogarithm', 'natural-logarithm'],
+  ['det', 'determinant'], ['Pr', 'Probability', 'probability']);
 
 while (@operators) {
-  my ($shortname, $longname) = (shift(@operators), shift(@operators));
+  my ($shortname, $longname, $meaning) = @{ shift(@operators) };
+  $meaning ||= $longname;
   Let('\\' . $longname, '\\' . $shortname);
   DefMacro('\\' . $shortname,
-    "\\lx\@physics\@operatorP{\\$shortname}{$longname}{\\operatorname{$shortname}}"); }
+    "\\lx\@physics\@operatorP{\\$shortname}{$meaning}{\\operatorname{$shortname}}"); }
 
 # New operators
 DefMacro('\trace',          '\lx@physics@operatorP{\tr}{trace}{\operatorname{tr}}');
@@ -367,7 +369,7 @@ Let('\flatfrac', '\ifrac');
 #  => (differential var [degree])
 DefMacro('\lx@physics@diff{}{}{}', sub {
     my ($gullet, $cs, $semantic, $diff) = @_;
-    my $cfunc = I_symbol({ meaning => $semantic });
+    my $cfunc  = I_symbol({ meaning => $semantic });
     my $pfunc  = I_wrap({ role => 'DIFFOP' }, $diff);
     my $degree = $gullet->readOptional;
     my ($arg, $open, $close) = phys_readArg($gullet, 0, '(' => T_OTHER(')'));
@@ -375,7 +377,7 @@ DefMacro('\lx@physics@diff{}{}{}', sub {
       { ($arg ? () : (role => 'DIFFOP')),
         reversion => Tokens($cs,
           ($degree ? (T_OTHER('['), I_arg(2), T_OTHER(']')) : ()),
-          ($arg ? phys_revArg(I_arg(1), $open, $close) : ())) },
+          ($arg    ? phys_revArg(I_arg(1), $open, $close)   : ())) },
       ($arg
         ? I_apply({}, $cfunc, I_arg(1), ($degree ? I_arg(2) : ()))
         : ($degree
@@ -488,8 +490,8 @@ DefMacro('\ket', sub {
 
 DefMacro('\bra', sub {
     my ($gullet) = @_;
-    my $size = ($gullet->readMatch(T_OTHER('*')) ? 0 : 1);
-    my $arg  = $gullet->readArg();
+    my $size     = ($gullet->readMatch(T_OTHER('*')) ? 0 : 1);
+    my $arg      = $gullet->readArg();
     if ($gullet->readMatch(T_CS('\ket'))) {    # join to make braket!
       $size = 0 if $gullet->readMatch(T_OTHER('*'));    # star here, too
       my $arg2 = $gullet->readArg();
@@ -511,10 +513,10 @@ DefMacro('\bra', sub {
 DefMacro('\lx@physics@qm@product{}{}{}{}{}', sub {
     my ($gullet, $cs, $semantic, $open, $middle, $close) = @_;
     my $cfunc = I_symbol({ meaning => $semantic });
-    my $size = ($gullet->readMatch(T_OTHER('*')) ? 0 : 1);
-    my $arg0 = $gullet->readArg();
-    my $argx = phys_readArg($gullet);
-    my $arg1 = $argx || $arg0;
+    my $size  = ($gullet->readMatch(T_OTHER('*')) ? 0 : 1);
+    my $arg0  = $gullet->readArg();
+    my $argx  = phys_readArg($gullet);
+    my $arg1  = $argx || $arg0;
     return I_dual(
       { reversion => Tokens($cs, phys_revSize($size),
           phys_revArg(I_arg(1)), phys_revArg(I_arg(2))) },
@@ -530,8 +532,8 @@ DefMacro('\outerproduct',
 
 DefMacro('\expectationvalue', sub {
     my ($gullet) = @_;
-    my $cfunc = I_symbol({ meaning => 'expectation-value' });
-    my $size  = ($gullet->readMatch(T_OTHER('*'))
+    my $cfunc    = I_symbol({ meaning => 'expectation-value' });
+    my $size     = ($gullet->readMatch(T_OTHER('*'))
       ? ($gullet->readMatch(T_OTHER('*')) ? 1 : 0)
       : 1);
     my ($open, $middle, $close) =
@@ -555,8 +557,8 @@ DefMacro('\expectationvalue', sub {
 
 DefMacro('\matrixelement', sub {
     my ($gullet) = @_;
-    my $cfunc = I_symbol({ meaning => 'expectation-value' });
-    my $size  = ($gullet->readMatch(T_OTHER('*'))
+    my $cfunc    = I_symbol({ meaning => 'expectation-value' });
+    my $size     = ($gullet->readMatch(T_OTHER('*'))
       ? ($gullet->readMatch(T_OTHER('*')) ? 1 : 0)
       : 1);
     my ($open, $middle, $close) =

--- a/lib/LaTeXML/Package/physics.sty.ltxml
+++ b/lib/LaTeXML/Package/physics.sty.ltxml
@@ -299,11 +299,11 @@ DefMacro('\lx@physics@operatorP{}{}{}', sub {
         $arg, ($power ? $power : ())); } });
 
 my @operators = (
-  ['sin', 'sine'], ['cos', 'cosine'], ['tan', 'tangent'], ['csc', 'cosecant'], ['sec', 'secand'], ['cot', 'cotangent'], ['hsin', 'hypsine', 'hyperbolic-sine'],
+  ['sin', 'sine'], ['cos', 'cosine'], ['tan', 'tangent'], ['csc', 'cosecant'], ['sec', 'secant'], ['cot', 'cotangent'], ['hsin', 'hypsine', 'hyperbolic-sine'],
   ['cosh', 'hypcosine', 'hyperbolic-cosine'], ['tanh', 'hyptangent', 'hyperbolic-tangent'], ['csch', 'hypcosecant', 'hyperbolic-cosecant'],
-  ['sech', 'hypsecand', 'hyperbolic-secand'], ['coth', 'hypcotangent', 'hyperbolic-cotangent'], ['arcsin', 'arcsine'], ['arccos', 'arccosine'],
-  ['arctan', 'arctangent'], ['arccsc', 'arccosecant'], ['arcsec', 'arcsecand'], ['arccot', 'arccotangent'], ['asin', 'asine', 'arcsine'],
-  ['acos', 'acosine', 'arccosine'], ['atan', 'atangent', 'arctangent'], ['acsc', 'acosecant', 'arccosecant'], ['asec', 'asecand', 'arcsecand'],
+  ['sech', 'hypsecant', 'hyperbolic-secant'], ['coth', 'hypcotangent', 'hyperbolic-cotangent'], ['arcsin', 'arcsine'], ['arccos', 'arccosine'],
+  ['arctan', 'arctangent'], ['arccsc', 'arccosecant'], ['arcsec', 'arcsecant'], ['arccot', 'arccotangent'], ['asin', 'asine', 'arcsine'],
+  ['acos', 'acosine', 'arccosine'], ['atan', 'atangent', 'arctangent'], ['acsc', 'acosecant', 'arccosecant'], ['asec', 'asecant', 'arcsecant'],
   ['acot', 'acotangent', 'arccotangent'], ['exp', 'exponential'], ['log', 'logarithm'], ['ln', 'naturallogarithm', 'natural-logarithm'],
   ['det', 'determinant'], ['Pr', 'Probability', 'probability']);
 

--- a/t/complex/physics.xml
+++ b/t/complex/physics.xml
@@ -1553,11 +1553,11 @@
                 </Math></td>
             </tr>
             <tr>
-              <td align="center"><Math mode="inline" tex="\displaystyle\sec(x)" text="secand@(x)" xml:id="S1.SS3.p2.m17">
+              <td align="center"><Math mode="inline" tex="\displaystyle\sec(x)" text="secant@(x)" xml:id="S1.SS3.p2.m17">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="secand"/>
+                        <XMTok meaning="secant"/>
                         <XMRef idref="S1.SS3.p2.m17.1"/>
                       </XMApp>
                       <XMApp>
@@ -1571,11 +1571,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\sech(x)" text="hyperbolic-secand@(x)" xml:id="S1.SS3.p2.m18">
+              <td align="center"><Math mode="inline" tex="\displaystyle\sech(x)" text="hyperbolic-secant@(x)" xml:id="S1.SS3.p2.m18">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="hyperbolic-secand"/>
+                        <XMTok meaning="hyperbolic-secant"/>
                         <XMRef idref="S1.SS3.p2.m18.1"/>
                       </XMApp>
                       <XMApp>
@@ -1589,11 +1589,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\arcsec(x)" text="arcsecand@(x)" xml:id="S1.SS3.p2.m19">
+              <td align="center"><Math mode="inline" tex="\displaystyle\arcsec(x)" text="arcsecant@(x)" xml:id="S1.SS3.p2.m19">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="arcsecand"/>
+                        <XMTok meaning="arcsecant"/>
                         <XMRef idref="S1.SS3.p2.m19.1"/>
                       </XMApp>
                       <XMApp>
@@ -1607,11 +1607,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\asec(x)" text="arcsecand@(x)" xml:id="S1.SS3.p2.m20">
+              <td align="center"><Math mode="inline" tex="\displaystyle\asec(x)" text="arcsecant@(x)" xml:id="S1.SS3.p2.m20">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="arcsecand"/>
+                        <XMTok meaning="arcsecant"/>
                         <XMRef idref="S1.SS3.p2.m20.1"/>
                       </XMApp>
                       <XMApp>

--- a/t/complex/physics.xml
+++ b/t/complex/physics.xml
@@ -1311,11 +1311,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\asin(x)" text="asine@(x)" xml:id="S1.SS3.p2.m4">
+              <td align="center"><Math mode="inline" tex="\displaystyle\asin(x)" text="arcsine@(x)" xml:id="S1.SS3.p2.m4">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="asine"/>
+                        <XMTok meaning="arcsine"/>
                         <XMRef idref="S1.SS3.p2.m4.1"/>
                       </XMApp>
                       <XMApp>
@@ -1349,11 +1349,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\cosh(x)" text="hypcosine@(x)" xml:id="S1.SS3.p2.m6">
+              <td align="center"><Math mode="inline" tex="\displaystyle\cosh(x)" text="hyperbolic-cosine@(x)" xml:id="S1.SS3.p2.m6">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="hypcosine"/>
+                        <XMTok meaning="hyperbolic-cosine"/>
                         <XMRef idref="S1.SS3.p2.m6.1"/>
                       </XMApp>
                       <XMApp>
@@ -1385,11 +1385,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\acos(x)" text="acosine@(x)" xml:id="S1.SS3.p2.m8">
+              <td align="center"><Math mode="inline" tex="\displaystyle\acos(x)" text="arccosine@(x)" xml:id="S1.SS3.p2.m8">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="acosine"/>
+                        <XMTok meaning="arccosine"/>
                         <XMRef idref="S1.SS3.p2.m8.1"/>
                       </XMApp>
                       <XMApp>
@@ -1423,11 +1423,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\tanh(x)" text="hyptangent@(x)" xml:id="S1.SS3.p2.m10">
+              <td align="center"><Math mode="inline" tex="\displaystyle\tanh(x)" text="hyperbolic-tangent@(x)" xml:id="S1.SS3.p2.m10">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="hyptangent"/>
+                        <XMTok meaning="hyperbolic-tangent"/>
                         <XMRef idref="S1.SS3.p2.m10.1"/>
                       </XMApp>
                       <XMApp>
@@ -1459,11 +1459,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\atan(x)" text="atangent@(x)" xml:id="S1.SS3.p2.m12">
+              <td align="center"><Math mode="inline" tex="\displaystyle\atan(x)" text="arctangent@(x)" xml:id="S1.SS3.p2.m12">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="atangent"/>
+                        <XMTok meaning="arctangent"/>
                         <XMRef idref="S1.SS3.p2.m12.1"/>
                       </XMApp>
                       <XMApp>
@@ -1497,11 +1497,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\csch(x)" text="hypcosecant@(x)" xml:id="S1.SS3.p2.m14">
+              <td align="center"><Math mode="inline" tex="\displaystyle\csch(x)" text="hyperbolic-cosecant@(x)" xml:id="S1.SS3.p2.m14">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="hypcosecant"/>
+                        <XMTok meaning="hyperbolic-cosecant"/>
                         <XMRef idref="S1.SS3.p2.m14.1"/>
                       </XMApp>
                       <XMApp>
@@ -1533,11 +1533,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\acsc(x)" text="acosecant@(x)" xml:id="S1.SS3.p2.m16">
+              <td align="center"><Math mode="inline" tex="\displaystyle\acsc(x)" text="arccosecant@(x)" xml:id="S1.SS3.p2.m16">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="acosecant"/>
+                        <XMTok meaning="arccosecant"/>
                         <XMRef idref="S1.SS3.p2.m16.1"/>
                       </XMApp>
                       <XMApp>
@@ -1571,11 +1571,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\sech(x)" text="hypsecand@(x)" xml:id="S1.SS3.p2.m18">
+              <td align="center"><Math mode="inline" tex="\displaystyle\sech(x)" text="hyperbolic-secand@(x)" xml:id="S1.SS3.p2.m18">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="hypsecand"/>
+                        <XMTok meaning="hyperbolic-secand"/>
                         <XMRef idref="S1.SS3.p2.m18.1"/>
                       </XMApp>
                       <XMApp>
@@ -1607,11 +1607,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\asec(x)" text="asecand@(x)" xml:id="S1.SS3.p2.m20">
+              <td align="center"><Math mode="inline" tex="\displaystyle\asec(x)" text="arcsecand@(x)" xml:id="S1.SS3.p2.m20">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="asecand"/>
+                        <XMTok meaning="arcsecand"/>
                         <XMRef idref="S1.SS3.p2.m20.1"/>
                       </XMApp>
                       <XMApp>
@@ -1645,11 +1645,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\coth(x)" text="hypcotangent@(x)" xml:id="S1.SS3.p2.m22">
+              <td align="center"><Math mode="inline" tex="\displaystyle\coth(x)" text="hyperbolic-cotangent@(x)" xml:id="S1.SS3.p2.m22">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="hypcotangent"/>
+                        <XMTok meaning="hyperbolic-cotangent"/>
                         <XMRef idref="S1.SS3.p2.m22.1"/>
                       </XMApp>
                       <XMApp>
@@ -1681,11 +1681,11 @@
                     </XMDual>
                   </XMath>
                 </Math></td>
-              <td align="center"><Math mode="inline" tex="\displaystyle\acot(x)" text="acotangent@(x)" xml:id="S1.SS3.p2.m24">
+              <td align="center"><Math mode="inline" tex="\displaystyle\acot(x)" text="arccotangent@(x)" xml:id="S1.SS3.p2.m24">
                   <XMath>
                     <XMDual>
                       <XMApp>
-                        <XMTok meaning="acotangent"/>
+                        <XMTok meaning="arccotangent"/>
                         <XMRef idref="S1.SS3.p2.m24.1"/>
                       </XMApp>
                       <XMApp>
@@ -1705,7 +1705,7 @@
       </para>
       <para xml:id="S1.SS3.p3">
         <equation xml:id="S1.Ex15">
-          <Math mode="display" tex="\exp(X^{Y})\qquad\log(X^{Y})\qquad\ln(X^{Y})\qquad\det(X^{Y})\qquad\Pr(X^{Y})" text="list@(exponential@(X ^ Y), logarithm@(X ^ Y), naturallogarithm@(X ^ Y), determinant@(X ^ Y), Probability@(X ^ Y))" xml:id="S1.Ex15.m1">
+          <Math mode="display" tex="\exp(X^{Y})\qquad\log(X^{Y})\qquad\ln(X^{Y})\qquad\det(X^{Y})\qquad\Pr(X^{Y})" text="list@(exponential@(X ^ Y), logarithm@(X ^ Y), natural-logarithm@(X ^ Y), determinant@(X ^ Y), probability@(X ^ Y))" xml:id="S1.Ex15.m1">
             <XMath>
               <XMDual>
                 <XMApp>
@@ -1757,7 +1757,7 @@
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
                   <XMDual xml:id="S1.Ex15.m1.13">
                     <XMApp>
-                      <XMTok meaning="naturallogarithm"/>
+                      <XMTok meaning="natural-logarithm"/>
                       <XMRef idref="S1.Ex15.m1.3"/>
                     </XMApp>
                     <XMApp>
@@ -1795,7 +1795,7 @@
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
                   <XMDual xml:id="S1.Ex15.m1.15">
                     <XMApp>
-                      <XMTok meaning="Probability"/>
+                      <XMTok meaning="probability"/>
                       <XMRef idref="S1.Ex15.m1.5"/>
                     </XMApp>
                     <XMApp>


### PR DESCRIPTION
Follow-up to commit 640cfc7a664f541f1e66ce4f3a805e8b51af1048

I was testing the a11y generation for all tests in `t/complex/physics.tex` and noticed sine of the names looked suboptimal (`asine`, `hypsine` etc). So I quickly edited them and regenerated the tests, feel free to review/adopt/adapt.