### PR TITLE
[arXiv patches] \endthebibliography, \@definecounter, low-level font size macros

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -5410,6 +5410,31 @@ DefMacro('\fontsize{}{}', Tokens());
 # https://tex.stackexchange.com/questions/112492/setfontsize-vs-fontsize#112501
 DefMacro('\@setfontsize{}{}{}', '\let\@currsize#1');
 
+DefMacroI('\@vpt',    undef, T_OTHER('5'));
+DefMacroI('\@vipt',   undef, T_OTHER('6'));
+DefMacroI('\@viipt',  undef, T_OTHER('7'));
+DefMacroI('\@viiipt', undef, T_OTHER('8'));
+DefMacroI('\@ixpt',   undef, T_OTHER('9'));
+DefMacro('\@xpt',    '10');
+DefMacro('\@xipt',   '10.95');
+DefMacro('\@xiipt',  '12');
+DefMacro('\@xivpt',  '14.4');
+DefMacro('\@xviipt', '17.28');
+DefMacro('\@xxpt',   '20.74');
+DefMacro('\@xxvpt',  '24.88');
+DefMacro('\vpt',     '\edef\f@size{\@vpt}\rm');
+DefMacro('\vipt',    '\edef\f@size{\@vipt}\rm');
+DefMacro('\viipt',   '\edef\f@size{\@viipt}\rm');
+DefMacro('\viiipt',  '\edef\f@size{\@viiipt}\rm');
+DefMacro('\ixpt',    '\edef\f@size{\@ixpt}\rm');
+DefMacro('\xpt',     '\edef\f@size{\@xpt}\rm');
+DefMacro('\xipt',    '\edef\f@size{\@xipt}\rm');
+DefMacro('\xiipt',   '\edef\f@size{\@xiipt}\rm');
+DefMacro('\xivpt',   '\edef\f@size{\@xivpt}\rm');
+DefMacro('\xviipt',  '\edef\f@size{\@xviipt}\rm');
+DefMacro('\xxpt',    '\edef\f@size{\@xxpt}\rm');
+DefMacro('\xxvpt',   '\edef\f@size{\@xxvpt}\rm');
+
 DefMacroI('\defaultscriptratio',       undef, '.7');
 DefMacroI('\defaultscriptscriptratio', undef, '.5');
 

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2880,6 +2880,7 @@ Tag('ltx:para', afterOpen => sub { GenerateID(@_, 'p'); });
 DefPrimitive('\newcounter{}[]', sub {
     NewCounter(ToString(Expand($_[1])), $_[2] && ToString(Expand($_[2])));
     return; });
+Let(T_CS('\@definecounter'), T_CS('\newcounter'));
 DefPrimitive('\setcounter{}{Number}',   sub { SetCounter(ToString(Expand($_[1])), $_[2]); });
 DefPrimitive('\addtocounter{}{Number}', sub { AddToCounter(ToString(Expand($_[1])), $_[2]); });
 DefPrimitive('\stepcounter{}',          sub { StepCounter(ToString(Expand($_[1])));    return; });
@@ -3522,6 +3523,9 @@ sub beforeDigestBibliography {
   AssignValue(inPreamble => 0); Digest('\@lx@inbibliographytrue');
   DefMacro('\bibliographystyle{}', '');
   DefMacro('\bibliography {}',     '');
+  DefConstructorI('\endthebibliography', undef,
+    "</ltx:biblist></ltx:bibliography>",
+    locked => 1);
   ResetCounter('@bibitem');
   return; }
 


### PR DESCRIPTION
Looking at the [error:unexpected](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/unexpected?all=false) report, I was surprised to see 1.18% of tasks sharing an error about an unexpected `\endlx@list` macro.

Debugging two articles:

1. In the first, [astro-ph/0001014](https://arxiv.org/abs/astro-ph/0001014), I noticed that the issue comes from redefining the bibliography macros in the custom local `.sty` file. We are successfully locking those when the new definition is done via `\def`, but for the ending macro the switch is done via `\let`:
    ```tex
    \let\endthebibliography=\endlist
    ```

   And locking macros against `\let`s isn't a viable strategy. However, I noticed we always execute a sub `beforeDigestBibliography` when `\thebibliography` is invoked, and it appears quite safe to simply redefine the constructor for `\endthebibliography` right then and there. Which I did, and reached a successful fix.

   A secondary issue was adding the internal macro behind `\newcounter`, namely `\@definecounter`, so that it is available for use in the local `.sty` files. Which is easy since the former is just the latter with an added check that the CS is definable.

2. In the second paper I checked, [cond-mat/0001346](https://arxiv.org/abs/cond-mat/0001346), there is the exact same issue with the bibliography ending, so there is hope this fix can help a large number of articles. 

   Here I also noticed the seemingly harmless use of the LaTeX low-level macros for storing pt sizes for fonts. These ought to be a recent introduction to the arXiv reports, as they are encountered in the local `.sty` files we are now interpreting raw from the paper's root directory. So I added them in, and the article converted nicely. I don't believe there should be any major side-effects, and hopefully it helps other articles avoid errors.

   So, these could be easy wins in arXiv, and easy merges to latexml!