### PR TITLE
add \meaning handling for \font-defined primitives

### DIFF
--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -167,6 +167,7 @@ sub decodeFontname {
     $props{size} = $size;
     # Experimental Hack !?!?!?
     $props{encoding} = 'OT1' unless defined $props{encoding};
+    $props{at}       = $at . "pt" if defined $at;
     return %props; }
   else {
     return; } }
@@ -713,7 +714,7 @@ sub mergePurestyle {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -285,9 +285,9 @@ sub readToken {
       $line =~ s/((\\ )*)\s*$/$1/s;
       # Then append the appropriaate \endlinechar, or "\r"
       if (my $eol = $STATE->lookupDefinition(T_CS('\endlinechar'))) {
-        # \endlinechar=-1 means what?
+        # \endlinechar<0 or >255 means no character is appended
         $eol = $eol->valueOf()->valueOf;
-        $line .= chr($eol) if $eol > 0; }
+        $line .= chr($eol) if $eol >= 0 and $eol <= 255; }
       else {
         $line .= "\r"; }
       $$self{chars}  = splitChars($line);

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -325,6 +325,9 @@ DefConstructorI(T_CS('\begin{document}'), undef, sub {
     $_[1]->setFont(LookupValue('font'));    # Start w/ whatever font was last selected.
     return @boxes; });
 
+# \document is used directly in e.g. expl3.sty
+Let(T_CS('\document'), T_CS('\begin{document}'), 'global');
+
 DefConstructorI(T_CS('\end{document}'), undef, sub {
     my ($document) = @_;
     $document->closeElement('ltx:document'); },

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -840,7 +840,11 @@ DefMacro('\meaning Token', sub {
       if ($type =~ /(primitive|conditional|constructor)$/i) {
         $definition = $definition->getCSorAlias;
         $type       = ref $definition;
-        $type =~ s/^LaTeXML:://; }
+        $type =~ s/^LaTeXML:://;
+        if (my $fontinfo = LookupValue('fontinfo_' . ToString($definition))) {
+          $meaning = 'select font ' . ($$fontinfo{fontname} || 'fontname');
+          $meaning .= ' at ' . $$fontinfo{at} if $$fontinfo{at};
+          $type = 'font'; } }
       # The actual tests start here
       if ($type =~ /token$/i) {
         my $cc         = $definition->getCatcode;
@@ -1282,7 +1286,8 @@ DefPrimitive('\font Token SkipMatch:= SkipSpaces TeXFileName', sub {
     if (!keys %props) {    # Failed?
       Info('unexpected', $name, $stomach, "Unrecognized font name '$name'",
         "Font switch macro " . ToString($cs) . " will have no effect"); }
-
+    else {
+      $props{fontname} = $name; }
     $gullet->skipSpaces;
     AssignValue('fontinfo_' . ToString($cs) => {%props});
     DefPrimitiveI($cs, undef, undef, font => {%props});


### PR DESCRIPTION
Fixes the texlive 2020 regression with expl3, while also enhancing further our `\meaning` emulation.

I double-coded [the previous PR](https://github.com/dginev/LaTeXML/pull/6) to avoid rebasing, since the diff was so small it was simpler to copy it directly over the new master.