### PR TITLE
use LaTeXML::Util::Test in maketests, better pathpi option name

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -652,13 +652,13 @@ sub new_latexml {
       push @pre, $pre;
     }
   }
-  my $includexmlpis = !($$opts{xsltparameters} && (@{ $$opts{xsltparameters} }[0] eq 'LATEXML_VERSION:TEST'));
+  my $includepathpis = !($$opts{xsltparameters} && (@{ $$opts{xsltparameters} }[0] eq 'LATEXML_VERSION:TEST'));
   require LaTeXML;
   my $latexml = LaTeXML::Core->new(preload => [@pre], searchpaths => [@{ $$opts{paths} }],
     graphicspaths   => ['.'],
     verbosity       => $$opts{verbosity}, strict => $$opts{strict},
     includecomments => $$opts{comments},
-    includexmlpis   => $includexmlpis,
+    includepathpis  => $includepathpis,
     inputencoding   => $$opts{inputencoding},
     includestyles   => $$opts{includestyles},
     documentid      => $$opts{documentid},

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -45,7 +45,7 @@ sub new {
     'global');
   $state->assignValue(INCLUDE_COMMENTS => (defined $options{includecomments} ? $options{includecomments} : 1),
     'global');
-  $state->assignValue(INCLUDE_XML_PIS => (defined $options{includexmlpis} ? $options{includexmlpis} : 1), 'global');
+  $state->assignValue(INCLUDE_PATH_PIS => (defined $options{includepathpis} ? $options{includepathpis} : 1), 'global');
   $state->assignValue(DOCUMENTID => (defined $options{documentid} ? $options{documentid} : ''),
     'global');
   $state->assignValue(SEARCHPATHS => [map { pathname_absolute(pathname_canonical($_)) }
@@ -205,7 +205,7 @@ sub convertDocument {
       NoteBegin("Building");
       $model->loadSchema();                                  # If needed?
       if (my $paths = $state->lookupValue('SEARCHPATHS')) {
-        if ($state->lookupValue('INCLUDE_XML_PIS')) {
+        if ($state->lookupValue('INCLUDE_PATH_PIS')) {
           $document->insertPI('latexml', searchpaths => join(',', @$paths)); } }
       foreach my $preload_by_reference (@{ $$self{preload} }) {
         my $preload = $preload_by_reference; # copy preload value, as we want to preserve the hash as-is, for (potential) future daemon calls

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -129,15 +129,16 @@ sub latexmlpost_ok {
     if (my $xmlstrings = process_xmlfile($postxmlpath, $name)) {
       return is_strings($texstrings, $xmlstrings, $name); } } }
 
+our %CORE_OPTIONS_FOR_TESTS = (
+  preload => [], searchpaths => [], includecomments => 0, includepathpis => 0, verbosity => -2);
+
 sub convert_texfile_as_test {
   my (%options)    = @_;
   my $texpath      = $options{texpath};
   my $name         = $options{name};
   my $compare_kind = $options{compare_kind};
-  my %core_options = $options{core_options} ? %{ $options{core_options} } : (
-    preload => [], searchpaths => [], includecomments => 0, includepathpis => 0, verbosity => -2
-  );
-  my $latexml = eval { LaTeXML::Core->new(%core_options) };
+  my %core_options = $options{core_options} ? %{ $options{core_options} } : %CORE_OPTIONS_FOR_TESTS;
+  my $latexml      = eval { LaTeXML::Core->new(%core_options) };
   if (!$latexml) {
     do_fail($name, "Couldn't instanciate LaTeXML: " . @!); return; }
   else {

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -17,7 +17,8 @@ use Config;
 use base qw(Exporter);
 #  @Test::More::EXPORT);
 our @EXPORT = (qw(&latexml_ok &latexml_tests),
-  qw(&process_domstring &process_xmlfile &is_strings),
+  qw(&process_domstring &process_xmlfile &is_strings
+    &convert_texfile_as_test &serialize_dom_as_test),
   @Test::More::EXPORT);
 # Note that this is a singlet; the same Builder is shared.
 
@@ -128,15 +129,13 @@ sub latexmlpost_ok {
     if (my $xmlstrings = process_xmlfile($postxmlpath, $name)) {
       return is_strings($texstrings, $xmlstrings, $name); } } }
 
-# These return the list-of-strings form of whatever was requested, if successful,
-# otherwise undef; and they will have reported the failure
-sub process_texfile {
+sub convert_texfile_as_test {
   my (%options)    = @_;
   my $texpath      = $options{texpath};
   my $name         = $options{name};
   my $compare_kind = $options{compare_kind};
   my %core_options = $options{core_options} ? %{ $options{core_options} } : (
-    preload => [], searchpaths => [], includecomments => 0, includexmlpis => 0, verbosity => -2
+    preload => [], searchpaths => [], includecomments => 0, includepathpis => 0, verbosity => -2
   );
   my $latexml = eval { LaTeXML::Core->new(%core_options) };
   if (!$latexml) {
@@ -146,7 +145,17 @@ sub process_texfile {
     if (!$dom) {
       do_fail($name, "Couldn't convert $texpath: " . @!); return; }
     else {
-      return process_dom($dom, $name, $compare_kind); } } }
+      return $dom; } } }
+
+# These return the list-of-strings form of whatever was requested, if successful,
+# otherwise undef; and they will have reported the failure
+sub process_texfile {
+  my (%options) = @_;
+  if (my $dom = convert_texfile_as_test(%options)) {
+    my $name         = $options{name};
+    my $compare_kind = $options{compare_kind};
+    return process_dom($dom, $name, $compare_kind); }
+  else { return; } }
 
 sub postprocess_xmlfile {
   my ($xmlpath, $name) = @_;
@@ -163,17 +172,20 @@ sub postprocess_xmlfile {
   return do_fail($name, "Couldn't process $name.xml") unless $doc;
   return process_dom($doc, $name); }
 
+sub serialize_dom_as_test {
+  my ($xmldom) = @_;
+  my $domstring = eval { my $string = $xmldom->toString(1);
+    my $parser = XML::LibXML->new(load_ext_dtd => 0, validation => 0, keep_blanks => 1);
+    $parser->parse_string($string)->toStringC14N(0); };
+  return $domstring; }
+
 sub process_dom {
   my ($xmldom, $name, $compare_kind) = @_;
   # We want the DOM to be BOTH indented AND canonical!!
-  my $domstring =
-    eval { my $string = $xmldom->toString(1);
-    my $parser = XML::LibXML->new(load_ext_dtd => 0, validation => 0, keep_blanks => 1);
-    $parser->parse_string($string)->toStringC14N(0); };
-  if (!$domstring) {
-    do_fail($name, "Couldn't convert dom to string: " . $@); return; }
+  if (my $domstring = serialize_dom_as_test($xmldom)) {
+    return process_domstring($domstring, $name, $compare_kind); }
   else {
-    return process_domstring($domstring, $name, $compare_kind); } }
+    do_fail($name, "Couldn't convert dom to string: " . $@); return; } }
 
 sub process_xmlfile {
   my ($xmlpath, $name, $compare_kind) = @_;

--- a/tools/maketests
+++ b/tools/maketests
@@ -237,6 +237,11 @@ sub stringifyDom {
 
 sub gen_xml {
   my ($dir, $name, $is_test) = @_;
+  # Ensure a sandbox for the LaTeXML conversion by forking and working in the child.
+  my $pid = fork();
+  if ($pid) {
+    waitpid($pid, 0);
+    return; }
   my $source = pathname_make(dir => $dir, name => $name, type => 'tex');
   my $xml    = pathname_make(dir => $dir, name => $name, type => $is_test ? 'test.xml' : 'xml');
   if (-f "$xml") {
@@ -253,7 +258,7 @@ sub gen_xml {
     close $test_fh; }
   else {
     die "Failed to convert $source: $!"; }
-  return; }
+  exit; }
 
 sub gen_pdf {
   my ($dir, $name) = @_;

--- a/tools/maketests
+++ b/tools/maketests
@@ -18,6 +18,7 @@ use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 use LaTeXML;
 use LaTeXML::Util::Pathname;
+use LaTeXML::Util::Test;
 use File::Copy;
 use File::Which;
 use File::Spec::Functions;
@@ -82,6 +83,7 @@ sub maketest_latexml {
   my $src_time = pathname_timestamp($source);
   my $xml_time = pathname_timestamp($xml_file);
   my $pdf_time = pathname_timestamp($pdf_file);
+
   if ($docompare) {
     (compare_xml($dir, $name) ? push(@FAIL, $name) : push(@PASS, $name)); }
   else {
@@ -173,10 +175,7 @@ sub compare_xml {
   my $test   = pathname_make(dir => $dir, name => $name, type => 'test.xml');
   #========================================
   # Generate the XML from the current latexml
-  system("$FindBin::RealBin/../blib/script/latexml", $source,
-    "--destination=" . $test,
-    "--nocomments", (map { "--verbose" } 1 .. $verbosity)) == 0
-    or die "Failed to convert $source: $!";
+  gen_xml($dir, $name);
 
   #========================================
   # Do the comparison
@@ -244,10 +243,14 @@ sub gen_xml {
     rename("$xml", "$xml.bak"); }
   #========================================
   # Generate the XML from the current latexml
-  system("$FindBin::RealBin/../blib/script/latexml", $source,
-    "--destination=" . $xml,
-    "--nocomments", (map { "--verbose" } 1 .. $verbosity)) == 0
-    or die "Failed to convert $source: $!";
+  if (my $dom = convert_texfile_as_test(texpath => $source, name => $name)) {
+    my $dom_str = serialize_dom_as_test($dom);
+    open(my $test_fh, '>', $xml) or die "Couldn't open output file $xml: $!";
+    binmode($test_fh, ":encoding(UTF-8)");
+    print $test_fh $dom_str;
+    close $test_fh; }
+  else {
+    die "Failed to convert $source: $!"; }
   return; }
 
 sub gen_pdf {
@@ -299,7 +302,7 @@ sub read_options {
 #======================================================================
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -455,7 +458,7 @@ Remember to add all three files to the SVN repository.
 
 =head2 Adding a Test Set
 
-To create a new set of tests, say I<newset>, create 
+To create a new set of tests, say I<newset>, create
 the directory I<t/newset> to contain the test cases
 and a driver program, I<t/##_newset.t>, (choose a number
 for I<##> to specifies when this test set will run in the sequence).
@@ -471,5 +474,3 @@ Remember to add the directory, driver and any tests
 to the SVN repository.
 
 =cut
-
-

--- a/tools/maketests
+++ b/tools/maketests
@@ -236,14 +236,14 @@ sub stringifyDom {
   return [grep { /\S/ } split("\n", $string)]; }
 
 sub gen_xml {
-  my ($dir, $name, $is_test) = @_;
+  my ($dir, $name, $for_comparison) = @_;
   # Ensure a sandbox for the LaTeXML conversion by forking and working in the child.
   my $pid = fork();
   if ($pid) {
     waitpid($pid, 0);
     return; }
   my $source = pathname_make(dir => $dir, name => $name, type => 'tex');
-  my $xml    = pathname_make(dir => $dir, name => $name, type => $is_test ? 'test.xml' : 'xml');
+  my $xml = pathname_make(dir => $dir, name => $name, type => $for_comparison ? 'test.xml' : 'xml');
   if (-f "$xml") {
     rename("$xml", "$xml.bak"); }
   #========================================

--- a/tools/maketests
+++ b/tools/maketests
@@ -175,7 +175,7 @@ sub compare_xml {
   my $test   = pathname_make(dir => $dir, name => $name, type => 'test.xml');
   #========================================
   # Generate the XML from the current latexml
-  gen_xml($dir, $name);
+  gen_xml($dir, $name, 1);
 
   #========================================
   # Do the comparison
@@ -236,9 +236,9 @@ sub stringifyDom {
   return [grep { /\S/ } split("\n", $string)]; }
 
 sub gen_xml {
-  my ($dir, $name) = @_;
+  my ($dir, $name, $is_test) = @_;
   my $source = pathname_make(dir => $dir, name => $name, type => 'tex');
-  my $xml    = pathname_make(dir => $dir, name => $name, type => 'xml');
+  my $xml    = pathname_make(dir => $dir, name => $name, type => $is_test ? 'test.xml' : 'xml');
   if (-f "$xml") {
     rename("$xml", "$xml.bak"); }
   #========================================

--- a/tools/maketests
+++ b/tools/maketests
@@ -243,8 +243,10 @@ sub gen_xml {
     rename("$xml", "$xml.bak"); }
   #========================================
   # Generate the XML from the current latexml
-  if (my $dom = convert_texfile_as_test(texpath => $source, name => $name)) {
-    my $dom_str = serialize_dom_as_test($dom);
+  my $gen_xml_core_options = {%LaTeXML::Util::Test::CORE_OPTIONS_FOR_TESTS};
+  $$gen_xml_core_options{verbosity} = $verbosity || 0;
+  if (my $dom = convert_texfile_as_test(texpath => $source, name => $name, core_options => $gen_xml_core_options)) {
+    my $dom_str = $dom->toString(1);
     open(my $test_fh, '>', $xml) or die "Couldn't open output file $xml: $!";
     binmode($test_fh, ":encoding(UTF-8)");
     print $test_fh $dom_str;


### PR DESCRIPTION
Further touchups on #1343 
 * renamed option to `includepathpis`
 * switched to using `LaTeXML::Util::Test` in `tools/maketests` for core test generation
 * separated out the conversion and serialization subroutines in Test, to reuse the exact same code paths for generation and testing
 * dropped the ability to control `--verbosity` in tools/maketests -- can reintroduce if considered important (I've never used it)