### PR TITLE
Use meaning over role in MathML::lookupContent

### DIFF
--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -63,8 +63,8 @@ sub preprocess {
   my ($self, $doc, @nodes) = @_;
   # Set up rational, modern, defaults.
   $$self{hackplane1} = 0 unless $$self{hackplane1};
-  $$self{plane1} = 1 if $$self{hackplane1} || !defined $$self{plane1};
-  $$self{nestmath} = 0 unless $$self{nestmath};
+  $$self{plane1}     = 1 if $$self{hackplane1} || !defined $$self{plane1};
+  $$self{nestmath}   = 0 unless $$self{nestmath};
   $doc->adjust_latexml_doctype('MathML');    # Add MathML if LaTeXML dtd.
   $doc->addNamespace($mmlURI, 'm');
   return; }
@@ -207,10 +207,18 @@ sub lookupPresenter {
 
 sub lookupContent {
   my ($mode, $role, $name) = @_;
-  $name = '?' unless $name;
-  $role = '?' unless $role;
-  return $$MMLTable_C{"$mode:$role:$name"} || $$MMLTable_C{"$mode:?:$name"}
-    || $$MMLTable_C{"$mode:$role:?"} || $$MMLTable_C{"$mode:?:?"}; }
+  # Content-first lookup. Idea:
+  # If we have a meaning/name provided, we can make a csymbol.
+  # 1. Sometimes we can make a role-specific adaptation to the symbol, so check that first
+  return $name ? (($role && $$MMLTable_C{"$mode:$role:$name"}) ||
+      # 2. Sometimes we want to make a name-specific adaptation, check that second
+      $$MMLTable_C{"$mode:?:$name"} ||
+      # 3. If no special code, but we have a name, use a generic handler for this element
+      $$MMLTable_C{"$mode:?:?"}) : (
+    # 4. If we do not have a name, check for a role-based handler
+    $$MMLTable_C{"$mode:$role:?"} ||
+      # 5. Always use a default handler if nothing is known
+      $$MMLTable_C{"$mode:?:?"}); }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Various needed maps
@@ -370,7 +378,7 @@ sub pmml {
   # Bind any other style information from the refering node or the current node
   # so that any tokens synthesized from strings recover that style.
   local $LaTeXML::MathML::DESIRED_SIZE = _getattr($refr, $node, 'fontsize') || $LaTeXML::MathML::DESIRED_SIZE;
-  local $LaTeXML::MathML::COLOR   = _getattr($refr, $node, 'color') || $LaTeXML::MathML::COLOR;
+  local $LaTeXML::MathML::COLOR = _getattr($refr, $node, 'color') || $LaTeXML::MathML::COLOR;
   local $LaTeXML::MathML::BGCOLOR = _getattr($refr, $node, 'backgroundcolor')
     || $LaTeXML::MathML::BGCOLOR;
   local $LaTeXML::MathML::OPACITY = _getattr($refr, $node, 'opacity') || $LaTeXML::MathML::OPACITY;
@@ -485,7 +493,7 @@ sub pmml_internal {
     my $vattach = $node->getAttribute('vattach');
     my $rowsep  = $node->getAttribute('rowsep') || '0pt';
     my $colsep  = $node->getAttribute('colsep') || '5pt';
-    $vattach = 'axis' if !$vattach || ($vattach eq 'middle');    # roughly MathML's axis?
+    $vattach = 'axis'    if !$vattach || ($vattach eq 'middle');    # roughly MathML's axis?
     $vattach = 'bottom1' if $vattach && ($vattach eq 'top');
     my $ostyle = $LaTeXML::MathML::STYLE;
     local $LaTeXML::MathML::STYLE
@@ -494,7 +502,7 @@ sub pmml_internal {
     my $nrows = 0;
     my $ncols = 0;
 
-    my @spanned = ();                                            # record columns to be skipped
+    my @spanned = ();                                               # record columns to be skipped
     foreach my $row (element_nodes($node)) {
       my @cols = ();
       my $nc   = 0;
@@ -502,7 +510,7 @@ sub pmml_internal {
       foreach my $col (element_nodes($row)) {
         $nc++;
         $spanned[$nc - 1]-- if $spanned[$nc - 1];
-        next                if $spanned[$nc - 1];                # Omit this mtd, if spanned by another!
+        next                if $spanned[$nc - 1];                   # Omit this mtd, if spanned by another!
         my $a    = $col->getAttribute('align');
         my $b    = $col->getAttribute('border');
         my $bc   = ($b ? join(' ', map { 'ltx_border_' . $_ } split(/\s/, $b)) : $b);
@@ -518,9 +526,9 @@ sub pmml_internal {
           for (my $i = 0 ; $i < ($cs || 1) ; $i++) {
             $spanned[$nc - 1 + $i] = ($rs || 1); } }
         push(@cols, ['m:mtd', { ($a ? (columnalign => $a) : ()),
-              ($c || $cl ? (class => ($c && $cl ? "$c $cl" : $c || $cl)) : ()),
-              ($cs ? (columnspan => $cs) : ()),
-              ($rs ? (rowspan    => $rs) : ()) },
+              ($c || $cl ? (class      => ($c && $cl ? "$c $cl" : $c || $cl)) : ()),
+              ($cs       ? (columnspan => $cs)                                : ()),
+              ($rs       ? (rowspan    => $rs)                                : ()) },
             @cell]); }
       $ncols = $nc if $nc > $ncols;
       push(@rows, ['m:mtr', {}, @cols]); }
@@ -593,10 +601,10 @@ sub pmml_mayberesize {
     if ($yoff) {    # assume this means to move the BOX? (not just the contents?)
       if (!$height) {
         if ($yoff =~ /^-/) { $height = $yoff; }
-        else { $height = "+" . $yoff; } }
+        else               { $height = "+" . $yoff; } }
       if (!$depth) {
         if ($yoff =~ /^-/) { $depth = $yoff; $depth =~ s/^-/+/; }
-        else { $depth = "-" . $yoff; } } }
+        else               { $depth = "-" . $yoff; } } }
     $$attr{width}   = $width  if $width;
     $$attr{height}  = $height if $height;
     $$attr{depth}   = $depth  if $depth;
@@ -782,8 +790,8 @@ sub stylizeContent {
       $size = undef; }
     # If requested relative size, and in script or scriptscript, we'll need to adjust the size
     elsif (($size =~ /%$/) && ($LaTeXML::MathML::STYLE =~ /script/)) {
-      my $req = $size; $req =~ s/%$//;
-      my $ex = $stylesize{$LaTeXML::MathML::STYLE}; $ex =~ s/%$//;
+      my $req = $size;                               $req =~ s/%$//;
+      my $ex  = $stylesize{$LaTeXML::MathML::STYLE}; $ex  =~ s/%$//;
       $size = int(100 * $req / $ex) . '%'; }
     # Note that symmetric is only allowed when stretchy, which looks crappy for specific sizes
     # so we'll pretend that delimiters are still stretchy, but restrict size by minsize & maxsize
@@ -842,7 +850,7 @@ sub stylizeContent {
     && ($mapping = ($plane1hack ? $plane1hack{$variant} : $plane1map{$variant}))) {
     my @c = map { $$mapping{$_} } split(//, (defined $text ? $text : ''));
     if (!grep { !defined $_ } @c) {    # Only if ALL chars in the token could be mapped... ?????
-      $text = join('', @c);
+      $text    = join('', @c);
       $variant = ($plane1hack && ($variant =~ /^bold/) ? 'bold' : undef); } }
   # Other attributes that should be copied?
   my $istoken = $tag =~ /^m:(?:mi|mo|mn)$/;                                               # mrow?
@@ -850,7 +858,7 @@ sub stylizeContent {
   my $title   = $istoken && ($iselement ? $item->getAttribute('title') : $attr{title});
   return ($text,
     ($variant ? (mathvariant => $variant) : ()),
-    ($size ? ($stretchyhack
+    ($size    ? ($stretchyhack
         ? (minsize => $size, maxsize => $size)
         : (mathsize => $size))
       : ()),
@@ -875,23 +883,23 @@ my %punctuation = (',' => 1, ';' => 1, "\x{2063}" => 1);                 # CONST
 
 # Generally, $item in the following ought to be a string.
 sub pmml_mi {
-  my ($item, %attr) = @_;
+  my ($item, %attr)    = @_;
   my ($text, %mmlattr) = stylizeContent($item, 'm:mi', %attr);
   #  return ['m:mi', {%mmlattr}, $text]; }
   return pmml_mayberesize($item, ['m:mi', {%mmlattr}, $text]); }
 
 # Really, the same issues as with mi.
 sub pmml_mn {
-  my ($item, %attr) = @_;
+  my ($item, %attr)    = @_;
   my ($text, %mmlattr) = stylizeContent($item, 'm:mn', %attr);
   #  return ['m:mn', {%mmlattr}, $text]; }
   return pmml_mayberesize($item, ['m:mn', {%mmlattr}, $text]); }
 
 # Note that $item should be either a string, or at most, an XMTok
 sub pmml_mo {
-  my ($item, %attr) = @_;
+  my ($item, %attr)    = @_;
   my ($text, %mmlattr) = stylizeContent($item, 'm:mo', %attr);
-  my $role = (ref $item ? $item->getAttribute('role') : $attr{role});
+  my $role      = (ref $item ? $item->getAttribute('role') : $attr{role});
   my $isfence   = $role && ($role =~ /^(OPEN|CLOSE)$/);
   my $ispunct   = $role && ($role eq 'PUNCT');
   my $islargeop = $role && ($role =~ /^(SUMOP|INTOP)$/);
@@ -907,7 +915,7 @@ sub pmml_mo {
     ['m:mo', { %mmlattr,
         ($isfence && !$fences{$text}      ? (fence     => 'true') : ()),
         ($ispunct && !$punctuation{$text} ? (separator => 'true') : ()),
-        ($islargeop ? (largeop   => 'true') : ()),
+        ($islargeop                       ? (largeop   => 'true') : ()),
         ($islargeop ? (symmetric => 'true') : ()),    # Not sure this is strictly correct...
                # Note that lspace,rspace is the left & right space that replaces Op.Dictionary
                # what we've recorded is _padding_, so we have to adjust the unknown OpDict entry!
@@ -922,8 +930,8 @@ sub pmml_mo {
       $text]); }
 
 sub pmml_bigop {
-  my ($op) = @_;
-  my $style = $op->getAttribute('mathstyle');
+  my ($op)      = @_;
+  my $style     = $op->getAttribute('mathstyle');
   my %styleattr = %{ ($style && ($style ne $LaTeXML::MathML::STYLE)
         && $stylemap{$LaTeXML::MathML::STYLE}{$style}) || {} };
   local $LaTeXML::MathML::STYLE
@@ -1328,9 +1336,9 @@ DefMathML("Token:NUMBER:?", \&pmml_mn, sub {
     my $n = $_[0]->textContent;
     return ['m:cn', { type => ($n =~ /^[+-]?\d+$/ ? 'integer' : 'float') }, $n]; });
 DefMathML("Token:?:absent", sub { return ['m:mi', {}] });    # Not m:none!
-        # Hints normally would have disappeared during parsing
-        # (turned into punctuation or padding?)
-        # but if they survive (unparsed?) turn them into space
+    # Hints normally would have disappeared during parsing
+    # (turned into punctuation or padding?)
+    # but if they survive (unparsed?) turn them into space
 DefMathML('Hint:?:?', sub {
     my ($node) = @_;
     if (my $w = $node->getAttribute('width')) {
@@ -1385,8 +1393,8 @@ DefMathML('Apply:?:?', sub {
   sub {
     my ($op, @args) = @_;
     return ['m:apply', {}, cmml($op), map { cmml($_) } @args]; });
-DefMathML('Apply:COMPOSEOP:?', \&pmml_infix, undef);
-DefMathML("Token:DIFFOP:?", sub { pmml_mo($_[0], rpadding => '-2.5pt'); }, undef);
+DefMathML('Apply:COMPOSEOP:?', \&pmml_infix,                                  undef);
+DefMathML("Token:DIFFOP:?",    sub { pmml_mo($_[0], rpadding => '-2.5pt'); }, undef);
 DefMathML("Apply:DIFFOP:?", sub {
     my ($op, @args) = @_;
 ###    return ['m:mrow', {}, map { pmml($_) } $op, @args]; },
@@ -1427,8 +1435,8 @@ DefMathML("Array:?:cases", undef, sub {
     foreach my $row (element_nodes($node)) {
       my @items = element_nodes($row);
       my $n     = scalar(@items);
-      if ($n == 0) { }    # empty row, just skip
-      elsif ($n == 1) {   # No condition? Perhaps it means "otherwise" ?
+      if ($n == 0) { }     # empty row, just skip
+      elsif ($n == 1) {    # No condition? Perhaps it means "otherwise" ?
         push(@otherwises, $items[0]); }
       elsif ($items[1]->textContent eq 'otherwise') {    # more robust test?
         push(@otherwises, $items[0]); }
@@ -1450,10 +1458,10 @@ DefMathML("Array:?:cases", undef, sub {
 
 # BRM:
 
-DefMathML("Token:ADDOP:?", \&pmml_mo, undef);
-DefMathML("Token:ADDOP:plus",  undef, sub { return ['m:plus']; });
-DefMathML("Token:ADDOP:minus", undef, sub { return ['m:minus']; });
-DefMathML('Apply:ADDOP:?', \&pmml_infix, undef);
+DefMathML("Token:ADDOP:?",     \&pmml_mo,    undef);
+DefMathML("Token:ADDOP:plus",  undef,        sub { return ['m:plus']; });
+DefMathML("Token:ADDOP:minus", undef,        sub { return ['m:minus']; });
+DefMathML('Apply:ADDOP:?',     \&pmml_infix, undef);
 
 DefMathML("Token:MULOP:?", \&pmml_mo,    undef);
 DefMathML('Apply:MULOP:?', \&pmml_infix, undef);


### PR DESCRIPTION
Consider the first token in the following XMath (generated by a semantic macro `\fnderive{f}{n}`):
```xml
  <XMath>
    <XMApp>
      <XMTok role="SUPERSCRIPTOP" scriptpos="post1" meaning="derivative-implicit-variable" name="fnderive@build"/>
      <XMTok role="UNKNOWN" xml:id="p1.m1.1" font="italic" fragid="p1.m1.1">f</XMTok>
      <XMDual xml:id="p1.m1.2" fragid="p1.m1.2">
        <XMRef idref="p1.m1.2.1"/>
        <XMWrap>
          <XMTok role="OPEN" stretchy="false" fontsize="70%">(</XMTok>
          <XMTok role="UNKNOWN" xml:id="p1.m1.2.1" font="italic" fontsize="70%" fragid="p1.m1.2.1">n</XMTok>
          <XMTok role="CLOSE" stretchy="false" fontsize="70%">)</XMTok>
        </XMWrap>
      </XMDual>
    </XMApp>
  </XMath>
```

The first token is the main operator, with role `SUPERSCRIPTOP` and a macro-provided meaning `derivative-implicit-variable`. I claim the expected behavior when generating Content MathML is currently wrong in master for such a case, as the handler called is the one for `Token:SUPERSCRIPTOP:?` rather than the generic `Token:?:?`.

I propose we correct to always use a provided `meaning` over `role`, also when doing the `DefMathML` table lookup. 

You can see the code diff of my reorganization to achieve that, the main improvement being _not_ defaulting to the `?` literal when a `$name` or `$role` haven't been provided, but using them undefined in some conditional checks, while adding comments about the intended fallback order.

Edit: here is a whitespace-neutral diff link:
https://github.com/brucemiller/LaTeXML/pull/1355/files?w=1

The example improves from master's:
```xml
    <m:apply>
      <m:csymbol cd="ambiguous">superscript</m:csymbol>
      <m:ci>𝑓</m:ci>
      <m:ci>𝑛</m:ci>
    </m:apply>
```

to the intended cmml:
```xml
    <m:apply>
      <m:csymbol cd="latexml">derivative-implicit-variable</m:csymbol>
      <m:ci>𝑓</m:ci>
      <m:ci>𝑛</m:ci>
    </m:apply>
```