### PR TITLE
Add basic support for newest aastex63

### DIFF
--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -320,35 +320,28 @@ Let(T_CS('\decimalcolnumbers'), T_CS('\deluxedecimalcolnumbers'));
 
 # http://tug.ctan.org/tex-archive/macros/latex/contrib/aastex/sample63.pdf
 # decimal alignment, 3.1.2
-DefColumnType('D', sub {
-    $LaTeXML::BUILD_TEMPLATE->addColumn(
-      before => Tokens(T_CS('\hfill')),
-      after  => Tokens(T_CS('\end@D@col@one')));
-    $LaTeXML::BUILD_TEMPLATE->addColumn(
-      after => Tokens(T_CS('\hfill')));
-    return; });
-
-DefColumnType('d', sub {    #TODO: these should be "eaten away" I think?
-    $LaTeXML::BUILD_TEMPLATE->addColumn(
-      before => Tokens(T_CS('\hfill')),
-      after  => Tokens(T_CS('\end@D@col@one')));
-    $LaTeXML::BUILD_TEMPLATE->addColumn(
-      after => Tokens(T_CS('\hfill')));
-    return; });
-
-DefMacro('\end@D@col@one', sub {
-    my ($gullet)         = @_;
-    my $smuggle_new      = 1;
-    my $current_location = $gullet->getLocator->toString;
-    if (my $smuggled_at = LookupValue('aas_smuggle_D_column')) {
-      if ($smuggled_at eq $current_location) {
-        $smuggle_new = 0;
-    } }
-    if ($smuggle_new) {
-      AssignValue('aas_smuggle_D_column', $current_location, 'local');
-      return T_CS('\@alignment@align'); }
-    else {
-      return (); } });
+sub build_d_columns {
+  $LaTeXML::BUILD_TEMPLATE->addColumn(
+    before => Tokens(T_CS('\hfill'), T_CS('\aas@start@D@column')),
+    after  => Tokens(T_CS('\aas@end@D@column')));
+  $LaTeXML::BUILD_TEMPLATE->addBetweenColumn();
+  $LaTeXML::BUILD_TEMPLATE->addColumn(
+    after => Tokens(T_CS('\hfill')));
+  return; }
+DefColumnType('D', \&build_d_columns);
+DefColumnType('d', \&build_d_columns);
+DefMacro('\aas@start@D@column XUntil:\aas@end@D@column', sub {
+    my ($gullet, $n) = @_;
+    my ($m,      $f) = SplitTokens($n, T_OTHER('.'));
+    return ($f ? (@$m,
+        T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_norightpad'), T_END,
+        T_CS('\@alignment@align'),
+        T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_noleftpad'), T_END,
+        T_OTHER('.'), @$f)
+      : ($n, T_CS('\@alignment@align')));
+##  return ($n,T_CS('\@alignment@align'));
+});
+DefPrimitive('\aas@end@D@column', '');
 
 # hidden column, 3.1.4
 Let(T_CS('\savedollar'), T_MATH);

--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -324,7 +324,6 @@ sub build_d_columns {
   $LaTeXML::BUILD_TEMPLATE->addColumn(
     before => Tokens(T_CS('\hfill'), T_CS('\aas@start@D@column')),
     after  => Tokens(T_CS('\aas@end@D@column')));
-  $LaTeXML::BUILD_TEMPLATE->addBetweenColumn();
   $LaTeXML::BUILD_TEMPLATE->addColumn(
     after => Tokens(T_CS('\hfill')));
   return; }
@@ -338,8 +337,9 @@ DefMacro('\aas@start@D@column XUntil:\aas@end@D@column', sub {
         T_CS('\@alignment@align'),
         T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_noleftpad'), T_END,
         T_OTHER('.'), @$f)
-      : ($n, T_CS('\@alignment@align')));
-##  return ($n,T_CS('\@alignment@align'));
+      : ($n,
+        T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_norightpad'), T_END,
+        T_CS('\@alignment@align')));
 });
 DefPrimitive('\aas@end@D@column', '');
 

--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -129,9 +129,11 @@ DefConstructor('\altaffiltext{}{}',
 
 DefMacro('\software{}',      '\@add@frontmatter{ltx:note}[role=software]{#1}');
 DefMacro('\submitjournal{}', '\@add@frontmatter{ltx:note}[role=journal]{#1}');
-DefMacro('\doi{}',           '\@add@frontmatter{ltx:classification}[scheme=doi]{#1}');
-DefMacro('\collaboration',   '');
-DefMacro('\nocollaboration', '');
+# Alas \doi is not frontmatter.
+DefConstructor('\doi{}',             '<ltx:ref href="https:/doi.org/#1">#1</ltx:ref>');
+DefConstructor('\@@@collaborator{}', "<ltx:note role='collaborator'>#1</ltx:note>");
+DefMacro('\collaboration{}{}', '\@add@to@frontmatter{ltx:creator}{\@@@collaborator{#2}}');
+DefMacro('\nocollaboration{}', '');
 #======================================================================
 # 2.4 Abstract
 # normal LaTeX

--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -47,6 +47,11 @@ DefMacro('\journalid{}{}', '');
 DefMacro('\articleid{}{}', '');
 DefMacro('\paperid{}',     '');
 DefMacro('\msid{}',        '');    # Manuscript id.
+DefMacro('\added{}',       '');
+DefMacro('\replaced{}',    '');
+DefMacro('\deleted{}',     '');
+DefMacro('\explain{}',     '');
+DefMacro('\edit{}{}',      '');
 
 #\ccc{code}
 DefMacro('\ccc{}', '');            # Ignorable?
@@ -94,8 +99,9 @@ DefMacro('\author{}',
   '\@add@frontmatter{ltx:creator}[role=author]{\@personname{#1}}');
 
 DefConstructor('\@@@affiliation{}', "^ <ltx:contact role='affiliation'>#1</ltx:contact>");
-DefMacro('\affil{}',       '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
-DefMacro('\affiliation{}', '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
+DefMacro('\affil{}',        '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
+DefMacro('\affiliation{}',  '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
+DefMacro('\altaffiliation', '\affiliation');
 DefConstructor('\@@@authoraddr{}', "^ <ltx:contact role='address'>#1</ltx:contact>");
 DefMacro('\authoraddr{}', '\@add@to@frontmatter{ltx:creator}{\@@@authoraddr{#1}}');
 
@@ -117,8 +123,11 @@ DefConstructor('\@altaffilmark{}',
 DefConstructor('\altaffiltext{}{}',
   "<ltx:note role='affiliationtext' mark='#1'>#2</ltx:note>");
 
+DefMacro('\software{}',      '\@add@frontmatter{ltx:note}[role=software]{#1}');
 DefMacro('\submitjournal{}', '\@add@frontmatter{ltx:note}[role=journal]{#1}');
-
+DefMacro('\doi{}',           '\@add@frontmatter{ltx:classification}[scheme=doi]{#1}');
+DefMacro('\collaboration',   '');
+DefMacro('\nocollaboration', '');
 #======================================================================
 # 2.4 Abstract
 # normal LaTeX
@@ -188,6 +197,8 @@ Let('\boxedfig', '\fig');
 DefMacro('\rotatefig {Number} Semiverbatim {Dimension}{}',
   '\begin{figure}\caption{#4}\includegraphics[width=#3,angle=#1]{#2}\end{figure}');
 
+DefEnvironment('{interactive}{}{}', '#body');
+
 #======================================================================
 # 2.9 Acknowledgements
 
@@ -202,6 +213,7 @@ Let('\acknowledgments', '\acknowledgements');
 # Ultimately, this would get some more explicit semantic markup, but..
 # \facility{facilityID}
 DefConstructor('\facility{}', "<ltx:text class='ltx_ast_facility'>#1</ltx:text>");
+DefMacro('\facilities{}', '\@add@frontmatter{ltx:note}[role=facilities]{#1}');
 
 #======================================================================
 # 2.11 Appendices
@@ -277,7 +289,8 @@ DefMacro('\plottwo Semiverbatim Semiverbatim',
 
 # \plotfiddle{epsfile}{vsize}{rot}{hsf}{vsf}{htrans}{vtrans}
 # Ugh...
-DefMacro('\plotfiddle Semiverbatim {}{}{}{}{}{}', '\includegraphics[width=#4pt,height=#5pt]{#1}');
+DefMacro('\plotfiddle Semiverbatim {}{}{}{}{}{}',
+  '\includegraphics[width=#4pt,height=#5pt]{#1}');
 
 #======================================================================
 # 2.14.2 Figure Captions
@@ -295,6 +308,68 @@ DefMacro('\figcaption', sub {
 RequirePackage('deluxetable');
 Let(T_CS('\begin{planotable}'), T_CS('\begin{deluxetable}'));
 Let(T_CS('\end{planotable}'),   T_CS('\end{deluxetable}'));
+
+DefConditional('\ifcolnumberson');
+DefConditional('\ifdeluxedecimals');
+DefMacro('\deluxedecimals', '\global\deluxedecimalstrue');
+RawTeX('\global\deluxedecimalsfalse');
+Let(T_CS('\decimals'), T_CS('\deluxedecimals'));
+DefMacro('\colnumbers',              '');                                       # TODO
+DefMacro('\deluxedecimalcolnumbers', '\deluxedecimalstrue\colnumbersontrue');
+Let(T_CS('\decimalcolnumbers'), T_CS('\deluxedecimalcolnumbers'));
+
+# http://tug.ctan.org/tex-archive/macros/latex/contrib/aastex/sample63.pdf
+# decimal alignment, 3.1.2
+DefColumnType('D', sub {
+    $LaTeXML::BUILD_TEMPLATE->addColumn(
+      before => Tokens(T_CS('\hfill')),
+      after  => Tokens(T_CS('\end@D@col@one')));
+    $LaTeXML::BUILD_TEMPLATE->addColumn(
+      after => Tokens(T_CS('\hfill')));
+    return; });
+
+DefColumnType('d', sub {    #TODO: these should be "eaten away" I think?
+    $LaTeXML::BUILD_TEMPLATE->addColumn(
+      before => Tokens(T_CS('\hfill')),
+      after  => Tokens(T_CS('\end@D@col@one')));
+    $LaTeXML::BUILD_TEMPLATE->addColumn(
+      after => Tokens(T_CS('\hfill')));
+    return; });
+
+DefMacro('\end@D@col@one', sub {
+    my ($gullet)         = @_;
+    my $smuggle_new      = 1;
+    my $current_location = $gullet->getLocator->toString;
+    if (my $smuggled_at = LookupValue('aas_smuggle_D_column')) {
+      if ($smuggled_at eq $current_location) {
+        $smuggle_new = 0;
+    } }
+    if ($smuggle_new) {
+      AssignValue('aas_smuggle_D_column', $current_location, 'local');
+      return T_CS('\@alignment@align'); }
+    else {
+      return (); } });
+
+# hidden column, 3.1.4
+Let(T_CS('\savedollar'), T_MATH);
+DefEnvironment('{eatone}', '');
+DefColumnType('h', sub {
+    $LaTeXML::BUILD_TEMPLATE->addColumn(
+      before => Tokens(T_BEGIN,            T_CS('\eatone')),
+      after  => Tokens(T_CS('\endeatone'), T_END));
+    return; });
+Let(T_CS('\begin{splitdeluxetable}'),  T_CS('\begin{deluxetable}'));
+Let(T_CS('\end{splitdeluxetable}'),    T_CS('\end{deluxetable}'));
+Let(T_CS('\begin{splitdeluxetable*}'), T_CS('\begin{deluxetable*}'));
+Let(T_CS('\end{splitdeluxetable*}'),   T_CS('\end{deluxetable*}'));
+
+DefColumnType('B', sub {    # TODO: fake for now, should break table eventually
+    $LaTeXML::BUILD_TEMPLATE->addColumn(
+      before => Tokens(T_BEGIN,            T_CS('\eatone')),
+      after  => Tokens(T_CS('\endeatone'), T_END));
+    return; });
+
+DefEnvironment('{longrotatetable}', '#body');
 
 DefMacro('\phn',   '\phantom{0}');
 DefMacro('\phd',   '\phantom{.}');
@@ -388,6 +463,7 @@ DefPrimitiveI('\arcdeg', undef, UTF(0xB0));
 Let('\degr', '\arcdeg');
 DefPrimitiveI('\arcmin', undef, "\x{2032}");
 DefPrimitiveI('\arcsec', undef, "\x{2033}");
+DefMacro('\nodata', ' ~$\cdots$~ ');
 
 # 1st arg is the original macro so that it can be the reversion for UnTeX!
 # 2nd arg is the superscript
@@ -398,7 +474,7 @@ DefConstructor('\aas@@fstack Undigested {}',
     . "<ltx:XMWrap>#2</ltx:XMWrap>"
     . "</ltx:XMApp>",
   properties => { scriptpos => sub { "mid" . $_[0]->getScriptLevel; } },
-  mode       => 'math', font => { shape => 'upright' }, bounded => 1, reversion => '#1');
+  mode => 'math', font => { shape => 'upright' }, bounded => 1, reversion => '#1');
 DefMacro('\aas@fstack{}', '\ensuremath{\aas@@fstack{#1}}');
 
 DefMacro('\fd',    '\ensuremath{\@fd}');
@@ -429,11 +505,11 @@ DefMacro('\onequarter', '\ifmmode\case{1}{4}\else\text@onequarter\fi');
 DefPrimitiveI('\text@onequarter', undef, UTF(0xBC));
 DefMacro('\threequarters', '\ifmmode\case{3}{4}\else\text@threequarters\fi');
 DefPrimitiveI('\text@threequarters', undef, UTF(0xBE));
-DefPrimitiveI('\ubvr', undef, "UBVR", bounded => 1, font => { shape => 'italic' });
-DefPrimitiveI('\ub', undef, "U\x{2000}B", bounded => 1, font => { shape => 'italic' });
-DefPrimitiveI('\bv', undef, "B\x{2000}V", bounded => 1, font => { shape => 'italic' });
-DefPrimitiveI('\vr', undef, "V\x{2000}R", bounded => 1, font => { shape => 'italic' });
-DefPrimitiveI('\ur', undef, "U\x{2000}R", bounded => 1, font => { shape => 'italic' });
+DefPrimitiveI('\ubvr', undef, "UBVR",       bounded => 1, font => { shape => 'italic' });
+DefPrimitiveI('\ub',   undef, "U\x{2000}B", bounded => 1, font => { shape => 'italic' });
+DefPrimitiveI('\bv',   undef, "B\x{2000}V", bounded => 1, font => { shape => 'italic' });
+DefPrimitiveI('\vr',   undef, "V\x{2000}R", bounded => 1, font => { shape => 'italic' });
+DefPrimitiveI('\ur',   undef, "U\x{2000}R", bounded => 1, font => { shape => 'italic' });
 
 # Remaining tables standard LaTeX or amssymb
 RequirePackage('latexsym');
@@ -442,6 +518,25 @@ RequirePackage('amssymb');
 # \lesssim,\gtrsim in amssymb
 Let('\la', '\lesssim');
 Let('\ga', '\gtrsim');
+
+# Nominal Conversion Constants
+
+DefMacro('\nomSolarEffTemp', '\leavevmode\hbox{\boldmath$\mathcal{T}^{\rm N}_{\mathrm{eff}\odot}$}');
+DefMacro('\nomTerrEqRadius',      '\leavevmode\hbox{\boldmath$\mathcal{R}^{\rm N}_{E\mathrm e}$}');
+DefMacro('\nomTerrPolarRadius',   '\leavevmode\hbox{\boldmath$\mathcal{R}^{\rm N}_{E\mathrm p}$}');
+DefMacro('\nomJovianEqRadius',    '\leavevmode\hbox{\boldmath$\mathcal{R}^{\rm N}_{J\mathrm e}$}');
+DefMacro('\nomJovianPolarRadius', '\leavevmode\hbox{\boldmath$\mathcal{R}^{\rm N}_{J\mathrm p}$}');
+DefMacro('\nomTerrMass',   '\leavevmode\hbox{\boldmath$(\mathcal{GM})^{\rm N}_{\mathrm E}$}');
+DefMacro('\nomJovianMass', '\leavevmode\hbox{\boldmath$(\mathcal{GM})^{\rm N}_{\mathrm J}$}');
+DefMacro('\Qnom',          '\leavevmode\hbox{\boldmath$\mathcal{Q}^{\rm N}_{\odot}$}');
+Let(T_CS('\Qn'), T_CS('\Qnom'));
+
+# Generic commands that can be given an argument:
+DefMacro('\nom{}',   '\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{\odot}$}');
+DefMacro('\Eenom{}', '\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{Ee}$}');
+DefMacro('\Epnom{}', '\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{Ep}$}');
+DefMacro('\Jenom{}', '\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{Je}$}');
+DefMacro('\Jpnom{}', '\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{Jp}$}');
 
 #======================================================================
 # 2.17.5 Hypertext Constructs

--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -38,9 +38,9 @@ RequirePackage('ulem');
 #======================================================================
 # 2.1.3 Editorial Information
 
-DefMacro('\received{}', '\@add@frontmatter{ltx:date}[role=received]{#1}');
-DefMacro('\revised{}',  '\@add@frontmatter{ltx:date}[role=revised]{#1}');
-DefMacro('\accepted{}', '\@add@frontmatter{ltx:date}[role=accepted]{#1}');
+DefMacro('\received{}', '\@add@frontmatter{ltx:date}[role=received,name=Received]{#1}');
+DefMacro('\revised{}',  '\@add@frontmatter{ltx:date}[role=revised,name=Revised]{#1}');
+DefMacro('\accepted{}', '\@add@frontmatter{ltx:date}[role=accepted,name=Accepted]{#1}');
 
 # Could add more metadata..
 DefMacro('\journalid{}{}', '');
@@ -94,14 +94,18 @@ DefMacro('\righthead{}', '');    # Obsolete form
 
 #======================================================================
 # 2.3 Title and Author Information
-
-DefMacro('\author{}',
-  '\@add@frontmatter{ltx:creator}[role=author]{\@personname{#1}}');
+AssignMapping('DOCUMENT_CLASSES', ltx_authors_multiline => 1);
+DefConstructor('\@@personname[]{}', "<ltx:personname>" .
+    "?#1(<ltx:ref href='https://orcid.org/#1' class='orcid'>#2</ltx:ref>)(#2)" .
+    "</ltx:personname>)");
+DefMacro('\author[]{}',
+  '\@add@frontmatter{ltx:creator}[role=author]{\@@personname[#1]{#2}}');
 
 DefConstructor('\@@@affiliation{}', "^ <ltx:contact role='affiliation'>#1</ltx:contact>");
-DefMacro('\affil{}',        '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
-DefMacro('\affiliation{}',  '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
-DefMacro('\altaffiliation', '\affiliation');
+DefMacro('\affiliation{}', '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
+DefMacro('\affil',         '\affiliation');
+DefConstructor('\@@@altaffil{}', "^ <ltx:contact role='affiliation'>#1</ltx:contact>");
+DefMacro('\altaffiliation{}', '\@add@to@frontmatter{ltx:creator}{\@@@altaffil{#1}}');
 DefConstructor('\@@@authoraddr{}', "^ <ltx:contact role='address'>#1</ltx:contact>");
 DefMacro('\authoraddr{}', '\@add@to@frontmatter{ltx:creator}{\@@@authoraddr{#1}}');
 

--- a/lib/LaTeXML/Package/aastex.cls.ltxml
+++ b/lib/LaTeXML/Package/aastex.cls.ltxml
@@ -26,7 +26,7 @@ foreach my $option (qw(10pt 11pt 12pt
   manuscript preprint preprint2 longabstract
   tighten landscape
   aasms4 aaspp4 aas2pp4 aj_pt4 apjpt4 astro
-  flushrt)) {
+  flushrt anonymous)) {
   DeclareOption($option, undef); }
 
 # Number equations within sections

--- a/lib/LaTeXML/Package/acmart.cls.ltxml
+++ b/lib/LaTeXML/Package/acmart.cls.ltxml
@@ -63,7 +63,7 @@ DefConstructor('\@@@orcid{}', "^ <ltx:contact role='orcid'>#1</ltx:contact>");
 DefMacro('\orcid{}', '\@add@to@frontmatter{ltx:creator}{\@@@orcid{#1}}');
 DefConstructor('\@@@affiliation{}', "^ <ltx:contact role='affiliation'>#1</ltx:contact>");
 DefMacro('\affiliation{}', '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
-DefConstructor('\@@@affiliation{}', "^ <ltx:contact role='additional_affiliation'>#1</ltx:contact>");
+DefConstructor('\@@@addaffiliation{}', "^ <ltx:contact role='additional_affiliation'>#1</ltx:contact>");
 DefMacro('\additionalaffiliation{}', '\@add@to@frontmatter{ltx:creator}{\@@@addaffiliation{#1}}');
 DefConstructor('\@@@email{}', "^ <ltx:contact role='email'>#1</ltx:contact>");
 DefMacro('\email [] Semiverbatim', '\@add@to@frontmatter{ltx:creator}{\@@@email{#2}}');

--- a/lib/LaTeXML/Package/deluxetable.sty.ltxml
+++ b/lib/LaTeXML/Package/deluxetable.sty.ltxml
@@ -71,8 +71,10 @@ Let('\tablecaption', '\caption');
 
 DefMacro('\tablehead{}',
   '\def\@deluxetable@header{\@tabular@begin@heading#1\\\\\hline\@tabular@end@heading}');
-DefMacro('\colhead{}',
-  '\multicolumn{1}{c}{#1}');
+DefMacro('\colhead{}',    '\multicolumn{1}{c}{#1}');
+DefMacro('\twocolhead{}', '\multicolumn{2}{c}{\hss #1 \hss}');
+DefMacro('\nocolhead{}',  '\multicolumn{1}{h}{#1}');
+DefMacro('\dcolhead{}',   '\multicolumn{1}{c}{$\relax#1$}');
 
 DefMacro('\nl',          '\\\\[0pt]');                     # Obsolete form
 DefMacro('\nextline',    '\\\\[0pt]');                     # Obsolete form

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -87,7 +87,7 @@
 /*======================================================================
   Para level */
 .ltx_float {
-    margin: 1ex 3em 1ex 3em; }    
+    margin: 1ex 3em 1ex 3em; }
 td.ltx_subfigure,
 td.ltx_subtable,
 td.ltx_subfloat { width:50%; }
@@ -123,6 +123,10 @@ td.ltx_subfloat { width:50%; }
 
 .ltx_tabular .ltx_tabular { width:100%; }
 .ltx_inline-block { display:inline-block; }
+
+/* avoid padding when aligning adjacent columns, e.g. for split decimals */
+.ltx_norightpad { padding-right:0!important; }
+.ltx_noleftpad { padding-left:0!important; }
 
 /* equations in non-aligned mode (not normally used) */
 .ltx_eqn_div { display:block; width:95%; text-align:center; }
@@ -203,7 +207,7 @@ dl.ltx_description dl.ltx_description dd { margin-left:3em; }
 .ltx_lst_numbers_left .ltx_listingline .ltx_tag {
     background-color:transparent;
     margin-left:-3em; width:2.5em;
-    position:absolute; 
+    position:absolute;
     text-align:right; }
 .ltx_lst_numbers_right .ltx_listingline .ltx_tag {
     background-color:transparent;
@@ -301,7 +305,7 @@ span.ltx_rowspan { position:absolute; top:0; bottom:0; }
 .ltx_note_content {
      max-width: 70%; font-size:90%; left:15%;
      text-align:left;
-     background-color: white; 
+     background-color: white;
      padding: 0.5em 1em 0.5em 1.5em;
      border: 1px solid black; border-radius: 0 5px 5px 5px; box-shadow: 5px 5px 10px gray; }
 .ltx_note_mark    { color:blue; }
@@ -314,7 +318,7 @@ span.ltx_rowspan { position:absolute; top:0; bottom:0; }
 
 .ltx_ERROR        { color:red; }
 .ltx_rdf          { display:none; }
-.ltx_missing      { color:red;} 
+.ltx_missing      { color:red;}
 .ltx_nounicode    { color:red; }
 /*======================================================================
  SVG (pgf/tikz ?) basics */
@@ -342,7 +346,7 @@ span.ltx_rowspan { position:absolute; top:0; bottom:0; }
 .ltx_font_slanted    { font-style: oblique; font-variant:normal; }
 .ltx_font_smallcaps  { font-variant: small-caps; font-style:normal; }
 .ltx_font_oldstyle   { font-variant: oldstyle-nums;  /* experimental css3 ? Doesn't seem to work!*/
-                       font-style:normal; 
+                       font-style:normal;
                        -moz-font-feature-settings: "onum";
                        -ms-font-feature-settings: "onum";
                        -webkit-font-feature-settings: "onum";
@@ -379,4 +383,3 @@ cite                 { font-style: normal; }
     -ms-fliter: "FlipV"; }
 
 /* .ltx_phantom handled in xslt */
-

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-/=====================================================================\ 
+/=====================================================================\
 |  LaTeXML-structure-xhtml.xsl                                        |
 |  Converting documents structure to xhtml                            |
 |=====================================================================|
@@ -107,7 +107,7 @@
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>
       <xsl:if test="@name">
-        <xsl:element name="h6" namespace="{$html_ns}">  
+        <xsl:element name="h6" namespace="{$html_ns}">
           <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
           <xsl:attribute name="class">ltx_title ltx_title_abstract</xsl:attribute>
           <xsl:apply-templates select="@name">
@@ -136,7 +136,7 @@
       </xsl:apply-templates>
       <xsl:if test="@name">
         <xsl:text>&#x0A;</xsl:text>
-        <xsl:element name="h6" namespace="{$html_ns}">  
+        <xsl:element name="h6" namespace="{$html_ns}">
           <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
           <xsl:attribute name="class">ltx_title ltx_title_acknowledgements</xsl:attribute>
           <xsl:apply-templates select="@name">
@@ -256,7 +256,7 @@
       </xsl:choose>
     </func:result>
   </func:function>
-  
+
   <!-- Attempt computing level based on "known" structural elements -->
   <func:function name="f:seclev-aux">
     <xsl:param name="name"/>
@@ -304,7 +304,7 @@
   <xsl:template match="ltx:title">
     <xsl:param name="context"/>
     <!-- Skip title, if the parent has a titlepage, or if writing a cv! -->
-    <xsl:if test="not(parent::*/child::ltx:titlepage)">    
+    <xsl:if test="not(parent::*/child::ltx:titlepage)">
       <xsl:text>&#x0A;</xsl:text>
       <!-- In html5, could have wrapped in hgroup, but that was deprecated -->
       <xsl:call-template name="maketitle">
@@ -580,7 +580,7 @@
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$innercontext"/>
       </xsl:apply-templates>
-      <xsl:element name="a" namespace="{$html_ns}">      
+      <xsl:element name="a" namespace="{$html_ns}">
         <xsl:attribute name="href"><xsl:value-of select="concat('mailto:',text())"/></xsl:attribute>
         <xsl:apply-templates>
           <xsl:with-param name="context" select="$innercontext"/>
@@ -604,7 +604,7 @@
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$innercontext"/>
       </xsl:apply-templates>
-      <xsl:element name="a" namespace="{$html_ns}">      
+      <xsl:element name="a" namespace="{$html_ns}">
         <xsl:attribute name="href"><xsl:value-of select="text()"/></xsl:attribute>
         <xsl:apply-templates>
           <xsl:with-param name="context" select="$innercontext"/>
@@ -657,9 +657,11 @@
         <xsl:apply-templates select="." mode="begin">
           <xsl:with-param name="context" select="$context"/>
         </xsl:apply-templates>
+        <xsl:text>(</xsl:text>
         <xsl:apply-templates select="$dates" mode="intitle">
           <xsl:with-param name="context" select="$context"/>
         </xsl:apply-templates>
+        <xsl:text>)</xsl:text>
         <xsl:apply-templates select="." mode="end">
           <xsl:with-param name="context" select="$context"/>
         </xsl:apply-templates>
@@ -673,7 +675,7 @@
     <xsl:apply-templates select="node()">
       <xsl:with-param name="context" select="$context"/>
     </xsl:apply-templates>
-    <xsl:text> </xsl:text>
+    <xsl:if test="following-sibling::ltx:date"><xsl:text>; </xsl:text></xsl:if>
   </xsl:template>
 
   <xsl:preserve-space elements="ltx:subtitle"/>

--- a/t/complex/aastex_test.xml
+++ b/t/complex/aastex_test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="aastex" options="12pt,preprint"?>
 <?latexml RelaxNGSchema="LaTeXML"?>
-<document xmlns="http://dlmf.nist.gov/LaTeXML">
+<document xmlns="http://dlmf.nist.gov/LaTeXML" class="ltx_authors_multiline">
   <resource src="LaTeXML.css" type="text/css"/>
   <resource src="ltx-article.css" type="text/css"/>
   <resource src="ltx-ulem.css" type="text/css"/>


### PR DESCRIPTION
Quick & dirty PR aimed at content-preserving, but presentationally imperfect, aastex63.cls arXiv documents.

Took me way too long to wrestle down an error-free version of the `D` column - but I managed! Still, I am making a PR with some remaining visual issues, hoping to borrow wisdom from @brucemiller as to what should be improved before the release and what after. I'd like to get the additions in for the latest arXiv run, since I have seen new papers using aastex63.cls.

As to what I managed to achieve, my main focus was getting the `sample63.tex` official template converting without issues to HTML, [online PDF here](http://tug.ctan.org/tex-archive/macros/latex/contrib/aastex/sample63.pdf).

Here are two side-by-side tables stress-testing the tricky new `h` and `D` column specifiers. HTML on the left, with known visual deficiencies (but all content is present, and conversion is problem-free):
![aastex63](https://user-images.githubusercontent.com/348975/97909767-b9493200-1d16-11eb-9aea-2b4d5122a473.png)

I am also attaching the full HTML converted via the PR for reference of the remaining flaws:
[sample63_html.zip](https://github.com/brucemiller/LaTeXML/files/5477514/sample63_html.zip)