### PR TITLE
[arXiv patches] Use .bbl heuristic when unpacking; handful extra latex macros

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -981,7 +981,14 @@ DefPrimitive('\markboth{}{}',    undef);
 DefPrimitiveI('\leftmark',  undef, undef);
 DefPrimitiveI('\rightmark', undef, undef);
 DefPrimitive('\pagenumbering{}', undef);
-
+DefMacro('\ps@empty',
+  '\let\@mkboth\@gobbletwo\let\@oddhead\@empty\let\@oddfoot\@empty' .
+    '\let\@evenhead\@empty\let\@evenfoot\@empty');
+DefMacro('\ps@plain', '\let\@mkboth\@gobbletwo' .
+    '\let\@oddhead\@empty\def\@oddfoot{\reset@font\hfil\thepage' .
+    '\hfil}\let\@evenhead\@empty\let\@evenfoot\@oddfoot');
+Let(T_CS('\@leftmark'),  T_CS('\@firstoftwo'));
+Let(T_CS('\@rightmark'), T_CS('\@secondoftwo'));
 # In normal latex, these should \clearpage; at least we want new paragraph?
 # Optional arg is sortof a heading, but w/o any particular styling(?)
 DefMacro('\twocolumn[]', '\ifx.#1.\else\par\noindent#1\fi\par');

--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -46,8 +46,7 @@ sub unpack_source {
   }
 
   # Heuristically determine the input (borrowed from arXiv::FileGuess)
-  my %Main_TeX_likelihood;
-  my %Main_TeX_level;
+  my (%Main_TeX_likelihood, %Main_TeX_level);
   my @vetoed = ();
   foreach my $tex_file (@TeX_file_members) {
     # Read in the content
@@ -139,8 +138,12 @@ sub unpack_source {
       $Main_TeX_level{$file} = $count;
       $min_count = $count if $min_count > $count; }
     @files_by_likelihood = grep { $Main_TeX_level{$_} == $min_count } @files_by_likelihood;
+    # if we still have multiples, check if some have a .bbl file
+    if (my @with_bbl = grep { my $base = $_; $base =~ s/\.tex$//; -e "$base.bbl"; } @files_by_likelihood) {
+      @files_by_likelihood = @with_bbl; }
     # last tie-breaker is lexicographical order
     @files_by_likelihood = sort { $a cmp $b } @files_by_likelihood;
+    print STDERR "all possible files: ", join(",", @files_by_likelihood), "\n";
     # set the main source
     $main_source = shift @files_by_likelihood; }
 
@@ -249,7 +252,7 @@ sub get_math {
     my $math_found = 0;
     while ($math_found != $math_count) {
       $math_found = $math->findnodes('.' . $math_xpath)->size;
-      $math_found++ if ($math->localname =~ /^math$/i);
+      $math_found++             if ($math->localname =~ /^math$/i);
       $math = $math->parentNode if ($math_found != $math_count);
     }
     $math = $math->parentNode while ($math->nodeName =~ '^t[rd]$'); }

--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -143,7 +143,6 @@ sub unpack_source {
       @files_by_likelihood = @with_bbl; }
     # last tie-breaker is lexicographical order
     @files_by_likelihood = sort { $a cmp $b } @files_by_likelihood;
-    print STDERR "all possible files: ", join(",", @files_by_likelihood), "\n";
     # set the main source
     $main_source = shift @files_by_likelihood; }
 


### PR DESCRIPTION
Fixes [1905.00934](https://arxiv.org/abs/1905.00934). More importantly, it has the potential of avoiding confusion in detecting the main TeX source file from an arXiv paper directory. 

For the example of this paper, there were equally viable `main.tex` and `main.v10.tex` source files in the root directory. If following the official `arXiv::AutoTeX` logic, the first lexicographic entry would be considered primary, i.e. `main.tex`, but in this case that is the wrong choice. I didn't find official language how arXiv would have found the right file, and the timestamps seem identical.

However, one of the files has a `.bbl` of the same name, while the other doesn't. So, for arXiv, this looks like a meaningful heuristic as a final tie-breaker between otherwise equally viable files. The one with a `.bbl` is primary.

Also, the custom `.sty` included with this paper used a couple of latex internals we hadn't defined, which seemed quite easy to just include as-is, so also added those. Paper completes with a single warning after the PR, for a single math formula that failed to parse.