### PR TITLE
Read single token if not balanced in hyperref \url

### DIFF
--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -64,19 +64,19 @@ foreach my $option (    # 3.1 General Options
 # \hypersetup{keyvals} configures various parameters,
 # for each pdf keyword, provide [property,(content|resource),datatype]
 our %pdfkey_property = (
-  baseurl     => '',                                # xmp:BaseURL ??
-  pdfauthor   => ['dcterms:creator', 'content'],
-  pdfkeywords => ['dcterms:subject', 'content'],    # & pdf:Keywords
+  baseurl     => '',                                 # xmp:BaseURL ??
+  pdfauthor   => ['dcterms:creator',  'content'],
+  pdfkeywords => ['dcterms:subject',  'content'],    # & pdf:Keywords
   pdflang     => ['dcterms:language', 'content'],
-  pdfproducer => '',                                # pdf:Producer & xmp:CreatorTool
+  pdfproducer => '',                                 # pdf:Producer & xmp:CreatorTool
   pdfsubject  => ['dcterms:subject', 'content'],
-  pdftitle    => ['dcterms:title', 'content'],
+  pdftitle    => ['dcterms:title',   'content'],
   # Include hyperxmp's keywords, as well.
-  pdfauthortitle   => '',                               # photoshop:AuthorsPosition
-  pdfcaptionwriter => '',                               # photoshop:CaptionWriter !?!?!?
-  pdfcopyright     => ['dcterms:rights', 'content'],    # & xmpRights:Marked
-  pdflicenseurl    => ['cc:licence', 'resource'],       # xmpRights:WebStatement
-  pdfmetalang      => '',                               # dcterms:language ??
+  pdfauthortitle   => '',                                # photoshop:AuthorsPosition
+  pdfcaptionwriter => '',                                # photoshop:CaptionWriter !?!?!?
+  pdfcopyright     => ['dcterms:rights', 'content'],     # & xmpRights:Marked
+  pdflicenseurl    => ['cc:licence',     'resource'],    # xmpRights:WebStatement
+  pdfmetalang      => '',                                # dcterms:language ??
 );
 # date=>dcterms:date xmp:CreateDate xmp:ModifyDate xmp:MetadataDate ?
 # document identifier => xmlMM:DocumentID
@@ -144,8 +144,8 @@ DefMacro('\@Url Token', sub {
       $open = T_OTHER('{'); $close = T_OTHER('}');
       $url  = $gullet->readBalanced(1); }            # Expand as we go!
     else {
-      $close = $open = T_OTHER($open->getString);
-      $url   = $gullet->readUntil($close); }
+      $url  = T_OTHER($open->getString);
+      $open = T_OTHER('{'); $close = T_OTHER('}'); }
     EndSemiverbatim();
     my @toks = grep { $_->getCatcode != CC_SPACE; } $url->unlist;
     # Identical with url's \@Url except, let CS's through!

--- a/lib/LaTeXML/Package/url.sty.ltxml
+++ b/lib/LaTeXML/Package/url.sty.ltxml
@@ -87,9 +87,12 @@ DefMacro('\url', '\begingroup\@Url\url', locked => 1);
 # \urldef{newcmd}\cmd{arg}
 # Kinda tricky, since we need to get the expansion of \cmd as the value of \newcmd
 # Along with the annoying \endgroup that must balance the one always preceding \Url!
-DefPrimitive('\urldef{}', sub {
-    my ($stomach, $cmd) = @_;
-    my $gullet    = $stomach->getGullet;
+DefPrimitive('\urldef{}{}', sub {
+    my ($stomach, $cmd, $start) = @_;
+    my $gullet = $stomach->getGullet;
+    # important to have a {} for $start in the macro signature,
+    # so that arg braces can be unwrapped, if provided
+    $gullet->unread($start);
     my @expansion = $stomach->digestNextBody(T_CS('\endgroup'));
     DefPrimitiveI($cmd, undef, sub { @expansion; });
     (); });


### PR DESCRIPTION
Took a break from Hard Debugging with some easy debugging.

We have a simple Fatal:misdefined  in arXiv from the `__ANON__` subroutines, likely rare, in [this paper](https://arxiv.org/abs/astro-ph/0001345), related to hyperref's url. I isolated the tex and added a second variation to be sure I am seeing things right:

```tex
\documentclass{article}
\usepackage{hyperref}
\begin{document}
T1: {\url http://cossc.gsfc.nasa.gov/cossc/batse/}.

T2: {\url|http://cossc.gsfc.nasa.gov/cossc/batse/|}.
\end{document}
```

And noticed the PDF only takes in the first token in this aberrant situation:
![url_wdelim_hyperref](https://user-images.githubusercontent.com/348975/98426362-88466580-2066-11eb-994b-a27ca9ea91cd.png)

while latexml is currently trying to use the leading `h` as an open delim. So this PR switches to the simpler pdflatex behavior. I also checked that this is indeed specific to hyperref itself, because if you instead do `\usepackage{url}`, pdflatex will produce what you would expect if you were using the h as a delimiter:

![url_wdelim_urlsty](https://user-images.githubusercontent.com/348975/98426398-ab711500-2066-11eb-8cd8-ac5e6c285a47.png)

Now, the paper in question uses neither of those directly. 
Instead, it relies on a genericly named `aastex.cls` dated at year 2000. Some digital archeology led me to what I believe may be [that cls file](http://www.ucolick.org/~bolte/LFPAPER2/aastex.cls), and lo and behold, it defines its own local `\url`, rather than relying on hyperref. Using that (via `\documentclass{aastex}` in my snippet above), I see with pdflatex:
![image](https://user-images.githubusercontent.com/348975/98426597-68637180-2067-11eb-8e1d-c9b8f102a0bc.png)

So it *did* work once! And, reading the \url definition there, it seems that it just took in the arguments and returned them, doing nothing of any interest at all with them...? 
```tex
\newcommand\anchor[2]{#2}% 
\newcommand\url{\@dblarg\@url}% 
\def\@url[#1]{\anchor{#1}}% 
```

Tempted to just ignore that patchy definition, and keep using hyperref with the harmless (i.e. no Fatal or Error) behavior with subtly broken markup. Submitted for your consideration :> 

Edit: I said possibly rare, but I am seeing some tens of these cases in the [\_\_ANON\_\_ report](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/fatal/misdefined/LaTeXML%3A%3APackage%3A%3APool%3A%3A%5F%5FANON%5F%5F), so maybe it gets a good handful of docs improved. One also hits `url.sty` directly, will add a second minor fix there... 