### PR TITLE
minor perl warning appeasement in main latexmlc calls

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -227,7 +227,7 @@ sub convert {
       my ($state) = @_;    # Sandbox state
       $$state{status} = {};
       $state->pushDaemonFrame;
-      $state->assignValue('_authlist', $$opts{authlist}, 'global');
+      $state->assignValue('_authlist',      $$opts{authlist}, 'global');
       $state->assignValue('REMOTE_REQUEST', (!$$opts{local}), 'global');
   });
 
@@ -460,7 +460,7 @@ sub convert_post {
     if ($$opts{crossref}) {
       require LaTeXML::Post::CrossRef;
       push(@procs, LaTeXML::Post::CrossRef->new(
-          db        => $DB, urlstyle => $$opts{urlstyle},
+          db => $DB, urlstyle => $$opts{urlstyle},
           extension => $$opts{extension},
           ($$opts{numbersections} ? (number_sections => 1)              : ()),
           ($$opts{navtoc}         ? (navigation_toc  => $$opts{navtoc}) : ()),
@@ -652,7 +652,8 @@ sub new_latexml {
       push @pre, $pre;
     }
   }
-  my $includepathpis = !($$opts{xsltparameters} && (@{ $$opts{xsltparameters} }[0] eq 'LATEXML_VERSION:TEST'));
+  my $includepathpis = !(exists $$opts{xsltparameters} &&
+    (grep { $_ eq 'LATEXML_VERSION:TEST' } @{ $$opts{xsltparameters} }));
   require LaTeXML;
   my $latexml = LaTeXML::Core->new(preload => [@pre], searchpaths => [@{ $$opts{paths} }],
     graphicspaths   => ['.'],
@@ -662,7 +663,7 @@ sub new_latexml {
     inputencoding   => $$opts{inputencoding},
     includestyles   => $$opts{includestyles},
     documentid      => $$opts{documentid},
-    nomathparse     => $$opts{nomathparse},                           # Backwards compatibility
+    nomathparse     => $$opts{nomathparse},     # Backwards compatibility
     mathparse       => $$opts{mathparse});
 
   if (my @baddirs = grep { !-d $_ } @{ $$opts{paths} }) {

--- a/lib/LaTeXML/Post/Scan.pm
+++ b/lib/LaTeXML/Post/Scan.pm
@@ -97,7 +97,7 @@ sub process {
   $self->scan($doc, $root, $$doc{parent_id});
 
   # Set up interconnections on multidocument site.
-  $$self{db}->register("DOCUMENT:" . $doc->siteRelativeDestination, id => $id);
+  $$self{db}->register("DOCUMENT:" . ($doc->siteRelativeDestination || ''), id => $id);
 
   # Question: If (on multidoc sites) a doc contains a single node (say ltx:chapter)
   # might it make sense to treat the doc as ONLY that node?
@@ -549,4 +549,3 @@ sub orNull {
 
 # ================================================================================
 1;
-


### PR DESCRIPTION
Very minor warnings (undef vs empty string) that showed up in some of the main latexmlc calls, best to get rid of them and keep the noise levels low.