### PR TITLE
Separate comments toggle from processing instruction toggle

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -192,7 +192,7 @@ sub convert {
   if ($$opts{whatsout} =~ /^archive/) {
     $$opts{archive_sitedirectory} = $$opts{sitedirectory};
     $$opts{archive_destination}   = $$opts{destination};
-    my $destination_name = $$opts{destination} ? pathname_name($$opts{destination}) : 'document';
+    my $destination_name  = $$opts{destination} ? pathname_name($$opts{destination}) : 'document';
     my $sandbox_directory = File::Temp->newdir(TMPDIR => 1);
     my $extension         = $$opts{format};
     $extension =~ s/\d+$//;
@@ -300,7 +300,7 @@ sub convert {
 
     # Close and restore STDERR to original condition.
     my $log = $self->flush_log;
-    $serialized = $dom if ($$opts{format} eq 'dom');
+    $serialized = $dom           if ($$opts{format} eq 'dom');
     $serialized = $dom->toString if ($dom && (!defined $serialized));
     # Using the Core::Document::serialize_aux, so need an explicit encode into bytes
     $serialized = Encode::encode('UTF-8', $serialized) if $serialized;
@@ -462,8 +462,8 @@ sub convert_post {
       push(@procs, LaTeXML::Post::CrossRef->new(
           db        => $DB, urlstyle => $$opts{urlstyle},
           extension => $$opts{extension},
-          ($$opts{numbersections} ? (number_sections => 1) : ()),
-          ($$opts{navtoc} ? (navigation_toc => $$opts{navtoc}) : ()),
+          ($$opts{numbersections} ? (number_sections => 1)              : ()),
+          ($$opts{navtoc}         ? (navigation_toc  => $$opts{navtoc}) : ()),
           %PostOPS)); }
     if ($$opts{picimages}) {
       require LaTeXML::Post::PictureImages;
@@ -493,20 +493,20 @@ sub convert_post {
           require LaTeXML::Post::MathML::Presentation;
           push(@mprocs, LaTeXML::Post::MathML::Presentation->new(
               linelength => $$opts{linelength},
-              (defined $$opts{plane1} ? (plane1 => $$opts{plane1}) : (plane1 => 1)),
-              ($$opts{hackplane1} ? (hackplane1 => 1) : ()),
+              (defined $$opts{plane1} ? (plane1     => $$opts{plane1}) : (plane1 => 1)),
+              ($$opts{hackplane1}     ? (hackplane1 => 1)              : ()),
               %PostOPS)); }
         elsif ($fmt eq 'cmml') {
           require LaTeXML::Post::MathML::Content;
           push(@mprocs, LaTeXML::Post::MathML::Content->new(
-              (defined $$opts{plane1} ? (plane1 => $$opts{plane1}) : (plane1 => 1)),
-              ($$opts{hackplane1} ? (hackplane1 => 1) : ()),
+              (defined $$opts{plane1} ? (plane1     => $$opts{plane1}) : (plane1 => 1)),
+              ($$opts{hackplane1}     ? (hackplane1 => 1)              : ()),
               %PostOPS)); }
         elsif ($fmt eq 'om') {
           require LaTeXML::Post::OpenMath;
           push(@mprocs, LaTeXML::Post::OpenMath->new(
-              (defined $$opts{plane1} ? (plane1 => $$opts{plane1}) : (plane1 => 1)),
-              ($$opts{hackplane1} ? (hackplane1 => 1) : ()),
+              (defined $$opts{plane1} ? (plane1     => $$opts{plane1}) : (plane1 => 1)),
+              ($$opts{hackplane1}     ? (hackplane1 => 1)              : ()),
               %PostOPS)); }
         elsif ($fmt eq 'images') {
           require LaTeXML::Post::MathImages;
@@ -652,11 +652,13 @@ sub new_latexml {
       push @pre, $pre;
     }
   }
+  my $includexmlpis = !($$opts{xsltparameters} && (@{ $$opts{xsltparameters} }[0] eq 'LATEXML_VERSION:TEST'));
   require LaTeXML;
   my $latexml = LaTeXML::Core->new(preload => [@pre], searchpaths => [@{ $$opts{paths} }],
     graphicspaths   => ['.'],
     verbosity       => $$opts{verbosity}, strict => $$opts{strict},
     includecomments => $$opts{comments},
+    includexmlpis   => $includexmlpis,
     inputencoding   => $$opts{inputencoding},
     includestyles   => $$opts{includestyles},
     documentid      => $$opts{documentid},

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -36,7 +36,7 @@ use base qw(LaTeXML::Common::Object);
 sub new {
   my ($class, %options) = @_;
   my $verbosity = defined $options{verbosity} ? $options{verbosity} : 0;
-  my $state = LaTeXML::Core::State->new(catcodes => 'standard',
+  my $state     = LaTeXML::Core::State->new(catcodes => 'standard',
     stomach => LaTeXML::Core::Stomach->new(verbosity => $verbosity),
     model   => $options{model} || LaTeXML::Common::Model->new());
   $state->assignValue(VERBOSITY => $verbosity,
@@ -45,6 +45,7 @@ sub new {
     'global');
   $state->assignValue(INCLUDE_COMMENTS => (defined $options{includecomments} ? $options{includecomments} : 1),
     'global');
+  $state->assignValue(INCLUDE_XML_PIS => (defined $options{includexmlpis} ? $options{includexmlpis} : 1), 'global');
   $state->assignValue(DOCUMENTID => (defined $options{documentid} ? $options{documentid} : ''),
     'global');
   $state->assignValue(SEARCHPATHS => [map { pathname_absolute(pathname_canonical($_)) }
@@ -204,7 +205,7 @@ sub convertDocument {
       NoteBegin("Building");
       $model->loadSchema();                                  # If needed?
       if (my $paths = $state->lookupValue('SEARCHPATHS')) {
-        if ($state->lookupValue('INCLUDE_COMMENTS')) {
+        if ($state->lookupValue('INCLUDE_XML_PIS')) {
           $document->insertPI('latexml', searchpaths => join(',', @$paths)); } }
       foreach my $preload_by_reference (@{ $$self{preload} }) {
         my $preload = $preload_by_reference; # copy preload value, as we want to preserve the hash as-is, for (potential) future daemon calls
@@ -258,7 +259,7 @@ sub initializeState {
   foreach my $preload (@files) {
     my ($options, $type);
     $options = $1 if $preload =~ s/^\[([^\]]*)\]//;
-    $type = ($preload =~ s/\.(\w+)$// ? $1 : 'sty');
+    $type    = ($preload =~ s/\.(\w+)$// ? $1 : 'sty');
     my $handleoptions = ($type eq 'sty') || ($type eq 'cls');
     if ($options) {
       if ($handleoptions) {

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -136,7 +136,7 @@ sub process_texfile {
   my $name         = $options{name};
   my $compare_kind = $options{compare_kind};
   my %core_options = $options{core_options} ? %{ $options{core_options} } : (
-    preload => [], searchpaths => [], includecomments => 0, verbosity => -2
+    preload => [], searchpaths => [], includecomments => 0, includexmlpis => 0, verbosity => -2
   );
   my $latexml = eval { LaTeXML::Core->new(%core_options) };
   if (!$latexml) {


### PR DESCRIPTION
Fixes #1342 .

Mainly detaches using `includecomments` of LaTeXML::Core to be used only for comments, introducing a new internal option `includexmlpis` to handle processing instructions.

Importantly, adapted the test cases to add this new option, and (more hackily) had the daemon API use the explicit xslt parameter to figure out this is a test environment. Simplest refactor that avoid introducing any user-facing new constructs that came to mind.