### PR TITLE
[arXiv patches] only need to expand in \newenvironment

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2677,7 +2677,7 @@ DefMacroI('\TH', undef, '\lx@utf@TH');
 
 DefPrimitive('\newenvironment OptionalMatch:* {}[Number][]{}{}', sub {
     my ($stomach, $star, $name, $nargs, $opt, $begin, $end) = @_;
-    $name = ToString(Digest($name));
+    $name = ToString(Expand($name));
     if (IsDefined(T_CS("\\$name"))) {
       Info('ignore', $name, $stomach,
         "Ignoring redefinition (\\newenvironment) of Environment '$name'")
@@ -2689,7 +2689,7 @@ DefPrimitive('\newenvironment OptionalMatch:* {}[Number][]{}{}', sub {
 
 DefPrimitive('\renewenvironment OptionalMatch:* {}[Number][]{}{}', sub {
     my ($stomach, $star, $name, $nargs, $opt, $begin, $end) = @_;
-    $name = ToString(Digest($name));
+    $name = ToString(Expand($name));
     DefMacroI(T_CS("\\$name"),    convertLaTeXArgs($nargs, $opt), $begin);
     DefMacroI(T_CS("\\end$name"), undef,                          $end); });
 


### PR DESCRIPTION
Another underscore error, [in this paper](https://arxiv.org/abs/cs/0208043), was wrongfully illegal in:
```tex
\newenvironment{theorem_cite}[1]
```

Turns out this is perfectly workable in the native TeX, due to `\csname` and `\endcsname` wrapping the `theorem_cite`. LaTeXML was doing a bit too much here, all the way to digesting, rather than simply expanding. So I switched to that and the paper seems to succeed well with the theorems looking good. latexml tests pass in a breeze. Should be an easy merge.