### PR TITLE
More precise binding for pgfNumber and pgfmath@smuggleone

### DIFF
--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -93,29 +93,13 @@ DefMacro('\@@@show@pgfmatharg@{}', sub {
     print STDERR "MATH ARG $arg\n";
     return; });
 
-# A variant on Expanded that omits the outer {}
+# A plain argument that is expanded in the parameter type definition,
+# then used for pgf computations.
 DefParameterType('pgfNumber', sub {
     my ($gullet) = @_;
-    my $token;
-    do { $token = $gullet->readXToken(0);
-    } while (defined $token && $$token[1] == CC_SPACE);    # Inline ->getCatcode!
-
-    my $result = '';
-    if ($token->getCatcode == CC_BEGIN) {
-      my @tokens = ();
-      my $level  = 1;
-      while ($token = $gullet->readXToken(0)) {
-        my $cc = $$token[1];
-        if ($cc == CC_END) {
-          $level--;
-          last unless $level; }
-        elsif ($cc == CC_BEGIN) {
-          $level++; }
-        $result .= $$token[0]; } }
-    else {
-      $result = $token->getString; }
-    $result = "0" if $result eq '.';    # Apparently "." is a valid number!
-    return $result; });
+    my $pgf_number = ToString(Expand($gullet->readArg()));
+    $pgf_number = "0" if $pgf_number eq '.';    # Apparently "." is a valid number!
+    return $pgf_number; });
 
 # This one expects {{number}{number}....} and returns an array of them
 DefParameterType('pgfNumbers', sub {
@@ -158,7 +142,7 @@ DefMacro('\pgfmathneg@ pgfNumber', sub {
 DefMacro('\pgfmathmultiply@ pgfNumber pgfNumber', sub {
     pgfmathresult($_[1] * $_[2]); return });
 DefMacro('\pgfmathdivide@ pgfNumber pgfNumber', sub {
-    pgfmathresult($_[1] / $_[2]); return });
+    pgfmathresult($_[1] / pgfmath_divisor($_[2])); return });
 DefMacro('\pgfmathpow@ pgfNumber pgfNumber', sub {
     pgfmathresult($_[1]**$_[2]); return });
 DefMacro('\pgfmathabs@ pgfNumber', sub {
@@ -275,6 +259,20 @@ DefMacro('\@@@test@mathresult{}{}{}', sub {
     else {
       print STDERR "PGFParse OK '$input' => '$pgfresult' or '$lxresult'\n"; }
     return; });
+
+DefMacro('\pgfmath@smuggleone Until:\endgroup', sub {
+    my ($gullet, $arg) = @_;
+    $arg = $$arg[0] if (ref $arg eq 'LaTeXML::Core::Tokens');
+    my $def = LookupDefinition($arg);
+    if (my $is_expandable = $def && $def->isExpandable) {
+      # Texlive 2020 definition:
+      return (T_CS('\expandafter'), T_CS('\endgroup'), T_CS('\expandafter'),
+        T_CS('\def'), T_CS('\expandafter'), $arg, T_CS('\expandafter'),
+        T_BEGIN, $arg, T_END); }
+    else {
+      # do nothing for primitives, bindings already declare them global,
+      # no need to smuggle up. In fact, infinite loop if done carelessly.
+      return T_CS('\endgroup'); } });
 
 our $PGFMATHGrammarSpec;
 our $PGFMATHGrammar;
@@ -422,7 +420,7 @@ sub pgfmath_leftrecapply {
 # (which is sensible for the ultimate output, but wreaks havoc w/ accuracy here!)
 sub pgfmath_convert {
   my ($number, $unit) = @_;
-  SetCondition(T_CS('\ifpgfmathunitsdeclared'), 1, 'global');                        # Saw units!
+  SetCondition(T_CS('\ifpgfmathunitsdeclared'),     1, 'global');                    # Saw units!
   SetCondition(T_CS('\ifpgfmathmathunitsdeclared'), 1, 'global') if $unit eq 'mu';
   return $number * $STATE->convertUnit($unit) / 65536; }    # return value in pts!
 
@@ -532,9 +530,9 @@ BEGIN {
     #    frac       => sub { },
     #    gcd        => sub { },
     #    height     => sub { },
-    hex => sub { sprintf("%x", $_[0]); },
-    Hex => sub { sprintf("%X", $_[0]); },
-    int => sub { int($_[0]); },
+    hex        => sub { sprintf("%x", $_[0]); },
+    Hex        => sub { sprintf("%X", $_[0]); },
+    int        => sub { int($_[0]); },
     ifthenelse => sub { ($_[0] ? $_[1] : $_[2]); },
     iseven     => sub { (int($_[0]) % 2) == 0 },
     isodd      => sub { (int($_[0]) % 2) == 1 },


### PR DESCRIPTION
Fixes #1168 .

May not be the ideal fix, but I feel confident I debugged the root issues:
 1. The original latex `\pgfmath@smuggleone` simply assumes it has a locally defined expandable macro on input, and re-defines it locally a level up after it closes a group with `\egroup`. 
    - However, the latexml binding handles certain internal constructs by creating Primitives with subroutines as their definition, making the technique of smuggle one equivalent to `\def#1{#1}` i.e. an infinite loop.
    - Solution: added a binding that checks for the non-expandable case, and only closes a group if in it (assuming that definition was already global).

 2. Separately, our parameter type for `pgfNumber` didn't strike me as accurate. Here too I debugged with `\tracingmacros=1` and reading attentively the differences in the numbers. Very majorly, a `90` angle got passed in as a `9`, since the first `readXToken` eagerly expanded the macro that contained that value too far. In the latex sources, these parameters are just regular plain parameters to a `\def` definition, but get expanded with trickery inside their bodies. So I reworked to reflect that a little closer.

 3. Lastly, one of the division by zero fatals could be made more lax as a warning, as we have done for all other divisions with one of my previous PRs. So I also added that guard.

Feel free to improve to a more disciplined fix, if one comes to mind. I can vouch this PR creates good SVG with no_problem status for the tikz from #1168 on texlive 2020.