### PR TITLE
adding lexeme attribute to ltx:Math schema

### DIFF
--- a/lib/LaTeXML/resources/RelaxNG/LaTeXML-math.rnc
+++ b/lib/LaTeXML/resources/RelaxNG/LaTeXML-math.rnc
@@ -1,4 +1,4 @@
-# /=====================================================================\ 
+# /=====================================================================\
 # |  LaTeXML-math.rnc                                                   |
 # | RelaxNG model for LaTeXML generated documents                       |
 # |=====================================================================|
@@ -24,19 +24,19 @@ Math.class   = XMath
 
 ## These elements comprise the internal math representation, being
 ## the content of the \elementref{XMath} element.
-XMath.class = 
+XMath.class =
     XMApp  | XMTok  | XMRef  | XMHint | XMArg
   | XMWrap | XMDual | XMText | XMArray | ERROR
 
 #======================================================================
 
 Math =
-## Outer container for all math. This holds the internal 
+## Outer container for all math. This holds the internal
 ## \elementref{XMath} representation, as well as image data and other representations.
 element Math { Math_attributes, Math_model }
 
 ## Attributes for \elementref{Math}.
-Math_attributes = 
+Math_attributes =
   Common.attributes,
   Imageable.attributes,
   ID.attributes,
@@ -52,7 +52,10 @@ Math_attributes =
   attribute content-tex { text }?,
 
   ## a textified representation of the math.
-  attribute text { text }?
+  attribute text { text }?,
+
+  ## preserved grammar-near lexemes for export to external apps
+  attribute lexemes { text }?
 
 ## Content model for \elementref{Math}.
 Math_model =   Math.class*
@@ -121,7 +124,7 @@ XMTok =
 element XMTok { XMTok_attributes, XMTok_model }
 
 ## Attributes for \elementref{XMTok}.
-XMTok_attributes = 
+XMTok_attributes =
   Common.attributes,
   XMath.attributes,
   ID.attributes,
@@ -158,7 +161,7 @@ XMApp =
 element XMApp { XMApp_attributes, XMApp_model }
 
 ## Attributes for \elementref{XMApp}.
-XMApp_attributes = 
+XMApp_attributes =
   Common.attributes,
   XMath.attributes,
   ID.attributes,
@@ -179,7 +182,7 @@ XMDual =
 element XMDual { XMDual_attributes, XMDual_model }
 
 ## Attributes for \elementref{XMDual}.
-XMDual_attributes = 
+XMDual_attributes =
   Common.attributes,
   XMath.attributes,
   ID.attributes
@@ -195,7 +198,7 @@ XMHint =
 element XMHint { XMHint_attributes, XMHint_model }
 
 ## Attributes for \elementref{XMHint}.
-XMHint_attributes = 
+XMHint_attributes =
   Common.attributes,
   XMath.attributes,
   ID.attributes
@@ -210,7 +213,7 @@ XMText =
 element XMText { XMText_attributes, XMText_model }
 
 ## Attributes for \elementref{XMText}.
-XMText_attributes = 
+XMText_attributes =
   Common.attributes,
   XMath.attributes,
   Backgroundable.attributes,
@@ -228,7 +231,7 @@ XMWrap =
 element XMWrap { XMWrap_attributes, XMWrap_model }
 
 ## Attributes for \elementref{XMWrap}.
-XMWrap_attributes = 
+XMWrap_attributes =
   Common.attributes,
   XMath.attributes,
   Backgroundable.attributes,
@@ -251,7 +254,7 @@ XMArg =
 element XMArg { XMArg_attributes, XMArg_model }
 
 ## Attributes for \elementref{XMArg}.
-XMArg_attributes = 
+XMArg_attributes =
   Common.attributes,
   XMath.attributes,
   ID.attributes,
@@ -270,7 +273,7 @@ XMRef =
 element XMRef { XMRef_attributes, XMRef_model }
 
 ## Attributes for \elementref{XMRef}.
-XMRef_attributes = 
+XMRef_attributes =
   Common.attributes,
   XMath.attributes,
   ID.attributes,
@@ -287,7 +290,7 @@ XMArray =
 element XMArray { XMArray_attributes, XMArray_model }
 
 ## Attributes for \elementref{XMArray}.
-XMArray_attributes = 
+XMArray_attributes =
   Common.attributes,
   XMath.attributes,
   ID.attributes,
@@ -322,7 +325,7 @@ XMCell =
 element XMCell { XMCell_attributes, XMCell_model }
 
 ## Attributes for \elementref{XMCell}.
-XMCell_attributes = 
+XMCell_attributes =
   Common.attributes,
   Backgroundable.attributes,
   ID.attributes,

--- a/lib/LaTeXML/resources/RelaxNG/LaTeXML-math.rng
+++ b/lib/LaTeXML/resources/RelaxNG/LaTeXML-math.rng
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  /=====================================================================\ 
+  /=====================================================================\
   |  LaTeXML-math.rnc                                                   |
   | RelaxNG model for LaTeXML generated documents                       |
   |=====================================================================|
@@ -44,7 +44,7 @@ the content of the \elementref{XMath} element.</a:documentation>
   <!-- ====================================================================== -->
   <define name="Math">
     <element name="Math">
-      <a:documentation>Outer container for all math. This holds the internal 
+      <a:documentation>Outer container for all math. This holds the internal
 \elementref{XMath} representation, as well as image data and other representations.</a:documentation>
       <ref name="Math_attributes"/>
       <ref name="Math_model"/>
@@ -78,6 +78,11 @@ the content of the \elementref{XMath} element.</a:documentation>
     <optional>
       <attribute name="text">
         <a:documentation>a textified representation of the math.</a:documentation>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lexemes">
+        <a:documentation>preserved grammar-near lexemes for export to external apps</a:documentation>
       </attribute>
     </optional>
   </define>

--- a/lib/LaTeXML/resources/RelaxNG/LaTeXML.model
+++ b/lib/LaTeXML/resources/RelaxNG/LaTeXML.model
@@ -89,7 +89,7 @@ subsubsection.body:=(ltx:ERROR,ltx:TOC,ltx:declare,ltx:figure,ltx:float,ltx:glos
 #Document{}(ltx:document)
 ANY{}(ANY)
 ltx:ERROR{about,aboutidref,aboutlabelref,class,content,cssstyle,datatype,fragid,prefix,property,rel,resource,resourceidref,resourcelabelref,rev,typeof,vocab,xml:id,xml:lang}(#PCDATA)
-ltx:Math{about,aboutidref,aboutlabelref,backgroundcolor,class,content,content-tex,cssstyle,datatype,description,fragid,imagedepth,imageheight,imagesrc,imagewidth,mode,prefix,property,rel,resource,resourceidref,resourcelabelref,rev,tex,text,typeof,vocab,xml:id,xml:lang}(ltx:XMath)
+ltx:Math{about,aboutidref,aboutlabelref,backgroundcolor,class,content,content-tex,cssstyle,datatype,description,fragid,imagedepth,imageheight,imagesrc,imagewidth,lexemes,mode,prefix,property,rel,resource,resourceidref,resourcelabelref,rev,tex,text,typeof,vocab,xml:id,xml:lang}(ltx:XMath)
 ltx:MathBranch{about,aboutidref,aboutlabelref,class,content,cssstyle,datatype,format,prefix,property,rel,resource,resourceidref,resourcelabelref,rev,typeof,vocab,xml:lang}(ltx:Math,ltx:td,ltx:tr)
 ltx:MathFork{about,aboutidref,aboutlabelref,class,content,cssstyle,datatype,prefix,property,rel,resource,resourceidref,resourcelabelref,rev,typeof,vocab,xml:lang}(ltx:Math,ltx:MathBranch,ltx:text)
 ltx:TOC{about,aboutidref,aboutlabelref,class,content,cssstyle,datatype,format,lists,name,prefix,property,rel,resource,resourceidref,resourcelabelref,rev,scope,select,show,typeof,vocab,xml:lang}(ltx:title,ltx:toclist)


### PR DESCRIPTION
Today I noticed the (still experimental, per PR #947 ) lexemes attribute is naturally considered illegal in validation, so I thought I might as well add it to the schema. Feedback welcome on what would be the best way to document it.

