### PR TITLE
Itemization ids

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -809,7 +809,8 @@ sub RefStepID {
 
 sub ResetCounter {
   my ($ctr) = @_;
-  AssignValue('\c@' . $ctr => Number(0), 'global');
+  AssignValue('\c@' . $ctr   => Number(0), 'global');
+  AssignValue('\c@UN' . $ctr => Number(0), 'global');    # ?????
   DefMacroI(T_CS("\\\@$ctr\@ID"), undef, Tokens(Explode(LookupValue('\c@' . $ctr)->valueOf)),
     scope => 'global');
   # and reset any within counters!

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1299,30 +1299,71 @@ DefMacro('\@itemlabel', '');         # Maybe needs to be same as \item will be u
 # by determining the right counter (level)
 # and binding the right \item ( \$type@item, if $type is defined)
 sub beginItemize {
-  my ($type, $counter, $nolevel) = @_;
+  my ($type, $counter, %options) = @_;
+  # The list-type and level of the *containing* list (if any!)
+  my $outercounter = LookupValue('itemcounter');
+  my $outerlevel   = $outercounter && (LookupValue($outercounter . 'level') || 0);
   $counter = '@item' unless $counter;
-  my $level = (LookupValue($counter . 'level') || 0) + 1;
+  my $listlevel = (LookupValue('itemization_level') || 0) + 1;    # level for this list overall
+  my $level     = (LookupValue($counter . 'level')  || 0) + 1;    # level for lists of specific type
   AssignRegister('\itemsep' => LookupDimension('\lx@default@itemsep'));
-  AssignValue($counter . 'level' => $level);
-  AssignValue(itemization_items  => 0);
-  my $postfix    = ToString(Tokens(roman($level)));
-  my $usecounter = ($nolevel ? $counter : $counter . $postfix);
+  AssignValue('itemization_level' => $listlevel);
+  AssignValue($counter . 'level'  => $level);
+  AssignValue(itemization_items   => 0);
+  my $listpostfix = ToString(Tokens(roman($listlevel)));
+  my $postfix     = ToString(Tokens(roman($level)));
+  my $usecounter  = ($options{nolevel} ? $counter : $counter . $postfix);
   Let('\item' => "\\" . $type . '@item') if defined $type;
-  Let('\par', '\normal@par');    # In case within odd environment.
+  Let('\par', '\normal@par');                                     # In case within odd environment.
   DefMacroI('\@listctr', undef, Tokens(Explode($usecounter)));
+  # Now arrange that this list's id's are relative to the current (outer) item (if any)
+  # And that the items within this list's id's are relative to this (new) list.
 ##  if(! LookupDefinition(T_CS('\@listcontext'))){
 ##    Let(T_CS('\@listcontext'), T_CS('\@currentlabel')); }
   AssignValue(itemcounter => $usecounter);
-  ResetCounter($usecounter);
-  return RefStepCounter('@itemize' . $postfix); }
+  my $listcounter = '@itemize' . $listpostfix;
+  if (!LookupValue('\c@' . $listcounter)) {    # Create new list counters as needed
+    NewCounter($listcounter); }                #,  $outercounter.ToString(Tokens(roman($outerlevel))),
+  if ($outercounter) {                         # Make this list's ID relative to outer list's ID
+    my $outerusecounter = $outercounter . ToString(Tokens(roman($outerlevel)));
+    DefMacroI('\the' . $listcounter . '@ID', undef,
+      '\the' . $outerusecounter . '@ID.I' . '\arabic{' . $listcounter . '}');
+    # AND reset this list's counter when the outer item is stepped
+    my $x;
+    AssignValue("\\cl\@$outerusecounter" =>
+        Tokens(T_CS($listcounter), (($x = LookupValue('\cl@' . $outerusecounter)) ? $x->unlist : ())),
+      'global');
+  }
+  # format the id of \item's relative to the id of this list
+  DefMacroI('\the' . $usecounter . '@ID', undef, '\the' . $listcounter . '@ID.i' . '\@' . $usecounter . '@ID');
 
-# These counters are only used for id's of the various itemize, enumerate, etc elements
-NewCounter('@itemizei',   'section',     idprefix => 'I');
-NewCounter('@itemizeii',  '@itemizei',   idprefix => 'I');
-NewCounter('@itemizeiii', '@itemizeii',  idprefix => 'I');
-NewCounter('@itemizeiv',  '@itemizeiii', idprefix => 'I');
-NewCounter('@itemizev',   '@itemizeiv',  idprefix => 'I');
-NewCounter('@itemizevi',  '@itemizev',   idprefix => 'I');
+  my $series;
+  if ($series = $options{series}) {
+    $series = ToString($series); }
+  if (my $start = $options{start}) {
+    SetCounter($usecounter, $start);
+    AddToCounter($usecounter, Number(-1)); }
+  elsif (my $s = $options{resume} || $options{'resume*'}) {
+    if (($s = ToString($s)) ne 'noseries') {
+      $series = ToString($s);
+      SetCounter($usecounter,
+        LookupValue('enumitem_series_' . $series . '_last') || Number(0)); } }
+  else {
+    ResetCounter($usecounter); }
+
+##  return RefStepCounter('@itemize' . $listpostfix); }
+  return (RefStepCounter('@itemize' . $listpostfix),
+    counter => $usecounter, series => $series); }    # So end can save counter value
+
+# These counters are ONLY used for id's of ALL the various itemize, enumerate, etc elements
+# Only create the 1st level (so that binding style can start numbering 'within' appropriately)
+# Additional ones created by need.
+NewCounter('@itemizei', 'section', idprefix => 'I');
+##NewCounter('@itemizeii',  '@itemizei',   idprefix => 'I');
+##NewCounter('@itemizeiii', '@itemizeii',  idprefix => 'I');
+##NewCounter('@itemizeiv',  '@itemizeiii', idprefix => 'I');
+##NewCounter('@itemizev',   '@itemizeiv',  idprefix => 'I');
+##NewCounter('@itemizevi',  '@itemizev',   idprefix => 'I');
 
 # Create id, and tags for an itemize type \item
 sub RefStepItemCounter {
@@ -1589,7 +1630,7 @@ DefMacro('\@listctr', '');
 DefPrimitive('\usecounter{}', sub {
     my ($stomach, $counter) = @_;
     $counter = ToString(Expand($counter));
-    beginItemize('list', $counter, ($counter ? 1 : 0));
+    beginItemize('list', $counter, ($counter ? (nolevel => 1) : ()));
     return; });
 
 DefMacro('\list{}{}',

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1359,11 +1359,6 @@ sub beginItemize {
 # Only create the 1st level (so that binding style can start numbering 'within' appropriately)
 # Additional ones created by need.
 NewCounter('@itemizei', 'section', idprefix => 'I');
-##NewCounter('@itemizeii',  '@itemizei',   idprefix => 'I');
-##NewCounter('@itemizeiii', '@itemizeii',  idprefix => 'I');
-##NewCounter('@itemizeiv',  '@itemizeiii', idprefix => 'I');
-##NewCounter('@itemizev',   '@itemizeiv',  idprefix => 'I');
-##NewCounter('@itemizevi',  '@itemizev',   idprefix => 'I');
 
 # Create id, and tags for an itemize type \item
 sub RefStepItemCounter {

--- a/lib/LaTeXML/Package/enumitem.sty.ltxml
+++ b/lib/LaTeXML/Package/enumitem.sty.ltxml
@@ -75,38 +75,16 @@ DefKeyVal('enumitem', 'after',  'UndigestedKey');    # TODO ?
 # \EnumitemId
 # \SetEnumerateShortLabel{key}{replacement}
 
-# Duplicate LaTeX's beginItemize, with modifications...
+# Extends LaTeX's beginItemize, with modifications...
 sub beginEnumItemize {
-  my ($type, $counter, $nolevel, $keys) = @_;
+  my ($type, $counter, $keys) = @_;
   $counter = '@item' unless $counter;
-  my $level = (LookupValue($counter . 'level') || 0) + 1;
-  AssignRegister('\itemsep' => LookupDimension('\lx@default@itemsep'));
-  AssignValue($counter . 'level' => $level);
-  AssignValue(itemization_items  => 0);
+  my $level      = (LookupValue($counter . 'level') || 0) + 1;
+  my $hash       = merged_enumitem_keyvals($type, $level, $keys);
   my $postfix    = ToString(Tokens(roman($level)));
-  my $usecounter = ($nolevel ? $counter : $counter . $postfix);
-  Let('\item' => "\\" . $type . '@item') if defined $type;
-  Let('\par', '\normal@par');    # In case within odd environment.
-  DefMacroI('\@listctr', undef, Tokens(Explode($usecounter)));
-  AssignValue(itemcounter => $usecounter);
+  my $usecounter = $counter . $postfix;
 
-  my $hash = merged_enumitem_keyvals($type, $level, $keys);
-  # Deal with counters, series, etc
-  my $series;
-  if ($series = $$hash{series}) {
-    $series = ToString($series); }
-  if (my $start = $$hash{start}) {
-    SetCounter($usecounter, $start);
-    AddToCounter($usecounter, Number(-1)); }
-  elsif (my $s = $$hash{resume} || $$hash{'resume*'}) {
-    if (($s = ToString($s)) ne 'noseries') {
-      $series = ToString($s);
-      SetCounter($usecounter,
-        LookupValue('enumitem_series_' . $series . '_last') || Number(0)); } }
-  else {
-    ResetCounter($usecounter); }
-
-  # Deal with label formatting
+  # Deal with label formatting [Seems this could be cleaned up & standardized a bit more]
   my ($firstkey, $firstvalue) = $keys && $keys->getPairs;
   if ($firstkey && !$firstvalue    # 1st key has no value
     && LookupValue('enumitem@shortlabels')                        # and shortlabels enabled
@@ -118,16 +96,16 @@ sub beginEnumItemize {
       $llabel = Tokens(T_CS('\label' . $counter . ToString(Tokens(roman($level - 1)))), $llabel); }
     DefMacroI('\the' . $usecounter,   undef, $llabel);
     DefMacroI('\label' . $usecounter, undef, $llabel);
-    DefMacroI('\fnum@' . $usecounter, undef,
-      '{\makelabel{\fnum@font@' . $usecounter . '\label' . $usecounter . '}}'); }
+###    DefMacroI('\fnum@' . $usecounter, undef,
+###      '{\makelabel{\fnum@font@' . $usecounter . '\label' . $usecounter . '}}');
+  }
   if (my $label = $$hash{ref}) {
     my $llabel = replace_star($label, T_OTHER($usecounter));
     DefMacroI('\the' . $usecounter, undef, $llabel); }
   if (my $font = $$hash{font} || $$hash{format}) {
     DefMacroI('\fnum@font@' . $usecounter, undef, $font); }
 
-  return (RefStepCounter('@itemize' . $postfix),
-    counter => $usecounter, series => $series); }    # So end can save counter value
+  return beginItemize($type, $counter, %$hash); }
 
 sub replace_star {
   my ($tokens, $replacement) = @_;
@@ -165,21 +143,21 @@ DefMacro('\restartlist{}', sub {
 if (!LookupValue('enumitem@loadonly')) {
   DefEnvironment('{itemize} OptionalKeyVals:enumitem',
     "<ltx:itemize xml:id='#id'>#body</ltx:itemize>",
-    properties      => sub { beginEnumItemize('itemize', '@item', 0, $_[1]); },
+    properties      => sub { beginEnumItemize('itemize', '@item', $_[1]); },
     beforeDigestEnd => sub { Digest('\par'); },
     afterDigestBody => sub { endEnumItemize($_[1]); },
-    locked => 1, mode => 'text');
+    locked          => 1, mode => 'text');
 
   DefEnvironment('{enumerate} OptionalKeyVals:enumitem',
     "<ltx:enumerate  xml:id='#id'>#body</ltx:enumerate>",
-    properties      => sub { beginEnumItemize('enumerate', 'enum', 0, $_[1]); },
+    properties      => sub { beginEnumItemize('enumerate', 'enum', $_[1]); },
     beforeDigestEnd => sub { Digest('\par'); },
     afterDigestBody => sub { endEnumItemize($_[1]); },
-    locked => 1, mode => 'text');
+    locked          => 1, mode => 'text');
   DefEnvironment('{description} OptionalKeyVals:enumitem',
     "<ltx:description  xml:id='#id'>#body</ltx:description>",
     beforeDigest    => sub { Let('\makelabel', '\descriptionlabel'); },
-    properties      => sub { beginEnumItemize('description', '@desc', 0, $_[1]); },
+    properties      => sub { beginEnumItemize('description', '@desc', $_[1]); },
     beforeDigestEnd => sub { Digest('\par'); },
     afterDigestBody => sub { endEnumItemize($_[1]); },
     locked          => 1, mode => 'text');
@@ -187,15 +165,15 @@ if (!LookupValue('enumitem@loadonly')) {
 if (LookupValue('enumitem@inline')) {
   DefEnvironment('{itemize*} OptionalKeyVals:enumitem',
     "<ltx:inline-itemize xml:id='#id'>#body</ltx:inline-itemize>",
-    properties      => sub { beginEnumItemize('inline@itemize', '@item', 0, $_[1]); },
+    properties      => sub { beginEnumItemize('inline@itemize', '@item', $_[1]); },
     afterDigestBody => sub { endEnumItemize($_[1]); },);
   DefEnvironment('{enumerate*} OptionalKeyVals:enumitem',
     "<ltx:inline-enumerate xml:id='#id'>#body</ltx:inline-enumerate>",
-    properties      => sub { beginEnumItemize('inline@enumerate', 'enum', 0, $_[1]); },
+    properties      => sub { beginEnumItemize('inline@enumerate', 'enum', $_[1]); },
     afterDigestBody => sub { endEnumItemize($_[1]); },);
   DefEnvironment('{description*} OptionalKeyVals:enumitem',
     "<ltx:inline-description xml:id='#id'>#body</ltx:inline-description>",
-    properties      => sub { beginEnumItemize('inline@description', '@desc', 0, $_[1]); },
+    properties      => sub { beginEnumItemize('inline@description', '@desc', $_[1]); },
     afterDigestBody => sub { endEnumItemize($_[1]); },);
 }
 DefPrimitive('\newlist{}{}{}', sub {
@@ -215,10 +193,10 @@ DefPrimitive('\newlist{}{}{}', sub {
       'global');
     DefEnvironment("{$listname} OptionalKeyVals:enumitem",
       "<ltx:$elementname xml:id='#id'>#body</ltx:$elementname>",
-      properties      => sub { beginEnumItemize($listname, $listname, 0, $_[1]); },
+      properties      => sub { beginEnumItemize($listname, $listname, $_[1]); },
       beforeDigestEnd => sub { Digest('\par'); },
       afterDigestBody => sub { endEnumItemize($_[1]); },
-      locked => 1, mode => 'text');
+      locked          => 1, mode => 'text');
     return; });
 Let('\renewlist', '\newlist');
 

--- a/lib/LaTeXML/Package/slides.cls.ltxml
+++ b/lib/LaTeXML/Package/slides.cls.ltxml
@@ -84,10 +84,10 @@ DefPrimitive('\showfont', sub {
     print STDERR "\nFONT IS: " . Stringify($font) . "\n";
     return; });
 
-RequirePackage('color');                                                # ?
+RequirePackage('color');           # ?
 # \@color, \@colorlist, \last@color,
 DefMacro('\blackandwhite', '');
-DefMacro('\colors{}',      '');                                         # ?
+DefMacro('\colors{}',      '');    # ?
 DefMacro('\colorslides{}', '');
 
 DefMacroI('\setupcounters', undef, '');
@@ -102,7 +102,7 @@ DefMacroI('\ps@slide',    undef, '');
 #**********************************************************************
 # The core sectioning commands are defined in LaTeX.pm
 # but the counter setup, etc, depends on article
-NewCounter('slide', 'document', idprefix => 's', nested => ['overlay']);
+NewCounter('slide',   'document', idprefix => 's', nested => ['overlay']);
 NewCounter('overlay', 'slide',    idprefix => 'o');
 NewCounter('note',    'document', idprefix => 'n');
 
@@ -113,12 +113,7 @@ DefMacro('\theoverlay', '\theslide.\arabic{overlay}');
 NewCounter('equation', 'document', idprefix => 'E');
 DefMacro('\theequation', '\arabic{equation}');
 
-NewCounter('@itemizei',   'document',    idprefix => 'I');
-NewCounter('@itemizeii',  '@itemizei',   idprefix => 'I');
-NewCounter('@itemizeiii', '@itemizeii',  idprefix => 'I');
-NewCounter('@itemizeiv',  '@itemizeiii', idprefix => 'I');
-NewCounter('@itemizev',   '@itemizeiv',  idprefix => 'I');
-NewCounter('@itemizevi',  '@itemizev',   idprefix => 'I');
+NewCounter('@itemizei', 'document', idprefix => 'I');
 
 NewCounter('enumi',   '@itemizei',   idprefix => 'i');
 NewCounter('enumii',  '@itemizeii',  idprefix => 'i');

--- a/t/ams/amsdisplay.xml
+++ b/t/ams/amsdisplay.xml
@@ -913,8 +913,8 @@
           </XMath>
         </Math>
       </equation>
-      <equation xml:id="S0.E15.x2">
-        <Math mode="display" tex="N=15a" text="N = 15 * a" xml:id="S0.E15.x2.m1">
+      <equation xml:id="S0.E15.x1">
+        <Math mode="display" tex="N=15a" text="N = 15 * a" xml:id="S0.E15.x1.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -928,8 +928,8 @@
           </XMath>
         </Math>
       </equation>
-      <equation xml:id="S0.E15.x3">
-        <Math mode="display" tex="N=15b" text="N = 15 * b" xml:id="S0.E15.x3.m1">
+      <equation xml:id="S0.E15.x2">
+        <Math mode="display" tex="N=15b" text="N = 15 * b" xml:id="S0.E15.x2.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -943,16 +943,16 @@
           </XMath>
         </Math>
       </equation>
-      <equation xml:id="S0.E15.x4">
+      <equation xml:id="S0.E15.x3">
         <tags>
-          <tag>(15a<Math mode="inline" tex="{}^{\prime}" text="^prime" xml:id="S0.E15.x4.m1">
+          <tag>(15a<Math mode="inline" tex="{}^{\prime}" text="^prime" xml:id="S0.E15.x3.m1">
               <XMath>
                 <XMApp role="FLOATSUPERSCRIPT" scriptpos="1">
                   <XMTok fontsize="70%" name="prime" role="SUPOP">′</XMTok>
                 </XMApp>
               </XMath>
             </Math>)</tag>
-          <tag role="refnum">15a<Math mode="inline" tex="{}^{\prime}" text="^prime" xml:id="S0.E15.x4.m2">
+          <tag role="refnum">15a<Math mode="inline" tex="{}^{\prime}" text="^prime" xml:id="S0.E15.x3.m2">
               <XMath>
                 <XMApp role="FLOATSUPERSCRIPT" scriptpos="1">
                   <XMTok fontsize="70%" name="prime" role="SUPOP">′</XMTok>
@@ -960,7 +960,7 @@
               </XMath>
             </Math></tag>
         </tags>
-        <Math mode="display" tex="N=15a" text="N = 15 * a" xml:id="S0.E15.x4.m3">
+        <Math mode="display" tex="N=15a" text="N = 15 * a" xml:id="S0.E15.x3.m3">
           <XMath>
             <XMApp>
               <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -974,16 +974,16 @@
           </XMath>
         </Math>
       </equation>
-      <equation xml:id="S0.E15.x5">
+      <equation xml:id="S0.E15.x4">
         <tags>
-          <tag>(15a<Math mode="inline" tex="{}^{\prime\prime}" text="^prime2" xml:id="S0.E15.x5.m1">
+          <tag>(15a<Math mode="inline" tex="{}^{\prime\prime}" text="^prime2" xml:id="S0.E15.x4.m1">
               <XMath>
                 <XMApp role="FLOATSUPERSCRIPT" scriptpos="1">
                   <XMTok fontsize="70%" name="prime2" role="SUPOP">′′</XMTok>
                 </XMApp>
               </XMath>
             </Math>)</tag>
-          <tag role="refnum">15a<Math mode="inline" tex="{}^{\prime\prime}" text="^prime2" xml:id="S0.E15.x5.m2">
+          <tag role="refnum">15a<Math mode="inline" tex="{}^{\prime\prime}" text="^prime2" xml:id="S0.E15.x4.m2">
               <XMath>
                 <XMApp role="FLOATSUPERSCRIPT" scriptpos="1">
                   <XMTok fontsize="70%" name="prime2" role="SUPOP">′′</XMTok>
@@ -991,7 +991,7 @@
               </XMath>
             </Math></tag>
         </tags>
-        <Math mode="display" tex="N=15b" text="N = 15 * b" xml:id="S0.E15.x5.m3">
+        <Math mode="display" tex="N=15b" text="N = 15 * b" xml:id="S0.E15.x4.m3">
           <XMath>
             <XMApp>
               <XMTok meaning="equals" role="RELOP">=</XMTok>

--- a/t/daemon/formats/jats.xml
+++ b/t/daemon/formats/jats.xml
@@ -118,12 +118,12 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           <list-item id="S1.I1.i2">
             <p id="S1.I1.i2.p1">two</p>
             <p>
-              <list list-type="bullet" id="S1.I1.I1">
-                <list-item id="S1.I1.i2.i1">
-                  <p id="S1.I1.i2.i1.p1">one</p>
+              <list list-type="bullet" id="S1.I1.i2.I1">
+                <list-item id="S1.I1.i2.I1.i1">
+                  <p id="S1.I1.i2.I1.i1.p1">one</p>
                 </list-item>
-                <list-item id="S1.I1.i2.i2">
-                  <p id="S1.I1.i2.i2.p1">two</p>
+                <list-item id="S1.I1.i2.I1.i2">
+                  <p id="S1.I1.i2.I1.i2.p1">two</p>
                 </list-item>
               </list>
             </p>
@@ -138,12 +138,12 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           <list-item id="S1.I2.i2">
             <p id="S1.I2.i2.p1">two</p>
             <p>
-              <list list-type="order" id="S1.I2.I1">
-                <list-item id="S1.I2.i2.i1">
-                  <p id="S1.I2.i2.i1.p1">one</p>
+              <list list-type="order" id="S1.I2.i2.I2">
+                <list-item id="S1.I2.i2.I2.i1">
+                  <p id="S1.I2.i2.I2.i1.p1">one</p>
                 </list-item>
-                <list-item id="S1.I2.i2.i2">
-                  <p id="S1.I2.i2.i2.p1">two</p>
+                <list-item id="S1.I2.i2.I2.i2">
+                  <p id="S1.I2.i2.I2.i2.p1">two</p>
                 </list-item>
               </list>
             </p>

--- a/t/daemon/formats/tei.xml
+++ b/t/daemon/formats/tei.xml
@@ -176,13 +176,13 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
                     <!-- The element tags
             is currently not supported for the main body.
         -->
-                    <p xml:id="S1.I1.i2.i1.p1">one</p>
+                    <p xml:id="S1.I1.i2.I1.i1.p1">one</p>
                   </item>
                   <item>
                     <!-- The element tags
             is currently not supported for the main body.
         -->
-                    <p xml:id="S1.I1.i2.i2.p1">two</p>
+                    <p xml:id="S1.I1.i2.I1.i2.p1">two</p>
                   </item>
                 </list>
               </p>
@@ -208,13 +208,13 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
                     <!-- The element tags
             is currently not supported for the main body.
         -->
-                    <p xml:id="S1.I2.i2.i1.p1">one</p>
+                    <p xml:id="S1.I2.i2.I2.i1.p1">one</p>
                   </item>
                   <item>
                     <!-- The element tags
             is currently not supported for the main body.
         -->
-                    <p xml:id="S1.I2.i2.i2.p1">two</p>
+                    <p xml:id="S1.I2.i2.I2.i2.p1">two</p>
                   </item>
                 </list>
               </p>

--- a/t/fonts/ding.xml
+++ b/t/fonts/ding.xml
@@ -87,34 +87,34 @@
             <tag role="typerefnum">item 1</tag>
           </tags>
           <para xml:id="S1.I3.i1.p1">
-            <enumerate xml:id="S1.I3.I1">
-              <item labels="LABEL:lst:1a" xml:id="S1.I3.i1.i1">
+            <enumerate xml:id="S1.I3.i1.I1">
+              <item labels="LABEL:lst:1a" xml:id="S1.I3.i1.I1.i1">
                 <tags>
                   <tag>➀</tag>
                   <tag role="refnum">➀</tag>
                   <tag role="typerefnum">item ➀</tag>
                 </tags>
-                <para xml:id="S1.I3.i1.i1.p1">
+                <para xml:id="S1.I3.i1.I1.i1.p1">
                   <p>first</p>
                 </para>
               </item>
-              <item labels="LABEL:lst:1b" xml:id="S1.I3.i1.i2">
+              <item labels="LABEL:lst:1b" xml:id="S1.I3.i1.I1.i2">
                 <tags>
                   <tag>➁</tag>
                   <tag role="refnum">➁</tag>
                   <tag role="typerefnum">item ➁</tag>
                 </tags>
-                <para xml:id="S1.I3.i1.i2.p1">
+                <para xml:id="S1.I3.i1.I1.i2.p1">
                   <p>second</p>
                 </para>
               </item>
-              <item labels="LABEL:lst:1c" xml:id="S1.I3.i1.i3">
+              <item labels="LABEL:lst:1c" xml:id="S1.I3.i1.I1.i3">
                 <tags>
                   <tag>➂</tag>
                   <tag role="refnum">➂</tag>
                   <tag role="typerefnum">item ➂</tag>
                 </tags>
-                <para xml:id="S1.I3.i1.i3.p1">
+                <para xml:id="S1.I3.i1.I1.i3.p1">
                   <p>third</p>
                 </para>
               </item>
@@ -128,34 +128,34 @@
             <tag role="typerefnum">item 2</tag>
           </tags>
           <para xml:id="S1.I3.i2.p1">
-            <enumerate xml:id="S1.I3.I2">
-              <item labels="LABEL:lst:2a" xml:id="S1.I3.i2.i1">
+            <enumerate xml:id="S1.I3.i2.I1">
+              <item labels="LABEL:lst:2a" xml:id="S1.I3.i2.I1.i1">
                 <tags>
                   <tag>❶</tag>
                   <tag role="refnum">❶</tag>
                   <tag role="typerefnum">item ❶</tag>
                 </tags>
-                <para xml:id="S1.I3.i2.i1.p1">
+                <para xml:id="S1.I3.i2.I1.i1.p1">
                   <p>first</p>
                 </para>
               </item>
-              <item labels="LABEL:lst:2b" xml:id="S1.I3.i2.i2">
+              <item labels="LABEL:lst:2b" xml:id="S1.I3.i2.I1.i2">
                 <tags>
                   <tag>❷</tag>
                   <tag role="refnum">❷</tag>
                   <tag role="typerefnum">item ❷</tag>
                 </tags>
-                <para xml:id="S1.I3.i2.i2.p1">
+                <para xml:id="S1.I3.i2.I1.i2.p1">
                   <p>second</p>
                 </para>
               </item>
-              <item labels="LABEL:lst:2c" xml:id="S1.I3.i2.i3">
+              <item labels="LABEL:lst:2c" xml:id="S1.I3.i2.I1.i3">
                 <tags>
                   <tag>❸</tag>
                   <tag role="refnum">❸</tag>
                   <tag role="typerefnum">item ❸</tag>
                 </tags>
-                <para xml:id="S1.I3.i2.i3.p1">
+                <para xml:id="S1.I3.i2.I1.i3.p1">
                   <p>third</p>
                 </para>
               </item>

--- a/t/structure/amsarticle.xml
+++ b/t/structure/amsarticle.xml
@@ -169,22 +169,22 @@
           </tags>
           <para xml:id="S1.I1.i2.p1">
             <p>two</p>
-            <itemize xml:id="S1.I1.I1">
-              <item xml:id="S1.I1.i2.i1">
+            <itemize xml:id="S1.I1.i2.I1">
+              <item xml:id="S1.I1.i2.I1.i1">
                 <tags>
                   <tag><text font="bold">–</text></tag>
                   <tag role="typerefnum">1st item</tag>
                 </tags>
-                <para xml:id="S1.I1.i2.i1.p1">
+                <para xml:id="S1.I1.i2.I1.i1.p1">
                   <p>one</p>
                 </para>
               </item>
-              <item xml:id="S1.I1.i2.i2">
+              <item xml:id="S1.I1.i2.I1.i2">
                 <tags>
                   <tag><text font="bold">–</text></tag>
                   <tag role="typerefnum">2nd item</tag>
                 </tags>
-                <para xml:id="S1.I1.i2.i2.p1">
+                <para xml:id="S1.I1.i2.I1.i2.p1">
                   <p>two</p>
                 </para>
               </item>
@@ -213,24 +213,24 @@
           </tags>
           <para xml:id="S1.I2.i2.p1">
             <p>two</p>
-            <enumerate xml:id="S1.I2.I1">
-              <item xml:id="S1.I2.i2.i1">
+            <enumerate xml:id="S1.I2.i2.I2">
+              <item xml:id="S1.I2.i2.I2.i1">
                 <tags>
                   <tag>(a)</tag>
                   <tag role="refnum">2a</tag>
                   <tag role="typerefnum">item 2a</tag>
                 </tags>
-                <para xml:id="S1.I2.i2.i1.p1">
+                <para xml:id="S1.I2.i2.I2.i1.p1">
                   <p>one</p>
                 </para>
               </item>
-              <item xml:id="S1.I2.i2.i2">
+              <item xml:id="S1.I2.i2.I2.i2">
                 <tags>
                   <tag>(b)</tag>
                   <tag role="refnum">2b</tag>
                   <tag role="typerefnum">item 2b</tag>
                 </tags>
-                <para xml:id="S1.I2.i2.i2.p1">
+                <para xml:id="S1.I2.i2.I2.i2.p1">
                   <p>two</p>
                 </para>
               </item>

--- a/t/structure/article.xml
+++ b/t/structure/article.xml
@@ -152,22 +152,22 @@
           </tags>
           <para xml:id="S1.I1.i2.p1">
             <p>two</p>
-            <itemize xml:id="S1.I1.I1">
-              <item xml:id="S1.I1.i2.i1">
+            <itemize xml:id="S1.I1.i2.I1">
+              <item xml:id="S1.I1.i2.I1.i1">
                 <tags>
                   <tag><text font="bold">–</text></tag>
                   <tag role="typerefnum">1st item</tag>
                 </tags>
-                <para xml:id="S1.I1.i2.i1.p1">
+                <para xml:id="S1.I1.i2.I1.i1.p1">
                   <p>one</p>
                 </para>
               </item>
-              <item xml:id="S1.I1.i2.i2">
+              <item xml:id="S1.I1.i2.I1.i2">
                 <tags>
                   <tag><text font="bold">–</text></tag>
                   <tag role="typerefnum">2nd item</tag>
                 </tags>
-                <para xml:id="S1.I1.i2.i2.p1">
+                <para xml:id="S1.I1.i2.I1.i2.p1">
                   <p>two</p>
                 </para>
               </item>
@@ -196,24 +196,24 @@
           </tags>
           <para xml:id="S1.I2.i2.p1">
             <p>two</p>
-            <enumerate xml:id="S1.I2.I1">
-              <item xml:id="S1.I2.i2.i1">
+            <enumerate xml:id="S1.I2.i2.I2">
+              <item xml:id="S1.I2.i2.I2.i1">
                 <tags>
                   <tag>(a)</tag>
                   <tag role="refnum">2a</tag>
                   <tag role="typerefnum">item 2a</tag>
                 </tags>
-                <para xml:id="S1.I2.i2.i1.p1">
+                <para xml:id="S1.I2.i2.I2.i1.p1">
                   <p>one</p>
                 </para>
               </item>
-              <item xml:id="S1.I2.i2.i2">
+              <item xml:id="S1.I2.i2.I2.i2">
                 <tags>
                   <tag>(b)</tag>
                   <tag role="refnum">2b</tag>
                   <tag role="typerefnum">item 2b</tag>
                 </tags>
-                <para xml:id="S1.I2.i2.i2.p1">
+                <para xml:id="S1.I2.i2.I2.i2.p1">
                   <p>two</p>
                 </para>
               </item>
@@ -440,24 +440,24 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           </tags>
           <para xml:id="S2.I1.i2.p1">
             <p>two</p>
-            <enumerate xml:id="S2.I1.I1">
-              <item xml:id="S2.I1.i2.i1">
+            <enumerate xml:id="S2.I1.i2.I1">
+              <item xml:id="S2.I1.i2.I1.i1">
                 <tags>
                   <tag>(a)</tag>
                   <tag role="refnum">2a</tag>
                   <tag role="typerefnum">item 2a</tag>
                 </tags>
-                <para xml:id="S2.I1.i2.i1.p1">
+                <para xml:id="S2.I1.i2.I1.i1.p1">
                   <p>one</p>
                 </para>
               </item>
-              <item xml:id="S2.I1.i2.i2">
+              <item xml:id="S2.I1.i2.I1.i2">
                 <tags>
                   <tag>(b)</tag>
                   <tag role="refnum">2b</tag>
                   <tag role="typerefnum">item 2b</tag>
                 </tags>
-                <para xml:id="S2.I1.i2.i2.p1">
+                <para xml:id="S2.I1.i2.I1.i2.p1">
                   <p>two</p>
                 </para>
               </item>

--- a/t/structure/book.xml
+++ b/t/structure/book.xml
@@ -172,22 +172,22 @@
             </tags>
             <para xml:id="Ch1.S1.I1.i2.p1">
               <p>two</p>
-              <itemize xml:id="Ch1.S1.I1.I1">
-                <item xml:id="Ch1.S1.I1.i2.i1">
+              <itemize xml:id="Ch1.S1.I1.i2.I1">
+                <item xml:id="Ch1.S1.I1.i2.I1.i1">
                   <tags>
                     <tag><text font="bold">–</text></tag>
                     <tag role="typerefnum">1st item</tag>
                   </tags>
-                  <para xml:id="Ch1.S1.I1.i2.i1.p1">
+                  <para xml:id="Ch1.S1.I1.i2.I1.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch1.S1.I1.i2.i2">
+                <item xml:id="Ch1.S1.I1.i2.I1.i2">
                   <tags>
                     <tag><text font="bold">–</text></tag>
                     <tag role="typerefnum">2nd item</tag>
                   </tags>
-                  <para xml:id="Ch1.S1.I1.i2.i2.p1">
+                  <para xml:id="Ch1.S1.I1.i2.I1.i2.p1">
                     <p>two</p>
                   </para>
                 </item>
@@ -216,24 +216,24 @@
             </tags>
             <para xml:id="Ch1.S1.I2.i2.p1">
               <p>two</p>
-              <enumerate xml:id="Ch1.S1.I2.I1">
-                <item xml:id="Ch1.S1.I2.i2.i1">
+              <enumerate xml:id="Ch1.S1.I2.i2.I2">
+                <item xml:id="Ch1.S1.I2.i2.I2.i1">
                   <tags>
                     <tag>(a)</tag>
                     <tag role="refnum">2a</tag>
                     <tag role="typerefnum">item 2a</tag>
                   </tags>
-                  <para xml:id="Ch1.S1.I2.i2.i1.p1">
+                  <para xml:id="Ch1.S1.I2.i2.I2.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch1.S1.I2.i2.i2">
+                <item xml:id="Ch1.S1.I2.i2.I2.i2">
                   <tags>
                     <tag>(b)</tag>
                     <tag role="refnum">2b</tag>
                     <tag role="typerefnum">item 2b</tag>
                   </tags>
-                  <para xml:id="Ch1.S1.I2.i2.i2.p1">
+                  <para xml:id="Ch1.S1.I2.i2.I2.i2.p1">
                     <p>two</p>
                   </para>
                 </item>
@@ -458,24 +458,24 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
             </tags>
             <para xml:id="Ch1.S2.I1.i2.p1">
               <p>two</p>
-              <enumerate xml:id="Ch1.S2.I1.I1">
-                <item xml:id="Ch1.S2.I1.i2.i1">
+              <enumerate xml:id="Ch1.S2.I1.i2.I1">
+                <item xml:id="Ch1.S2.I1.i2.I1.i1">
                   <tags>
                     <tag>(a)</tag>
                     <tag role="refnum">2a</tag>
                     <tag role="typerefnum">item 2a</tag>
                   </tags>
-                  <para xml:id="Ch1.S2.I1.i2.i1.p1">
+                  <para xml:id="Ch1.S2.I1.i2.I1.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch1.S2.I1.i2.i2">
+                <item xml:id="Ch1.S2.I1.i2.I1.i2">
                   <tags>
                     <tag>(b)</tag>
                     <tag role="refnum">2b</tag>
                     <tag role="typerefnum">item 2b</tag>
                   </tags>
-                  <para xml:id="Ch1.S2.I1.i2.i2.p1">
+                  <para xml:id="Ch1.S2.I1.i2.I1.i2.p1">
                     <p>two</p>
                   </para>
                 </item>
@@ -642,24 +642,24 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
             </tags>
             <para xml:id="Ch2.S1.I1.i2.p1">
               <p>two</p>
-              <enumerate xml:id="Ch2.S1.I1.I1">
-                <item xml:id="Ch2.S1.I1.i2.i1">
+              <enumerate xml:id="Ch2.S1.I1.i2.I1">
+                <item xml:id="Ch2.S1.I1.i2.I1.i1">
                   <tags>
                     <tag>(a)</tag>
                     <tag role="refnum">2a</tag>
                     <tag role="typerefnum">item 2a</tag>
                   </tags>
-                  <para xml:id="Ch2.S1.I1.i2.i1.p1">
+                  <para xml:id="Ch2.S1.I1.i2.I1.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch2.S1.I1.i2.i2">
+                <item xml:id="Ch2.S1.I1.i2.I1.i2">
                   <tags>
                     <tag>(b)</tag>
                     <tag role="refnum">2b</tag>
                     <tag role="typerefnum">item 2b</tag>
                   </tags>
-                  <para xml:id="Ch2.S1.I1.i2.i2.p1">
+                  <para xml:id="Ch2.S1.I1.i2.I1.i2.p1">
                     <p>two</p>
                   </para>
                 </item>
@@ -811,24 +811,24 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
             </tags>
             <para xml:id="Ch2.S2.I1.i2.p1">
               <p>two</p>
-              <enumerate xml:id="Ch2.S2.I1.I1">
-                <item xml:id="Ch2.S2.I1.i2.i1">
+              <enumerate xml:id="Ch2.S2.I1.i2.I1">
+                <item xml:id="Ch2.S2.I1.i2.I1.i1">
                   <tags>
                     <tag>(a)</tag>
                     <tag role="refnum">2a</tag>
                     <tag role="typerefnum">item 2a</tag>
                   </tags>
-                  <para xml:id="Ch2.S2.I1.i2.i1.p1">
+                  <para xml:id="Ch2.S2.I1.i2.I1.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch2.S2.I1.i2.i2">
+                <item xml:id="Ch2.S2.I1.i2.I1.i2">
                   <tags>
                     <tag>(b)</tag>
                     <tag role="refnum">2b</tag>
                     <tag role="typerefnum">item 2b</tag>
                   </tags>
-                  <para xml:id="Ch2.S2.I1.i2.i2.p1">
+                  <para xml:id="Ch2.S2.I1.i2.I1.i2.p1">
                     <p>two</p>
                   </para>
                 </item>

--- a/t/structure/enum.xml
+++ b/t/structure/enum.xml
@@ -188,41 +188,41 @@
     </para>
     <para xml:id="S2.p6">
       <enumerate xml:id="S2.I6">
-        <item xml:id="fontyi1">
+        <item xml:id="S2.I6.i1">
           <tags>
             <tag><text font="bold">1)</text></tag>
             <tag role="refnum">1)</tag>
           </tags>
-          <para xml:id="fontyi1.p1">
+          <para xml:id="S2.I6.i1.p1">
             <p>A</p>
           </para>
         </item>
-        <item xml:id="fontyi2">
+        <item xml:id="S2.I6.i2">
           <tags>
             <tag><text font="bold">2)</text></tag>
             <tag role="refnum">2)</tag>
           </tags>
-          <para xml:id="fontyi2.p1">
+          <para xml:id="S2.I6.i2.p1">
             <p>B</p>
           </para>
         </item>
       </enumerate>
       <enumerate xml:id="S2.I7">
-        <item xml:id="fontyi1a">
+        <item xml:id="S2.I7.i1">
           <tags>
             <tag><text font="bold">i]</text></tag>
             <tag role="refnum">i]</tag>
           </tags>
-          <para xml:id="fontyi1a.p1">
+          <para xml:id="S2.I7.i1.p1">
             <p>A</p>
           </para>
         </item>
-        <item xml:id="fontyi2a">
+        <item xml:id="S2.I7.i2">
           <tags>
             <tag><text font="bold">ii]</text></tag>
             <tag role="refnum">ii]</tag>
           </tags>
-          <para xml:id="fontyi2a.p1">
+          <para xml:id="S2.I7.i2.p1">
             <p>B</p>
           </para>
         </item>
@@ -365,14 +365,14 @@ And more.</p>
           </tags>
           <para xml:id="S5.I1.i12.p1">
             <p>Line one</p>
-            <enumerate xml:id="S5.I1.I1">
-              <item xml:id="S5.I1.i12.i7">
+            <enumerate xml:id="S5.I1.i12.I1">
+              <item xml:id="S5.I1.i12.I1.i7">
                 <tags>
                   <tag>(l.vii)</tag>
                   <tag role="refnum">(l)(l.vii)</tag>
                   <tag role="typerefnum">item (l)(l.vii)</tag>
                 </tags>
-                <para xml:id="S5.I1.i12.i7.p1">
+                <para xml:id="S5.I1.i12.I1.i7.p1">
                   <p>Line one, first</p>
                 </para>
               </item>
@@ -387,14 +387,14 @@ And more.</p>
           </tags>
           <para xml:id="S5.I1.i13.p1">
             <p>rocín flaco, y</p>
-            <enumerate xml:id="S5.I1.I2">
-              <item xml:id="S5.I1.i13.i8">
+            <enumerate xml:id="S5.I1.i13.I1">
+              <item xml:id="S5.I1.i13.I1.i8">
                 <tags>
                   <tag>(m.viii)</tag>
                   <tag role="refnum">(m)(m.viii)</tag>
                   <tag role="typerefnum">item (m)(m.viii)</tag>
                 </tags>
-                <para xml:id="S5.I1.i13.i8.p1">
+                <para xml:id="S5.I1.i13.I1.i8.p1">
                   <p>Line one, second</p>
                 </para>
               </item>
@@ -448,58 +448,58 @@ And more.</p>
     </para>
     <para xml:id="S5.p3">
       <enumerate xml:id="S5.I3">
-        <item xml:id="legali1">
+        <item xml:id="S5.I3.i1">
           <tags>
             <tag>1.</tag>
             <tag role="refnum">1.</tag>
           </tags>
-          <para xml:id="legali1.p1">
+          <para xml:id="S5.I3.i1.p1">
             <p>A</p>
-            <enumerate xml:id="S5.I3.I1">
-              <item xml:id="legalii1">
+            <enumerate xml:id="S5.I3.i1.I2">
+              <item xml:id="S5.I3.i1.I2.i1">
                 <tags>
                   <tag>1.1.</tag>
                   <tag role="refnum">1.1.</tag>
                 </tags>
-                <para xml:id="legalii1.p1">
+                <para xml:id="S5.I3.i1.I2.i1.p1">
                   <p>AA</p>
                 </para>
               </item>
-              <item xml:id="legalii2">
+              <item xml:id="S5.I3.i1.I2.i2">
                 <tags>
                   <tag>1.2.</tag>
                   <tag role="refnum">1.2.</tag>
                 </tags>
-                <para xml:id="legalii2.p1">
+                <para xml:id="S5.I3.i1.I2.i2.p1">
                   <p>AB</p>
                 </para>
               </item>
             </enumerate>
           </para>
         </item>
-        <item xml:id="legali2">
+        <item xml:id="S5.I3.i2">
           <tags>
             <tag>2.</tag>
             <tag role="refnum">2.</tag>
           </tags>
-          <para xml:id="legali2.p1">
+          <para xml:id="S5.I3.i2.p1">
             <p>B</p>
-            <enumerate xml:id="S5.I3.I2">
-              <item xml:id="legalii1a">
+            <enumerate xml:id="S5.I3.i2.I1">
+              <item xml:id="S5.I3.i2.I1.i1">
                 <tags>
                   <tag>2.1.</tag>
                   <tag role="refnum">2.1.</tag>
                 </tags>
-                <para xml:id="legalii1a.p1">
+                <para xml:id="S5.I3.i2.I1.i1.p1">
                   <p>BA</p>
                 </para>
               </item>
-              <item xml:id="legalii2a">
+              <item xml:id="S5.I3.i2.I1.i2">
                 <tags>
                   <tag>2.2.</tag>
                   <tag role="refnum">2.2.</tag>
                 </tags>
-                <para xml:id="legalii2a.p1">
+                <para xml:id="S5.I3.i2.I1.i2.p1">
                   <p>BB</p>
                 </para>
               </item>
@@ -518,34 +518,34 @@ And more.</p>
     <title><tag close=" ">6</tag>Series</title>
     <para xml:id="S6.p1">
       <enumerate xml:id="S6.I1">
-        <item xml:id="conti1">
+        <item xml:id="S6.I1.i1">
           <tags>
             <tag>(1)</tag>
             <tag role="refnum">(1)</tag>
           </tags>
-          <para xml:id="conti1.p1">
+          <para xml:id="S6.I1.i1.p1">
             <p>A Thing</p>
           </para>
         </item>
       </enumerate>
       <enumerate xml:id="S6.I2">
-        <item xml:id="conti2">
+        <item xml:id="S6.I2.i2">
           <tags>
             <tag>(2)</tag>
             <tag role="refnum">(2)</tag>
           </tags>
-          <para xml:id="conti2.p1">
+          <para xml:id="S6.I2.i2.p1">
             <p>A Thing</p>
           </para>
         </item>
       </enumerate>
       <enumerate xml:id="S6.I3">
-        <item xml:id="conti3">
+        <item xml:id="S6.I3.i3">
           <tags>
             <tag>(3)</tag>
             <tag role="refnum">(3)</tag>
           </tags>
-          <para xml:id="conti3.p1">
+          <para xml:id="S6.I3.i3.p1">
             <p>A Thing</p>
           </para>
         </item>
@@ -609,30 +609,30 @@ And more.</p>
     <title><tag close=" ">7</tag>New Lists</title>
     <para xml:id="S7.p1">
       <itemize xml:id="S7.I1">
-        <item xml:id="ingredientsi1">
+        <item xml:id="S7.I1.i1">
           <tags>
             <tag>•</tag>
             <tag role="refnum">•</tag>
           </tags>
-          <para xml:id="ingredientsi1.p1">
+          <para xml:id="S7.I1.i1.p1">
             <p>flour</p>
           </para>
         </item>
-        <item xml:id="ingredientsi2">
+        <item xml:id="S7.I1.i2">
           <tags>
             <tag>•</tag>
             <tag role="refnum">•</tag>
           </tags>
-          <para xml:id="ingredientsi2.p1">
+          <para xml:id="S7.I1.i2.p1">
             <p>eggs</p>
           </para>
         </item>
-        <item xml:id="ingredientsi3">
+        <item xml:id="S7.I1.i3">
           <tags>
             <tag>•</tag>
             <tag role="refnum">•</tag>
           </tags>
-          <para xml:id="ingredientsi3.p1">
+          <para xml:id="S7.I1.i3.p1">
             <p>milk</p>
           </para>
         </item>
@@ -640,30 +640,30 @@ And more.</p>
     </para>
     <para xml:id="S7.p2">
       <enumerate xml:id="S7.I2">
-        <item xml:id="stepsi1">
+        <item xml:id="S7.I2.i1">
           <tags>
             <tag>(1)</tag>
             <tag role="refnum">(1)</tag>
           </tags>
-          <para xml:id="stepsi1.p1">
+          <para xml:id="S7.I2.i1.p1">
             <p>first</p>
           </para>
         </item>
-        <item xml:id="stepsi2">
+        <item xml:id="S7.I2.i2">
           <tags>
             <tag>(2)</tag>
             <tag role="refnum">(2)</tag>
           </tags>
-          <para xml:id="stepsi2.p1">
+          <para xml:id="S7.I2.i2.p1">
             <p>second</p>
           </para>
         </item>
-        <item xml:id="stepsi3">
+        <item xml:id="S7.I2.i3">
           <tags>
             <tag>(3)</tag>
             <tag role="refnum">(3)</tag>
           </tags>
-          <para xml:id="stepsi3.p1">
+          <para xml:id="S7.I2.i3.p1">
             <p>third</p>
           </para>
         </item>
@@ -672,7 +672,7 @@ And more.</p>
     <para xml:id="S7.p3">
       <p>Inline:
 <inline-enumerate xml:id="S7.I3">
-          <inline-item xml:id="istepsi1">
+          <inline-item xml:id="S7.I3.i1">
             <tags>
               <tag>(1)</tag>
               <tag role="refnum">(1)</tag>
@@ -680,7 +680,7 @@ And more.</p>
             <text>first
 </text>
           </inline-item>
-          <inline-item xml:id="istepsi2">
+          <inline-item xml:id="S7.I3.i2">
             <tags>
               <tag>(2)</tag>
               <tag role="refnum">(2)</tag>
@@ -688,7 +688,7 @@ And more.</p>
             <text>second
 </text>
           </inline-item>
-          <inline-item xml:id="istepsi3">
+          <inline-item xml:id="S7.I3.i3">
             <tags>
               <tag>(3)</tag>
               <tag role="refnum">(3)</tag>

--- a/t/structure/itemize.xml
+++ b/t/structure/itemize.xml
@@ -141,34 +141,34 @@
           </tags>
           <para xml:id="S4.I1.i1.p1">
             <p>One</p>
-            <enumerate xml:id="S4.I1.I1">
-              <item xml:id="S4.I1.i1.i1">
+            <enumerate xml:id="S4.I1.i1.I1">
+              <item xml:id="S4.I1.i1.I1.i1">
                 <tags>
                   <tag>(a)</tag>
                   <tag role="refnum">1a</tag>
                   <tag role="typerefnum">item 1a</tag>
                 </tags>
-                <para xml:id="S4.I1.i1.i1.p1">
+                <para xml:id="S4.I1.i1.I1.i1.p1">
                   <p>One</p>
                 </para>
               </item>
-              <item xml:id="S4.I1.i1.i2">
+              <item xml:id="S4.I1.i1.I1.i2">
                 <tags>
                   <tag>(b)</tag>
                   <tag role="refnum">1b</tag>
                   <tag role="typerefnum">item 1b</tag>
                 </tags>
-                <para xml:id="S4.I1.i1.i2.p1">
+                <para xml:id="S4.I1.i1.I1.i2.p1">
                   <p>Two</p>
                 </para>
               </item>
-              <item xml:id="S4.I1.i1.i3">
+              <item xml:id="S4.I1.i1.I1.i3">
                 <tags>
                   <tag>(c)</tag>
                   <tag role="refnum">1c</tag>
                   <tag role="typerefnum">item 1c</tag>
                 </tags>
-                <para xml:id="S4.I1.i1.i3.p1">
+                <para xml:id="S4.I1.i1.I1.i3.p1">
                   <p>Three</p>
                 </para>
               </item>
@@ -183,34 +183,34 @@
           </tags>
           <para xml:id="S4.I1.i2.p1">
             <p>Two</p>
-            <enumerate xml:id="S4.I1.I2">
-              <item xml:id="S4.I1.i2.i1">
+            <enumerate xml:id="S4.I1.i2.I1">
+              <item xml:id="S4.I1.i2.I1.i1">
                 <tags>
                   <tag>(a)</tag>
                   <tag role="refnum">2a</tag>
                   <tag role="typerefnum">item 2a</tag>
                 </tags>
-                <para xml:id="S4.I1.i2.i1.p1">
+                <para xml:id="S4.I1.i2.I1.i1.p1">
                   <p>One</p>
                 </para>
               </item>
-              <item xml:id="S4.I1.i2.i2">
+              <item xml:id="S4.I1.i2.I1.i2">
                 <tags>
                   <tag>(b)</tag>
                   <tag role="refnum">2b</tag>
                   <tag role="typerefnum">item 2b</tag>
                 </tags>
-                <para xml:id="S4.I1.i2.i2.p1">
+                <para xml:id="S4.I1.i2.I1.i2.p1">
                   <p>Two</p>
                 </para>
               </item>
-              <item xml:id="S4.I1.i2.i3">
+              <item xml:id="S4.I1.i2.I1.i3">
                 <tags>
                   <tag>(c)</tag>
                   <tag role="refnum">2c</tag>
                   <tag role="typerefnum">item 2c</tag>
                 </tags>
-                <para xml:id="S4.I1.i2.i3.p1">
+                <para xml:id="S4.I1.i2.I1.i3.p1">
                   <p>Three</p>
                 </para>
               </item>
@@ -225,34 +225,34 @@
           </tags>
           <para xml:id="S4.I1.i3.p1">
             <p>Three</p>
-            <enumerate xml:id="S4.I1.I3">
-              <item xml:id="S4.I1.i3.i1">
+            <enumerate xml:id="S4.I1.i3.I1">
+              <item xml:id="S4.I1.i3.I1.i1">
                 <tags>
                   <tag>(a)</tag>
                   <tag role="refnum">3a</tag>
                   <tag role="typerefnum">item 3a</tag>
                 </tags>
-                <para xml:id="S4.I1.i3.i1.p1">
+                <para xml:id="S4.I1.i3.I1.i1.p1">
                   <p>One</p>
                 </para>
               </item>
-              <item xml:id="S4.I1.i3.i2">
+              <item xml:id="S4.I1.i3.I1.i2">
                 <tags>
                   <tag>(b)</tag>
                   <tag role="refnum">3b</tag>
                   <tag role="typerefnum">item 3b</tag>
                 </tags>
-                <para xml:id="S4.I1.i3.i2.p1">
+                <para xml:id="S4.I1.i3.I1.i2.p1">
                   <p>Two</p>
                 </para>
               </item>
-              <item xml:id="S4.I1.i3.i3">
+              <item xml:id="S4.I1.i3.I1.i3">
                 <tags>
                   <tag>(c)</tag>
                   <tag role="refnum">3c</tag>
                   <tag role="typerefnum">item 3c</tag>
                 </tags>
-                <para xml:id="S4.I1.i3.i3.p1">
+                <para xml:id="S4.I1.i3.I1.i3.p1">
                   <p>Three</p>
                 </para>
               </item>
@@ -492,12 +492,12 @@
             <p>Second.</p>
           </para>
         </item>
-        <item xml:id="S7.I1.ix2">
+        <item xml:id="S7.I1.ix1">
           <tags>
             <tag>foo</tag>
             <tag role="typerefnum">item foo</tag>
           </tags>
-          <para xml:id="S7.I1.ix2.p1">
+          <para xml:id="S7.I1.ix1.p1">
             <p>bar</p>
           </para>
         </item>
@@ -518,39 +518,39 @@
     </para>
     <para xml:id="S7.p2">
       <itemize>
-        <item xml:id="exer1">
+        <item xml:id="S7.I2.i1">
           <tags>
             <tag><text font="bold">7 - 1</text></tag>
             <tag role="refnum">1</tag>
           </tags>
-          <para xml:id="exer1.p1">
+          <para xml:id="S7.I2.i1.p1">
             <p>First item.</p>
           </para>
         </item>
-        <item xml:id="exer2">
+        <item xml:id="S7.I2.i2">
           <tags>
             <tag><text font="bold">7 - 2</text></tag>
             <tag role="refnum">2</tag>
           </tags>
-          <para xml:id="exer2.p1">
+          <para xml:id="S7.I2.i2.p1">
             <p>Second.</p>
           </para>
         </item>
-        <item xml:id="exerx1">
+        <item xml:id="S7.I2.ix1">
           <tags>
             <tag>foo</tag>
             <tag role="typerefnum">item foo</tag>
           </tags>
-          <para xml:id="exerx1.p1">
+          <para xml:id="S7.I2.ix1.p1">
             <p>bar</p>
           </para>
         </item>
-        <item xml:id="exer3">
+        <item xml:id="S7.I2.i3">
           <tags>
             <tag><text font="bold">7 - 3</text></tag>
             <tag role="refnum">3</tag>
           </tags>
-          <para xml:id="exer3.p1">
+          <para xml:id="S7.I2.i3.p1">
             <p>And the third.</p>
           </para>
         </item>

--- a/t/structure/paralists.xml
+++ b/t/structure/paralists.xml
@@ -162,22 +162,22 @@
         </tags>
         <para xml:id="S0.I6.i2.p1">
           <p>two</p>
-          <itemize xml:id="S0.I6.I1">
-            <item xml:id="S0.I6.i2.i1">
+          <itemize xml:id="S0.I6.i2.I1">
+            <item xml:id="S0.I6.i2.I1.i1">
               <tags>
                 <tag><text font="bold">–</text></tag>
                 <tag role="typerefnum">1st item</tag>
               </tags>
-              <para xml:id="S0.I6.i2.i1.p1">
+              <para xml:id="S0.I6.i2.I1.i1.p1">
                 <p>one</p>
               </para>
             </item>
-            <item xml:id="S0.I6.i2.i2">
+            <item xml:id="S0.I6.i2.I1.i2">
               <tags>
                 <tag><text font="bold">–</text></tag>
                 <tag role="typerefnum">2nd item</tag>
               </tags>
-              <para xml:id="S0.I6.i2.i2.p1">
+              <para xml:id="S0.I6.i2.I1.i2.p1">
                 <p>two</p>
               </para>
             </item>
@@ -219,24 +219,24 @@
         </tags>
         <para xml:id="S0.I7.i2.p1">
           <p>two</p>
-          <enumerate xml:id="S0.I7.I1">
-            <item xml:id="S0.I7.i2.i1">
+          <enumerate xml:id="S0.I7.i2.I1">
+            <item xml:id="S0.I7.i2.I1.i1">
               <tags>
                 <tag>b.1</tag>
                 <tag role="refnum">b.1</tag>
                 <tag role="typerefnum">item b.1</tag>
               </tags>
-              <para xml:id="S0.I7.i2.i1.p1">
+              <para xml:id="S0.I7.i2.I1.i1.p1">
                 <p>one</p>
               </para>
             </item>
-            <item xml:id="S0.I7.i2.i2">
+            <item xml:id="S0.I7.i2.I1.i2">
               <tags>
                 <tag>b.2</tag>
                 <tag role="refnum">b.2</tag>
                 <tag role="typerefnum">item b.2</tag>
               </tags>
-              <para xml:id="S0.I7.i2.i2.p1">
+              <para xml:id="S0.I7.i2.I1.i2.p1">
                 <p>two</p>
               </para>
             </item>
@@ -279,37 +279,37 @@
   </para>
   <para xml:id="p9">
     <description xml:id="S0.I9">
-      <item xml:id="S0.I9.ix3">
+      <item xml:id="S0.I9.ix1">
         <tags>
-          <tag><Math mode="inline" tex="\{" text="{" xml:id="S0.I9.ix3.m1">
+          <tag><Math mode="inline" tex="\{" text="{" xml:id="S0.I9.ix1.m1">
               <XMath>
                 <XMTok role="OPEN" stretchy="false">{</XMTok>
               </XMath>
-            </Math><text font="italic">do<Math mode="inline" tex="\}" text="}" xml:id="S0.I9.ix3.m2">
+            </Math><text font="italic">do<Math mode="inline" tex="\}" text="}" xml:id="S0.I9.ix1.m2">
                 <XMath>
                   <XMTok font="upright" role="CLOSE" stretchy="false">}</XMTok>
                 </XMath>
               </Math> </text></tag>
           <tag role="typerefnum">item do</tag>
         </tags>
-        <para xml:id="S0.I9.ix3.p1">
+        <para xml:id="S0.I9.ix1.p1">
           <p>a deer, a female deer</p>
         </para>
       </item>
-      <item xml:id="S0.I9.ix4">
+      <item xml:id="S0.I9.ix2">
         <tags>
-          <tag><Math mode="inline" tex="\{" text="{" xml:id="S0.I9.ix4.m1">
+          <tag><Math mode="inline" tex="\{" text="{" xml:id="S0.I9.ix2.m1">
               <XMath>
                 <XMTok role="OPEN" stretchy="false">{</XMTok>
               </XMath>
-            </Math><text font="italic">re<Math mode="inline" tex="\}" text="}" xml:id="S0.I9.ix4.m2">
+            </Math><text font="italic">re<Math mode="inline" tex="\}" text="}" xml:id="S0.I9.ix2.m2">
                 <XMath>
                   <XMTok font="upright" role="CLOSE" stretchy="false">}</XMTok>
                 </XMath>
               </Math> </text></tag>
           <tag role="typerefnum">item re</tag>
         </tags>
-        <para xml:id="S0.I9.ix4.p1">
+        <para xml:id="S0.I9.ix2.p1">
           <p>a pocket full of sun</p>
         </para>
       </item>

--- a/t/structure/report.xml
+++ b/t/structure/report.xml
@@ -166,22 +166,22 @@
             </tags>
             <para xml:id="Ch1.S1.I1.i2.p1">
               <p>two</p>
-              <itemize xml:id="Ch1.S1.I1.I1">
-                <item xml:id="Ch1.S1.I1.i2.i1">
+              <itemize xml:id="Ch1.S1.I1.i2.I1">
+                <item xml:id="Ch1.S1.I1.i2.I1.i1">
                   <tags>
                     <tag><text font="bold">–</text></tag>
                     <tag role="typerefnum">1st item</tag>
                   </tags>
-                  <para xml:id="Ch1.S1.I1.i2.i1.p1">
+                  <para xml:id="Ch1.S1.I1.i2.I1.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch1.S1.I1.i2.i2">
+                <item xml:id="Ch1.S1.I1.i2.I1.i2">
                   <tags>
                     <tag><text font="bold">–</text></tag>
                     <tag role="typerefnum">2nd item</tag>
                   </tags>
-                  <para xml:id="Ch1.S1.I1.i2.i2.p1">
+                  <para xml:id="Ch1.S1.I1.i2.I1.i2.p1">
                     <p>two</p>
                   </para>
                 </item>
@@ -210,24 +210,24 @@
             </tags>
             <para xml:id="Ch1.S1.I2.i2.p1">
               <p>two</p>
-              <enumerate xml:id="Ch1.S1.I2.I1">
-                <item xml:id="Ch1.S1.I2.i2.i1">
+              <enumerate xml:id="Ch1.S1.I2.i2.I2">
+                <item xml:id="Ch1.S1.I2.i2.I2.i1">
                   <tags>
                     <tag>(a)</tag>
                     <tag role="refnum">2a</tag>
                     <tag role="typerefnum">item 2a</tag>
                   </tags>
-                  <para xml:id="Ch1.S1.I2.i2.i1.p1">
+                  <para xml:id="Ch1.S1.I2.i2.I2.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch1.S1.I2.i2.i2">
+                <item xml:id="Ch1.S1.I2.i2.I2.i2">
                   <tags>
                     <tag>(b)</tag>
                     <tag role="refnum">2b</tag>
                     <tag role="typerefnum">item 2b</tag>
                   </tags>
-                  <para xml:id="Ch1.S1.I2.i2.i2.p1">
+                  <para xml:id="Ch1.S1.I2.i2.I2.i2.p1">
                     <p>two</p>
                   </para>
                 </item>
@@ -452,24 +452,24 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
             </tags>
             <para xml:id="Ch1.S2.I1.i2.p1">
               <p>two</p>
-              <enumerate xml:id="Ch1.S2.I1.I1">
-                <item xml:id="Ch1.S2.I1.i2.i1">
+              <enumerate xml:id="Ch1.S2.I1.i2.I1">
+                <item xml:id="Ch1.S2.I1.i2.I1.i1">
                   <tags>
                     <tag>(a)</tag>
                     <tag role="refnum">2a</tag>
                     <tag role="typerefnum">item 2a</tag>
                   </tags>
-                  <para xml:id="Ch1.S2.I1.i2.i1.p1">
+                  <para xml:id="Ch1.S2.I1.i2.I1.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch1.S2.I1.i2.i2">
+                <item xml:id="Ch1.S2.I1.i2.I1.i2">
                   <tags>
                     <tag>(b)</tag>
                     <tag role="refnum">2b</tag>
                     <tag role="typerefnum">item 2b</tag>
                   </tags>
-                  <para xml:id="Ch1.S2.I1.i2.i2.p1">
+                  <para xml:id="Ch1.S2.I1.i2.I1.i2.p1">
                     <p>two</p>
                   </para>
                 </item>
@@ -585,24 +585,24 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
             </tags>
             <para xml:id="Ch2.S1.I1.i2.p1">
               <p>two</p>
-              <enumerate xml:id="Ch2.S1.I1.I1">
-                <item xml:id="Ch2.S1.I1.i2.i1">
+              <enumerate xml:id="Ch2.S1.I1.i2.I1">
+                <item xml:id="Ch2.S1.I1.i2.I1.i1">
                   <tags>
                     <tag>(a)</tag>
                     <tag role="refnum">2a</tag>
                     <tag role="typerefnum">item 2a</tag>
                   </tags>
-                  <para xml:id="Ch2.S1.I1.i2.i1.p1">
+                  <para xml:id="Ch2.S1.I1.i2.I1.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch2.S1.I1.i2.i2">
+                <item xml:id="Ch2.S1.I1.i2.I1.i2">
                   <tags>
                     <tag>(b)</tag>
                     <tag role="refnum">2b</tag>
                     <tag role="typerefnum">item 2b</tag>
                   </tags>
-                  <para xml:id="Ch2.S1.I1.i2.i2.p1">
+                  <para xml:id="Ch2.S1.I1.i2.I1.i2.p1">
                     <p>two</p>
                   </para>
                 </item>
@@ -709,24 +709,24 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
             </tags>
             <para xml:id="Ch2.S2.I1.i2.p1">
               <p>two</p>
-              <enumerate xml:id="Ch2.S2.I1.I1">
-                <item xml:id="Ch2.S2.I1.i2.i1">
+              <enumerate xml:id="Ch2.S2.I1.i2.I1">
+                <item xml:id="Ch2.S2.I1.i2.I1.i1">
                   <tags>
                     <tag>(a)</tag>
                     <tag role="refnum">2a</tag>
                     <tag role="typerefnum">item 2a</tag>
                   </tags>
-                  <para xml:id="Ch2.S2.I1.i2.i1.p1">
+                  <para xml:id="Ch2.S2.I1.i2.I1.i1.p1">
                     <p>one</p>
                   </para>
                 </item>
-                <item xml:id="Ch2.S2.I1.i2.i2">
+                <item xml:id="Ch2.S2.I1.i2.I1.i2">
                   <tags>
                     <tag>(b)</tag>
                     <tag role="refnum">2b</tag>
                     <tag role="typerefnum">item 2b</tag>
                   </tags>
-                  <para xml:id="Ch2.S2.I1.i2.i2.p1">
+                  <para xml:id="Ch2.S2.I1.i2.I1.i2.p1">
                     <p>two</p>
                   </para>
                 </item>


### PR DESCRIPTION
This PR makes the ids of all nested lists (itemize, enumerate, description, ...) relative to the item's id (irrespective of what kind of list). Alas it makes the ids longer and the code is a bit more obscure, but avoids id clashes.