### PR TITLE
[WiP] Brace as XMHint

### DIFF
--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -26,12 +26,12 @@ our @EXPORT = (
 
 sub Box {
   my ($string, $font, $locator, $tokens, %properties) = @_;
-  $font = $STATE->lookupValue('font') unless defined $font;
+  $font    = $STATE->lookupValue('font')               unless defined $font;
   $locator = $STATE->getStomach->getGullet->getLocator unless defined $locator;
-  $tokens = LaTeXML::Core::Token::T_OTHER($string) if $string && !defined $tokens;
+  $tokens  = LaTeXML::Core::Token::T_OTHER($string) if $string && !defined $tokens;
   my $state = $STATE;
   if ($state->lookupValue('IN_MATH')) {
-    my $attr = (defined $string) && $state->lookupValue('math_token_attributes_' . $string);
+    my $attr      = (defined $string) && $state->lookupValue('math_token_attributes_' . $string);
     my $usestring = ($attr && $$attr{replace}) || $string;
     return LaTeXML::Core::Box->new($usestring, $font->specialize($string), $locator, $tokens,
       mode => 'math', ($attr ? %$attr : ()), %properties); }
@@ -119,14 +119,18 @@ sub beAbsorbed {
     ? ($mode eq 'math'
       ? $document->insertMathToken($string, %{ $$self{properties} })
       : $document->openText($string, $$self{properties}{font}))
-    : undef); }
+###    : undef); }
+    : ($mode eq 'math'
+      ? $document->insertElement('ltx:XMHint', undef,
+        name => $$self{properties}{name} || ToString($$self{tokens}))
+      : undef)); }
 
 sub getProperty {
   my ($self, $key) = @_;
   if ($key eq 'isSpace') {
     return $$self{properties}{$key} if defined $$self{properties}{$key};
-    my $tex = LaTeXML::Core::Token::UnTeX($$self{tokens});    # !
-    return (defined $tex) && ($tex =~ /^\s*$/); }    # Check the TeX code, not (just) the string!
+    my $tex = LaTeXML::Core::Token::UnTeX($$self{tokens});  # !
+    return (defined $tex) && ($tex =~ /^\s*$/); }           # Check the TeX code, not (just) the string!
   else {
     return $$self{properties}{$key}; } }
 

--- a/lib/LaTeXML/Core/Rewrite.pm
+++ b/lib/LaTeXML/Core/Rewrite.pm
@@ -124,15 +124,21 @@ sub applyClause {
       $parent->removeChild($sib);
       unshift(@following, $sib);
       last if $tree->isSameNode($sib); }
-    my @replaced = map { shift(@following) } 1 .. $nmatched;    # Remove the nodes to be replaced
+###    my @replaced = map { shift(@following) } 1 .. $nmatched;    # Remove the nodes to be replaced
+    my @replaced = ();
+    my $nm       = $nmatched;
+    while ($nm && @following) {
+      my $nd = shift(@following);
+      if ($document->getNodeQName($nd) ne 'ltx:XMHint') {
+        $nm--; push(@replaced, $nd); } }
     map { $document->unRecordNodeIDs($_) } @replaced;
     # Carry out the operation, inserting whatever nodes.
     $document->setNode($parent);
     my $point = $parent->lastChild;
-    &$pattern($document, @replaced);                            # Carry out the insertion.
+    &$pattern($document, @replaced);    # Carry out the insertion.
 
     # Now collect the newly inserted nodes for any needed patching
-    my @inserted = ();                                          # Collect the newly added nodes.
+    my @inserted = ();                  # Collect the newly added nodes.
     if ($point) {
       my @sibs = $parent->childNodes;
       while (my $sib = pop(@sibs)) {
@@ -143,8 +149,8 @@ sub applyClause {
 
     # Now make any adjustments to the new nodes
     map { $document->recordNodeIDs($_) } @inserted;
-    my $font = $document->getNodeFont($tree);                   # the font of the matched node
-    foreach my $ins (@inserted) {    # Copy the non-semantic parts of font to the replacement
+    my $font = $document->getNodeFont($tree);   # the font of the matched node
+    foreach my $ins (@inserted) {               # Copy the non-semantic parts of font to the replacement
       $document->mergeNodeFontRec($ins => $font); }
     # Now, replace the following nodes.
     map { $parent->appendChild($_) } @following; }
@@ -445,7 +451,7 @@ sub domToXPath_rec {
     elsif ($qname eq 'ltx:XMRef') {
       my $id = $node->getAttribute('idref');
       my $r  = $id && $document->lookupID($id);
-      my $rq = $r && $document->getNodeQName($r);    # eq '_WildCard_')
+      my $rq = $r  && $document->getNodeQName($r);    # eq '_WildCard_')
       if ($rq && ($rq =~ /ltx:(?:XMArg|XMWrap)$/)) {
         my @rc = $r->childNodes;
         if ((scalar(@rc) == 1)) {

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -116,7 +116,7 @@ DefParameterType('DefPlain', sub {
       ($value) = $inner->reparseArgument($gullet, $value); }
     return $value; },
   packParameters => 1,
-  reversion => sub {
+  reversion      => sub {
     my ($arg, $inner) = @_;
     (T_BEGIN,
       ($inner ? $inner->revertArguments($arg) : Revert($arg)),
@@ -252,7 +252,7 @@ DefParameterType('DefExpanded', sub {
     my $expanded = ($token->getCatcode == CC_BEGIN ? $gullet->readBalanced(1) : $token);
     return $expanded; },
   packParameters => 1,
-  reversion => sub {
+  reversion      => sub {
     my ($arg) = @_;
     (T_BEGIN, Revert($arg), T_END); });
 
@@ -302,7 +302,7 @@ DefParameterType('OptionalUndigested', sub { $_[0]->readOptional; },
 
 # Read a keyword value (KeyVals), that will not be digested.
 DefParameterType('UndigestedKey', sub { $_[0]->readArg; }, undigested => 1);
-DefParameterType('UndigestedDefKey', sub { $_[0]->readArg; }, undigested => 1, packParameters=>1);
+DefParameterType('UndigestedDefKey', sub { $_[0]->readArg; }, undigested => 1, packParameters => 1);
 
 # Read a token as used when defining it, ie. it may be enclosed in braces.
 DefParameterType('DefToken', sub {
@@ -3376,7 +3376,7 @@ Tag('ltx:Math', afterClose => \&cleanup_Math);
 sub cleanup_Math {
   my ($document, $mathnode) = @_;
   # If the Math ONLY contains XMath/XMText, it apparently isn't math at all!?!
-  if (!$document->findnodes('ltx:XMath/ltx:*[local-name() != "XMText"]', $mathnode)) {
+  if (!$document->findnodes('ltx:XMath/ltx:*[local-name() != "XMText" and (local-name() != "XMHint" or @width)]', $mathnode)) {
     # So unwrap down to the contents of the XMText's.
     my @xmtexts = map { $_->childNodes } map { $_->childNodes } $mathnode->childNodes;
     my @texts   = ();
@@ -3873,7 +3873,13 @@ sub scriptHandler {
       last if @stuff; }
     Fatal('expected', '{', $stomach, "Missing { in sub/super-script argument", $gullet->showUnexpected)
       unless @stuff;
-    my $script = shift(@stuff);    # ONLY the first box is the script!
+    my $script = shift(@stuff);     # ONLY the first box is the script!
+                                    # Strip braces from script;  REALLY UGLY!!!
+    my @b      = $script->unlist;
+    if ((ref $b[0] eq 'LaTeXML::Core::Box') && (ToString($b[0]->revert) eq '{')
+      && (ref $b[-1] eq 'LaTeXML::Core::Box') && (ToString($b[-1]->revert) eq '}')) {
+      shift(@b); pop(@b);
+      $script = List(@b); }
     unshift(@stuff,
       LaTeXML::Core::Whatsit->new(LookupDefinition(T_CS($cs)), [$script],
         locator     => $gullet->getLocator,
@@ -4293,8 +4299,10 @@ foreach my $digit (qw(0 1 2 3 4 5 6 7 8 9)) {
   DefMathI($digit, undef, $digit, role => 'NUMBER', meaning => $digit); }
 
 # Would probably be best to collapse all XMHint/spaces at the earliest stage.
-our %space_chars = (negthinspace => '', thinspace => "\x{2009}",
-  medspace => "\x{2005}", thickspace => "\x{2004}");
+our %space_chars = (
+  negthinspace => { char => '', break => 1 }, thinspace => { char => "\x{2009}" },
+  medspace     => { char => "\x{2005}" }, thickspace => { char => "\x{2004}" },
+  '{'          => { char => '' },         '}'        => { char => '' });
 
 # This is getting out-of-hand;
 # (1) this gets done after document build, so we query the document/node for language
@@ -4341,8 +4349,9 @@ DefMathLigature(matcher => sub { my ($document, $node) = @_;
 ##        if (($w = $node->getAttribute('width')) && ($w=Dimension($w)->valueOf) && ($w >= 0) && ($w <= $skip)) {
 ##          $string = $text . $string; } # Add to string, but omit from number
         my $s;
-        if (($s = $node->getAttribute('name')) && ($s = $space_chars{$s})) {
-          $string = $s . $string; }
+##        if (($s = $node->getAttribute('name')) && defined($s = $space_chars{$s})) {
+        if (($s = $node->getAttribute('name')) && ($s = $space_chars{$s}) && !$$s{break}) {
+          $string = ($$s{char} || '') . $string; }
         else {
           last; } }
       else {

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -116,7 +116,7 @@ sub amsalignBindings {
       closeRow    => sub { $_[0]->closeElement('ltx:equation'); },
       openColumn  => sub { $_[0]->openElement('ltx:_Capture_', @_[1 .. $#_]); },
       closeColumn => sub { $_[0]->closeElement('ltx:_Capture_'); },
-      properties => {%properties}));
+      properties  => {%properties}));
   Let(T_ALIGN,       '\@alignment@align');
   Let("\\\\",        '\@ams@newline');
   Let('\cr',         '\@alignment@cr');
@@ -152,8 +152,8 @@ sub extractXMArrayCells {
         my @nodes = element_nodes($arg);
         # Strip leading & trailing XMHint's from cells;
         # they're (presumably) only for positioning and interfere with interpretation of the whole.
-        if (@nodes && ($document->getNodeQName($nodes[0]) eq 'ltx:XMHint'))  { shift(@nodes); }
-        if (@nodes && ($document->getNodeQName($nodes[-1]) eq 'ltx:XMHint')) { pop(@nodes); }
+        while (@nodes && ($document->getNodeQName($nodes[0]) eq 'ltx:XMHint'))  { shift(@nodes); }
+        while (@nodes && ($document->getNodeQName($nodes[-1]) eq 'ltx:XMHint')) { pop(@nodes); }
         # Some cultures duplicate an operator at the end of one row and beginning of next
         # when we merge the cells together, this confuses the parser
         if (my $prev = $contents[-1]) {
@@ -339,7 +339,7 @@ DefConstructor('\lx@ams@marksplitinalign', sub {
     $capture->setAttribute(align   => 'center'); },
   # Skip a column (for left/right alignment)
   afterDigest => sub { LookupValue('Alignment')->nextColumn; return; },
-  reversion   => '', sizer => 0);
+  reversion => '', sizer => 0);
 
 DefMacro('\split',
   '\if@inamsalign\lx@ams@marksplitinalign\fi'
@@ -561,7 +561,7 @@ DefConstructor('\@@gathered DigestedBody',
   '#1',
   beforeDigest => sub { $_[0]->bgroup; },
   afterDigest  => sub { $_[1]->setProperty('MULTIROW_ALIGNMENT_RULE' => { 'default' => 'center' }); },
-  reversion      => '\begin{gathered}#1\end{gathered}',
+  reversion    => '\begin{gathered}#1\end{gathered}',
   afterConstruct => sub { rearrangeAMSMultirow($_[0], $_[1], $_[0]->getNode->lastChild); });
 
 DefMacro('\aligned[]',     '\@hidden@bgroup\@@amsaligned\@start@alignment');
@@ -701,7 +701,7 @@ DefConstructor('\intertext{}', "<ltx:p class='ltx_intertext'>#1</ltx:p>", mode =
 # Section 3.11.1 Numbering hierarchy
 DefPrimitive('\numberwithin[]{}{}', sub {
     my ($ignore, $format, $counter, $within) = @_;
-    $format = ($format ? ToString($format) : '\arabic');
+    $format  = ($format ? ToString($format) : '\arabic');
     $counter = ToString(Expand($counter)); $within = ToString(Expand($within));
     NewCounter($counter, $within);
     DefMacroI("\\the$counter", undef,
@@ -864,7 +864,7 @@ DefMacro('\hdotsfor Number', sub {
 # This currently doesn't see deeply enough into $after, eg. \boldsymbol{+}
 DefPrimitive('\lx@math@dots Digested', sub {
     my ($stomach, $after) = @_;
-    my $role = $after && $after->getProperty('role');
+    my $role   = $after && $after->getProperty('role');
     my %binops = (ADDOP => 1, BINOP => 1, MULOP => 1, RELOP => 1);
     return (Box(($role && $binops{$role} ? "\x{22EF}" : "\x{2026}"),
         undef, undef, T_CS('\dots'), mode => 'math', name => 'dots', role => 'ID'),
@@ -902,7 +902,7 @@ DefConstructor('\boxed@text{}',
     . "#1"
     . "</ltx:XMath>"
     . "</ltx:Math>",
-  mode         => 'math', bounded => 1,
+  mode => 'math', bounded => 1,
   beforeDigest => sub {
     Let("\\\\", '\@block@cr'); },
   alias => '\boxed');


### PR DESCRIPTION
I couldn't help myself to try a "quick" experiment: What if braces `{}` turn to `ltx:XMHint` in Math? Then we could use these for TeX-like adjustments of operator spacing, as in `{}+x`.  First step, convert the boxes to XMHints, rather than discard them. Then start dealing with all the places that hadn't expected hints to appear (rewrites, etc).

Alas, turns out to rather more odd places, mostly still in DLMF.  Since there are more pressing issues ATM, I'm parking this as WiP for now.  Hopefully can revive it before it becomes completely stale.