### PR TITLE
[arXiv patches] Stubs for a few extra pdftex primitives, bound by expl3

### DIFF
--- a/lib/LaTeXML/Package/pdfTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/pdfTeX.pool.ltxml
@@ -134,8 +134,12 @@ DefRegister('\pdfretval'               => Number(0));
 # \pdfximage [ image attr spec ] general text (h, v, m)
 # \pdfrefximage object number (h, v, m)
 # \pdfannot annot type spec (h, v, m)
+DefPrimitive('\pdfannot OpenAnnotSpecification', undef);
+
 # \pdfstartlink [ rule spec ] [ attr spec ] action spec (h, m)
+DefPrimitive('\pdfstartlink', undef);
 # \pdfendlink (h, m)
+DefPrimitive('\pdfendlink', undef);
 # \pdfoutline outline spec (h, v, m)
 # \pdfdest dest spec (h, v, m)
 # \pdfthread thread spec (h, v, m)
@@ -155,6 +159,23 @@ DefParameterType('OpenActionSpecification', sub {
   } } },
   optional => 1, undigested => 1);
 
+DefParameterType('OpenAnnotSpecification', sub {
+    my ($gullet) = @_;
+    my $general_text_param = LookupMapping('PARAMETER_TYPES', 'GeneralText');
+
+    if    ($gullet->readKeyword('reserveobjnum')) { return; }
+    elsif ($gullet->readKeyword('useobjnum')) {
+      my $discard = $gullet->readNumber; }
+    elsif ($gullet->readKeyword('stream')) {
+      if ($gullet->readKeyword('attr')) {
+        $gullet->skipSpaces;
+        my $discard_stream = &{ $$general_text_param{reader} }($gullet); }
+    }
+    $gullet->skipSpaces;
+    my $discard_spec = &{ $$general_text_param{reader} }($gullet);
+    return; }
+  , optional => 1, undigested => 1);
+
 DefMacro('\pdfcatalog{} OpenActionSpecification', '');
 DefMacro('\pdfnames{}',                           {});
 DefMacro('\pdftrailer{}',                         {});
@@ -165,6 +186,7 @@ DefMacro('\pdfmapline{}',                         '');
 # \vadjust [ pre spec ] filler { vertical mode material } (h, m)
 DefMacro('\quitvmode', '');
 # \pdfliteral [ pdfliteral spec ] general text (h, v, m)
+DefPrimitive('\pdfliteral OptionalMatch:direct OptionalMatch:page GeneralText', undef);
 # \special pdfspecial spec
 # \pdfresettimer
 # \pdfsetrandomseed number
@@ -173,6 +195,19 @@ DefMacro('\quitvmode', '');
 # TODO: https://tex.stackexchange.com/questions/13771/let-a-control-sequence-to-a-redefined-primitive
 DefMacro('\pdfprimitive DefToken', '#1');    # we can just ignore the advanced effects for now.
 # \pdfcolorstack stack number stack action general text
+DefPrimitive('\pdfcolorstack Number OptionalMatch:set OptionalMatch:push OptionalMatch:pop OptionalMatch:current', sub {
+    # for now, carefully read and discard all arguments
+    my ($stomach, $number, $set, $push, $pop, $current) = @_;
+    return if ($pop);
+    my $gullet = $stomach->getGullet;
+    $gullet->skipSpaces;
+    my $general_text_param = LookupMapping('PARAMETER_TYPES', 'GeneralText');
+    my $discard            = &{ $$general_text_param{reader} }($gullet);
+    return; });
+DefPrimitive('\pdfobj OpenAnnotSpecification', sub {
+    # for now, carefully read and discard all arguments
+    return; });
+# [ stream [ attr spec ] ] object contents
 DefMacro('\pdfsetmatrix', '');
 DefMacro('\pdfsave',      '');
 DefMacro('\pdfrestore',   '');

--- a/lib/LaTeXML/Package/quantumarticle.cls.ltxml
+++ b/lib/LaTeXML/Package/quantumarticle.cls.ltxml
@@ -45,5 +45,6 @@ RawTeX(<<'EoTeX');
 \newenvironment{widetext}{}{}
 EoTeX
 
+DefEnvironment('{acknowledgments}', "<ltx:acknowledgements>#body</ltx:acknowledgements>");
 #**********************************************************************
 1;


### PR DESCRIPTION
I remembered engrafo has some [latexml-running tests](https://github.com/arxiv-vanity/engrafo/tree/master/tests/integration) for arxiv-vanity and tried to run them as sources of potential regressions yesterday. Still going through the last few, mostly OK.

A paper that was a bit "too loud" with pointless errors was [1803.07574](https://github.com/arxiv-vanity/engrafo/tree/master/tests/integration/papers/1803.07574), mostly due to expl3 wanting to bind some extra pdftex primitives which we hadn't added stubs for.

So I added stubs, trying to be at least a little precise with some of the argument specs (but not with all, just enough to get the paper+expl happy). I also added a missing `{acknowledgements}` definition to the rare class file of the article. Moving to the other tests... 