### PR TITLE
[arXiv patches] Allow semiverbatim in \figcaption filenames

### DIFF
--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -304,8 +304,9 @@ DefMacro('\plotfiddle Semiverbatim {}{}{}{}{}{}',
 # For figures added externally; Used at end of file.
 # \figcaption[filename]{text\label{key}}
 # But sometimes used just like \caption!
-DefMacro('\@figcaption OptionalSemiverbatim {}', '\begin{figure}[#1]#2\end{figure}');
-DefMacro('\figcaption', sub {
+DefMacro('\@figcaption {}', '\begin{figure}#1\end{figure}');
+# Note that the optional [filename] seems unused, so we just read and drop it.
+DefMacro('\figcaption OptionalSemiverbatim', sub {
     (((LookupValue('current_environment') || '') =~ 'figure')
       ? T_CS('\caption') : T_CS('\@figcaption')); });
 


### PR DESCRIPTION
A number of documents in the 1.77% [error:unexpected:_](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/unexpected/%5F?all=false) report seem to be due to underscores in captions, in particular at the filename optional argument, e.g. in [astro-ph/0001049](https://arxiv.org/abs/astro-ph/0001049):

```tex
\figcaption[dev_join.eps]{The equivalent number of Gaussian standard...}
```

It turns out this is handled correctly as semiverbatim in the aas_support binding with:
```perl
DefMacro('\@figcaption OptionalSemiverbatim {}', ...
```

but in the cases where the macro is used inside a `{figure}`, it gets redirected to the main LaTeX.pool `\caption` macro. And there the expected optional argument was plain, rather than semiverbatim. Changing that gets the article in question to succeed with `no problems`, so another one in the books.