### PR TITLE
Fixes #1351

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2697,18 +2697,17 @@ DefPrimitive('\renewenvironment OptionalMatch:* {}[Number][]{}{}', sub {
 # The core non-customizable part is defined here.
 # For customizable theorems, see amsthm.
 AssignValue('thm@swap' => 0);
-DefRegister('\thm@style'        => Tokenize('plain'));
-DefRegister('\thm@headfont'     => Tokens(T_CS('\bfseries')));
-DefRegister('\thm@notefont'     => Tokens(T_CS('\the'), T_CS('\thm@headfont')));
-DefRegister('\thm@bodyfont'     => Tokens(T_CS('\itshape')));
-DefRegister('\thm@headpunct'    => Tokens());
-DefRegister('\thm@styling'      => Tokens());
-DefRegister('\thm@headstyling'  => Tokens());
-DefRegister('\thm@prework'      => Tokens());
-DefRegister('\thm@postwork'     => Tokens());
-DefRegister('\thm@symbol'       => Tokens());
-DefRegister('\thm@numbering'    => Tokens(T_CS('\arabic')));
-DefRegister('\thm@headformater' => undef);
+DefRegister('\thm@style'       => Tokenize('plain'));
+DefRegister('\thm@headfont'    => Tokens(T_CS('\bfseries')));
+DefRegister('\thm@notefont'    => Tokens(T_CS('\the'), T_CS('\thm@headfont')));
+DefRegister('\thm@bodyfont'    => Tokens(T_CS('\itshape')));
+DefRegister('\thm@headpunct'   => Tokens());
+DefRegister('\thm@styling'     => Tokens());
+DefRegister('\thm@headstyling' => Tokens());
+DefRegister('\thm@prework'     => Tokens());
+DefRegister('\thm@postwork'    => Tokens());
+DefRegister('\thm@symbol'      => Tokens());
+DefRegister('\thm@numbering'   => Tokens(T_CS('\arabic')));
 
 DefPrimitive('\th@plain', sub {
     AssignValue('\thm@bodyfont'    => T_CS('\itshape'));
@@ -2748,9 +2747,10 @@ sub useTheoremStyle {
   my ($name) = @_;
   my $savable = LookupValue('SAVABLE_THEOREM_PARAMETERS');
   if (my $params = LookupValue('THEOREM_' . ToString($name) . '_PARAMETERS')) {
-    foreach my $key (keys %$params) {
-      if ($$savable{$key}) {    # Only use the officieally saved ones
-        AssignValue($key => $$params{$key}); } } }
+    for my $param_key (keys %$savable) {
+      if (exists $$params{$param_key}) {
+        AssignValue($param_key => $$params{$param_key}); }
+  } }
   return; }
 
 sub saveTheoremStyle {
@@ -2759,7 +2759,7 @@ sub saveTheoremStyle {
   AssignValue('THEOREM_' . $name . '_PARAMETERS' => {%parameters}, 'global');
   return; }
 
-RawTeX('\th@plain');            # Activate the default style.
+RawTeX('\th@plain');    # Activate the default style.
 # [or just make it's values the defaults...]
 
 Tag('ltx:theorem', autoClose => 1);
@@ -2814,7 +2814,9 @@ sub defineNewTheorem {
   my $headformatter = LookupValue('\thm@headformatter');
   DefMacroI('\format@title@' . $thmset, convertLaTeXArgs(1, 0),
     ($headformatter
-      ? Tokens($headformatter->unlist,
+      ? Tokens(
+        T_CS('\the'), T_CS('\thm@headfont'),
+        $headformatter->unlist,
         T_BEGIN, ($type ? $type->unlist : ()), T_END,
         T_CS('\the' . $counter), T_BEGIN, Tokens(T_PARAM, T_OTHER('1')), T_END,
         T_CS('\the'), T_CS('\thm@headpunct'))

--- a/lib/LaTeXML/Package/amsthm.sty.ltxml
+++ b/lib/LaTeXML/Package/amsthm.sty.ltxml
@@ -38,7 +38,7 @@ DefRegister('\thm@notefont' => Tokens(T_CS('\fontseries'), T_CS('\mddefault'), T
 # amsthm also saves headfont!
 setSavableTheoremParameters(qw(
     \thm@headfont \thm@bodyfont \thm@headpunct
-    \thm@styling \thm@headstyling thm@swap));
+    \thm@styling \thm@headstyling \thm@headformatter thm@swap));
 
 # activate a certain theorem style
 DefPrimitive('\theoremstyle{}', sub {
@@ -71,12 +71,12 @@ DefPrimitive('\newtheoremstyle{}{}{}{}{}{}{}{}{}', sub {
 
     $name = ToString($name);
     saveTheoremStyle($name,
-      '\thm@bodyfont'    => $bodyfont,
-      '\thm@headfont'    => $headfont,
-      '\thm@headpunct'   => $headpunct,
-      '\thm@headstyling' => (Equals($spaceafter, Tokens(T_CS('\newline')))
-        ? Tokens() : T_CS('\lx@makerunin')),
-      '\thm@headformatter' => $headformatter);
+      '\thm@bodyfont'      => $bodyfont,
+      '\thm@headfont'      => $headfont,
+      '\thm@headpunct'     => $headpunct,
+      '\thm@headformatter' => $headformatter,
+      '\thm@headstyling'   => (Equals($spaceafter, Tokens(T_CS('\newline')))
+        ? Tokens() : T_CS('\lx@makerunin')));
     DefMacroI(T_CS('\th@' . $name), undef, sub { useTheoremStyle($name); });
     return; });
 
@@ -103,7 +103,7 @@ DefMacroI('\thmheadnl', undef, Tokens());
 
 AssignValue('QED@stack', []);
 DefMacro('\pushQED{}', sub { PushValue('QED@stack', $_[1]); });
-DefMacro('\popQED', sub { (PopValue('QED@stack') || ()); });
+DefMacro('\popQED',    sub { (PopValue('QED@stack') || ()); });
 
 # Should mark this as somehow ignorable for math,
 # but we DO want to keep it in the formula...


### PR DESCRIPTION
Should be a mostly correct fix, getting a little closer to the TeX behavior for the head formatter of a new theorem environment. Here is a screenshot showing HTML-to-PDF parity with the example of the reporting issue:

![image](https://user-images.githubusercontent.com/348975/97956699-5c319880-1d77-11eb-87c2-35739a376c2c.png)

If tests pass, it ought to be a safe chance, or at least no more dangerous than the code we have already :> 