### PR TITLE
Cleanup semantics

### DIFF
--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -32,7 +32,8 @@ sub Box {
   my $state = $STATE;
   if ($state->lookupValue('IN_MATH')) {
     my $attr = (defined $string) && $state->lookupValue('math_token_attributes_' . $string);
-    return LaTeXML::Core::Box->new($string, $font->specialize($string), $locator, $tokens,
+    my $usestring = ($attr && $$attr{replace}) || $string;
+    return LaTeXML::Core::Box->new($usestring, $font->specialize($string), $locator, $tokens,
       mode => 'math', ($attr ? %$attr : ()), %properties); }
   else {
     return LaTeXML::Core::Box->new($string, $font, $locator, $tokens, %properties); } }

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -1499,7 +1499,6 @@ sub compactXMDual {
   return if scalar(@content_args) != scalar(@pres_args);
 
   my @new_args = ();
-  my $single_duality;
   # walk the corresponding children, and double-check they are referenced in the same order
   while ((my $c_arg = shift(@content_args)) and (my $p_arg = shift(@pres_args))) {
     my $c_idref = $c_arg->getAttribute('idref');
@@ -1511,16 +1510,11 @@ sub compactXMDual {
       push @new_args, $c_arg;
       next; }    # pres-refs-content, OK
 
-    # Next up: differences. If:
-    # 1) we saw such a difference beforehand, or
-    # 2) the tree is too complex - give up on compacting and return.
-    # we handle a single content-side XMTok, to any XM* presentation subtree differing for now.
-    if ($single_duality || ($self->getNodeQName($c_arg) ne 'ltx:XMTok')) {
+    # we can handle content-side XMToks, to any XM* presentation subtree differing for now.
+    if ($self->getNodeQName($c_arg) ne 'ltx:XMTok') {
       return; }
     else { # otherwise we can compact this case. but delay actual libxml changes until we are *sure* the entire tree is compactable
-      $single_duality = [$c_arg, $p_arg];
-      push(@new_args, $single_duality); } }
-  return unless $single_duality;
+      push(@new_args, [$c_arg, $p_arg]); } }
 
 # If we made it here, this is a dual with two mirrored applications and a single XMTok difference, compact it.
   my $compact_apply = $self->openElementAt($dual->parentNode, 'ltx:XMApp');

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -916,9 +916,10 @@ sub textrec {
   my $tag = getQName($node);
   $outer_bp   = 0  unless defined $outer_bp;
   $outer_name = '' unless defined $outer_name;
-  if ($tag eq 'ltx:XMApp') {
-    if (my $meaning = p_getAttribute($node, 'meaning') || p_getAttribute($node, 'name')) {
-      return $meaning; }
+  # If node has meaning, that's the text form.
+  if (my $meaning = p_getAttribute($node, 'meaning') || p_getAttribute($node, 'name')) {
+    return $PREFIX_ALIAS{$meaning} || $meaning; }
+  elsif ($tag eq 'ltx:XMApp') {
     my $app_role = $node->getAttribute('role');
     my ($op, @args) = element_nodes($node);
     $op = realizeXMNode($op);
@@ -930,8 +931,6 @@ sub textrec {
       return (($bp < $outer_bp) || (($bp == $outer_bp) && ($name ne $outer_name))
         ? '(' . $string . ')' : $string); } }
   elsif ($tag eq 'ltx:XMDual') {
-    if (my $meaning = p_getAttribute($node, 'meaning') || p_getAttribute($node, 'name')) {
-      return $meaning; }
     my ($content, $presentation) = element_nodes($node);
     my $text = textrec($content, $outer_bp, $outer_name);    # Just send out the semantic form.
            # Fall back to presentation, if content has poor semantics (eg. from replacement patterns)

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1477,8 +1477,10 @@ sub DefMathI {
   # If single character, handle with a rewrite rule
   if (length($csname) == 1) {
     ###print STDERR "Defining ".Stringify($cs)." as rewrite\n";
+    if ($csname ne ToString($presentation)) {
+      $options{replace} = $presentation;
+      delete $options{name}; }
     defmath_rewrite($cs, %options); }
-
   # If the macro involves arguments,
   # we will create an XMDual to separate simple content application
   # from the (likely) convoluted presentation.
@@ -1522,7 +1524,8 @@ sub defmath_rewrite {
   # No, do NOT make mathactive; screws up things like babel french, or... ?
   # EXPERIMENT: store XMTok attributes for if this char ends up a Math Token.
   # But only some DefMath options make sense!
-  my $rw_options = { name => 1, meaning => 1, omcd => 1, decl_id => 1, role => 1, mathstyle => 1, stretchy => 1 }; # (well, mathstyle?)
+  my $rw_options = { name => 1, meaning => 1, omcd => 1, decl_id => 1, role => 1,
+    replace => 1, mathstyle => 1, stretchy => 1 };    # (well, mathstyle?)
   CheckOptions("DefMath reimplemented as DefRewrite ($csname)", $rw_options, %options);
   AssignValue('math_token_attributes_' . $csname => {%options}, 'global');
   return; }
@@ -1663,7 +1666,7 @@ sub defmath_cons {
   my $end_tok = (defined $presentation ? '>' . $qpresentation . '</ltx:XMTok>' : "/>");
   my $cons_attr = "name='#name' meaning='#meaning' omcd='#omcd' decl_id='#decl_id' mathstyle='#mathstyle'";
   my $nargs = ($paramlist ? scalar($paramlist->getParameters) : 0);
-  if ((! defined $options{reversion}) && !$nargs && !(defined $options{alias})) {
+  if ((!defined $options{reversion}) && !$nargs && !(defined $options{alias})) {
     $options{reversion} = sub {
       (!$options{revert_as}
           || ($options{revert_as} eq 'content')

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -6166,7 +6166,7 @@ DefMath('\bmod', 'mod', role => 'MODIFIEROP', meaning => 'modulo');
 # keys are
 #  name  : the name of the environment (for reversion)
 #  datameaning: the (presumed) meaning of the array construct (typically 'matrix')
-#  delimitermeaning  : the meaning of an operator to be applied to the array (if any, eg, 'norm')
+#  delimitermeaning  : the operator meaning due to delimiters (eg. norm)(as applied to the array)
 #  style : typically \displaystyle, \textstyle...
 #  left  : TeX code for left of matrix
 #  right  : TeX code for right
@@ -6183,12 +6183,16 @@ DefPrimitive('\lx@gen@matrix@bindings RequiredKeyVals:lx@GEN', sub {
     my @colspec = (before => Tokens(($align =~ /^(?:c|r)/ ? (T_CS('\hfil')) : ()),
         Invocation(T_CS('\@hidden'), $style)),
       after => Tokens(($align =~ /^(?:c|l)/ ? (T_CS('\hfil')) : ())));
-    my $ncols = ToString($kv->getValue('ncolumns'));
+    my $ncols      = ToString($kv->getValue('ncolumns'));
+    my %attributes = ();
+    foreach my $key (qw(rowsep)) {    # Probably more?
+      if (my $value = $kv->getValue($key)) {
+        $attributes{$key} = $value; } }
     alignmentBindings(LaTeXML::Core::Alignment::Template->new(
         ($ncols ? (columns => [map { { @colspec } } 1 .. $ncols])
           : (repeated => [{@colspec}]))),
       'math',
-      attributes => { meaning => $kv->getValue('datameaning') }); });
+      (keys %attributes ? (attributes => {%attributes}) : ())); });
 DefPrimitive('\lx@end@gen@matrix', sub { $_[0]->egroup; });
 
 DefMacro('\lx@gen@plain@matrix{}{}',
@@ -6201,14 +6205,11 @@ DefMacro('\lx@gen@plain@matrix{}{}',
 DefConstructor('\lx@gen@plain@matrix@ RequiredKeyVals:lx@GEN {}',
   "?#needXMDual("
     . "<ltx:XMDual>"
-    . "?#delimitermeaning("
-    . "<ltx:XMApp>"
-    . "<ltx:XMTok meaning='#delimitermeaning'/>"
+    . "?#delimitermeaning(<ltx:XMApp><ltx:XMTok meaning='#delimitermeaning'/>)()"
+    . "?#datameaning(<ltx:XMApp><ltx:XMTok meaning='#datameaning'/>)()"
     . "<ltx:XMRef _xmkey='#xmkey'/>"
-    . "</ltx:XMApp>"
-    . ")("
-    . "<ltx:XMRef _xmkey='#xmkey'/>"
-    . ")"
+    . "?#delimitermeaning(</ltx:XMApp>)()"
+    . "?#datameaning(</ltx:XMApp>)()"
     . "<ltx:XMWrap>#left<ltx:XMArg _xmkey='#xmkey'>#2</ltx:XMArg>#right</ltx:XMWrap>"
     . "</ltx:XMDual>"
     . ")("
@@ -6222,7 +6223,7 @@ DefConstructor('\lx@gen@plain@matrix@ RequiredKeyVals:lx@GEN {}',
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $kv = $whatsit->getArg(1);
-    if ($kv->getValue('left') || $kv->getValue('right')) {
+    if ($kv->getValue('datameaning') || $kv->getValue('delimitermeaning')) {
       $whatsit->setProperties(
         needXMDual => 1,
         xmkey      => LaTeXML::Package::getXMArgID()); }
@@ -6232,8 +6233,8 @@ DefConstructor('\lx@gen@plain@matrix@ RequiredKeyVals:lx@GEN {}',
 DefMacro('\matrix{}',
   '\lx@gen@plain@matrix{name=matrix,datameaning=matrix}{#1}');
 
-DefMacro('\bordermatrix{}',
-  '\lx@hack@bordermatrix{\lx@gen@plain@matrix{name=bordermatrix,datameaning=matrix}{#1}}');
+DefMacro('\bordermatrix{}',    # Semantics?
+  '\lx@hack@bordermatrix{\lx@gen@plain@matrix{name=bordermatrix}{#1}}');
 # HACK the newly created border matrix to add columns for the (spanned) parentheses!!!
 # Assume (for now) that there's no XMDual structure here.
 # What is the semantics, anyway?
@@ -6664,7 +6665,7 @@ sub I_keyvals {
   my @options = ();
   if ($keyvals) {
     while (my ($key, $value) = each %$keyvals) {
-      $value = TokenizeInternal($value) if $value && !ref $value;
+      $value = TokenizeInternal($value) if defined $value && !ref $value;
       push(@options, T_OTHER(',')) if @options;
       push(@options, T_OTHER($key), T_OTHER('='), T_BEGIN, $value, T_END); } }
   return (@options ? Tokens(T_OTHER('['), @options, T_OTHER(']')) : ()); }

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -4203,9 +4203,11 @@ sub addMeaningRec {
 #======================================================================
 # Properties for plain characters.
 # These are allowed in plain text, but need to act a bit special in math.
-DefMathI('=', undef, '=', role => 'RELOP',   meaning  => 'equals');
-DefMathI('+', undef, '+', role => 'ADDOP',   meaning  => 'plus');
-DefMathI('-', undef, '-', role => 'ADDOP',   meaning  => 'minus');
+DefMathI('=', undef, '=', role => 'RELOP', meaning => 'equals');
+DefMathI('+', undef, '+', role => 'ADDOP', meaning => 'plus');
+DefMathI('-', undef, '-', role => 'ADDOP', meaning => 'minus');
+## Redefine, if we want Unicode minus
+##DefMathI('-', undef, "\x{2212}", role => 'ADDOP',   meaning  => 'minus');
 DefMathI('*', undef, '*', role => 'MULOP',   meaning  => 'times');
 DefMathI('/', undef, '/', role => 'MULOP',   meaning  => 'divide');
 DefMathI('!', undef, '!', role => 'POSTFIX', meaning  => 'factorial');

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -6779,8 +6779,7 @@ DefKeyVal('XMath', 'reversion',              'UndigestedKey');
 DefKeyVal('XMath', 'content_reversion',      'UndigestedKey');
 DefKeyVal('XMath', 'presentation_reversion', 'UndigestedKey');
 DefConstructor('\lx@dual OptionalKeyVals:XMath {}{}',
-  #  "<ltx:XMDual role='&GetKeyVal(#1,role)'>#2<ltx:XMWrap>#3</ltx:XMWrap></ltx:XMDual>",
-  "<ltx:XMDual role='#role'>#2<ltx:XMWrap>#3</ltx:XMWrap></ltx:XMDual>",
+  "<ltx:XMDual $XMath_attributes>#2<ltx:XMWrap>#3</ltx:XMWrap></ltx:XMDual>",
   beforeDigest => sub {
     PushValue(PENDING_DUAL_XMARGS => {});
     return; },

--- a/lib/LaTeXML/Package/amscd.sty.ltxml
+++ b/lib/LaTeXML/Package/amscd.sty.ltxml
@@ -29,24 +29,19 @@ use LaTeXML::Package;
 # the more general svg(-like) problems.
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-DefMacro('\CD',    '\@@CD\@start@alignment');
-DefMacro('\endCD', '\@finish@alignment\@end@CD');
-DefPrimitive('\@end@CD', sub { $_[0]->egroup; });
-DefConstructor('\@@CD DigestedBody',
-  '#1',
-  beforeDigest => sub {
-    $_[0]->bgroup;
-    alignmentBindings(MatrixTemplate(), 'math', attributes => { meaning => 'commutative-diagram' });
+DefMacro('\CD', '\lx@ams@CD{name=CD,datameaning=commutative-diagram}');
+DefMacro('\lx@ams@CD RequiredKeyVals:lx@GEN',
+  '\lx@gen@matrix@bindings{#1}\lx@ams@CD@bindings\lx@ams@matrix@{#1}\@start@alignment');
+DefMacro('\endCD', '\@finish@alignment\lx@end@gen@matrix');
+DefPrimitive('\lx@ams@CD@bindings', sub {
     Let(T_ALIGN, '\@cd@invisible@align');
     Let("\\\\",  '\@alignment@newline@noskip');
     $STATE->assignMathcode('@' => 0x8000);
-    Let('@', '\cd@'); },
-  reversion => '\begin{CD}#1\end{CD}');
+    Let('@', '\cd@'); });
 
 DefMacroI('\@cd@invisible@align', undef,
   '\@close@inner@column\@close@column'
     . '\@open@column\@open@inner@column');
-#DefConstructorI('\@alignment@align@marker',undef,'',reversion=>'&');
 
 DefMacro('\cd@ Token', sub {
     my ($gullet, $token) = @_;
@@ -83,8 +78,7 @@ DefMath('\@cd@vert@', "\x{2225}", role => 'ARROW', font => { size => 'Big' }, re
 
 DefRegister('\minaw@' => Dimension('11.111pt'));
 
-# deal with under, over & underover!
-DefConstructor('\cd@stack Undigested {}{}{}', sub {
+DefConstructor('\cd@stack Undigested {} ScriptStyle ScriptStyle', sub {
     my ($document, $reversion, $op, $over, $under, %props) = @_;
     my $scriptpos = $props{scriptpos};
     if ($under->unlist) {
@@ -109,14 +103,12 @@ DefConstructor('\cd@stack Undigested {}{}{}', sub {
     else {
       $document->insertElement('ltx:XMArg', $op); } },
   properties => { scriptpos => sub { "mid" . $_[0]->getScriptLevel; } },
-  reversion => '@#1{#3}#1{#4}#1');
+  reversion  => '@#1{#3}#1{#4}#1');
 
-# \cd@adj{}{}{}
 # Temporary...
 # Later deal with vertically centering the side things, parser issues...
-#DefMacro('\cd@adjacent{}{}{}{}','{#3}{#2}{#4}');
 
-DefConstructor('\cd@adjacent Undigested {}{}{}', sub {
+DefConstructor('\cd@adjacent Undigested {} ScriptStyle ScriptStyle', sub {
     my ($document, $reversion, $op, $left, $right, %props) = @_;
     $document->openElement('ltx:XMWrap', role => 'ARROW');    # Role?
     $document->insertElement('ltx:XMArg', $left)  if $left->unlist;

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -729,7 +729,7 @@ DefMacro('\endsubequations', '\lx@equationgroup@subnumbering@end');
 # keys are
 #  name  : the name of the environment (for reversion)
 #  datameaning: the (presumed) meaning of the array construct
-#  opmeaning  : the meaning of an operator to be applied to the array (if any)
+#  delimitermeaning  : the operator meaning due to delimiters (eg. norm)(as applied to the array)
 #  style : (display|text|script|scriptscript)
 #  left  : TeX code for left of matrix
 #  right  : TeX code for right
@@ -746,18 +746,15 @@ DefMacro('\lx@end@ams@matrix',
 # HOWEVER, the delimeters may also signify an OPERATION on the matrix
 # in which case the application & meaning of that operator must be supplied.
 
-# Similar to \lx#gen@plain@matrix@, but for the body & reversion!
+# Essentially same as \lx#gen@plain@matrix@, but for the body & reversion!
 DefConstructor('\lx@ams@matrix@ RequiredKeyVals:lx@GEN DigestedBody',
   "?#needXMDual("
     . "<ltx:XMDual>"
-    . "?#delimitermeaning("
-    . "<ltx:XMApp>"
-    . "<ltx:XMTok meaning='#delimitermeaning'/>"
+    . "?#delimitermeaning(<ltx:XMApp><ltx:XMTok meaning='#delimitermeaning'/>)()"
+    . "?#datameaning(<ltx:XMApp><ltx:XMTok meaning='#datameaning'/>)()"
     . "<ltx:XMRef _xmkey='#xmkey'/>"
-    . "</ltx:XMApp>"
-    . ")("
-    . "<ltx:XMRef _xmkey='#xmkey'/>"
-    . ")"
+    . "?#delimitermeaning(</ltx:XMApp>)()"
+    . "?#datameaning(</ltx:XMApp>)()"
     . "<ltx:XMWrap>#left<ltx:XMArg _xmkey='#xmkey'>#2</ltx:XMArg>#right</ltx:XMWrap>"
     . "</ltx:XMDual>"
     . ")("
@@ -767,7 +764,7 @@ DefConstructor('\lx@ams@matrix@ RequiredKeyVals:lx@GEN DigestedBody',
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $kv = $whatsit->getArg(1);
-    if ($kv->getValue('left') || $kv->getValue('right')) {
+    if ($kv->getValue('datameaning') || $kv->getValue('delimitermeaning')) {
       $whatsit->setProperties(
         needXMDual => 1,
         xmkey      => LaTeXML::Package::getXMArgID()); }
@@ -777,9 +774,12 @@ DefConstructor('\lx@ams@matrix@ RequiredKeyVals:lx@GEN DigestedBody',
     my $name  = $kv->getValue('name');
     my $align = $kv->getValue('alignment');
     (($name ? (T_CS('\begin'), T_BEGIN, Revert($name), T_END) : ()),
-      ($align && $align->unlist ? (T_OTHER('['), Revert($align), T_OTHER(']')) : ()),
+      ($align && $align->unlist ?
+          ($kv->getValue('alignment-required')
+          ? (T_BEGIN, Revert($align), T_END) : (T_OTHER('['), Revert($align), T_OTHER(']')))
+        : ()),
       Revert($body),
-     ($name ? (T_CS('\end'), T_BEGIN, Revert($name), T_END) : ())); }
+      ($name ? (T_CS('\end'), T_BEGIN, Revert($name), T_END) : ())); }
 );
 
 # NOTE: Use \@left,\@right here, to avoid the hidden grouping (see TeX.pool, \@hidden@bgroup)
@@ -1157,18 +1157,9 @@ DefMath('\pod{}', '(#1)', role => 'MODIFIER',   meaning => 'modulo');    # Well,
 #  \substack, \begin{subarray}
 # These make the combining operator be list, but often formulae would be better
 DefMacro('\substack{}', '\begin{subarray}{c}#1\end{subarray}');
-DefEnvironment('{subarray}{}',
-  "<ltx:XMArray mathstyle='script' name='list' class='ltx_align_#1' rowsep='#rowsep'>"
-    . "<ltx:XMRow><ltx:XMCell><ltx:XMArg>#body</ltx:XMArg></ltx:XMCell></ltx:XMRow>"
-    . "</ltx:XMArray>",
-  properties   => { rowsep => Dimension('0') },
-  beforeDigest => sub { DefConstructor("\\\\ OptionalMatch:* [Dimension]",
-      "</ltx:XMArg></ltx:XMCell></ltx:XMRow><ltx:XMRow><ltx:XMCell><ltx:XMArg>",
-      reversion => Tokens(T_CS("\\\\"), T_CR));
-    Let('\cr', "\\\\");
-    MergeFont(mathstyle => 'script');
-  });
-
+DefMacro('\subarray{}',
+'\lx@ams@matrix{name=subarray,style=\scriptsize,datameaning=list,rowsep=0pt,alignment=#1,alignment-required=true}');
+DefMacro('\endsubarray', '\lx@end@ams@matrix');
 #======================================================================
 # Section 7.2 the \sideset command
 

--- a/lib/LaTeXML/Package/physics.sty.ltxml
+++ b/lib/LaTeXML/Package/physics.sty.ltxml
@@ -87,7 +87,7 @@ sub phys_close {
 sub phys_readArg {
   my ($gullet, $required, %delimiters) = @_;
   my ($arg, $open, $close);
-  my $next = $gullet->readToken();          # or XToken ?
+  my $next = $gullet->readToken();    # or XToken ?
   if ($next && $next->equals(T_BEGIN)) {    # Read regular arg, use default delimiters
     $gullet->unread($next);
     $arg = $gullet->readArg(); }
@@ -369,7 +369,7 @@ Let('\flatfrac', '\ifrac');
 #  => (differential var [degree])
 DefMacro('\lx@physics@diff{}{}{}', sub {
     my ($gullet, $cs, $semantic, $diff) = @_;
-    my $cfunc  = I_symbol({ meaning => $semantic });
+    my $cfunc = I_symbol({ meaning => $semantic });
     my $pfunc  = I_wrap({ role => 'DIFFOP' }, $diff);
     my $degree = $gullet->readOptional;
     my ($arg, $open, $close) = phys_readArg($gullet, 0, '(' => T_OTHER(')'));
@@ -377,7 +377,7 @@ DefMacro('\lx@physics@diff{}{}{}', sub {
       { ($arg ? () : (role => 'DIFFOP')),
         reversion => Tokens($cs,
           ($degree ? (T_OTHER('['), I_arg(2), T_OTHER(']')) : ()),
-          ($arg    ? phys_revArg(I_arg(1), $open, $close)   : ())) },
+          ($arg ? phys_revArg(I_arg(1), $open, $close) : ())) },
       ($arg
         ? I_apply({}, $cfunc, I_arg(1), ($degree ? I_arg(2) : ()))
         : ($degree
@@ -490,8 +490,8 @@ DefMacro('\ket', sub {
 
 DefMacro('\bra', sub {
     my ($gullet) = @_;
-    my $size     = ($gullet->readMatch(T_OTHER('*')) ? 0 : 1);
-    my $arg      = $gullet->readArg();
+    my $size = ($gullet->readMatch(T_OTHER('*')) ? 0 : 1);
+    my $arg  = $gullet->readArg();
     if ($gullet->readMatch(T_CS('\ket'))) {    # join to make braket!
       $size = 0 if $gullet->readMatch(T_OTHER('*'));    # star here, too
       my $arg2 = $gullet->readArg();
@@ -513,10 +513,10 @@ DefMacro('\bra', sub {
 DefMacro('\lx@physics@qm@product{}{}{}{}{}', sub {
     my ($gullet, $cs, $semantic, $open, $middle, $close) = @_;
     my $cfunc = I_symbol({ meaning => $semantic });
-    my $size  = ($gullet->readMatch(T_OTHER('*')) ? 0 : 1);
-    my $arg0  = $gullet->readArg();
-    my $argx  = phys_readArg($gullet);
-    my $arg1  = $argx || $arg0;
+    my $size = ($gullet->readMatch(T_OTHER('*')) ? 0 : 1);
+    my $arg0 = $gullet->readArg();
+    my $argx = phys_readArg($gullet);
+    my $arg1 = $argx || $arg0;
     return I_dual(
       { reversion => Tokens($cs, phys_revSize($size),
           phys_revArg(I_arg(1)), phys_revArg(I_arg(2))) },
@@ -532,8 +532,8 @@ DefMacro('\outerproduct',
 
 DefMacro('\expectationvalue', sub {
     my ($gullet) = @_;
-    my $cfunc    = I_symbol({ meaning => 'expectation-value' });
-    my $size     = ($gullet->readMatch(T_OTHER('*'))
+    my $cfunc = I_symbol({ meaning => 'expectation-value' });
+    my $size  = ($gullet->readMatch(T_OTHER('*'))
       ? ($gullet->readMatch(T_OTHER('*')) ? 1 : 0)
       : 1);
     my ($open, $middle, $close) =
@@ -557,8 +557,8 @@ DefMacro('\expectationvalue', sub {
 
 DefMacro('\matrixelement', sub {
     my ($gullet) = @_;
-    my $cfunc    = I_symbol({ meaning => 'expectation-value' });
-    my $size     = ($gullet->readMatch(T_OTHER('*'))
+    my $cfunc = I_symbol({ meaning => 'expectation-value' });
+    my $size  = ($gullet->readMatch(T_OTHER('*'))
       ? ($gullet->readMatch(T_OTHER('*')) ? 1 : 0)
       : 1);
     my ($open, $middle, $close) =
@@ -694,7 +694,7 @@ DefMacro('\lx@physics@mat{}{}{}{}{}', sub {
 # Like matrix & smallmatrix except NO NAME.
 DefMacro('\lx@physics@matrix',         '\lx@ams@matrix{datameaning=matrix}');
 DefMacro('\endlx@physics@matrix',      '\lx@end@ams@matrix');
-DefMacro('\lx@physics@smallmatrix',    '\lx@ams@matrix{atameaning=matrix,style=\scriptsize}');
+DefMacro('\lx@physics@smallmatrix',    '\lx@ams@matrix{datameaning=matrix,style=\scriptsize}');
 DefMacro('\endlx@physics@smallmatrix', '\lx@end@ams@matrix');
 
 DefMacro('\matrixquantity', '\lx@physics@mat{\matrixquantity}{}{lx@physics@matrix}{}{}');

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -86,6 +86,8 @@ sub outerWrapper {
   my $wrapped = ['m:math', { display => ($mode eq 'display' ? 'block' : 'inline'),
       class   => $math->getAttribute('class'),
       alttext => $math->getAttribute('tex'),
+#### Handy for debugging math
+###      title => $math->getAttribute('text'),
       @rdfa,
       @img },
     $mml];
@@ -744,6 +746,8 @@ my %normally_stretchy = map { $_ => 1 }
   "\x{2225}", "\x{2225}", "\x{2016}", "\x{2016}", "\x{2223}", "\x{2223}", "\x{007C}", "\x{007C}",
   "\x{20D7}", "\x{20D6}", "\x{20E1}", "\x{20D1}", "\x{20D0}", "\x{21A9}", "\x{21AA}", "\x{23B0}",
   "\x{23B1}");
+my %default_token_content = (
+  MULOP => "\x{2062}", ADDOP => "\x{2064}", PUNCT => "\x{2063}");
 # Given an item (string or token element w/attributes) and latexml attributes,
 # convert the string to the appropriate unicode (possibly plane1)
 # & MathML presentation attributes (mathvariant, mathsize, mathcolor, stretchy)
@@ -800,8 +804,11 @@ sub stylizeContent {
     $stretchy = undef; }                 # Otherwise, doesn't need to be said at all.
 
   if ((!defined $text) || ($text eq '')) {    # Failsafe for empty tokens?
-    $text = ($iselement ? $item->getAttribute('name') || $item->getAttribute('meaning') || $role : '?');
-    $color = 'red'; }
+    if (my $default = $role && $default_token_content{$role}) {
+      $text = $default; }
+    else {
+      $text = ($iselement ? $item->getAttribute('name') || $item->getAttribute('meaning') || $role : '?');
+      $color = 'red'; } }
 
   if ($font && !$variant) {
     Warn('unexpected', $font, undef, "Unrecognized font variant '$font'"); $variant = ''; }

--- a/t/alignment/plainmath.xml
+++ b/t/alignment/plainmath.xml
@@ -4,33 +4,39 @@
   <resource src="LaTeXML.css" type="text/css"/>
   <para>
     <equation>
-      <Math mode="display" tex="\matrix{a&amp;b\cr c&amp;d}" text="matrix[[a, b], [c, d]]">
+      <Math mode="display" tex="\matrix{a&amp;b\cr c&amp;d}" text="matrix@(Array[[a, b], [c, d]])">
         <XMath>
-          <XMArray meaning="matrix">
-            <XMRow>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">a</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">b</XMTok>
-              </XMCell>
-            </XMRow>
-            <XMRow>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">c</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">d</XMTok>
-              </XMCell>
-            </XMRow>
-          </XMArray>
+          <XMDual>
+            <XMApp>
+              <XMTok meaning="matrix"/>
+              <XMRef idref="id1"/>
+            </XMApp>
+            <XMArray xml:id="id1">
+              <XMRow>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                </XMCell>
+              </XMRow>
+              <XMRow>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                </XMCell>
+              </XMRow>
+            </XMArray>
+          </XMDual>
         </XMath>
       </Math>
     </equation>
     <equation>
-      <Math mode="display" tex="\bordermatrix{&amp;A&amp;B\cr C&amp;0&amp;1\cr D&amp;2&amp;3}" text="matrix[[absent, , A, B, ], [C, (@ , 0, 1, )@ ], [D, , 2, 3, ]]">
+      <Math mode="display" tex="\bordermatrix{&amp;A&amp;B\cr C&amp;0&amp;1\cr D&amp;2&amp;3}" text="Array[[absent, , A, B, ], [C, (@ , 0, 1, )@ ], [D, , 2, 3, ]]">
         <XMath>
-          <XMArray meaning="matrix">
+          <XMArray>
             <XMRow>
               <XMCell align="center">
                 <XMTok meaning="absent"/>
@@ -85,13 +91,16 @@
       </Math>
     </equation>
     <equation>
-      <Math mode="display" tex="\pmatrix{a&amp;b\cr c&amp;d}" text="matrix[[a, b], [c, d]]">
+      <Math mode="display" tex="\pmatrix{a&amp;b\cr c&amp;d}" text="matrix@(Array[[a, b], [c, d]])">
         <XMath>
           <XMDual>
-            <XMRef idref="id1"/>
+            <XMApp>
+              <XMTok meaning="matrix"/>
+              <XMRef idref="id2"/>
+            </XMApp>
             <XMWrap>
               <XMTok role="OPEN" stretchy="true">(</XMTok>
-              <XMArray meaning="matrix" xml:id="id1">
+              <XMArray xml:id="id2">
                 <XMRow>
                   <XMCell align="center">
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
@@ -126,10 +135,10 @@
               <XMTok meaning="times" role="MULOP">⁢</XMTok>
               <XMTok font="italic" role="UNKNOWN">s</XMTok>
               <XMDual>
-                <XMRef idref="id7"/>
+                <XMRef idref="id8"/>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">(</XMTok>
-                  <XMTok font="italic" role="UNKNOWN" xml:id="id7">x</XMTok>
+                  <XMTok font="italic" role="UNKNOWN" xml:id="id8">x</XMTok>
                   <XMTok role="CLOSE" stretchy="false">)</XMTok>
                 </XMWrap>
               </XMDual>
@@ -137,11 +146,11 @@
             <XMDual>
               <XMApp>
                 <XMTok meaning="cases"/>
-                <XMRef idref="id2"/>
                 <XMRef idref="id3"/>
                 <XMRef idref="id4"/>
                 <XMRef idref="id5"/>
                 <XMRef idref="id6"/>
+                <XMRef idref="id7"/>
                 <XMText><text font="italic">otherwise</text></XMText>
               </XMApp>
               <XMWrap>
@@ -149,24 +158,24 @@
                 <XMArray>
                   <XMRow>
                     <XMCell align="left">
-                      <XMApp xml:id="id2">
+                      <XMApp xml:id="id3">
                         <XMTok meaning="plus" role="ADDOP">+</XMTok>
                         <XMTok meaning="1" role="NUMBER">1</XMTok>
                       </XMApp>
                     </XMCell>
                     <XMCell align="left">
-                      <XMText xml:id="id3">whatever</XMText>
+                      <XMText xml:id="id4">whatever</XMText>
                     </XMCell>
                   </XMRow>
                   <XMRow>
                     <XMCell align="left">
-                      <XMApp xml:id="id4">
+                      <XMApp xml:id="id5">
                         <XMTok meaning="minus" role="ADDOP">-</XMTok>
                         <XMTok meaning="1" role="NUMBER">1</XMTok>
                       </XMApp>
                     </XMCell>
                     <XMCell align="left">
-                      <XMApp xml:id="id5">
+                      <XMApp xml:id="id6">
                         <XMTok meaning="less-than" role="RELOP">&lt;</XMTok>
                         <XMTok font="italic" role="UNKNOWN">x</XMTok>
                         <XMTok meaning="0" role="NUMBER">0</XMTok>
@@ -175,7 +184,7 @@
                   </XMRow>
                   <XMRow>
                     <XMCell align="left">
-                      <XMTok meaning="0" role="NUMBER" xml:id="id6">0</XMTok>
+                      <XMTok meaning="0" role="NUMBER" xml:id="id7">0</XMTok>
                     </XMCell>
                     <XMCell/>
                   </XMRow>
@@ -300,10 +309,10 @@
               </XMCell>
               <XMCell align="left">
                 <XMDual>
-                  <XMRef idref="id8"/>
+                  <XMRef idref="id9"/>
                   <XMWrap>
                     <XMTok role="OPEN" stretchy="false">(</XMTok>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="id8">x</XMTok>
+                    <XMTok font="italic" role="UNKNOWN" xml:id="id9">x</XMTok>
                     <XMTok role="CLOSE" stretchy="false">)</XMTok>
                   </XMWrap>
                 </XMDual>
@@ -351,10 +360,10 @@
               </XMCell>
               <XMCell align="left">
                 <XMDual>
-                  <XMRef idref="id9"/>
+                  <XMRef idref="id10"/>
                   <XMWrap>
                     <XMTok role="OPEN" stretchy="false">(</XMTok>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="id9">x</XMTok>
+                    <XMTok font="italic" role="UNKNOWN" xml:id="id10">x</XMTok>
                     <XMTok role="CLOSE" stretchy="false">)</XMTok>
                   </XMWrap>
                 </XMDual>

--- a/t/ams/cd.xml
+++ b/t/ams/cd.xml
@@ -12,96 +12,108 @@
         <tag>(1)</tag>
         <tag role="refnum">1</tag>
       </tags>
-      <Math mode="display" tex="\begin{CD}S^{{\mathcal{W}}_{\Lambda}}\otimes T@&gt;{j}&gt;{}&gt;T\\&#10;@V{}V{}V@V{}V{\operatorname{End}P}V\\&#10;(S\otimes T)/I@=(Z\otimes T)/J\end{CD}" text="commutative-diagram[[S ^ (W _ Lambda) tensor-product T, rightarrowfill@ ^ j, T], [downarrow, , absent downarrow End@(P), , ], [(S tensor-product T) / I, @cd@equals@, (Z tensor-product T) / J]]" xml:id="S0.E1.m1">
+      <Math mode="display" tex="\begin{CD}S^{{\mathcal{W}}_{\Lambda}}\otimes T@&gt;{j}&gt;{}&gt;T\\&#10;@V{}V{}V@V{}V{\operatorname{End}P}V\\&#10;(S\otimes T)/I@=(Z\otimes T)/J\end{CD}" text="commutative-diagram@(Array[[S ^ (W _ Lambda) tensor-product T, rightarrowfill@ ^ j, T], [downarrow, absent, absent downarrow End@(P), absent, absent], [(S tensor-product T) / I, @cd@equals@, (Z tensor-product T) / J]])" xml:id="S0.E1.m1">
         <XMath>
-          <XMArray meaning="commutative-diagram">
-            <XMRow>
-              <XMCell align="center">
-                <XMApp>
-                  <XMTok meaning="tensor-product" name="otimes" role="MULOP">⊗</XMTok>
+          <XMDual>
+            <XMApp>
+              <XMTok meaning="commutative-diagram"/>
+              <XMRef idref="S0.E1.m1.1"/>
+            </XMApp>
+            <XMArray xml:id="S0.E1.m1.1">
+              <XMRow>
+                <XMCell align="center">
                   <XMApp>
-                    <XMTok role="SUPERSCRIPTOP" scriptpos="post6"/>
-                    <XMTok font="italic" role="UNKNOWN">S</XMTok>
+                    <XMTok meaning="tensor-product" name="otimes" role="MULOP">⊗</XMTok>
                     <XMApp>
-                      <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                      <XMTok font="caligraphic" fontsize="70%" role="UNKNOWN">W</XMTok>
-                      <XMTok fontsize="50%" name="Lambda" role="UNKNOWN">Λ</XMTok>
+                      <XMTok role="SUPERSCRIPTOP" scriptpos="post6"/>
+                      <XMTok font="italic" role="UNKNOWN">S</XMTok>
+                      <XMApp>
+                        <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                        <XMTok font="caligraphic" fontsize="70%" role="UNKNOWN">W</XMTok>
+                        <XMTok fontsize="50%" name="Lambda" role="UNKNOWN">Λ</XMTok>
+                      </XMApp>
+                    </XMApp>
+                    <XMTok font="italic" role="UNKNOWN">T</XMTok>
+                  </XMApp>
+                </XMCell>
+                <XMCell align="center">
+                  <XMApp>
+                    <XMTok role="SUPERSCRIPTOP" scriptpos="mid6"/>
+                    <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
+                    <XMTok font="italic" fontsize="70%" role="UNKNOWN">j</XMTok>
+                  </XMApp>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">T</XMTok>
+                </XMCell>
+              </XMRow>
+              <XMRow>
+                <XMCell align="center">
+                  <XMTok fontsize="160%" name="downarrow" role="ARROW">↓</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok meaning="absent"/>
+                </XMCell>
+                <XMCell align="center">
+                  <XMApp role="ARROW">
+                    <XMTok fontsize="160%" name="downarrow" role="ARROW">↓</XMTok>
+                    <XMTok meaning="absent"/>
+                    <XMApp>
+                      <XMTok fontsize="70%" role="OPFUNCTION" scriptpos="post">End</XMTok>
+                      <XMTok font="italic" fontsize="70%" role="UNKNOWN">P</XMTok>
                     </XMApp>
                   </XMApp>
-                  <XMTok font="italic" role="UNKNOWN">T</XMTok>
-                </XMApp>
-              </XMCell>
-              <XMCell align="center">
-                <XMApp>
-                  <XMTok role="SUPERSCRIPTOP" scriptpos="mid6"/>
-                  <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
-                  <XMTok font="italic" role="UNKNOWN">j</XMTok>
-                </XMApp>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">T</XMTok>
-              </XMCell>
-            </XMRow>
-            <XMRow>
-              <XMCell align="center">
-                <XMTok fontsize="160%" name="downarrow" role="ARROW">↓</XMTok>
-              </XMCell>
-              <XMCell/>
-              <XMCell align="center">
-                <XMApp role="ARROW">
-                  <XMTok fontsize="160%" name="downarrow" role="ARROW">↓</XMTok>
+                </XMCell>
+                <XMCell align="center">
                   <XMTok meaning="absent"/>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok meaning="absent"/>
+                </XMCell>
+              </XMRow>
+              <XMRow>
+                <XMCell align="center">
                   <XMApp>
-                    <XMTok role="OPFUNCTION" scriptpos="post">End</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">P</XMTok>
+                    <XMTok meaning="divide" role="MULOP">/</XMTok>
+                    <XMDual>
+                      <XMRef idref="S0.E1.m1.1.1"/>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMApp xml:id="S0.E1.m1.1.1">
+                          <XMTok meaning="tensor-product" name="otimes" role="MULOP">⊗</XMTok>
+                          <XMTok font="italic" role="UNKNOWN">S</XMTok>
+                          <XMTok font="italic" role="UNKNOWN">T</XMTok>
+                        </XMApp>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMDual>
+                    <XMTok font="italic" role="UNKNOWN">I</XMTok>
                   </XMApp>
-                </XMApp>
-              </XMCell>
-              <XMCell/>
-              <XMCell/>
-            </XMRow>
-            <XMRow>
-              <XMCell align="center">
-                <XMApp>
-                  <XMTok meaning="divide" role="MULOP">/</XMTok>
-                  <XMDual>
-                    <XMRef idref="S0.E1.m1.1"/>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMApp xml:id="S0.E1.m1.1">
-                        <XMTok meaning="tensor-product" name="otimes" role="MULOP">⊗</XMTok>
-                        <XMTok font="italic" role="UNKNOWN">S</XMTok>
-                        <XMTok font="italic" role="UNKNOWN">T</XMTok>
-                      </XMApp>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMDual>
-                  <XMTok font="italic" role="UNKNOWN">I</XMTok>
-                </XMApp>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok name="@cd@equals@" role="ARROW" stretchy="true">=</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMApp>
-                  <XMTok meaning="divide" role="MULOP">/</XMTok>
-                  <XMDual>
-                    <XMRef idref="S0.E1.m1.2"/>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMApp xml:id="S0.E1.m1.2">
-                        <XMTok meaning="tensor-product" name="otimes" role="MULOP">⊗</XMTok>
-                        <XMTok font="italic" role="UNKNOWN">Z</XMTok>
-                        <XMTok font="italic" role="UNKNOWN">T</XMTok>
-                      </XMApp>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMDual>
-                  <XMTok font="italic" role="UNKNOWN">J</XMTok>
-                </XMApp>
-              </XMCell>
-            </XMRow>
-          </XMArray>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok name="@cd@equals@" role="ARROW" stretchy="true">=</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMApp>
+                    <XMTok meaning="divide" role="MULOP">/</XMTok>
+                    <XMDual>
+                      <XMRef idref="S0.E1.m1.1.2"/>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMApp xml:id="S0.E1.m1.1.2">
+                          <XMTok meaning="tensor-product" name="otimes" role="MULOP">⊗</XMTok>
+                          <XMTok font="italic" role="UNKNOWN">Z</XMTok>
+                          <XMTok font="italic" role="UNKNOWN">T</XMTok>
+                        </XMApp>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMDual>
+                    <XMTok font="italic" role="UNKNOWN">J</XMTok>
+                  </XMApp>
+                </XMCell>
+              </XMRow>
+            </XMArray>
+          </XMDual>
         </XMath>
       </Math>
     </equation>
@@ -110,179 +122,195 @@
         <tag>(2)</tag>
         <tag role="refnum">2</tag>
       </tags>
-      <Math mode="display" tex="\begin{CD}\operatorname{cov}(\mathcal{L})@&gt;{}&gt;{}&gt;\operatorname{non}(\mathcal{K%&#10;})@&gt;{}&gt;{}&gt;\operatorname{cf}(\mathcal{K})@&gt;{}&gt;{}&gt;\operatorname{cf}(\mathcal{L})%&#10;\\&#10;@V{}V{}V@A{}A{}A@A{}A{}A@V{}V{}V\\&#10;\operatorname{add}(\mathcal{L})@&gt;{}&gt;{}&gt;\operatorname{add}(\mathcal{K})@&gt;{}&gt;{}&gt;%&#10;\operatorname{cov}(\mathcal{K})@&gt;{}&gt;{}&gt;\operatorname{non}(\mathcal{L})\end{CD}" text="commutative-diagram[[cov@(L), rightarrowfill@, non@(K), rightarrowfill@, cf@(K), rightarrowfill@, cf@(L)], [downarrow, , uparrow, , uparrow, , downarrow, , ], [add@(L), rightarrowfill@, add@(K), rightarrowfill@, cov@(K), rightarrowfill@, non@(L)]]" xml:id="S0.E2.m1">
+      <Math mode="display" tex="\begin{CD}\operatorname{cov}(\mathcal{L})@&gt;{}&gt;{}&gt;\operatorname{non}(\mathcal{K%&#10;})@&gt;{}&gt;{}&gt;\operatorname{cf}(\mathcal{K})@&gt;{}&gt;{}&gt;\operatorname{cf}(\mathcal{L})%&#10;\\&#10;@V{}V{}V@A{}A{}A@A{}A{}A@V{}V{}V\\&#10;\operatorname{add}(\mathcal{L})@&gt;{}&gt;{}&gt;\operatorname{add}(\mathcal{K})@&gt;{}&gt;{}&gt;%&#10;\operatorname{cov}(\mathcal{K})@&gt;{}&gt;{}&gt;\operatorname{non}(\mathcal{L})\end{CD}" text="commutative-diagram@(Array[[cov@(L), rightarrowfill@, non@(K), rightarrowfill@, cf@(K), rightarrowfill@, cf@(L)], [downarrow, absent, uparrow, absent, uparrow, absent, downarrow, absent, absent], [add@(L), rightarrowfill@, add@(K), rightarrowfill@, cov@(K), rightarrowfill@, non@(L)]])" xml:id="S0.E2.m1">
         <XMath>
-          <XMArray meaning="commutative-diagram">
-            <XMRow>
-              <XMCell align="center">
-                <XMDual>
-                  <XMApp>
-                    <XMRef idref="S0.E2.m1.1"/>
-                    <XMRef idref="S0.E2.m1.2"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.1">cov</XMTok>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.2">L</XMTok>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMApp>
-                </XMDual>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMDual>
-                  <XMApp>
-                    <XMRef idref="S0.E2.m1.3"/>
-                    <XMRef idref="S0.E2.m1.4"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.3">non</XMTok>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.4">K</XMTok>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMApp>
-                </XMDual>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMDual>
-                  <XMApp>
-                    <XMRef idref="S0.E2.m1.5"/>
-                    <XMRef idref="S0.E2.m1.6"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.5">cf</XMTok>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.6">K</XMTok>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMApp>
-                </XMDual>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMDual>
-                  <XMApp>
-                    <XMRef idref="S0.E2.m1.7"/>
-                    <XMRef idref="S0.E2.m1.8"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.7">cf</XMTok>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.8">L</XMTok>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMApp>
-                </XMDual>
-              </XMCell>
-            </XMRow>
-            <XMRow>
-              <XMCell align="center">
-                <XMTok fontsize="160%" name="downarrow" role="ARROW">↓</XMTok>
-              </XMCell>
-              <XMCell/>
-              <XMCell align="center">
-                <XMTok fontsize="160%" name="uparrow" role="ARROW">↑</XMTok>
-              </XMCell>
-              <XMCell/>
-              <XMCell align="center">
-                <XMTok fontsize="160%" name="uparrow" role="ARROW">↑</XMTok>
-              </XMCell>
-              <XMCell/>
-              <XMCell align="center">
-                <XMTok fontsize="160%" name="downarrow" role="ARROW">↓</XMTok>
-              </XMCell>
-              <XMCell/>
-              <XMCell/>
-            </XMRow>
-            <XMRow>
-              <XMCell align="center">
-                <XMDual>
-                  <XMApp>
-                    <XMRef idref="S0.E2.m1.9"/>
-                    <XMRef idref="S0.E2.m1.10"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.9">add</XMTok>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.10">L</XMTok>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMApp>
-                </XMDual>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMDual>
-                  <XMApp>
-                    <XMRef idref="S0.E2.m1.11"/>
-                    <XMRef idref="S0.E2.m1.12"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.11">add</XMTok>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.12">K</XMTok>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMApp>
-                </XMDual>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMDual>
-                  <XMApp>
-                    <XMRef idref="S0.E2.m1.13"/>
-                    <XMRef idref="S0.E2.m1.14"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.13">cov</XMTok>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.14">K</XMTok>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMApp>
-                </XMDual>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMDual>
-                  <XMApp>
-                    <XMRef idref="S0.E2.m1.15"/>
-                    <XMRef idref="S0.E2.m1.16"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.15">non</XMTok>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="false">(</XMTok>
-                      <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.16">L</XMTok>
-                      <XMTok role="CLOSE" stretchy="false">)</XMTok>
-                    </XMWrap>
-                  </XMApp>
-                </XMDual>
-              </XMCell>
-            </XMRow>
-          </XMArray>
+          <XMDual>
+            <XMApp>
+              <XMTok meaning="commutative-diagram"/>
+              <XMRef idref="S0.E2.m1.1"/>
+            </XMApp>
+            <XMArray xml:id="S0.E2.m1.1">
+              <XMRow>
+                <XMCell align="center">
+                  <XMDual>
+                    <XMApp>
+                      <XMRef idref="S0.E2.m1.1.1"/>
+                      <XMRef idref="S0.E2.m1.1.2"/>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.1.1">cov</XMTok>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.1.2">L</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMApp>
+                  </XMDual>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMDual>
+                    <XMApp>
+                      <XMRef idref="S0.E2.m1.1.3"/>
+                      <XMRef idref="S0.E2.m1.1.4"/>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.1.3">non</XMTok>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.1.4">K</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMApp>
+                  </XMDual>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMDual>
+                    <XMApp>
+                      <XMRef idref="S0.E2.m1.1.5"/>
+                      <XMRef idref="S0.E2.m1.1.6"/>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.1.5">cf</XMTok>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.1.6">K</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMApp>
+                  </XMDual>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMDual>
+                    <XMApp>
+                      <XMRef idref="S0.E2.m1.1.7"/>
+                      <XMRef idref="S0.E2.m1.1.8"/>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.1.7">cf</XMTok>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.1.8">L</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMApp>
+                  </XMDual>
+                </XMCell>
+              </XMRow>
+              <XMRow>
+                <XMCell align="center">
+                  <XMTok fontsize="160%" name="downarrow" role="ARROW">↓</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok meaning="absent"/>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok fontsize="160%" name="uparrow" role="ARROW">↑</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok meaning="absent"/>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok fontsize="160%" name="uparrow" role="ARROW">↑</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok meaning="absent"/>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok fontsize="160%" name="downarrow" role="ARROW">↓</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok meaning="absent"/>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok meaning="absent"/>
+                </XMCell>
+              </XMRow>
+              <XMRow>
+                <XMCell align="center">
+                  <XMDual>
+                    <XMApp>
+                      <XMRef idref="S0.E2.m1.1.9"/>
+                      <XMRef idref="S0.E2.m1.1.10"/>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.1.9">add</XMTok>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.1.10">L</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMApp>
+                  </XMDual>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMDual>
+                    <XMApp>
+                      <XMRef idref="S0.E2.m1.1.11"/>
+                      <XMRef idref="S0.E2.m1.1.12"/>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.1.11">add</XMTok>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.1.12">K</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMApp>
+                  </XMDual>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMDual>
+                    <XMApp>
+                      <XMRef idref="S0.E2.m1.1.13"/>
+                      <XMRef idref="S0.E2.m1.1.14"/>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.1.13">cov</XMTok>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.1.14">K</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMApp>
+                  </XMDual>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok name="rightarrowfill@" role="ARROW" stretchy="true">→</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMDual>
+                    <XMApp>
+                      <XMRef idref="S0.E2.m1.1.15"/>
+                      <XMRef idref="S0.E2.m1.1.16"/>
+                    </XMApp>
+                    <XMApp>
+                      <XMTok role="OPFUNCTION" scriptpos="post" xml:id="S0.E2.m1.1.15">non</XMTok>
+                      <XMWrap>
+                        <XMTok role="OPEN" stretchy="false">(</XMTok>
+                        <XMTok font="caligraphic" role="UNKNOWN" xml:id="S0.E2.m1.1.16">L</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">)</XMTok>
+                      </XMWrap>
+                    </XMApp>
+                  </XMDual>
+                </XMCell>
+              </XMRow>
+            </XMArray>
+          </XMDual>
         </XMath>
       </Math>
     </equation>

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -1533,133 +1533,154 @@ Then a switch of tag forms.</p>
     <title><tag close=" ">4</tag>Matrices</title>
     <para xml:id="S4.p1">
       <equation xml:id="S4.Ex23">
-        <Math mode="display" tex="\begin{matrix}c&amp;cocococococo\\&#10;c&amp;c\end{matrix}" text="matrix[[c, c * o * c * o * c * o * c * o * c * o * c * o], [c, c]]" xml:id="S4.Ex23.m1">
+        <Math mode="display" tex="\begin{matrix}c&amp;cocococococo\\&#10;c&amp;c\end{matrix}" text="matrix@(Array[[c, c * o * c * o * c * o * c * o * c * o * c * o], [c, c]])" xml:id="S4.Ex23.m1">
           <XMath>
-            <XMArray meaning="matrix">
-              <XMRow>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                </XMCell>
-                <XMCell align="center">
-                  <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+            <XMDual>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S4.Ex23.m1.1"/>
+              </XMApp>
+              <XMArray xml:id="S4.Ex23.m1.1">
+                <XMRow>
+                  <XMCell align="center">
                     <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">o</XMTok>
+                  </XMCell>
+                  <XMCell align="center">
+                    <XMApp>
+                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">o</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">o</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">o</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">o</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">o</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">o</XMTok>
+                    </XMApp>
+                  </XMCell>
+                </XMRow>
+                <XMRow>
+                  <XMCell align="center">
                     <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">o</XMTok>
+                  </XMCell>
+                  <XMCell align="center">
                     <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">o</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">o</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">o</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">o</XMTok>
-                  </XMApp>
-                </XMCell>
-              </XMRow>
-              <XMRow>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                </XMCell>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                </XMCell>
-              </XMRow>
-            </XMArray>
+                  </XMCell>
+                </XMRow>
+              </XMArray>
+            </XMDual>
           </XMath>
         </Math>
       </equation>
     </para>
     <para xml:id="S4.p2">
       <equation xml:id="S4.Ex24">
-        <Math mode="display" tex="\begin{matrix}[l]lalalalalala&amp;l\\&#10;l&amp;l\end{matrix}" text="matrix[[l * a * l * a * l * a * l * a * l * a * l * a, l], [l, l]]" xml:id="S4.Ex24.m1">
+        <Math mode="display" tex="\begin{matrix}[l]lalalalalala&amp;l\\&#10;l&amp;l\end{matrix}" text="matrix@(Array[[l * a * l * a * l * a * l * a * l * a * l * a, l], [l, l]])" xml:id="S4.Ex24.m1">
           <XMath>
-            <XMArray meaning="matrix">
-              <XMRow>
-                <XMCell align="left">
-                  <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+            <XMDual>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S4.Ex24.m1.1"/>
+              </XMApp>
+              <XMArray xml:id="S4.Ex24.m1.1">
+                <XMRow>
+                  <XMCell align="left">
+                    <XMApp>
+                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">l</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">l</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">l</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">l</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">l</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">l</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                    </XMApp>
+                  </XMCell>
+                  <XMCell align="left">
                     <XMTok font="italic" role="UNKNOWN">l</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                  </XMCell>
+                </XMRow>
+                <XMRow>
+                  <XMCell align="left">
                     <XMTok font="italic" role="UNKNOWN">l</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                  </XMCell>
+                  <XMCell align="left">
                     <XMTok font="italic" role="UNKNOWN">l</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">l</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">l</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">l</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                  </XMApp>
-                </XMCell>
-                <XMCell align="left">
-                  <XMTok font="italic" role="UNKNOWN">l</XMTok>
-                </XMCell>
-              </XMRow>
-              <XMRow>
-                <XMCell align="left">
-                  <XMTok font="italic" role="UNKNOWN">l</XMTok>
-                </XMCell>
-                <XMCell align="left">
-                  <XMTok font="italic" role="UNKNOWN">l</XMTok>
-                </XMCell>
-              </XMRow>
-            </XMArray>
+                  </XMCell>
+                </XMRow>
+              </XMArray>
+            </XMDual>
           </XMath>
         </Math>
       </equation>
     </para>
     <para xml:id="S4.p3">
       <equation xml:id="S4.Ex25">
-        <Math mode="display" tex="\begin{matrix}[r]rererererere&amp;r\\&#10;r&amp;r\end{matrix}" text="matrix[[r * e * r * e * r * e * r * e * r * e * r * e, r], [r, r]]" xml:id="S4.Ex25.m1">
+        <Math mode="display" tex="\begin{matrix}[r]rererererere&amp;r\\&#10;r&amp;r\end{matrix}" text="matrix@(Array[[r * e * r * e * r * e * r * e * r * e * r * e, r], [r, r]])" xml:id="S4.Ex25.m1">
           <XMath>
-            <XMArray meaning="matrix">
-              <XMRow>
-                <XMCell align="right">
-                  <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+            <XMDual>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S4.Ex25.m1.1"/>
+              </XMApp>
+              <XMArray xml:id="S4.Ex25.m1.1">
+                <XMRow>
+                  <XMCell align="right">
+                    <XMApp>
+                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">r</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">r</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">r</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">r</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">r</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">r</XMTok>
+                      <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                    </XMApp>
+                  </XMCell>
+                  <XMCell align="right">
                     <XMTok font="italic" role="UNKNOWN">r</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                  </XMCell>
+                </XMRow>
+                <XMRow>
+                  <XMCell align="right">
                     <XMTok font="italic" role="UNKNOWN">r</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                  </XMCell>
+                  <XMCell align="right">
                     <XMTok font="italic" role="UNKNOWN">r</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">e</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">r</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">e</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">r</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">e</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">r</XMTok>
-                    <XMTok font="italic" role="UNKNOWN">e</XMTok>
-                  </XMApp>
-                </XMCell>
-                <XMCell align="right">
-                  <XMTok font="italic" role="UNKNOWN">r</XMTok>
-                </XMCell>
-              </XMRow>
-              <XMRow>
-                <XMCell align="right">
-                  <XMTok font="italic" role="UNKNOWN">r</XMTok>
-                </XMCell>
-                <XMCell align="right">
-                  <XMTok font="italic" role="UNKNOWN">r</XMTok>
-                </XMCell>
-              </XMRow>
-            </XMArray>
+                  </XMCell>
+                </XMRow>
+              </XMArray>
+            </XMDual>
           </XMath>
         </Math>
       </equation>
     </para>
     <para xml:id="S4.p4">
       <equation xml:id="S4.Ex26">
-        <Math mode="display" tex="\begin{pmatrix}[l]ppppppp&amp;foo\\&#10;l&amp;ppppppppppppppp\end{pmatrix}" text="matrix[[p * p * p * p * p * p * p, f * o * o], [l, p * p * p * p * p * p * p * p * p * p * p * p * p * p * p]]" xml:id="S4.Ex26.m1">
+        <Math mode="display" tex="\begin{pmatrix}[l]ppppppp&amp;foo\\&#10;l&amp;ppppppppppppppp\end{pmatrix}" text="matrix@(Array[[p * p * p * p * p * p * p, f * o * o], [l, p * p * p * p * p * p * p * p * p * p * p * p * p * p * p]])" xml:id="S4.Ex26.m1">
           <XMath>
             <XMDual>
-              <XMRef idref="S4.Ex26.m1.1"/>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S4.Ex26.m1.1"/>
+              </XMApp>
               <XMWrap>
                 <XMTok role="OPEN" stretchy="true">(</XMTok>
-                <XMArray meaning="matrix" xml:id="S4.Ex26.m1.1">
+                <XMArray xml:id="S4.Ex26.m1.1">
                   <XMRow>
                     <XMCell align="left">
                       <XMApp>
@@ -1717,13 +1738,16 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p5">
       <equation xml:id="S4.Ex27">
-        <Math mode="display" tex="\begin{bmatrix}b&amp;b\\&#10;b&amp;b\end{bmatrix}" text="matrix[[b, b], [b, b]]" xml:id="S4.Ex27.m1">
+        <Math mode="display" tex="\begin{bmatrix}b&amp;b\\&#10;b&amp;b\end{bmatrix}" text="matrix@(Array[[b, b], [b, b]])" xml:id="S4.Ex27.m1">
           <XMath>
             <XMDual>
-              <XMRef idref="S4.Ex27.m1.1"/>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S4.Ex27.m1.1"/>
+              </XMApp>
               <XMWrap>
                 <XMTok role="OPEN" stretchy="true">[</XMTok>
-                <XMArray meaning="matrix" xml:id="S4.Ex27.m1.1">
+                <XMArray xml:id="S4.Ex27.m1.1">
                   <XMRow>
                     <XMCell align="center">
                       <XMTok font="italic" role="UNKNOWN">b</XMTok>
@@ -1750,13 +1774,16 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p6">
       <equation xml:id="S4.Ex28">
-        <Math mode="display" tex="\begin{Bmatrix}[r]B&amp;B\\&#10;B&amp;BBBBBBBrBBBBBB\end{Bmatrix}" text="matrix[[B, B], [B, B * B * B * B * B * B * B * r * B * B * B * B * B * B]]" xml:id="S4.Ex28.m1">
+        <Math mode="display" tex="\begin{Bmatrix}[r]B&amp;B\\&#10;B&amp;BBBBBBBrBBBBBB\end{Bmatrix}" text="matrix@(Array[[B, B], [B, B * B * B * B * B * B * B * r * B * B * B * B * B * B]])" xml:id="S4.Ex28.m1">
           <XMath>
             <XMDual>
-              <XMRef idref="S4.Ex28.m1.1"/>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S4.Ex28.m1.1"/>
+              </XMApp>
               <XMWrap>
                 <XMTok role="OPEN" stretchy="true">{</XMTok>
-                <XMArray meaning="matrix" xml:id="S4.Ex28.m1.1">
+                <XMArray xml:id="S4.Ex28.m1.1">
                   <XMRow>
                     <XMCell align="right">
                       <XMTok font="italic" role="UNKNOWN">B</XMTok>
@@ -1799,16 +1826,19 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p7">
       <equation xml:id="S4.Ex29">
-        <Math mode="display" tex="\begin{vmatrix}v&amp;v\\&#10;v&amp;v\end{vmatrix}" text="determinant@(matrix[[v, v], [v, v]])" xml:id="S4.Ex29.m1">
+        <Math mode="display" tex="\begin{vmatrix}v&amp;v\\&#10;v&amp;v\end{vmatrix}" text="determinant@(matrix@(Array[[v, v], [v, v]]))" xml:id="S4.Ex29.m1">
           <XMath>
             <XMDual>
               <XMApp>
                 <XMTok meaning="determinant"/>
-                <XMRef idref="S4.Ex29.m1.1"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S4.Ex29.m1.1"/>
+                </XMApp>
               </XMApp>
               <XMWrap>
                 <XMTok role="VERTBAR" stretchy="true">|</XMTok>
-                <XMArray meaning="matrix" xml:id="S4.Ex29.m1.1">
+                <XMArray xml:id="S4.Ex29.m1.1">
                   <XMRow>
                     <XMCell align="center">
                       <XMTok font="italic" role="UNKNOWN">v</XMTok>
@@ -1835,16 +1865,19 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p8">
       <equation xml:id="S4.Ex30">
-        <Math mode="display" tex="\begin{Vmatrix}[c]V&amp;V\\&#10;VVVVVVcVVVVVV&amp;bar\end{Vmatrix}" text="norm@(matrix[[V, V], [V * V * V * V * V * V * c * V * V * V * V * V * V, b * a * r]])" xml:id="S4.Ex30.m1">
+        <Math mode="display" tex="\begin{Vmatrix}[c]V&amp;V\\&#10;VVVVVVcVVVVVV&amp;bar\end{Vmatrix}" text="norm@(matrix@(Array[[V, V], [V * V * V * V * V * V * c * V * V * V * V * V * V, b * a * r]]))" xml:id="S4.Ex30.m1">
           <XMath>
             <XMDual>
               <XMApp>
                 <XMTok meaning="norm"/>
-                <XMRef idref="S4.Ex30.m1.1"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S4.Ex30.m1.1"/>
+                </XMApp>
               </XMApp>
               <XMWrap>
                 <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-                <XMArray meaning="matrix" xml:id="S4.Ex30.m1.1">
+                <XMArray xml:id="S4.Ex30.m1.1">
                   <XMRow>
                     <XMCell align="center">
                       <XMTok font="italic" role="UNKNOWN">V</XMTok>
@@ -1891,16 +1924,19 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p9">
       <equation xml:id="S4.Ex31">
-        <Math mode="display" tex="\begin{vmatrix}[l]a&amp;blblblbllbblblblblblblbl\\&#10;c&amp;d\end{vmatrix}" text="determinant@(matrix[[a, b * l * b * l * b * l * b * l * l * b * b * l * b * l * b * l * b * l * b * l * b * l * b * l], [c, d]])" xml:id="S4.Ex31.m1">
+        <Math mode="display" tex="\begin{vmatrix}[l]a&amp;blblblbllbblblblblblblbl\\&#10;c&amp;d\end{vmatrix}" text="determinant@(matrix@(Array[[a, b * l * b * l * b * l * b * l * l * b * b * l * b * l * b * l * b * l * b * l * b * l * b * l], [c, d]]))" xml:id="S4.Ex31.m1">
           <XMath>
             <XMDual>
               <XMApp>
                 <XMTok meaning="determinant"/>
-                <XMRef idref="S4.Ex31.m1.1"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S4.Ex31.m1.1"/>
+                </XMApp>
               </XMApp>
               <XMWrap>
                 <XMTok role="VERTBAR" stretchy="true">|</XMTok>
-                <XMArray meaning="matrix" xml:id="S4.Ex31.m1.1">
+                <XMArray xml:id="S4.Ex31.m1.1">
                   <XMRow>
                     <XMCell align="left">
                       <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
@@ -1953,15 +1989,18 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p10">
       <equation xml:id="S4.Ex32">
-        <Math mode="display" tex="\begin{bmatrix}a&amp;-b\\&#10;-c&amp;d\end{bmatrix}\begin{bmatrix}[r]a&amp;-b\\&#10;-c&amp;d\end{bmatrix}" text="matrix[[a, - b], [- c, d]] * matrix[[a, - b], [- c, d]]" xml:id="S4.Ex32.m1">
+        <Math mode="display" tex="\begin{bmatrix}a&amp;-b\\&#10;-c&amp;d\end{bmatrix}\begin{bmatrix}[r]a&amp;-b\\&#10;-c&amp;d\end{bmatrix}" text="matrix@(Array[[a, - b], [- c, d]]) * matrix@(Array[[a, - b], [- c, d]])" xml:id="S4.Ex32.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="times" role="MULOP">⁢</XMTok>
               <XMDual>
-                <XMRef idref="S4.Ex32.m1.1"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S4.Ex32.m1.1"/>
+                </XMApp>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">[</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex32.m1.1">
+                  <XMArray xml:id="S4.Ex32.m1.1">
                     <XMRow>
                       <XMCell align="center">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
@@ -1989,10 +2028,13 @@ Then a switch of tag forms.</p>
                 </XMWrap>
               </XMDual>
               <XMDual>
-                <XMRef idref="S4.Ex32.m1.2"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S4.Ex32.m1.2"/>
+                </XMApp>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">[</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex32.m1.2">
+                  <XMArray xml:id="S4.Ex32.m1.2">
                     <XMRow>
                       <XMCell align="right">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
@@ -2026,18 +2068,21 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p11">
       <equation xml:id="S4.Ex33">
-        <Math mode="display" tex="\begin{Vmatrix}e&amp;-f\\&#10;-g&amp;h\end{Vmatrix}\begin{Vmatrix}[r]e&amp;-f\\&#10;-g&amp;h\end{Vmatrix}" text="norm@(matrix[[e, - f], [- g, h]]) * norm@(matrix[[e, - f], [- g, h]])" xml:id="S4.Ex33.m1">
+        <Math mode="display" tex="\begin{Vmatrix}e&amp;-f\\&#10;-g&amp;h\end{Vmatrix}\begin{Vmatrix}[r]e&amp;-f\\&#10;-g&amp;h\end{Vmatrix}" text="norm@(matrix@(Array[[e, - f], [- g, h]])) * norm@(matrix@(Array[[e, - f], [- g, h]]))" xml:id="S4.Ex33.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="times" role="MULOP">⁢</XMTok>
               <XMDual>
                 <XMApp>
                   <XMTok meaning="norm"/>
-                  <XMRef idref="S4.Ex33.m1.1"/>
+                  <XMApp>
+                    <XMTok meaning="matrix"/>
+                    <XMRef idref="S4.Ex33.m1.1"/>
+                  </XMApp>
                 </XMApp>
                 <XMWrap>
                   <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex33.m1.1">
+                  <XMArray xml:id="S4.Ex33.m1.1">
                     <XMRow>
                       <XMCell align="center">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">e</XMTok>
@@ -2067,11 +2112,14 @@ Then a switch of tag forms.</p>
               <XMDual>
                 <XMApp>
                   <XMTok meaning="norm"/>
-                  <XMRef idref="S4.Ex33.m1.2"/>
+                  <XMApp>
+                    <XMTok meaning="matrix"/>
+                    <XMRef idref="S4.Ex33.m1.2"/>
+                  </XMApp>
                 </XMApp>
                 <XMWrap>
                   <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex33.m1.2">
+                  <XMArray xml:id="S4.Ex33.m1.2">
                     <XMRow>
                       <XMCell align="right">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">e</XMTok>
@@ -2105,15 +2153,18 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p12">
       <equation xml:id="S4.Ex34">
-        <Math mode="display" tex="\begin{bmatrix}a&amp;-bbbbb\\&#10;-c&amp;d\end{bmatrix}\begin{bmatrix}[r]a&amp;-bbbbb\\&#10;-c&amp;d\end{bmatrix}" text="matrix[[a, - b * b * b * b * b], [- c, d]] * matrix[[a, - b * b * b * b * b], [- c, d]]" xml:id="S4.Ex34.m1">
+        <Math mode="display" tex="\begin{bmatrix}a&amp;-bbbbb\\&#10;-c&amp;d\end{bmatrix}\begin{bmatrix}[r]a&amp;-bbbbb\\&#10;-c&amp;d\end{bmatrix}" text="matrix@(Array[[a, - b * b * b * b * b], [- c, d]]) * matrix@(Array[[a, - b * b * b * b * b], [- c, d]])" xml:id="S4.Ex34.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="times" role="MULOP">⁢</XMTok>
               <XMDual>
-                <XMRef idref="S4.Ex34.m1.1"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S4.Ex34.m1.1"/>
+                </XMApp>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">[</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex34.m1.1">
+                  <XMArray xml:id="S4.Ex34.m1.1">
                     <XMRow>
                       <XMCell align="center">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
@@ -2148,10 +2199,13 @@ Then a switch of tag forms.</p>
                 </XMWrap>
               </XMDual>
               <XMDual>
-                <XMRef idref="S4.Ex34.m1.2"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S4.Ex34.m1.2"/>
+                </XMApp>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">[</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex34.m1.2">
+                  <XMArray xml:id="S4.Ex34.m1.2">
                     <XMRow>
                       <XMCell align="right">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
@@ -2192,18 +2246,21 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p13">
       <equation xml:id="S4.Ex35">
-        <Math mode="display" tex="\begin{Vmatrix}e&amp;-fffff\\&#10;-g&amp;h\end{Vmatrix}\begin{Vmatrix}[r]e&amp;-fffff\\&#10;-g&amp;h\end{Vmatrix}" text="norm@(matrix[[e, - f * f * f * f * f], [- g, h]]) * norm@(matrix[[e, - f * f * f * f * f], [- g, h]])" xml:id="S4.Ex35.m1">
+        <Math mode="display" tex="\begin{Vmatrix}e&amp;-fffff\\&#10;-g&amp;h\end{Vmatrix}\begin{Vmatrix}[r]e&amp;-fffff\\&#10;-g&amp;h\end{Vmatrix}" text="norm@(matrix@(Array[[e, - f * f * f * f * f], [- g, h]])) * norm@(matrix@(Array[[e, - f * f * f * f * f], [- g, h]]))" xml:id="S4.Ex35.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="times" role="MULOP">⁢</XMTok>
               <XMDual>
                 <XMApp>
                   <XMTok meaning="norm"/>
-                  <XMRef idref="S4.Ex35.m1.1"/>
+                  <XMApp>
+                    <XMTok meaning="matrix"/>
+                    <XMRef idref="S4.Ex35.m1.1"/>
+                  </XMApp>
                 </XMApp>
                 <XMWrap>
                   <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex35.m1.1">
+                  <XMArray xml:id="S4.Ex35.m1.1">
                     <XMRow>
                       <XMCell align="center">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">e</XMTok>
@@ -2240,11 +2297,14 @@ Then a switch of tag forms.</p>
               <XMDual>
                 <XMApp>
                   <XMTok meaning="norm"/>
-                  <XMRef idref="S4.Ex35.m1.2"/>
+                  <XMApp>
+                    <XMTok meaning="matrix"/>
+                    <XMRef idref="S4.Ex35.m1.2"/>
+                  </XMApp>
                 </XMApp>
                 <XMWrap>
                   <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex35.m1.2">
+                  <XMArray xml:id="S4.Ex35.m1.2">
                     <XMRow>
                       <XMCell align="right">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">e</XMTok>
@@ -2285,15 +2345,18 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p14">
       <equation xml:id="S4.Ex36">
-        <Math mode="display" tex="\begin{bmatrix}[l]a&amp;-bbbbb\\&#10;-c&amp;d\end{bmatrix}\begin{bmatrix}[r]a&amp;-bbbbb\\&#10;-c&amp;d\end{bmatrix}" text="matrix[[a, - b * b * b * b * b], [- c, d]] * matrix[[a, - b * b * b * b * b], [- c, d]]" xml:id="S4.Ex36.m1">
+        <Math mode="display" tex="\begin{bmatrix}[l]a&amp;-bbbbb\\&#10;-c&amp;d\end{bmatrix}\begin{bmatrix}[r]a&amp;-bbbbb\\&#10;-c&amp;d\end{bmatrix}" text="matrix@(Array[[a, - b * b * b * b * b], [- c, d]]) * matrix@(Array[[a, - b * b * b * b * b], [- c, d]])" xml:id="S4.Ex36.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="times" role="MULOP">⁢</XMTok>
               <XMDual>
-                <XMRef idref="S4.Ex36.m1.1"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S4.Ex36.m1.1"/>
+                </XMApp>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">[</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex36.m1.1">
+                  <XMArray xml:id="S4.Ex36.m1.1">
                     <XMRow>
                       <XMCell align="left">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
@@ -2328,10 +2391,13 @@ Then a switch of tag forms.</p>
                 </XMWrap>
               </XMDual>
               <XMDual>
-                <XMRef idref="S4.Ex36.m1.2"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S4.Ex36.m1.2"/>
+                </XMApp>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">[</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex36.m1.2">
+                  <XMArray xml:id="S4.Ex36.m1.2">
                     <XMRow>
                       <XMCell align="right">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
@@ -2372,18 +2438,21 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S4.p15">
       <equation xml:id="S4.Ex37">
-        <Math mode="display" tex="\begin{Vmatrix}[l]e&amp;-fffff\\&#10;-g&amp;h\end{Vmatrix}\begin{Vmatrix}[r]e&amp;-fffff\\&#10;-g&amp;h\end{Vmatrix}" text="norm@(matrix[[e, - f * f * f * f * f], [- g, h]]) * norm@(matrix[[e, - f * f * f * f * f], [- g, h]])" xml:id="S4.Ex37.m1">
+        <Math mode="display" tex="\begin{Vmatrix}[l]e&amp;-fffff\\&#10;-g&amp;h\end{Vmatrix}\begin{Vmatrix}[r]e&amp;-fffff\\&#10;-g&amp;h\end{Vmatrix}" text="norm@(matrix@(Array[[e, - f * f * f * f * f], [- g, h]])) * norm@(matrix@(Array[[e, - f * f * f * f * f], [- g, h]]))" xml:id="S4.Ex37.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="times" role="MULOP">⁢</XMTok>
               <XMDual>
                 <XMApp>
                   <XMTok meaning="norm"/>
-                  <XMRef idref="S4.Ex37.m1.1"/>
+                  <XMApp>
+                    <XMTok meaning="matrix"/>
+                    <XMRef idref="S4.Ex37.m1.1"/>
+                  </XMApp>
                 </XMApp>
                 <XMWrap>
                   <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex37.m1.1">
+                  <XMArray xml:id="S4.Ex37.m1.1">
                     <XMRow>
                       <XMCell align="left">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">e</XMTok>
@@ -2420,11 +2489,14 @@ Then a switch of tag forms.</p>
               <XMDual>
                 <XMApp>
                   <XMTok meaning="norm"/>
-                  <XMRef idref="S4.Ex37.m1.2"/>
+                  <XMApp>
+                    <XMTok meaning="matrix"/>
+                    <XMRef idref="S4.Ex37.m1.2"/>
+                  </XMApp>
                 </XMApp>
                 <XMWrap>
                   <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-                  <XMArray meaning="matrix" xml:id="S4.Ex37.m1.2">
+                  <XMArray xml:id="S4.Ex37.m1.2">
                     <XMRow>
                       <XMCell align="right">
                         <XMTok font="italic" fontsize="70%" role="UNKNOWN">e</XMTok>
@@ -5351,56 +5423,65 @@ Then a switch of tag forms.</p>
     <para xml:id="S10.p1">
       <p>Spread it</p>
       <equation xml:id="S10.Ex74">
-        <Math mode="display" tex="\begin{matrix}a&amp;b&amp;c\\&#10;d&amp;e&amp;f\\&#10;g&amp;h&amp;i\end{matrix}" text="matrix[[a, b, c], [d, e, f], [g, h, i]]" xml:id="S10.Ex74.m1">
+        <Math mode="display" tex="\begin{matrix}a&amp;b&amp;c\\&#10;d&amp;e&amp;f\\&#10;g&amp;h&amp;i\end{matrix}" text="matrix@(Array[[a, b, c], [d, e, f], [g, h, i]])" xml:id="S10.Ex74.m1">
           <XMath>
-            <XMArray meaning="matrix">
-              <XMRow>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                </XMCell>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">b</XMTok>
-                </XMCell>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                </XMCell>
-              </XMRow>
-              <XMRow>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                </XMCell>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">e</XMTok>
-                </XMCell>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">f</XMTok>
-                </XMCell>
-              </XMRow>
-              <XMRow>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">g</XMTok>
-                </XMCell>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">h</XMTok>
-                </XMCell>
-                <XMCell align="center">
-                  <XMTok font="italic" role="UNKNOWN">i</XMTok>
-                </XMCell>
-              </XMRow>
-            </XMArray>
+            <XMDual>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S10.Ex74.m1.1"/>
+              </XMApp>
+              <XMArray xml:id="S10.Ex74.m1.1">
+                <XMRow>
+                  <XMCell align="center">
+                    <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                  </XMCell>
+                  <XMCell align="center">
+                    <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                  </XMCell>
+                  <XMCell align="center">
+                    <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                  </XMCell>
+                </XMRow>
+                <XMRow>
+                  <XMCell align="center">
+                    <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                  </XMCell>
+                  <XMCell align="center">
+                    <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                  </XMCell>
+                  <XMCell align="center">
+                    <XMTok font="italic" role="UNKNOWN">f</XMTok>
+                  </XMCell>
+                </XMRow>
+                <XMRow>
+                  <XMCell align="center">
+                    <XMTok font="italic" role="UNKNOWN">g</XMTok>
+                  </XMCell>
+                  <XMCell align="center">
+                    <XMTok font="italic" role="UNKNOWN">h</XMTok>
+                  </XMCell>
+                  <XMCell align="center">
+                    <XMTok font="italic" role="UNKNOWN">i</XMTok>
+                  </XMCell>
+                </XMRow>
+              </XMArray>
+            </XMDual>
           </XMath>
         </Math>
       </equation>
     </para>
     <para xml:id="S10.p2">
       <equation xml:id="S10.Ex75">
-        <Math mode="display" tex="\begin{pmatrix}a_{1,1}&amp;a_{1,2}&amp;\cdots&amp;a_{1,n}\\&#10;a_{2,1}&amp;a_{2,2}&amp;\cdots&amp;a_{2,n}\\&#10;\vdots&amp;\vdots&amp;\ddots&amp;\vdots\\&#10;a_{m,1}&amp;a_{m,2}&amp;\cdots&amp;a_{m,n}\end{pmatrix}" text="matrix[[a _ (list@(1, 1)), a _ (list@(1, 2)), cdots, a _ (list@(1, n))], [a _ (list@(2, 1)), a _ (list@(2, 2)), cdots, a _ (list@(2, n))], [vdots, vdots, ddots, vdots], [a _ (list@(m, 1)), a _ (list@(m, 2)), cdots, a _ (list@(m, n))]]" xml:id="S10.Ex75.m1">
+        <Math mode="display" tex="\begin{pmatrix}a_{1,1}&amp;a_{1,2}&amp;\cdots&amp;a_{1,n}\\&#10;a_{2,1}&amp;a_{2,2}&amp;\cdots&amp;a_{2,n}\\&#10;\vdots&amp;\vdots&amp;\ddots&amp;\vdots\\&#10;a_{m,1}&amp;a_{m,2}&amp;\cdots&amp;a_{m,n}\end{pmatrix}" text="matrix@(Array[[a _ (list@(1, 1)), a _ (list@(1, 2)), cdots, a _ (list@(1, n))], [a _ (list@(2, 1)), a _ (list@(2, 2)), cdots, a _ (list@(2, n))], [vdots, vdots, ddots, vdots], [a _ (list@(m, 1)), a _ (list@(m, 2)), cdots, a _ (list@(m, n))]])" xml:id="S10.Ex75.m1">
           <XMath>
             <XMDual>
-              <XMRef idref="S10.Ex75.m1.1"/>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S10.Ex75.m1.1"/>
+              </XMApp>
               <XMWrap>
                 <XMTok role="OPEN" stretchy="true">(</XMTok>
-                <XMArray meaning="matrix" xml:id="S10.Ex75.m1.1">
+                <XMArray xml:id="S10.Ex75.m1.1">
                   <XMRow>
                     <XMCell align="center">
                       <XMApp>
@@ -6615,30 +6696,36 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S10.p13">
       <equation xml:id="S10.Ex80">
-        <Math mode="display" tex="\bigl{(}\begin{matrix}[l]a&amp;b\\&#10;c&amp;d\end{matrix}\bigr{)}" text="matrix[[a, b], [c, d]]" xml:id="S10.Ex80.m1">
+        <Math mode="display" tex="\bigl{(}\begin{matrix}[l]a&amp;b\\&#10;c&amp;d\end{matrix}\bigr{)}" text="matrix@(Array[[a, b], [c, d]])" xml:id="S10.Ex80.m1">
           <XMath>
             <XMDual>
-              <XMRef idref="S10.Ex80.m1.1"/>
+              <XMRef idref="S10.Ex80.m1.2"/>
               <XMWrap>
                 <XMTok fontsize="120%" role="OPEN" stretchy="false">(</XMTok>
-                <XMArray meaning="matrix" xml:id="S10.Ex80.m1.1">
-                  <XMRow>
-                    <XMCell align="left">
-                      <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                    </XMCell>
-                    <XMCell align="left">
-                      <XMTok font="italic" fontsize="70%" role="UNKNOWN">b</XMTok>
-                    </XMCell>
-                  </XMRow>
-                  <XMRow>
-                    <XMCell align="left">
-                      <XMTok font="italic" fontsize="70%" role="UNKNOWN">c</XMTok>
-                    </XMCell>
-                    <XMCell align="left">
-                      <XMTok font="italic" fontsize="70%" role="UNKNOWN">d</XMTok>
-                    </XMCell>
-                  </XMRow>
-                </XMArray>
+                <XMDual xml:id="S10.Ex80.m1.2">
+                  <XMApp>
+                    <XMTok meaning="matrix"/>
+                    <XMRef idref="S10.Ex80.m1.1"/>
+                  </XMApp>
+                  <XMArray xml:id="S10.Ex80.m1.1">
+                    <XMRow>
+                      <XMCell align="left">
+                        <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                      </XMCell>
+                      <XMCell align="left">
+                        <XMTok font="italic" fontsize="70%" role="UNKNOWN">b</XMTok>
+                      </XMCell>
+                    </XMRow>
+                    <XMRow>
+                      <XMCell align="left">
+                        <XMTok font="italic" fontsize="70%" role="UNKNOWN">c</XMTok>
+                      </XMCell>
+                      <XMCell align="left">
+                        <XMTok font="italic" fontsize="70%" role="UNKNOWN">d</XMTok>
+                      </XMCell>
+                    </XMRow>
+                  </XMArray>
+                </XMDual>
                 <XMTok fontsize="120%" role="CLOSE" stretchy="false">)</XMTok>
               </XMWrap>
             </XMDual>
@@ -6648,35 +6735,41 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S10.p14">
       <equation xml:id="S10.Ex81">
-        <Math mode="display" tex="\sum_{\begin{subarray}{l}i\in\Lambda\\&#10;0&lt;j&lt;n\end{subarray}}P(i,j)" text="(sum _ list[[i element-of Lambda], [0 &lt; j &lt; n]])@(P * open-interval@(i, j))" xml:id="S10.Ex81.m1">
+        <Math mode="display" tex="\sum_{\begin{subarray}{l}i\in\Lambda\\&#10;0&lt;j&lt;n\end{subarray}}P(i,j)" text="(sum _ (list@(Array[[i element-of Lambda], [0 &lt; j &lt; n]])))@(P * open-interval@(i, j))" xml:id="S10.Ex81.m1">
           <XMath>
             <XMApp>
               <XMApp scriptpos="mid">
                 <XMTok role="SUBSCRIPTOP" scriptpos="mid1"/>
                 <XMTok mathstyle="display" meaning="sum" role="SUMOP" scriptpos="mid">∑</XMTok>
-                <XMArray class="ltx_align_l" name="list" rowsep="0.0pt">
-                  <XMRow>
-                    <XMCell>
-                      <XMApp>
-                        <XMTok fontsize="70%" meaning="element-of" name="in" role="RELOP">∈</XMTok>
-                        <XMTok font="italic" fontsize="70%" role="UNKNOWN">i</XMTok>
-                        <XMTok fontsize="70%" name="Lambda" role="UNKNOWN">Λ</XMTok>
-                      </XMApp>
-                    </XMCell>
-                  </XMRow>
-                  <XMRow>
-                    <XMCell>
-                      <XMApp>
-                        <XMTok meaning="multirelation"/>
-                        <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                        <XMTok fontsize="70%" meaning="less-than" role="RELOP">&lt;</XMTok>
-                        <XMTok font="italic" fontsize="70%" role="UNKNOWN">j</XMTok>
-                        <XMTok fontsize="70%" meaning="less-than" role="RELOP">&lt;</XMTok>
-                        <XMTok font="italic" fontsize="70%" role="UNKNOWN">n</XMTok>
-                      </XMApp>
-                    </XMCell>
-                  </XMRow>
-                </XMArray>
+                <XMDual>
+                  <XMApp>
+                    <XMTok meaning="list"/>
+                    <XMRef idref="S10.Ex81.m1.1"/>
+                  </XMApp>
+                  <XMArray rowsep="0pt" xml:id="S10.Ex81.m1.1">
+                    <XMRow>
+                      <XMCell align="left">
+                        <XMApp>
+                          <XMTok fontsize="70%" meaning="element-of" name="in" role="RELOP">∈</XMTok>
+                          <XMTok font="italic" fontsize="70%" role="UNKNOWN">i</XMTok>
+                          <XMTok fontsize="70%" name="Lambda" role="UNKNOWN">Λ</XMTok>
+                        </XMApp>
+                      </XMCell>
+                    </XMRow>
+                    <XMRow>
+                      <XMCell align="left">
+                        <XMApp>
+                          <XMTok meaning="multirelation"/>
+                          <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                          <XMTok fontsize="70%" meaning="less-than" role="RELOP">&lt;</XMTok>
+                          <XMTok font="italic" fontsize="70%" role="UNKNOWN">j</XMTok>
+                          <XMTok fontsize="70%" meaning="less-than" role="RELOP">&lt;</XMTok>
+                          <XMTok font="italic" fontsize="70%" role="UNKNOWN">n</XMTok>
+                        </XMApp>
+                      </XMCell>
+                    </XMRow>
+                  </XMArray>
+                </XMDual>
               </XMApp>
               <XMApp>
                 <XMTok meaning="times" role="MULOP">⁢</XMTok>
@@ -6684,14 +6777,14 @@ Then a switch of tag forms.</p>
                 <XMDual>
                   <XMApp>
                     <XMTok meaning="open-interval"/>
-                    <XMRef idref="S10.Ex81.m1.1"/>
                     <XMRef idref="S10.Ex81.m1.2"/>
+                    <XMRef idref="S10.Ex81.m1.3"/>
                   </XMApp>
                   <XMWrap>
                     <XMTok role="OPEN" stretchy="false">(</XMTok>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="S10.Ex81.m1.1">i</XMTok>
+                    <XMTok font="italic" role="UNKNOWN" xml:id="S10.Ex81.m1.2">i</XMTok>
                     <XMTok role="PUNCT">,</XMTok>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="S10.Ex81.m1.2">j</XMTok>
+                    <XMTok font="italic" role="UNKNOWN" xml:id="S10.Ex81.m1.3">j</XMTok>
                     <XMTok role="CLOSE" stretchy="false">)</XMTok>
                   </XMWrap>
                 </XMDual>

--- a/t/ams/matrix.xml
+++ b/t/ams/matrix.xml
@@ -7,34 +7,43 @@
   <resource src="ltx-article.css" type="text/css"/>
   <para xml:id="p1">
     <equation xml:id="S0.Ex1">
-      <Math mode="display" tex="\begin{matrix}a&amp;b\\&#10;c\\&#10;\end{matrix}" text="matrix[[a, b], [c]]" xml:id="S0.Ex1.m1">
+      <Math mode="display" tex="\begin{matrix}a&amp;b\\&#10;c\\&#10;\end{matrix}" text="matrix@(Array[[a, b], [c]])" xml:id="S0.Ex1.m1">
         <XMath>
-          <XMArray meaning="matrix">
-            <XMRow>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">a</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">b</XMTok>
-              </XMCell>
-            </XMRow>
-            <XMRow>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">c</XMTok>
-              </XMCell>
-            </XMRow>
-          </XMArray>
+          <XMDual>
+            <XMApp>
+              <XMTok meaning="matrix"/>
+              <XMRef idref="S0.Ex1.m1.1"/>
+            </XMApp>
+            <XMArray xml:id="S0.Ex1.m1.1">
+              <XMRow>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                </XMCell>
+              </XMRow>
+              <XMRow>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                </XMCell>
+              </XMRow>
+            </XMArray>
+          </XMDual>
         </XMath>
       </Math>
     </equation>
     <equation xml:id="S0.Ex2">
-      <Math mode="display" tex="\begin{pmatrix}a&amp;b\\&#10;c\\&#10;\end{pmatrix}" text="matrix[[a, b], [c]]" xml:id="S0.Ex2.m1">
+      <Math mode="display" tex="\begin{pmatrix}a&amp;b\\&#10;c\\&#10;\end{pmatrix}" text="matrix@(Array[[a, b], [c]])" xml:id="S0.Ex2.m1">
         <XMath>
           <XMDual>
-            <XMRef idref="S0.Ex2.m1.1"/>
+            <XMApp>
+              <XMTok meaning="matrix"/>
+              <XMRef idref="S0.Ex2.m1.1"/>
+            </XMApp>
             <XMWrap>
               <XMTok role="OPEN" stretchy="true">(</XMTok>
-              <XMArray meaning="matrix" xml:id="S0.Ex2.m1.1">
+              <XMArray xml:id="S0.Ex2.m1.1">
                 <XMRow>
                   <XMCell align="center">
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
@@ -56,13 +65,16 @@
       </Math>
     </equation>
     <equation xml:id="S0.Ex3">
-      <Math mode="display" tex="\begin{bmatrix}a&amp;b\\&#10;c\\&#10;\end{bmatrix}" text="matrix[[a, b], [c]]" xml:id="S0.Ex3.m1">
+      <Math mode="display" tex="\begin{bmatrix}a&amp;b\\&#10;c\\&#10;\end{bmatrix}" text="matrix@(Array[[a, b], [c]])" xml:id="S0.Ex3.m1">
         <XMath>
           <XMDual>
-            <XMRef idref="S0.Ex3.m1.1"/>
+            <XMApp>
+              <XMTok meaning="matrix"/>
+              <XMRef idref="S0.Ex3.m1.1"/>
+            </XMApp>
             <XMWrap>
               <XMTok role="OPEN" stretchy="true">[</XMTok>
-              <XMArray meaning="matrix" xml:id="S0.Ex3.m1.1">
+              <XMArray xml:id="S0.Ex3.m1.1">
                 <XMRow>
                   <XMCell align="center">
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
@@ -84,13 +96,16 @@
       </Math>
     </equation>
     <equation xml:id="S0.Ex4">
-      <Math mode="display" tex="\begin{Bmatrix}a&amp;b\\&#10;c\\&#10;\end{Bmatrix}" text="matrix[[a, b], [c]]" xml:id="S0.Ex4.m1">
+      <Math mode="display" tex="\begin{Bmatrix}a&amp;b\\&#10;c\\&#10;\end{Bmatrix}" text="matrix@(Array[[a, b], [c]])" xml:id="S0.Ex4.m1">
         <XMath>
           <XMDual>
-            <XMRef idref="S0.Ex4.m1.1"/>
+            <XMApp>
+              <XMTok meaning="matrix"/>
+              <XMRef idref="S0.Ex4.m1.1"/>
+            </XMApp>
             <XMWrap>
               <XMTok role="OPEN" stretchy="true">{</XMTok>
-              <XMArray meaning="matrix" xml:id="S0.Ex4.m1.1">
+              <XMArray xml:id="S0.Ex4.m1.1">
                 <XMRow>
                   <XMCell align="center">
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
@@ -112,16 +127,19 @@
       </Math>
     </equation>
     <equation xml:id="S0.Ex5">
-      <Math mode="display" tex="\begin{vmatrix}a&amp;b\\&#10;c\\&#10;\end{vmatrix}" text="determinant@(matrix[[a, b], [c]])" xml:id="S0.Ex5.m1">
+      <Math mode="display" tex="\begin{vmatrix}a&amp;b\\&#10;c\\&#10;\end{vmatrix}" text="determinant@(matrix@(Array[[a, b], [c]]))" xml:id="S0.Ex5.m1">
         <XMath>
           <XMDual>
             <XMApp>
               <XMTok meaning="determinant"/>
-              <XMRef idref="S0.Ex5.m1.1"/>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S0.Ex5.m1.1"/>
+              </XMApp>
             </XMApp>
             <XMWrap>
               <XMTok role="VERTBAR" stretchy="true">|</XMTok>
-              <XMArray meaning="matrix" xml:id="S0.Ex5.m1.1">
+              <XMArray xml:id="S0.Ex5.m1.1">
                 <XMRow>
                   <XMCell align="center">
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
@@ -143,16 +161,19 @@
       </Math>
     </equation>
     <equation xml:id="S0.Ex6">
-      <Math mode="display" tex="\begin{Vmatrix}a&amp;b\\&#10;c\\&#10;\end{Vmatrix}" text="norm@(matrix[[a, b], [c]])" xml:id="S0.Ex6.m1">
+      <Math mode="display" tex="\begin{Vmatrix}a&amp;b\\&#10;c\\&#10;\end{Vmatrix}" text="norm@(matrix@(Array[[a, b], [c]]))" xml:id="S0.Ex6.m1">
         <XMath>
           <XMDual>
             <XMApp>
               <XMTok meaning="norm"/>
-              <XMRef idref="S0.Ex6.m1.1"/>
+              <XMApp>
+                <XMTok meaning="matrix"/>
+                <XMRef idref="S0.Ex6.m1.1"/>
+              </XMApp>
             </XMApp>
             <XMWrap>
               <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-              <XMArray meaning="matrix" xml:id="S0.Ex6.m1.1">
+              <XMArray xml:id="S0.Ex6.m1.1">
                 <XMRow>
                   <XMCell align="center">
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>

--- a/t/complex/physics.xml
+++ b/t/complex/physics.xml
@@ -4063,13 +4063,16 @@
       <title><tag close=" ">1.7</tag>Matrix macros</title>
       <para xml:id="S1.SS7.p1">
         <equation xml:id="S1.Ex38">
-          <Math mode="display" tex="\begin{pmatrix}1&amp;0\\&#10;0&amp;1\\&#10;a&amp;b\end{pmatrix}" text="matrix[[1, 0], [0, 1], [a, b]]" xml:id="S1.Ex38.m1">
+          <Math mode="display" tex="\begin{pmatrix}1&amp;0\\&#10;0&amp;1\\&#10;a&amp;b\end{pmatrix}" text="matrix@(Array[[1, 0], [0, 1], [a, b]])" xml:id="S1.Ex38.m1">
             <XMath>
               <XMDual>
-                <XMRef idref="S1.Ex38.m1.1"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S1.Ex38.m1.1"/>
+                </XMApp>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">(</XMTok>
-                  <XMArray meaning="matrix" xml:id="S1.Ex38.m1.1">
+                  <XMArray xml:id="S1.Ex38.m1.1">
                     <XMRow>
                       <XMCell align="center">
                         <XMTok meaning="1" role="NUMBER">1</XMTok>
@@ -4104,52 +4107,67 @@
       </para>
       <para xml:id="S1.SS7.p2">
         <equation xml:id="S1.Ex39">
-          <Math mode="display" tex="\begin{pmatrix}\matrixquantity{1&amp;0\\&#10;0&amp;1}&amp;\matrixquantity{a\\&#10;b}\\&#10;\matrixquantity{c&amp;d}&amp;e\end{pmatrix}" text="matrix[[matrix[[1, 0], [0, 1]], matrix[[a], [b]]], [matrix[[c, d]], e]]" xml:id="S1.Ex39.m1">
+          <Math mode="display" tex="\begin{pmatrix}\matrixquantity{1&amp;0\\&#10;0&amp;1}&amp;\matrixquantity{a\\&#10;b}\\&#10;\matrixquantity{c&amp;d}&amp;e\end{pmatrix}" text="matrix@(Array[[matrix@(Array[[1, 0], [0, 1]]), matrix@(Array[[a], [b]])], [matrix@(Array[[c, d]]), e]])" xml:id="S1.Ex39.m1">
             <XMath>
               <XMDual>
-                <XMRef idref="S1.Ex39.m1.1"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S1.Ex39.m1.1"/>
+                </XMApp>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">(</XMTok>
-                  <XMArray meaning="matrix" xml:id="S1.Ex39.m1.1">
+                  <XMArray xml:id="S1.Ex39.m1.1">
                     <XMRow>
                       <XMCell align="center">
                         <XMDual>
                           <XMRef idref="S1.Ex39.m1.1.1"/>
-                          <XMArray meaning="matrix" xml:id="S1.Ex39.m1.1.1">
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok meaning="1" role="NUMBER">1</XMTok>
-                              </XMCell>
-                              <XMCell align="center">
-                                <XMTok meaning="0" role="NUMBER">0</XMTok>
-                              </XMCell>
-                            </XMRow>
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok meaning="0" role="NUMBER">0</XMTok>
-                              </XMCell>
-                              <XMCell align="center">
-                                <XMTok meaning="1" role="NUMBER">1</XMTok>
-                              </XMCell>
-                            </XMRow>
-                          </XMArray>
+                          <XMDual xml:id="S1.Ex39.m1.1.1">
+                            <XMApp>
+                              <XMTok meaning="matrix"/>
+                              <XMRef idref="S1.Ex39.m1.1.1.1"/>
+                            </XMApp>
+                            <XMArray xml:id="S1.Ex39.m1.1.1.1">
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMTok meaning="1" role="NUMBER">1</XMTok>
+                                </XMCell>
+                                <XMCell align="center">
+                                  <XMTok meaning="0" role="NUMBER">0</XMTok>
+                                </XMCell>
+                              </XMRow>
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMTok meaning="0" role="NUMBER">0</XMTok>
+                                </XMCell>
+                                <XMCell align="center">
+                                  <XMTok meaning="1" role="NUMBER">1</XMTok>
+                                </XMCell>
+                              </XMRow>
+                            </XMArray>
+                          </XMDual>
                         </XMDual>
                       </XMCell>
                       <XMCell align="center">
                         <XMDual>
                           <XMRef idref="S1.Ex39.m1.1.2"/>
-                          <XMArray meaning="matrix" xml:id="S1.Ex39.m1.1.2">
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                              </XMCell>
-                            </XMRow>
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">b</XMTok>
-                              </XMCell>
-                            </XMRow>
-                          </XMArray>
+                          <XMDual xml:id="S1.Ex39.m1.1.2">
+                            <XMApp>
+                              <XMTok meaning="matrix"/>
+                              <XMRef idref="S1.Ex39.m1.1.2.1"/>
+                            </XMApp>
+                            <XMArray xml:id="S1.Ex39.m1.1.2.1">
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                                </XMCell>
+                              </XMRow>
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                                </XMCell>
+                              </XMRow>
+                            </XMArray>
+                          </XMDual>
                         </XMDual>
                       </XMCell>
                     </XMRow>
@@ -4157,16 +4175,22 @@
                       <XMCell align="center">
                         <XMDual>
                           <XMRef idref="S1.Ex39.m1.1.3"/>
-                          <XMArray meaning="matrix" xml:id="S1.Ex39.m1.1.3">
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                              </XMCell>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                              </XMCell>
-                            </XMRow>
-                          </XMArray>
+                          <XMDual xml:id="S1.Ex39.m1.1.3">
+                            <XMApp>
+                              <XMTok meaning="matrix"/>
+                              <XMRef idref="S1.Ex39.m1.1.3.1"/>
+                            </XMApp>
+                            <XMArray xml:id="S1.Ex39.m1.1.3.1">
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                                </XMCell>
+                                <XMCell align="center">
+                                  <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                                </XMCell>
+                              </XMRow>
+                            </XMArray>
+                          </XMDual>
                         </XMDual>
                       </XMCell>
                       <XMCell align="center">
@@ -4183,76 +4207,100 @@
       </para>
       <para xml:id="S1.SS7.p3">
         <equation xml:id="S1.Ex40">
-          <Math mode="display" tex="\matrixquantity(\matrixquantity{1&amp;0\\&#10;0&amp;1}&amp;\matrixquantity{a\\&#10;b}\\&#10;\matrixquantity{c&amp;d}&amp;e)" text="matrix[[matrix[[1, 0], [0, 1]], matrix[[a], [b]]], [matrix[[c, d]], e]]" xml:id="S1.Ex40.m1">
+          <Math mode="display" tex="\matrixquantity(\matrixquantity{1&amp;0\\&#10;0&amp;1}&amp;\matrixquantity{a\\&#10;b}\\&#10;\matrixquantity{c&amp;d}&amp;e)" text="matrix@(Array[[matrix@(Array[[1, 0], [0, 1]]), matrix@(Array[[a], [b]])], [matrix@(Array[[c, d]]), e]])" xml:id="S1.Ex40.m1">
             <XMath>
               <XMDual>
                 <XMRef idref="S1.Ex40.m1.1"/>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">(</XMTok>
-                  <XMArray meaning="matrix" xml:id="S1.Ex40.m1.1">
-                    <XMRow>
-                      <XMCell align="center">
-                        <XMDual>
-                          <XMRef idref="S1.Ex40.m1.1.1"/>
-                          <XMArray meaning="matrix" xml:id="S1.Ex40.m1.1.1">
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok meaning="1" role="NUMBER">1</XMTok>
-                              </XMCell>
-                              <XMCell align="center">
-                                <XMTok meaning="0" role="NUMBER">0</XMTok>
-                              </XMCell>
-                            </XMRow>
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok meaning="0" role="NUMBER">0</XMTok>
-                              </XMCell>
-                              <XMCell align="center">
-                                <XMTok meaning="1" role="NUMBER">1</XMTok>
-                              </XMCell>
-                            </XMRow>
-                          </XMArray>
-                        </XMDual>
-                      </XMCell>
-                      <XMCell align="center">
-                        <XMDual>
-                          <XMRef idref="S1.Ex40.m1.1.2"/>
-                          <XMArray meaning="matrix" xml:id="S1.Ex40.m1.1.2">
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                              </XMCell>
-                            </XMRow>
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">b</XMTok>
-                              </XMCell>
-                            </XMRow>
-                          </XMArray>
-                        </XMDual>
-                      </XMCell>
-                    </XMRow>
-                    <XMRow>
-                      <XMCell align="center">
-                        <XMDual>
-                          <XMRef idref="S1.Ex40.m1.1.3"/>
-                          <XMArray meaning="matrix" xml:id="S1.Ex40.m1.1.3">
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                              </XMCell>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                              </XMCell>
-                            </XMRow>
-                          </XMArray>
-                        </XMDual>
-                      </XMCell>
-                      <XMCell align="center">
-                        <XMTok font="italic" role="UNKNOWN">e</XMTok>
-                      </XMCell>
-                    </XMRow>
-                  </XMArray>
+                  <XMDual xml:id="S1.Ex40.m1.1">
+                    <XMApp>
+                      <XMTok meaning="matrix"/>
+                      <XMRef idref="S1.Ex40.m1.1.1"/>
+                    </XMApp>
+                    <XMArray xml:id="S1.Ex40.m1.1.1">
+                      <XMRow>
+                        <XMCell align="center">
+                          <XMDual>
+                            <XMRef idref="S1.Ex40.m1.1.1.1"/>
+                            <XMDual xml:id="S1.Ex40.m1.1.1.1">
+                              <XMApp>
+                                <XMTok meaning="matrix"/>
+                                <XMRef idref="S1.Ex40.m1.1.1.1.1"/>
+                              </XMApp>
+                              <XMArray xml:id="S1.Ex40.m1.1.1.1.1">
+                                <XMRow>
+                                  <XMCell align="center">
+                                    <XMTok meaning="1" role="NUMBER">1</XMTok>
+                                  </XMCell>
+                                  <XMCell align="center">
+                                    <XMTok meaning="0" role="NUMBER">0</XMTok>
+                                  </XMCell>
+                                </XMRow>
+                                <XMRow>
+                                  <XMCell align="center">
+                                    <XMTok meaning="0" role="NUMBER">0</XMTok>
+                                  </XMCell>
+                                  <XMCell align="center">
+                                    <XMTok meaning="1" role="NUMBER">1</XMTok>
+                                  </XMCell>
+                                </XMRow>
+                              </XMArray>
+                            </XMDual>
+                          </XMDual>
+                        </XMCell>
+                        <XMCell align="center">
+                          <XMDual>
+                            <XMRef idref="S1.Ex40.m1.1.1.2"/>
+                            <XMDual xml:id="S1.Ex40.m1.1.1.2">
+                              <XMApp>
+                                <XMTok meaning="matrix"/>
+                                <XMRef idref="S1.Ex40.m1.1.1.2.1"/>
+                              </XMApp>
+                              <XMArray xml:id="S1.Ex40.m1.1.1.2.1">
+                                <XMRow>
+                                  <XMCell align="center">
+                                    <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                                  </XMCell>
+                                </XMRow>
+                                <XMRow>
+                                  <XMCell align="center">
+                                    <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                                  </XMCell>
+                                </XMRow>
+                              </XMArray>
+                            </XMDual>
+                          </XMDual>
+                        </XMCell>
+                      </XMRow>
+                      <XMRow>
+                        <XMCell align="center">
+                          <XMDual>
+                            <XMRef idref="S1.Ex40.m1.1.1.3"/>
+                            <XMDual xml:id="S1.Ex40.m1.1.1.3">
+                              <XMApp>
+                                <XMTok meaning="matrix"/>
+                                <XMRef idref="S1.Ex40.m1.1.1.3.1"/>
+                              </XMApp>
+                              <XMArray xml:id="S1.Ex40.m1.1.1.3.1">
+                                <XMRow>
+                                  <XMCell align="center">
+                                    <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                                  </XMCell>
+                                  <XMCell align="center">
+                                    <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                                  </XMCell>
+                                </XMRow>
+                              </XMArray>
+                            </XMDual>
+                          </XMDual>
+                        </XMCell>
+                        <XMCell align="center">
+                          <XMTok font="italic" role="UNKNOWN">e</XMTok>
+                        </XMCell>
+                      </XMRow>
+                    </XMArray>
+                  </XMDual>
                   <XMTok role="CLOSE" stretchy="true">)</XMTok>
                 </XMWrap>
               </XMDual>
@@ -4263,56 +4311,71 @@
       <para xml:id="S1.SS7.p4">
         <p>But, alignment is illusion</p>
         <equation xml:id="S1.Ex41">
-          <Math mode="display" tex="\begin{pmatrix}\matrixquantity{1&amp;0\\&#10;0&amp;1}&amp;\matrixquantity{\displaystyle\frac{x}{y}\\&#10;b}\\&#10;\matrixquantity{u+v+w+x+y+z&amp;d}&amp;e\end{pmatrix}" text="matrix[[matrix[[1, 0], [0, 1]], matrix[[x / y], [b]]], [matrix[[u + v + w + x + y + z, d]], e]]" xml:id="S1.Ex41.m1">
+          <Math mode="display" tex="\begin{pmatrix}\matrixquantity{1&amp;0\\&#10;0&amp;1}&amp;\matrixquantity{\displaystyle\frac{x}{y}\\&#10;b}\\&#10;\matrixquantity{u+v+w+x+y+z&amp;d}&amp;e\end{pmatrix}" text="matrix@(Array[[matrix@(Array[[1, 0], [0, 1]]), matrix@(Array[[x / y], [b]])], [matrix@(Array[[u + v + w + x + y + z, d]]), e]])" xml:id="S1.Ex41.m1">
             <XMath>
               <XMDual>
-                <XMRef idref="S1.Ex41.m1.1"/>
+                <XMApp>
+                  <XMTok meaning="matrix"/>
+                  <XMRef idref="S1.Ex41.m1.1"/>
+                </XMApp>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="true">(</XMTok>
-                  <XMArray meaning="matrix" xml:id="S1.Ex41.m1.1">
+                  <XMArray xml:id="S1.Ex41.m1.1">
                     <XMRow>
                       <XMCell align="center">
                         <XMDual>
                           <XMRef idref="S1.Ex41.m1.1.1"/>
-                          <XMArray meaning="matrix" xml:id="S1.Ex41.m1.1.1">
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok meaning="1" role="NUMBER">1</XMTok>
-                              </XMCell>
-                              <XMCell align="center">
-                                <XMTok meaning="0" role="NUMBER">0</XMTok>
-                              </XMCell>
-                            </XMRow>
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok meaning="0" role="NUMBER">0</XMTok>
-                              </XMCell>
-                              <XMCell align="center">
-                                <XMTok meaning="1" role="NUMBER">1</XMTok>
-                              </XMCell>
-                            </XMRow>
-                          </XMArray>
+                          <XMDual xml:id="S1.Ex41.m1.1.1">
+                            <XMApp>
+                              <XMTok meaning="matrix"/>
+                              <XMRef idref="S1.Ex41.m1.1.1.1"/>
+                            </XMApp>
+                            <XMArray xml:id="S1.Ex41.m1.1.1.1">
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMTok meaning="1" role="NUMBER">1</XMTok>
+                                </XMCell>
+                                <XMCell align="center">
+                                  <XMTok meaning="0" role="NUMBER">0</XMTok>
+                                </XMCell>
+                              </XMRow>
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMTok meaning="0" role="NUMBER">0</XMTok>
+                                </XMCell>
+                                <XMCell align="center">
+                                  <XMTok meaning="1" role="NUMBER">1</XMTok>
+                                </XMCell>
+                              </XMRow>
+                            </XMArray>
+                          </XMDual>
                         </XMDual>
                       </XMCell>
                       <XMCell align="center">
                         <XMDual>
                           <XMRef idref="S1.Ex41.m1.1.2"/>
-                          <XMArray meaning="matrix" xml:id="S1.Ex41.m1.1.2">
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMApp>
-                                  <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
-                                  <XMTok font="italic" role="UNKNOWN">x</XMTok>
-                                  <XMTok font="italic" role="UNKNOWN">y</XMTok>
-                                </XMApp>
-                              </XMCell>
-                            </XMRow>
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">b</XMTok>
-                              </XMCell>
-                            </XMRow>
-                          </XMArray>
+                          <XMDual xml:id="S1.Ex41.m1.1.2">
+                            <XMApp>
+                              <XMTok meaning="matrix"/>
+                              <XMRef idref="S1.Ex41.m1.1.2.1"/>
+                            </XMApp>
+                            <XMArray xml:id="S1.Ex41.m1.1.2.1">
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMApp>
+                                    <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
+                                    <XMTok font="italic" role="UNKNOWN">x</XMTok>
+                                    <XMTok font="italic" role="UNKNOWN">y</XMTok>
+                                  </XMApp>
+                                </XMCell>
+                              </XMRow>
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                                </XMCell>
+                              </XMRow>
+                            </XMArray>
+                          </XMDual>
                         </XMDual>
                       </XMCell>
                     </XMRow>
@@ -4320,24 +4383,30 @@
                       <XMCell align="center">
                         <XMDual>
                           <XMRef idref="S1.Ex41.m1.1.3"/>
-                          <XMArray meaning="matrix" xml:id="S1.Ex41.m1.1.3">
-                            <XMRow>
-                              <XMCell align="center">
-                                <XMApp>
-                                  <XMTok meaning="plus" role="ADDOP">+</XMTok>
-                                  <XMTok font="italic" role="UNKNOWN">u</XMTok>
-                                  <XMTok font="italic" role="UNKNOWN">v</XMTok>
-                                  <XMTok font="italic" role="UNKNOWN">w</XMTok>
-                                  <XMTok font="italic" role="UNKNOWN">x</XMTok>
-                                  <XMTok font="italic" role="UNKNOWN">y</XMTok>
-                                  <XMTok font="italic" role="UNKNOWN">z</XMTok>
-                                </XMApp>
-                              </XMCell>
-                              <XMCell align="center">
-                                <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                              </XMCell>
-                            </XMRow>
-                          </XMArray>
+                          <XMDual xml:id="S1.Ex41.m1.1.3">
+                            <XMApp>
+                              <XMTok meaning="matrix"/>
+                              <XMRef idref="S1.Ex41.m1.1.3.1"/>
+                            </XMApp>
+                            <XMArray xml:id="S1.Ex41.m1.1.3.1">
+                              <XMRow>
+                                <XMCell align="center">
+                                  <XMApp>
+                                    <XMTok meaning="plus" role="ADDOP">+</XMTok>
+                                    <XMTok font="italic" role="UNKNOWN">u</XMTok>
+                                    <XMTok font="italic" role="UNKNOWN">v</XMTok>
+                                    <XMTok font="italic" role="UNKNOWN">w</XMTok>
+                                    <XMTok font="italic" role="UNKNOWN">x</XMTok>
+                                    <XMTok font="italic" role="UNKNOWN">y</XMTok>
+                                    <XMTok font="italic" role="UNKNOWN">z</XMTok>
+                                  </XMApp>
+                                </XMCell>
+                                <XMCell align="center">
+                                  <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                                </XMCell>
+                              </XMRow>
+                            </XMArray>
+                          </XMDual>
                         </XMDual>
                       </XMCell>
                       <XMCell align="center">
@@ -4354,7 +4423,7 @@
       </para>
       <para xml:id="S1.SS7.p5">
         <equation xml:id="S1.Ex42">
-          <Math mode="display" tex="\matrixquantity{a&amp;b\\&#10;c&amp;d}\qquad{\matrixquantity(a&amp;b\\&#10;c&amp;d)}\qquad{\matrixquantity*(a&amp;b\\&#10;c&amp;d)}\qquad{\matrixquantity[a&amp;b\\&#10;c&amp;d]}\qquad{\matrixquantity|a&amp;b\\&#10;c&amp;d|}\qquad\smallmatrixquantity{a&amp;b\\&#10;c&amp;d}\qquad{\matrixdeterminant{\begin{matrix}a&amp;b\\&#10;c&amp;d\end{matrix}}}\qquad{\smallmatrixdeterminant{\begin{smallmatrix}a&amp;b\\&#10;c&amp;d\end{smallmatrix}}}" text="list@(matrix[[a, b], [c, d]], matrix[[a, b], [c, d]], matrix[[a, b], [c, d]], matrix[[a, b], [c, d]], matrix[[a, b], [c, d]], Array[[a, b], [c, d]], determinant@(matrix[[a, b], [c, d]]), determinant@(Array[[a, b], [c, d]]))" xml:id="S1.Ex42.m1">
+          <Math mode="display" tex="\matrixquantity{a&amp;b\\&#10;c&amp;d}\qquad{\matrixquantity(a&amp;b\\&#10;c&amp;d)}\qquad{\matrixquantity*(a&amp;b\\&#10;c&amp;d)}\qquad{\matrixquantity[a&amp;b\\&#10;c&amp;d]}\qquad{\matrixquantity|a&amp;b\\&#10;c&amp;d|}\qquad\smallmatrixquantity{a&amp;b\\&#10;c&amp;d}\qquad{\matrixdeterminant{\begin{matrix}a&amp;b\\&#10;c&amp;d\end{matrix}}}\qquad{\smallmatrixdeterminant{\begin{smallmatrix}a&amp;b\\&#10;c&amp;d\end{smallmatrix}}}" text="list@(matrix@(Array[[a, b], [c, d]]), matrix@(Array[[a, b], [c, d]]), matrix@(Array[[a, b], [c, d]]), matrix@(Array[[a, b], [c, d]]), matrix@(Array[[a, b], [c, d]]), matrix@(Array[[a, b], [c, d]]), determinant@(matrix@(Array[[a, b], [c, d]])), determinant@(Array[[a, b], [c, d]]))" xml:id="S1.Ex42.m1">
             <XMath>
               <XMDual>
                 <XMApp>
@@ -4371,31 +4440,12 @@
                 <XMWrap>
                   <XMDual xml:id="S1.Ex42.m1.9">
                     <XMRef idref="S1.Ex42.m1.1"/>
-                    <XMArray meaning="matrix" xml:id="S1.Ex42.m1.1">
-                      <XMRow>
-                        <XMCell align="center">
-                          <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                        </XMCell>
-                        <XMCell align="center">
-                          <XMTok font="italic" role="UNKNOWN">b</XMTok>
-                        </XMCell>
-                      </XMRow>
-                      <XMRow>
-                        <XMCell align="center">
-                          <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                        </XMCell>
-                        <XMCell align="center">
-                          <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                        </XMCell>
-                      </XMRow>
-                    </XMArray>
-                  </XMDual>
-                  <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
-                  <XMDual xml:id="S1.Ex42.m1.10">
-                    <XMRef idref="S1.Ex42.m1.2"/>
-                    <XMWrap>
-                      <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray meaning="matrix" xml:id="S1.Ex42.m1.2">
+                    <XMDual xml:id="S1.Ex42.m1.1">
+                      <XMApp>
+                        <XMTok meaning="matrix"/>
+                        <XMRef idref="S1.Ex42.m1.1.1"/>
+                      </XMApp>
+                      <XMArray xml:id="S1.Ex42.m1.1.1">
                         <XMRow>
                           <XMCell align="center">
                             <XMTok font="italic" role="UNKNOWN">a</XMTok>
@@ -4413,6 +4463,37 @@
                           </XMCell>
                         </XMRow>
                       </XMArray>
+                    </XMDual>
+                  </XMDual>
+                  <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
+                  <XMDual xml:id="S1.Ex42.m1.10">
+                    <XMRef idref="S1.Ex42.m1.2"/>
+                    <XMWrap>
+                      <XMTok role="OPEN" stretchy="true">(</XMTok>
+                      <XMDual xml:id="S1.Ex42.m1.2">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex42.m1.2.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex42.m1.2.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4421,24 +4502,30 @@
                     <XMRef idref="S1.Ex42.m1.3"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray meaning="matrix" xml:id="S1.Ex42.m1.3">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">b</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex42.m1.3">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex42.m1.3.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex42.m1.3.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4447,24 +4534,30 @@
                     <XMRef idref="S1.Ex42.m1.4"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">[</XMTok>
-                      <XMArray meaning="matrix" xml:id="S1.Ex42.m1.4">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">b</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex42.m1.4">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex42.m1.4.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex42.m1.4.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">]</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4473,48 +4566,60 @@
                     <XMRef idref="S1.Ex42.m1.5"/>
                     <XMWrap>
                       <XMTok role="VERTBAR" stretchy="true">|</XMTok>
-                      <XMArray meaning="matrix" xml:id="S1.Ex42.m1.5">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">b</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex42.m1.5">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex42.m1.5.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex42.m1.5.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="VERTBAR" stretchy="true">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
                   <XMDual xml:id="S1.Ex42.m1.14">
                     <XMRef idref="S1.Ex42.m1.6"/>
-                    <XMArray xml:id="S1.Ex42.m1.6">
-                      <XMRow>
-                        <XMCell align="center">
-                          <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                        </XMCell>
-                        <XMCell align="center">
-                          <XMTok font="italic" fontsize="70%" role="UNKNOWN">b</XMTok>
-                        </XMCell>
-                      </XMRow>
-                      <XMRow>
-                        <XMCell align="center">
-                          <XMTok font="italic" fontsize="70%" role="UNKNOWN">c</XMTok>
-                        </XMCell>
-                        <XMCell align="center">
-                          <XMTok font="italic" fontsize="70%" role="UNKNOWN">d</XMTok>
-                        </XMCell>
-                      </XMRow>
-                    </XMArray>
+                    <XMDual xml:id="S1.Ex42.m1.6">
+                      <XMApp>
+                        <XMTok meaning="matrix"/>
+                        <XMRef idref="S1.Ex42.m1.6.1"/>
+                      </XMApp>
+                      <XMArray xml:id="S1.Ex42.m1.6.1">
+                        <XMRow>
+                          <XMCell align="center">
+                            <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                          </XMCell>
+                          <XMCell align="center">
+                            <XMTok font="italic" fontsize="70%" role="UNKNOWN">b</XMTok>
+                          </XMCell>
+                        </XMRow>
+                        <XMRow>
+                          <XMCell align="center">
+                            <XMTok font="italic" fontsize="70%" role="UNKNOWN">c</XMTok>
+                          </XMCell>
+                          <XMCell align="center">
+                            <XMTok font="italic" fontsize="70%" role="UNKNOWN">d</XMTok>
+                          </XMCell>
+                        </XMRow>
+                      </XMArray>
+                    </XMDual>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
                   <XMDual xml:id="S1.Ex42.m1.15">
@@ -4524,24 +4629,30 @@
                     </XMApp>
                     <XMWrap>
                       <XMTok role="VERTBAR" stretchy="true">|</XMTok>
-                      <XMArray meaning="matrix" xml:id="S1.Ex42.m1.7">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">b</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">c</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex42.m1.7">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex42.m1.7.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex42.m1.7.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="VERTBAR" stretchy="true">|</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4580,7 +4691,7 @@
           </Math>
         </equation>
         <equation xml:id="S1.Ex43">
-          <Math mode="display" tex="\smallmatrixquantity(1&amp;0&amp;0\\&#10;0&amp;1&amp;0\\&#10;0&amp;0&amp;1)\qquad\smallmatrixquantity(1&amp;1&amp;1\\&#10;1&amp;1&amp;1)\qquad\smallmatrixquantity(a_{11}&amp;a_{12}&amp;a_{13}\\&#10;a_{21}&amp;a_{22}&amp;a_{23}\\&#10;a_{31}&amp;a_{32}&amp;a_{33})\qquad\smallmatrixquantity(a_{1}\\&#10;a_{2}\\&#10;a_{3})\qquad\smallmatrixquantity(a_{1}&amp;a_{2}&amp;a_{3})\qquad\smallmatrixquantity(%&#10;0&amp;0\\&#10;0&amp;0)" text="list@(Array[[1, 0, 0], [0, 1, 0], [0, 0, 1]], Array[[1, 1, 1], [1, 1, 1]], Array[[a _ (list@(1, 1)), a _ (list@(1, 2)), a _ (list@(1, 3))], [a _ (list@(2, 1)), a _ (list@(2, 2)), a _ (list@(2, 3))], [a _ (list@(3, 1)), a _ (list@(3, 2)), a _ (list@(3, 3))]], Array[[a _ 1], [a _ 2], [a _ 3]], Array[[a _ 1, a _ 2, a _ 3]], Array[[0, 0], [0, 0]])" xml:id="S1.Ex43.m1">
+          <Math mode="display" tex="\smallmatrixquantity(1&amp;0&amp;0\\&#10;0&amp;1&amp;0\\&#10;0&amp;0&amp;1)\qquad\smallmatrixquantity(1&amp;1&amp;1\\&#10;1&amp;1&amp;1)\qquad\smallmatrixquantity(a_{11}&amp;a_{12}&amp;a_{13}\\&#10;a_{21}&amp;a_{22}&amp;a_{23}\\&#10;a_{31}&amp;a_{32}&amp;a_{33})\qquad\smallmatrixquantity(a_{1}\\&#10;a_{2}\\&#10;a_{3})\qquad\smallmatrixquantity(a_{1}&amp;a_{2}&amp;a_{3})\qquad\smallmatrixquantity(%&#10;0&amp;0\\&#10;0&amp;0)" text="list@(matrix@(Array[[1, 0, 0], [0, 1, 0], [0, 0, 1]]), matrix@(Array[[1, 1, 1], [1, 1, 1]]), matrix@(Array[[a _ (list@(1, 1)), a _ (list@(1, 2)), a _ (list@(1, 3))], [a _ (list@(2, 1)), a _ (list@(2, 2)), a _ (list@(2, 3))], [a _ (list@(3, 1)), a _ (list@(3, 2)), a _ (list@(3, 3))]]), matrix@(Array[[a _ 1], [a _ 2], [a _ 3]]), matrix@(Array[[a _ 1, a _ 2, a _ 3]]), matrix@(Array[[0, 0], [0, 0]]))" xml:id="S1.Ex43.m1">
             <XMath>
               <XMDual>
                 <XMApp>
@@ -4597,41 +4708,47 @@
                     <XMRef idref="S1.Ex43.m1.1"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex43.m1.1">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex43.m1.1">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex43.m1.1.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex43.m1.1.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4640,30 +4757,36 @@
                     <XMRef idref="S1.Ex43.m1.2"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex43.m1.2">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex43.m1.2">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex43.m1.2.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex43.m1.2.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4672,176 +4795,182 @@
                     <XMRef idref="S1.Ex43.m1.3"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex43.m1.3">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMDual>
-                                <XMApp>
-                                  <XMTok meaning="list"/>
-                                  <XMRef idref="S1.Ex43.m1.3.1"/>
-                                  <XMRef idref="S1.Ex43.m1.3.2"/>
-                                </XMApp>
-                                <XMWrap>
-                                  <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.1">1</XMTok>
-                                  <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
-                                  <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.2">1</XMTok>
-                                </XMWrap>
-                              </XMDual>
-                            </XMApp>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMDual>
-                                <XMApp>
-                                  <XMTok meaning="list"/>
-                                  <XMRef idref="S1.Ex43.m1.3.3"/>
-                                  <XMRef idref="S1.Ex43.m1.3.4"/>
-                                </XMApp>
-                                <XMWrap>
-                                  <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.3">1</XMTok>
-                                  <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
-                                  <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.4">2</XMTok>
-                                </XMWrap>
-                              </XMDual>
-                            </XMApp>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMDual>
-                                <XMApp>
-                                  <XMTok meaning="list"/>
-                                  <XMRef idref="S1.Ex43.m1.3.5"/>
-                                  <XMRef idref="S1.Ex43.m1.3.6"/>
-                                </XMApp>
-                                <XMWrap>
-                                  <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.5">1</XMTok>
-                                  <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
-                                  <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.6">3</XMTok>
-                                </XMWrap>
-                              </XMDual>
-                            </XMApp>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMDual>
-                                <XMApp>
-                                  <XMTok meaning="list"/>
-                                  <XMRef idref="S1.Ex43.m1.3.7"/>
-                                  <XMRef idref="S1.Ex43.m1.3.8"/>
-                                </XMApp>
-                                <XMWrap>
-                                  <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.7">2</XMTok>
-                                  <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
-                                  <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.8">1</XMTok>
-                                </XMWrap>
-                              </XMDual>
-                            </XMApp>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMDual>
-                                <XMApp>
-                                  <XMTok meaning="list"/>
-                                  <XMRef idref="S1.Ex43.m1.3.9"/>
-                                  <XMRef idref="S1.Ex43.m1.3.10"/>
-                                </XMApp>
-                                <XMWrap>
-                                  <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.9">2</XMTok>
-                                  <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
-                                  <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.10">2</XMTok>
-                                </XMWrap>
-                              </XMDual>
-                            </XMApp>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMDual>
-                                <XMApp>
-                                  <XMTok meaning="list"/>
-                                  <XMRef idref="S1.Ex43.m1.3.11"/>
-                                  <XMRef idref="S1.Ex43.m1.3.12"/>
-                                </XMApp>
-                                <XMWrap>
-                                  <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.11">2</XMTok>
-                                  <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
-                                  <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.12">3</XMTok>
-                                </XMWrap>
-                              </XMDual>
-                            </XMApp>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMDual>
-                                <XMApp>
-                                  <XMTok meaning="list"/>
-                                  <XMRef idref="S1.Ex43.m1.3.13"/>
-                                  <XMRef idref="S1.Ex43.m1.3.14"/>
-                                </XMApp>
-                                <XMWrap>
-                                  <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.13">3</XMTok>
-                                  <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
-                                  <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.14">1</XMTok>
-                                </XMWrap>
-                              </XMDual>
-                            </XMApp>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMDual>
-                                <XMApp>
-                                  <XMTok meaning="list"/>
-                                  <XMRef idref="S1.Ex43.m1.3.15"/>
-                                  <XMRef idref="S1.Ex43.m1.3.16"/>
-                                </XMApp>
-                                <XMWrap>
-                                  <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.15">3</XMTok>
-                                  <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
-                                  <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.16">2</XMTok>
-                                </XMWrap>
-                              </XMDual>
-                            </XMApp>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMDual>
-                                <XMApp>
-                                  <XMTok meaning="list"/>
-                                  <XMRef idref="S1.Ex43.m1.3.17"/>
-                                  <XMRef idref="S1.Ex43.m1.3.18"/>
-                                </XMApp>
-                                <XMWrap>
-                                  <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.17">3</XMTok>
-                                  <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
-                                  <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.18">3</XMTok>
-                                </XMWrap>
-                              </XMDual>
-                            </XMApp>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex43.m1.3">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex43.m1.3.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex43.m1.3.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMDual>
+                                  <XMApp>
+                                    <XMTok meaning="list"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.1"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.2"/>
+                                  </XMApp>
+                                  <XMWrap>
+                                    <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.1.1">1</XMTok>
+                                    <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
+                                    <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.1.2">1</XMTok>
+                                  </XMWrap>
+                                </XMDual>
+                              </XMApp>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMDual>
+                                  <XMApp>
+                                    <XMTok meaning="list"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.3"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.4"/>
+                                  </XMApp>
+                                  <XMWrap>
+                                    <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.1.3">1</XMTok>
+                                    <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
+                                    <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.1.4">2</XMTok>
+                                  </XMWrap>
+                                </XMDual>
+                              </XMApp>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMDual>
+                                  <XMApp>
+                                    <XMTok meaning="list"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.5"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.6"/>
+                                  </XMApp>
+                                  <XMWrap>
+                                    <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.1.5">1</XMTok>
+                                    <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
+                                    <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.1.6">3</XMTok>
+                                  </XMWrap>
+                                </XMDual>
+                              </XMApp>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMDual>
+                                  <XMApp>
+                                    <XMTok meaning="list"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.7"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.8"/>
+                                  </XMApp>
+                                  <XMWrap>
+                                    <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.1.7">2</XMTok>
+                                    <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
+                                    <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.1.8">1</XMTok>
+                                  </XMWrap>
+                                </XMDual>
+                              </XMApp>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMDual>
+                                  <XMApp>
+                                    <XMTok meaning="list"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.9"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.10"/>
+                                  </XMApp>
+                                  <XMWrap>
+                                    <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.1.9">2</XMTok>
+                                    <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
+                                    <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.1.10">2</XMTok>
+                                  </XMWrap>
+                                </XMDual>
+                              </XMApp>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMDual>
+                                  <XMApp>
+                                    <XMTok meaning="list"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.11"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.12"/>
+                                  </XMApp>
+                                  <XMWrap>
+                                    <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.1.11">2</XMTok>
+                                    <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
+                                    <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.1.12">3</XMTok>
+                                  </XMWrap>
+                                </XMDual>
+                              </XMApp>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMDual>
+                                  <XMApp>
+                                    <XMTok meaning="list"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.13"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.14"/>
+                                  </XMApp>
+                                  <XMWrap>
+                                    <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.1.13">3</XMTok>
+                                    <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
+                                    <XMTok fontsize="49%" meaning="1" role="NUMBER" xml:id="S1.Ex43.m1.3.1.14">1</XMTok>
+                                  </XMWrap>
+                                </XMDual>
+                              </XMApp>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMDual>
+                                  <XMApp>
+                                    <XMTok meaning="list"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.15"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.16"/>
+                                  </XMApp>
+                                  <XMWrap>
+                                    <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.1.15">3</XMTok>
+                                    <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
+                                    <XMTok fontsize="49%" meaning="2" role="NUMBER" xml:id="S1.Ex43.m1.3.1.16">2</XMTok>
+                                  </XMWrap>
+                                </XMDual>
+                              </XMApp>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMDual>
+                                  <XMApp>
+                                    <XMTok meaning="list"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.17"/>
+                                    <XMRef idref="S1.Ex43.m1.3.1.18"/>
+                                  </XMApp>
+                                  <XMWrap>
+                                    <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.1.17">3</XMTok>
+                                    <XMTok fontsize="49%" role="PUNCT">⁣</XMTok>
+                                    <XMTok fontsize="49%" meaning="3" role="NUMBER" xml:id="S1.Ex43.m1.3.1.18">3</XMTok>
+                                  </XMWrap>
+                                </XMDual>
+                              </XMApp>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4850,35 +4979,41 @@
                     <XMRef idref="S1.Ex43.m1.4"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex43.m1.4">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMTok fontsize="49%" meaning="1" role="NUMBER">1</XMTok>
-                            </XMApp>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMTok fontsize="49%" meaning="2" role="NUMBER">2</XMTok>
-                            </XMApp>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMTok fontsize="49%" meaning="3" role="NUMBER">3</XMTok>
-                            </XMApp>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex43.m1.4">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex43.m1.4.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex43.m1.4.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMTok fontsize="49%" meaning="1" role="NUMBER">1</XMTok>
+                              </XMApp>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMTok fontsize="49%" meaning="2" role="NUMBER">2</XMTok>
+                              </XMApp>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMTok fontsize="49%" meaning="3" role="NUMBER">3</XMTok>
+                              </XMApp>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4887,31 +5022,37 @@
                     <XMRef idref="S1.Ex43.m1.5"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex43.m1.5">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMTok fontsize="49%" meaning="1" role="NUMBER">1</XMTok>
-                            </XMApp>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMTok fontsize="49%" meaning="2" role="NUMBER">2</XMTok>
-                            </XMApp>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
-                              <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
-                              <XMTok fontsize="49%" meaning="3" role="NUMBER">3</XMTok>
-                            </XMApp>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex43.m1.5">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex43.m1.5.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex43.m1.5.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMTok fontsize="49%" meaning="1" role="NUMBER">1</XMTok>
+                              </XMApp>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMTok fontsize="49%" meaning="2" role="NUMBER">2</XMTok>
+                              </XMApp>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok role="SUBSCRIPTOP" scriptpos="post7"/>
+                                <XMTok font="italic" fontsize="70%" role="UNKNOWN">a</XMTok>
+                                <XMTok fontsize="49%" meaning="3" role="NUMBER">3</XMTok>
+                              </XMApp>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4920,24 +5061,30 @@
                     <XMRef idref="S1.Ex43.m1.6"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex43.m1.6">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex43.m1.6">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex43.m1.6.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex43.m1.6.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4947,7 +5094,7 @@
           </Math>
         </equation>
         <equation xml:id="S1.Ex44">
-          <Math mode="display" tex="\smallmatrixquantity(1&amp;0\\&#10;0&amp;1)\qquad\smallmatrixquantity(0&amp;1\\&#10;1&amp;0)\qquad\smallmatrixquantity(0&amp;-i\\&#10;i&amp;0)\qquad\smallmatrixquantity(1&amp;0\\&#10;0&amp;-1)" text="list@(Array[[1, 0], [0, 1]], Array[[0, 1], [1, 0]], Array[[0, - imaginary-unit], [imaginary-unit, 0]], Array[[1, 0], [0, - 1]])" xml:id="S1.Ex44.m1">
+          <Math mode="display" tex="\smallmatrixquantity(1&amp;0\\&#10;0&amp;1)\qquad\smallmatrixquantity(0&amp;1\\&#10;1&amp;0)\qquad\smallmatrixquantity(0&amp;-i\\&#10;i&amp;0)\qquad\smallmatrixquantity(1&amp;0\\&#10;0&amp;-1)" text="list@(matrix@(Array[[1, 0], [0, 1]]), matrix@(Array[[0, 1], [1, 0]]), matrix@(Array[[0, - imaginary-unit], [imaginary-unit, 0]]), matrix@(Array[[1, 0], [0, - 1]]))" xml:id="S1.Ex44.m1">
             <XMath>
               <XMDual>
                 <XMApp>
@@ -4962,24 +5109,30 @@
                     <XMRef idref="S1.Ex44.m1.1"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex44.m1.1">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex44.m1.1">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex44.m1.1.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex44.m1.1.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -4988,24 +5141,30 @@
                     <XMRef idref="S1.Ex44.m1.2"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex44.m1.2">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex44.m1.2">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex44.m1.2.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex44.m1.2.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -5014,27 +5173,33 @@
                     <XMRef idref="S1.Ex44.m1.3"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex44.m1.3">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok fontsize="70%" meaning="minus" role="ADDOP">-</XMTok>
+                      <XMDual xml:id="S1.Ex44.m1.3">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex44.m1.3.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex44.m1.3.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok fontsize="70%" meaning="minus" role="ADDOP">-</XMTok>
+                                <XMTok font="italic" fontsize="70%" meaning="imaginary-unit" name="i" role="UNKNOWN">i</XMTok>
+                              </XMApp>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
                               <XMTok font="italic" fontsize="70%" meaning="imaginary-unit" name="i" role="UNKNOWN">i</XMTok>
-                            </XMApp>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok font="italic" fontsize="70%" meaning="imaginary-unit" name="i" role="UNKNOWN">i</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -5043,27 +5208,33 @@
                     <XMRef idref="S1.Ex44.m1.4"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray xml:id="S1.Ex44.m1.4">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMApp>
-                              <XMTok fontsize="70%" meaning="minus" role="ADDOP">-</XMTok>
+                      <XMDual xml:id="S1.Ex44.m1.4">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex44.m1.4.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex44.m1.4.1">
+                          <XMRow>
+                            <XMCell align="center">
                               <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
-                            </XMApp>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok fontsize="70%" meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMApp>
+                                <XMTok fontsize="70%" meaning="minus" role="ADDOP">-</XMTok>
+                                <XMTok fontsize="70%" meaning="1" role="NUMBER">1</XMTok>
+                              </XMApp>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -5073,7 +5244,7 @@
           </Math>
         </equation>
         <equation xml:id="S1.Ex45">
-          <Math mode="display" tex="\matrixquantity(1&amp;&amp;\\&#10;&amp;2&amp;\\&#10;&amp;&amp;3)\qquad\matrixquantity(1&amp;0\\&#10;0&amp;2)\qquad\matrixquantity(1&amp;\\&#10;&amp;\begin{matrix}2&amp;3\\&#10;4&amp;5\end{matrix})\qquad\matrixquantity(&amp;&amp;1\\&#10;&amp;2&amp;\\&#10;3&amp;&amp;)" text="list@(matrix[[1, absent, absent], [absent, 2, absent], [absent, absent, 3]], matrix[[1, 0], [0, 2]], matrix[[1, absent], [absent, matrix[[2, 3], [4, 5]]]], matrix[[absent, absent, 1], [absent, 2, absent], [3, absent, absent]])" xml:id="S1.Ex45.m1">
+          <Math mode="display" tex="\matrixquantity(1&amp;&amp;\\&#10;&amp;2&amp;\\&#10;&amp;&amp;3)\qquad\matrixquantity(1&amp;0\\&#10;0&amp;2)\qquad\matrixquantity(1&amp;\\&#10;&amp;\begin{matrix}2&amp;3\\&#10;4&amp;5\end{matrix})\qquad\matrixquantity(&amp;&amp;1\\&#10;&amp;2&amp;\\&#10;3&amp;&amp;)" text="list@(matrix@(Array[[1, absent, absent], [absent, 2, absent], [absent, absent, 3]]), matrix@(Array[[1, 0], [0, 2]]), matrix@(Array[[1, absent], [absent, matrix@(Array[[2, 3], [4, 5]])]]), matrix@(Array[[absent, absent, 1], [absent, 2, absent], [3, absent, absent]]))" xml:id="S1.Ex45.m1">
             <XMath>
               <XMDual>
                 <XMApp>
@@ -5088,41 +5259,47 @@
                     <XMRef idref="S1.Ex45.m1.1"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray meaning="matrix" xml:id="S1.Ex45.m1.1">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="2" role="NUMBER">2</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="3" role="NUMBER">3</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex45.m1.1">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex45.m1.1.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex45.m1.1.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="2" role="NUMBER">2</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="3" role="NUMBER">3</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -5131,24 +5308,30 @@
                     <XMRef idref="S1.Ex45.m1.2"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray meaning="matrix" xml:id="S1.Ex45.m1.2">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="0" role="NUMBER">0</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="2" role="NUMBER">2</XMTok>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex45.m1.2">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex45.m1.2.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex45.m1.2.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="0" role="NUMBER">0</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="2" role="NUMBER">2</XMTok>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -5157,41 +5340,53 @@
                     <XMRef idref="S1.Ex45.m1.3"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray meaning="matrix" xml:id="S1.Ex45.m1.3">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMArray meaning="matrix">
-                              <XMRow>
-                                <XMCell align="center">
-                                  <XMTok meaning="2" role="NUMBER">2</XMTok>
-                                </XMCell>
-                                <XMCell align="center">
-                                  <XMTok meaning="3" role="NUMBER">3</XMTok>
-                                </XMCell>
-                              </XMRow>
-                              <XMRow>
-                                <XMCell align="center">
-                                  <XMTok meaning="4" role="NUMBER">4</XMTok>
-                                </XMCell>
-                                <XMCell align="center">
-                                  <XMTok meaning="5" role="NUMBER">5</XMTok>
-                                </XMCell>
-                              </XMRow>
-                            </XMArray>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex45.m1.3">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex45.m1.3.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex45.m1.3.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMDual>
+                                <XMApp>
+                                  <XMTok meaning="matrix"/>
+                                  <XMRef idref="S1.Ex45.m1.3.1.1"/>
+                                </XMApp>
+                                <XMArray xml:id="S1.Ex45.m1.3.1.1">
+                                  <XMRow>
+                                    <XMCell align="center">
+                                      <XMTok meaning="2" role="NUMBER">2</XMTok>
+                                    </XMCell>
+                                    <XMCell align="center">
+                                      <XMTok meaning="3" role="NUMBER">3</XMTok>
+                                    </XMCell>
+                                  </XMRow>
+                                  <XMRow>
+                                    <XMCell align="center">
+                                      <XMTok meaning="4" role="NUMBER">4</XMTok>
+                                    </XMCell>
+                                    <XMCell align="center">
+                                      <XMTok meaning="5" role="NUMBER">5</XMTok>
+                                    </XMCell>
+                                  </XMRow>
+                                </XMArray>
+                              </XMDual>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -5200,41 +5395,47 @@
                     <XMRef idref="S1.Ex45.m1.4"/>
                     <XMWrap>
                       <XMTok role="OPEN" stretchy="true">(</XMTok>
-                      <XMArray meaning="matrix" xml:id="S1.Ex45.m1.4">
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="1" role="NUMBER">1</XMTok>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="2" role="NUMBER">2</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                        </XMRow>
-                        <XMRow>
-                          <XMCell align="center">
-                            <XMTok meaning="3" role="NUMBER">3</XMTok>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                          <XMCell align="center">
-                            <XMTok meaning="absent"/>
-                          </XMCell>
-                        </XMRow>
-                      </XMArray>
+                      <XMDual xml:id="S1.Ex45.m1.4">
+                        <XMApp>
+                          <XMTok meaning="matrix"/>
+                          <XMRef idref="S1.Ex45.m1.4.1"/>
+                        </XMApp>
+                        <XMArray xml:id="S1.Ex45.m1.4.1">
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="1" role="NUMBER">1</XMTok>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="2" role="NUMBER">2</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                          </XMRow>
+                          <XMRow>
+                            <XMCell align="center">
+                              <XMTok meaning="3" role="NUMBER">3</XMTok>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                            <XMCell align="center">
+                              <XMTok meaning="absent"/>
+                            </XMCell>
+                          </XMRow>
+                        </XMArray>
+                      </XMDual>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>

--- a/t/complex/physics.xml
+++ b/t/complex/physics.xml
@@ -2984,18 +2984,11 @@
           <Math mode="display" tex="\differential[2][\frac{X}{Y}]" text="(functional-power@(differential, 2))@(delimited-[]@(X / Y))" xml:id="S1.Ex27.m1">
             <XMath>
               <XMApp>
-                <XMDual role="DIFFOP">
-                  <XMApp>
-                    <XMTok meaning="functional-power"/>
-                    <XMTok meaning="differential"/>
-                    <XMRef idref="S1.Ex27.m1.1"/>
-                  </XMApp>
-                  <XMApp role="DIFFOP">
-                    <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
-                    <XMTok role="DIFFOP">d</XMTok>
-                    <XMTok fontsize="70%" meaning="2" role="NUMBER" xml:id="S1.Ex27.m1.1">2</XMTok>
-                  </XMApp>
-                </XMDual>
+                <XMApp role="DIFFOP">
+                  <XMTok meaning="functional-power" role="SUPERSCRIPTOP" scriptpos="post1"/>
+                  <XMTok meaning="differential" role="DIFFOP">d</XMTok>
+                  <XMTok fontsize="70%" meaning="2" role="NUMBER" xml:id="S1.Ex27.m1.1">2</XMTok>
+                </XMApp>
                 <XMDual>
                   <XMApp>
                     <XMTok meaning="delimited-[]"/>

--- a/t/math/array.xml
+++ b/t/math/array.xml
@@ -49,26 +49,32 @@
       </Math>
     </equation>
     <equation xml:id="S0.Ex2">
-      <Math mode="display" tex="\matrix{a&amp;b\cr c&amp;d}" text="matrix[[a, b], [c, d]]" xml:id="S0.Ex2.m1">
+      <Math mode="display" tex="\matrix{a&amp;b\cr c&amp;d}" text="matrix@(Array[[a, b], [c, d]])" xml:id="S0.Ex2.m1">
         <XMath>
-          <XMArray meaning="matrix">
-            <XMRow>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">a</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">b</XMTok>
-              </XMCell>
-            </XMRow>
-            <XMRow>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">c</XMTok>
-              </XMCell>
-              <XMCell align="center">
-                <XMTok font="italic" role="UNKNOWN">d</XMTok>
-              </XMCell>
-            </XMRow>
-          </XMArray>
+          <XMDual>
+            <XMApp>
+              <XMTok meaning="matrix"/>
+              <XMRef idref="S0.Ex2.m1.1"/>
+            </XMApp>
+            <XMArray xml:id="S0.Ex2.m1.1">
+              <XMRow>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">a</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">b</XMTok>
+                </XMCell>
+              </XMRow>
+              <XMRow>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">c</XMTok>
+                </XMCell>
+                <XMCell align="center">
+                  <XMTok font="italic" role="UNKNOWN">d</XMTok>
+                </XMCell>
+              </XMRow>
+            </XMArray>
+          </XMDual>
         </XMath>
       </Math>
     </equation>

--- a/t/math/sampler.xml
+++ b/t/math/sampler.xml
@@ -1357,75 +1357,90 @@ are not currently tested.</p>
           <tag>(22)</tag>
           <tag role="refnum">22</tag>
         </tags>
-        <Math mode="display" tex="\begin{matrix}-1&amp;3\\&#10;2&amp;-4\end{matrix},\qquad\begin{matrix}[r]-1&amp;3\\&#10;2&amp;-4\end{matrix},\qquad\begin{Vmatrix}-1&amp;3\\&#10;2&amp;-4\end{Vmatrix},\qquad\begin{Vmatrix}[r]-1&amp;3\\&#10;2&amp;-4\end{Vmatrix}" text="list@(matrix[[- 1, 3], [2, - 4]], matrix[[- 1, 3], [2, - 4]], norm@(matrix[[- 1, 3], [2, - 4]]), norm@(matrix[[- 1, 3], [2, - 4]]))" xml:id="S4.E22.m1">
+        <Math mode="display" tex="\begin{matrix}-1&amp;3\\&#10;2&amp;-4\end{matrix},\qquad\begin{matrix}[r]-1&amp;3\\&#10;2&amp;-4\end{matrix},\qquad\begin{Vmatrix}-1&amp;3\\&#10;2&amp;-4\end{Vmatrix},\qquad\begin{Vmatrix}[r]-1&amp;3\\&#10;2&amp;-4\end{Vmatrix}" text="list@(matrix@(Array[[- 1, 3], [2, - 4]]), matrix@(Array[[- 1, 3], [2, - 4]]), norm@(matrix@(Array[[- 1, 3], [2, - 4]])), norm@(matrix@(Array[[- 1, 3], [2, - 4]])))" xml:id="S4.E22.m1">
           <XMath>
             <XMDual>
               <XMApp>
                 <XMTok meaning="list"/>
-                <XMRef idref="S4.E22.m1.3"/>
-                <XMRef idref="S4.E22.m1.4"/>
                 <XMRef idref="S4.E22.m1.5"/>
                 <XMRef idref="S4.E22.m1.6"/>
+                <XMRef idref="S4.E22.m1.7"/>
+                <XMRef idref="S4.E22.m1.8"/>
               </XMApp>
               <XMWrap>
-                <XMArray meaning="matrix" xml:id="S4.E22.m1.3">
-                  <XMRow>
-                    <XMCell align="center">
-                      <XMApp>
-                        <XMTok meaning="minus" role="ADDOP">-</XMTok>
-                        <XMTok meaning="1" role="NUMBER">1</XMTok>
-                      </XMApp>
-                    </XMCell>
-                    <XMCell align="center">
-                      <XMTok meaning="3" role="NUMBER">3</XMTok>
-                    </XMCell>
-                  </XMRow>
-                  <XMRow>
-                    <XMCell align="center">
-                      <XMTok meaning="2" role="NUMBER">2</XMTok>
-                    </XMCell>
-                    <XMCell align="center">
-                      <XMApp>
-                        <XMTok meaning="minus" role="ADDOP">-</XMTok>
-                        <XMTok meaning="4" role="NUMBER">4</XMTok>
-                      </XMApp>
-                    </XMCell>
-                  </XMRow>
-                </XMArray>
-                <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
-                <XMArray meaning="matrix" xml:id="S4.E22.m1.4">
-                  <XMRow>
-                    <XMCell align="right">
-                      <XMApp>
-                        <XMTok meaning="minus" role="ADDOP">-</XMTok>
-                        <XMTok meaning="1" role="NUMBER">1</XMTok>
-                      </XMApp>
-                    </XMCell>
-                    <XMCell align="right">
-                      <XMTok meaning="3" role="NUMBER">3</XMTok>
-                    </XMCell>
-                  </XMRow>
-                  <XMRow>
-                    <XMCell align="right">
-                      <XMTok meaning="2" role="NUMBER">2</XMTok>
-                    </XMCell>
-                    <XMCell align="right">
-                      <XMApp>
-                        <XMTok meaning="minus" role="ADDOP">-</XMTok>
-                        <XMTok meaning="4" role="NUMBER">4</XMTok>
-                      </XMApp>
-                    </XMCell>
-                  </XMRow>
-                </XMArray>
-                <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
                 <XMDual xml:id="S4.E22.m1.5">
                   <XMApp>
-                    <XMTok meaning="norm"/>
+                    <XMTok meaning="matrix"/>
                     <XMRef idref="S4.E22.m1.1"/>
+                  </XMApp>
+                  <XMArray xml:id="S4.E22.m1.1">
+                    <XMRow>
+                      <XMCell align="center">
+                        <XMApp>
+                          <XMTok meaning="minus" role="ADDOP">-</XMTok>
+                          <XMTok meaning="1" role="NUMBER">1</XMTok>
+                        </XMApp>
+                      </XMCell>
+                      <XMCell align="center">
+                        <XMTok meaning="3" role="NUMBER">3</XMTok>
+                      </XMCell>
+                    </XMRow>
+                    <XMRow>
+                      <XMCell align="center">
+                        <XMTok meaning="2" role="NUMBER">2</XMTok>
+                      </XMCell>
+                      <XMCell align="center">
+                        <XMApp>
+                          <XMTok meaning="minus" role="ADDOP">-</XMTok>
+                          <XMTok meaning="4" role="NUMBER">4</XMTok>
+                        </XMApp>
+                      </XMCell>
+                    </XMRow>
+                  </XMArray>
+                </XMDual>
+                <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
+                <XMDual xml:id="S4.E22.m1.6">
+                  <XMApp>
+                    <XMTok meaning="matrix"/>
+                    <XMRef idref="S4.E22.m1.2"/>
+                  </XMApp>
+                  <XMArray xml:id="S4.E22.m1.2">
+                    <XMRow>
+                      <XMCell align="right">
+                        <XMApp>
+                          <XMTok meaning="minus" role="ADDOP">-</XMTok>
+                          <XMTok meaning="1" role="NUMBER">1</XMTok>
+                        </XMApp>
+                      </XMCell>
+                      <XMCell align="right">
+                        <XMTok meaning="3" role="NUMBER">3</XMTok>
+                      </XMCell>
+                    </XMRow>
+                    <XMRow>
+                      <XMCell align="right">
+                        <XMTok meaning="2" role="NUMBER">2</XMTok>
+                      </XMCell>
+                      <XMCell align="right">
+                        <XMApp>
+                          <XMTok meaning="minus" role="ADDOP">-</XMTok>
+                          <XMTok meaning="4" role="NUMBER">4</XMTok>
+                        </XMApp>
+                      </XMCell>
+                    </XMRow>
+                  </XMArray>
+                </XMDual>
+                <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
+                <XMDual xml:id="S4.E22.m1.7">
+                  <XMApp>
+                    <XMTok meaning="norm"/>
+                    <XMApp>
+                      <XMTok meaning="matrix"/>
+                      <XMRef idref="S4.E22.m1.3"/>
+                    </XMApp>
                   </XMApp>
                   <XMWrap>
                     <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-                    <XMArray meaning="matrix" xml:id="S4.E22.m1.1">
+                    <XMArray xml:id="S4.E22.m1.3">
                       <XMRow>
                         <XMCell align="center">
                           <XMApp>
@@ -1453,14 +1468,17 @@ are not currently tested.</p>
                   </XMWrap>
                 </XMDual>
                 <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
-                <XMDual xml:id="S4.E22.m1.6">
+                <XMDual xml:id="S4.E22.m1.8">
                   <XMApp>
                     <XMTok meaning="norm"/>
-                    <XMRef idref="S4.E22.m1.2"/>
+                    <XMApp>
+                      <XMTok meaning="matrix"/>
+                      <XMRef idref="S4.E22.m1.4"/>
+                    </XMApp>
                   </XMApp>
                   <XMWrap>
                     <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
-                    <XMArray meaning="matrix" xml:id="S4.E22.m1.2">
+                    <XMArray xml:id="S4.E22.m1.4">
                       <XMRow>
                         <XMCell align="right">
                           <XMApp>

--- a/t/math/sampler.xml
+++ b/t/math/sampler.xml
@@ -457,58 +457,30 @@ and <text font="typewriter">m:mstyle</text>:</p>
                       <XMTok role="CLOSE" stretchy="true">)</XMTok>
                     </XMWrap>
                   </XMDual>
-                  <XMDual>
-                    <XMApp>
-                      <XMRef idref="S2.E10.m1.3"/>
-                      <XMRef idref="S2.E10.m1.4"/>
-                      <XMRef idref="S2.E10.m1.5"/>
-                    </XMApp>
-                    <XMApp>
-                      <XMTok mathstyle="display" role="FRACOP" thickness="0.0pt" xml:id="S2.E10.m1.3"/>
-                      <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.4">a</XMTok>
-                      <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.5">b</XMTok>
-                    </XMApp>
-                  </XMDual>
+                  <XMApp>
+                    <XMTok mathstyle="display" role="FRACOP" thickness="0.0pt" xml:id="S2.E10.m1.3"/>
+                    <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.4">a</XMTok>
+                    <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.5">b</XMTok>
+                  </XMApp>
                 </XMApp>
                 <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
-                <XMDual xml:id="S2.E10.m1.16">
-                  <XMApp>
-                    <XMRef idref="S2.E10.m1.6"/>
-                    <XMRef idref="S2.E10.m1.7"/>
-                    <XMRef idref="S2.E10.m1.8"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok mathstyle="display" meaning="divide" role="FRACOP" thickness="0.0pt" xml:id="S2.E10.m1.6"/>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.7">a</XMTok>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.8">b</XMTok>
-                  </XMApp>
-                </XMDual>
+                <XMApp xml:id="S2.E10.m1.16">
+                  <XMTok mathstyle="display" meaning="divide" role="FRACOP" thickness="0.0pt" xml:id="S2.E10.m1.6"/>
+                  <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.7">a</XMTok>
+                  <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.8">b</XMTok>
+                </XMApp>
                 <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
-                <XMDual xml:id="S2.E10.m1.17">
-                  <XMApp>
-                    <XMRef idref="S2.E10.m1.9"/>
-                    <XMRef idref="S2.E10.m1.10"/>
-                    <XMRef idref="S2.E10.m1.11"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok mathstyle="display" meaning="divide" role="FRACOP" thickness="0.4pt" xml:id="S2.E10.m1.9"/>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.10">a</XMTok>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.11">b</XMTok>
-                  </XMApp>
-                </XMDual>
+                <XMApp xml:id="S2.E10.m1.17">
+                  <XMTok mathstyle="display" meaning="divide" role="FRACOP" thickness="0.4pt" xml:id="S2.E10.m1.9"/>
+                  <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.10">a</XMTok>
+                  <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.11">b</XMTok>
+                </XMApp>
                 <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
-                <XMDual xml:id="S2.E10.m1.18">
-                  <XMApp>
-                    <XMRef idref="S2.E10.m1.12"/>
-                    <XMRef idref="S2.E10.m1.13"/>
-                    <XMRef idref="S2.E10.m1.14"/>
-                  </XMApp>
-                  <XMApp>
-                    <XMTok mathstyle="display" meaning="divide" role="FRACOP" thickness="4.3pt" xml:id="S2.E10.m1.12"/>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.13">a</XMTok>
-                    <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.14">b</XMTok>
-                  </XMApp>
-                </XMDual>
+                <XMApp xml:id="S2.E10.m1.18">
+                  <XMTok mathstyle="display" meaning="divide" role="FRACOP" thickness="4.3pt" xml:id="S2.E10.m1.12"/>
+                  <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.13">a</XMTok>
+                  <XMTok font="italic" role="UNKNOWN" xml:id="S2.E10.m1.14">b</XMTok>
+                </XMApp>
               </XMWrap>
             </XMDual>
           </XMath>


### PR DESCRIPTION
Another iteration in cleaning up the mathematical semantics.  This one focusing on the confusion of "matrix" as a type vs a constructor.  First, we enforce (a bit more) the idea that if a math subtree has a meaning attribute, that is the meaning of the whole subtree.  Then, we take the view that when we are constructing an XMArray that we believe is matrix, rather than misguidedly giving the array a meaning attribute, we apply "meaning" to the array as a constructor. 

[This still leaves open any eventual type or property attribute where we may wish to assert that a particular symbol (say X) is a matrix]