### PR TITLE
ensure intended extensions only in FindFile wrt documentstyle

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1955,8 +1955,11 @@ sub FindFile_fallback {
   # Supported:
   # Numeric suffixes (version nums, dates) with optional separators
   my $fallback_file = $file;
+  my $type          = $options{type};
   if ($fallback_file =~ s/\.(sty|cls)$//) {
-    my $ltxtype = $1;
+    # if we provide the type, that remains primary.
+    $type = $1 unless $type; }
+  if ($type) {    # if we know what we're dealing with...
     my $discard = "";
     if ($fallback_file =~ s/([-_](?:arxiv|conference|workshop))$//) {
       # arxiv-specific suffixes, maybe move those out to an extension package?
@@ -1967,7 +1970,7 @@ sub FindFile_fallback {
       $discard = "$1$discard";
     }
     if ($discard) {    # we had something to discard, so a new query is needed
-      my $fallback_query = "$fallback_file.$ltxtype";
+      my $fallback_query = "$fallback_file.$type";
       if (my $path = pathname_find("$fallback_query.ltxml", paths => $ltxml_paths, installation_subdir => 'Package')) {
         Info('fallback', $file, $STATE->getStomach->getGullet,
 "Interpreted $discard as a versioned package/class name, falling back to generic $fallback_query\n");

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -83,8 +83,9 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
 #
 # EXCEPTION: of course there is an exception. Older arXiv articles use \documentstyle{aipproc}
 # to load a different aipproc.sty than the later evolved aipproc.cls. And of course we need to support that.
-    if (FindFile($class, type => 'sty')) {
-      InputDefinitions('article', type => 'cls', noerror => 1, handleoptions => 1);
+    if (FindFile($class, type => 'sty', notex => !LookupValue('INCLUDE_CLASSES'))) {
+      InputDefinitions('article', type => 'cls', noerror => 1,
+        withoptions => 1, handleoptions => 1, options => $options);
       RequirePackage($class, options => $options, as_class => 1,
         after => Tokens(T_CS('\compat@loadpackages'))); }
     elsif (FindFile($class, type => 'cls', notex => !LookupValue('INCLUDE_CLASSES'))) {

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -85,16 +85,17 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
 # to load a different aipproc.sty than the later evolved aipproc.cls. And of course we need to support that.
     if (FindFile($class, type => 'sty', notex => !LookupValue('INCLUDE_CLASSES'))) {
       InputDefinitions('article', type => 'cls', noerror => 1,
-        withoptions => 1, handleoptions => 1, options => $options);
+        handleoptions => 1, options => $options);
       RequirePackage($class, options => $options, as_class => 1,
         after => Tokens(T_CS('\compat@loadpackages'))); }
     elsif (FindFile($class, type => 'cls', notex => !LookupValue('INCLUDE_CLASSES'))) {
       LoadClass($class, options => $options,
         after => Tokens(T_CS('\compat@loadpackages'))); }
     else {
-      InputDefinitions('OmniBus', type => 'cls', noerror => 1, handleoptions => 1);
-      RequirePackage($class, options => $options, as_class => 1,
-        after => Tokens(T_CS('\compat@loadpackages'))); }
+      InputDefinitions('OmniBus', type => 'cls', noerror => 1,
+        handleoptions => 1, options => $options,
+        after => Tokens(T_CS('\compat@loadpackages')));
+      RequirePackage($class, options => $options, as_class => 1); }
     return; });
 
 DefPrimitiveI('\compat@loadpackages', undef, sub {


### PR DESCRIPTION
Quick follow-up to #1300 , I did some related testing with:
```tex
\documentstyle[xcolor]{article}
\begin{document}
test \color{red} test.
\end{document}
```

and realized my kpsewhich found `article.sty` in texlive and tried to load it even though I did not provide `--includestyles`. So, patched!