### PR TITLE
Less restrictive of recursion (usually redundant svg:g)

### DIFF
--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -162,9 +162,9 @@ sub canContain {
 sub canContainIndirect {
   my ($self, $tag, $child) = @_;
   my $model = $$self{model};
-  $tag = $model->getNodeQName($tag) if ref $tag;          # In case tag is a node.
+  $tag   = $model->getNodeQName($tag)   if ref $tag;      # In case tag is a node.
   $child = $model->getNodeQName($child) if ref $child;    # In case child is a node.
-        # $imodel{$tag}{$child} => $intermediate || $child
+      # $imodel{$tag}{$child} => $intermediate || $child
   my $imodel = $STATE->lookupValue('INDIRECT_MODEL');
   if (!$imodel) {
     $imodel = $self->computeIndirectModel();
@@ -206,7 +206,7 @@ sub computeIndirectModel_aux {
   my ($model, $tag, $start, $desirability) = @_;
   my $x;
   foreach my $kid ($model->getTagContents($tag)) {
-    next if $::DESC{$kid}{$start};    # Already solved
+    next                                  if $::DESC{$kid}{$start};    # Already solved
     $::DESC{$kid}{$start} = $desirability if $start;
     if (($kid ne '#PCDATA') && ($x = $::OPENABILITY{$kid})) {
       computeIndirectModel_aux($model, $kid, $start || $kid, $desirability * $x); } }
@@ -215,14 +215,14 @@ sub computeIndirectModel_aux {
 sub canContainSomehow {
   my ($self, $tag, $child) = @_;
   my $model = $$self{model};
-  $tag   = $model->getNodeQName($tag)   if ref $tag;      # In case tag is a node.
-  $child = $model->getNodeQName($child) if ref $child;    # In case child is a node.
+  $tag   = $model->getNodeQName($tag)   if ref $tag;                   # In case tag is a node.
+  $child = $model->getNodeQName($child) if ref $child;                 # In case child is a node.
   return $model->canContain($tag, $child) || $self->canContainIndirect($tag, $child); }
 
 sub canHaveAttribute {
   my ($self, $tag, $attrib) = @_;
   my $model = $$self{model};
-  $tag = $model->getNodeQName($tag) if ref $tag;          # In case tag is a node.
+  $tag = $model->getNodeQName($tag) if ref $tag;                       # In case tag is a node.
   return $model->canHaveAttribute($tag, $attrib); }
 
 sub canAutoOpen {
@@ -257,9 +257,9 @@ sub getTagActionList {
     ($p, $n) = ($1, $2); }
   my $when0   = $when . ':early';
   my $when1   = $when . ':late';
-  my $taghash = $STATE->lookupMapping('TAG_PROPERTIES', $tag) || {};
+  my $taghash = $STATE->lookupMapping('TAG_PROPERTIES', $tag)                        || {};
   my $nshash  = ((defined $p) && $STATE->lookupMapping('TAG_PROPERTIES', $p . ':*')) || {};
-  my $allhash = $STATE->lookupMapping('TAG_PROPERTIES', '*') || {};
+  my $allhash = $STATE->lookupMapping('TAG_PROPERTIES', '*')                         || {};
   my $v;
   return (
     (($v = $$taghash{$when0}) ? @$v : ()),
@@ -325,7 +325,7 @@ sub doctest_head {
   my ($self, $parent, $node, $severe) = @_;
   # Check consistency of document, parent & type, before proceeding
   print STDERR "  NODE $$node [" if $severe;    # BEFORE checking nodeType!
-  print STDERR "d" if $severe;
+  print STDERR "d"               if $severe;
   if (!$node->ownerDocument->isSameNode($self->getDocument)) {
     print STDERR "!" if $severe; }
   print STDERR "p" if $severe;
@@ -365,6 +365,7 @@ sub finalize {
 sub finalize_rec {
   my ($self, $node) = @_;
   my $model = $$self{model};
+  no warnings 'recursion';
   my $qname = $model->getNodeQName($node);
   # _standalone_font is typically for metadata that gets extracted out of context
   my $declared_font = ($node->getAttribute('_standalone_font')
@@ -467,6 +468,7 @@ sub toString {
 # but keep XML declaration, comments and don't convert empty elements.
 sub serialize_aux {
   my ($self, $node, $depth, $noindent, $heuristic) = @_;
+  no warnings 'recursion';
   my $type   = $node->nodeType;
   my $model  = $$self{model};
   my $indent = ('  ' x $depth);
@@ -1259,7 +1261,7 @@ sub mergeAttributes {
       # Several length attributes should be cummulative; sum them up, if present on both.
       elsif ($merge_attribute_sumlength{$key}) {
         if (my $val2 = $to->getAttribute($key)) {
-          my $v1 = $val =~ /^([\+\-\d\.]*)pt$/  && $1;
+          my $v1 = $val  =~ /^([\+\-\d\.]*)pt$/ && $1;
           my $v2 = $val2 =~ /^([\+\-\d\.]*)pt$/ && $1;
           $to->setAttribute($key => ($v1 + $v2) . 'pt'); }
         else {
@@ -1300,7 +1302,7 @@ sub setAttribute {
   $value = $value->toAttribute if ref $value;
   if ((defined $value) && ($value ne '')) {    # Skip if `empty'; but 0 is OK!
     if ($key eq 'xml:id') {                    # If it's an ID attribute
-      $value = $self->recordID($value, $node);    # Do id book keeping
+      $value = $self->recordID($value, $node);                                 # Do id book keeping
       $node->setAttributeNS($LaTeXML::Common::XML::XML_NS, 'id', $value); }    # and bypass all ns stuff
     elsif ($key !~ /:/) {    # No colon; no namespace (the common case!)
                              # Ignore attributes not allowed by the model,
@@ -1314,7 +1316,7 @@ sub setAttribute {
       if ($ns) {             # If namespaced attribute (must have prefix!
         my $prefix = $node->lookupNamespacePrefix($ns);    # namespace already declared?
         if (!$prefix) {                                    # if namespace not already declared
-          $prefix = $$self{model}->getDocumentNamespacePrefix($ns, 1);    # get the prefix to use
+          $prefix = $$self{model}->getDocumentNamespacePrefix($ns, 1);             # get the prefix to use
           $self->getDocument->documentElement->setNamespace($ns, $prefix, 0); }    # and declare it
         if ($prefix eq '#default') {    # Probably shouldn't happen...?
           $node->setAttribute($name => $value); }
@@ -1538,7 +1540,7 @@ sub collapseXMDual {
   # The other branch is not visible, nor referenced,
   # but the dual may have an id and be referenced
   if (my $dualid = $dual->getAttribute('xml:id')) {
-    $self->unRecordID($dualid);    # We'll move or remove the ID from the dual
+    $self->unRecordID($dualid);                              # We'll move or remove the ID from the dual
     if (my $branchid = $branch->getAttribute('xml:id')) {    # branch has id too!
       foreach my $ref ($self->findnodes("//*[\@idref='$dualid']")) {
         $ref->setAttribute(idref => $branchid); } }          # Change dualid refs to branchid
@@ -1665,7 +1667,7 @@ sub openElementAt {
   my $font = $attributes{_font} || $attributes{font};
   my $box  = $attributes{_box};
   $box = $$self{node_boxes}{$box} if $box && !ref $box;    # may already be the string key
-         # If this will be the document root node, things are slightly more involved.
+      # If this will be the document root node, things are slightly more involved.
   if ($point->nodeType == XML_DOCUMENT_NODE) {    # First node! (?)
     $$self{model}->addSchemaDeclaration($self, $tag);
     map { $$self{document}->appendChild($_) } @{ $$self{pending} };    # Add saved comments, PI's
@@ -1683,16 +1685,16 @@ sub openElementAt {
         $newnode->setNamespace($ns, $attprefix, 0); }
       $newnode->setNamespace($ns, $prefix, 1); } }
   else {
-    $font = $self->getNodeFont($point) unless $font;
-    $box  = $self->getNodeBox($point)  unless $box;
+    $font    = $self->getNodeFont($point) unless $font;
+    $box     = $self->getNodeBox($point)  unless $box;
     $newnode = $self->openElement_internal($point, $ns, $tag); }
 
   foreach my $key (sort keys %attributes) {
     next if $key eq 'font';       # !!!
     next if $key eq 'locator';    # !!!
     $self->setAttribute($newnode, $key, $attributes{$key}); }
-  $self->setNodeFont($newnode, $font) if $font;
-  $self->setNodeBox($newnode, $box) if $box;
+  $self->setNodeFont($newnode, $font)                                                   if $font;
+  $self->setNodeBox($newnode, $box)                                                     if $box;
   print STDERR "Inserting " . Stringify($newnode) . " into " . Stringify($point) . "\n" if $LaTeXML::Core::Document::DEBUG;
 
   # Run afterOpen operations

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -107,7 +107,11 @@ DefEnvironment('{keywords}', '',
 
 DefMacro('\classification{}', '\@add@frontmatter{ltx:classification}{#1}');
 DefMacro('\pacs{}',           '\@add@frontmatter{ltx:classification}[scheme=pacs]{#1}');
-DefMacro('\doi{}',            '\@add@frontmatter{ltx:classification}[scheme=doi]{#1}');
+# \doi{doi} might be frontmatter, or just a \url-like thing.  So, let's guess!
+DefMacro('\doi{}',
+  '\if@in@preamble{\@add@frontmatter{ltx:classification}[scheme=doi]{#1}'
+    . '\else\lx@doi{#1}\fi');
+DefConstructor('\lx@doi{}', '<ltx:ref href="https:/doi.org/#1">#1</ltx:ref>');
 
 for my $env (qw(conjecture proposition lemma corollary example definition)) {
   my $beginenv = "\\begin{$env}";

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -116,7 +116,7 @@ DefParameterType('DefPlain', sub {
       ($value) = $inner->reparseArgument($gullet, $value); }
     return $value; },
   packParameters => 1,
-  reversion => sub {
+  reversion      => sub {
     my ($arg, $inner) = @_;
     (T_BEGIN,
       ($inner ? $inner->revertArguments($arg) : Revert($arg)),
@@ -252,7 +252,7 @@ DefParameterType('DefExpanded', sub {
     my $expanded = ($token->getCatcode == CC_BEGIN ? $gullet->readBalanced(1) : $token);
     return $expanded; },
   packParameters => 1,
-  reversion => sub {
+  reversion      => sub {
     my ($arg) = @_;
     (T_BEGIN, Revert($arg), T_END); });
 
@@ -302,7 +302,7 @@ DefParameterType('OptionalUndigested', sub { $_[0]->readOptional; },
 
 # Read a keyword value (KeyVals), that will not be digested.
 DefParameterType('UndigestedKey', sub { $_[0]->readArg; }, undigested => 1);
-DefParameterType('UndigestedDefKey', sub { $_[0]->readArg; }, undigested => 1, packParameters=>1);
+DefParameterType('UndigestedDefKey', sub { $_[0]->readArg; }, undigested => 1, packParameters => 1);
 
 # Read a token as used when defining it, ie. it may be enclosed in braces.
 DefParameterType('DefToken', sub {
@@ -4787,6 +4787,8 @@ DefPrimitiveI('\narrower', undef, undef);
 # Note: could be circumstances where you'd want modular frontmatter?
 # (ie. frontmatter for each sectional unit)
 AssignValue(frontmatter => {}, 'global');
+
+DefConditionalI('\if@in@preamble', undef, sub { LookupValue('inPreamble'); });
 
 # Add a new frontmatter item that will be enclosed in <$tag %attr>...</$tag>
 # The content is the result of digesting $tokens.

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -106,7 +106,7 @@ sub getStatusMessage {
 sub getsorter {
   my ($self, $lang) = @_;
   my $collator;
-  if ($collator = $$self{collatorcache}{$lang}) { }
+  if    ($collator = $$self{collatorcache}{$lang}) { }
   elsif ($collator = eval {
       local $LaTeXML::IGNORE_ERRORS = 1;
       require 'Unicode/Collate/Locale.pm';
@@ -195,11 +195,11 @@ sub desiredResourcePathname {
 # but I think we've accommodated absolute ones.
 sub generateResourcePathname {
   my ($self, $doc, $node, $source, $type) = @_;
-  my $subdir = $$self{resource_directory} || '';
-  my $prefix = $$self{resource_prefix}    || "x";
+  my $subdir  = $$self{resource_directory} || '';
+  my $prefix  = $$self{resource_prefix}    || "x";
   my $counter = join('_', "_max", $subdir, $prefix, "counter_");
-  my $n    = $doc->cacheLookup($counter) || 0;
-  my $name = $prefix . ++$n;
+  my $n       = $doc->cacheLookup($counter) || 0;
+  my $name    = $prefix . ++$n;
   $doc->cacheStore($counter, $n);
   return pathname_make(dir => $subdir, name => $name, type => $type); }
 
@@ -223,7 +223,9 @@ sub find_documentclass_and_packages {
       $classoptions = $$entry{options} || 'onecolumn';
       $oldstyle     = $$entry{oldstyle}; }
     elsif ($$entry{package}) {
-      push(@packages, [$$entry{package}, $$entry{options} || '']); } }
+      my @p = grep { $_; } split(/\s*,\s*/, $$entry{package});
+      foreach my $package (@p) {
+        push(@packages, [$package, $$entry{options} || '']); } } }
   if (!$class) {
     Warn('expected', 'class', undef, "No document class found; using article");
     $class = 'article'; }
@@ -670,9 +672,9 @@ sub new_internal {
     else {
       $data{siteDirectory} = $data{destinationDirectory}; } }
   # Start, at least, with our own namespaces.
-  $data{namespaces}    = { ltx    => $NSURI } unless $data{namespaces};
-  $data{namespaceURIs} = { $NSURI => 'ltx' }  unless $data{namespaceURIs};
-  $data{idcache}       = {};
+  $data{namespaces}       = { ltx    => $NSURI } unless $data{namespaces};
+  $data{namespaceURIs}    = { $NSURI => 'ltx' }  unless $data{namespaceURIs};
+  $data{idcache}          = {};
   $data{idcache_reusable} = {};
   $data{idcache_reserve}  = {};
 
@@ -1099,7 +1101,7 @@ sub addNodes {
           my $atype = $attr->nodeType;
           if ($atype == XML_ATTRIBUTE_NODE) {
             my $key = $attr->nodeName;
-            if ($key =~ /^_/) { }    # don't copy internal attributes
+            if    ($key =~ /^_/) { }     # don't copy internal attributes
             elsif ($key eq 'xml:id') {
               my $value = $attr->getValue;
               my $old;
@@ -1134,7 +1136,7 @@ sub removeNodes {
   my ($self, @nodes) = @_;
   foreach my $node (@nodes) {
     my $ref = ref $node;
-    if (!$ref) { }
+    if    (!$ref) { }
     elsif ($ref eq 'ARRAY') {
       my ($t, $a, @n) = @$node;
       if (my $id = $$a{'xml:id'}) {
@@ -1156,7 +1158,7 @@ sub preremoveNodes {
   my ($self, @nodes) = @_;
   foreach my $node (@nodes) {
     my $ref = ref $node;
-    if (!$ref) { }
+    if    (!$ref) { }
     elsif ($ref eq 'ARRAY') {
       my ($t, $a, @n) = @$node;
       if (my $id = $$a{'xml:id'}) {

--- a/lib/LaTeXML/Post/Scan.pm
+++ b/lib/LaTeXML/Post/Scan.pm
@@ -134,6 +134,7 @@ sub process {
 
 sub scan {
   my ($self, $doc, $node, $parent_id) = @_;
+  no warnings 'recursion';
   my $tag     = $doc->getQName($node);
   my $handler = $$self{handlers}{$tag} || \&default_handler;
   &$handler($self, $doc, $node, $tag, $parent_id);
@@ -141,6 +142,7 @@ sub scan {
 
 sub scanChildren {
   my ($self, $doc, $node, $parent_id) = @_;
+  no warnings 'recursion';
   foreach my $child ($node->childNodes) {
     if ($child->nodeType == XML_ELEMENT_NODE) {
       $self->scan($doc, $child, $parent_id); } }
@@ -268,6 +270,7 @@ sub addCommon {
 
 sub default_handler {
   my ($self, $doc, $node, $tag, $parent_id) = @_;
+  no warnings 'recursion';
   my $id = $node->getAttribute('xml:id');
   if ($id) {
     $$self{db}->register("ID:$id",

--- a/lib/LaTeXML/Post/XSLT.pm
+++ b/lib/LaTeXML/Post/XSLT.pm
@@ -44,12 +44,13 @@ sub new {
   $stylesheet = $stylesheet && LaTeXML::Common::XML::XSLT->new($stylesheet);
   if ((!ref $stylesheet) || !($stylesheet->can('transform'))) {
     Error('expected', 'stylesheet', undef, "Stylesheet '$stylesheet' is not a usable stylesheet!"); }
+  XML::LibXSLT->max_depth(500);
   $$self{stylesheet} = $stylesheet;
   my %params = ();
-  %params = %{ $options{parameters} } if $options{parameters};
+  %params                    = %{ $options{parameters} } if $options{parameters};
   $$self{parameters}         = {%params};
   $$self{noresources}        = $options{noresources};
-  $$self{resource_directory} = $options{resource_directory};    # ???
+  $$self{resource_directory} = $options{resource_directory};                        # ???
   return $self; }
 
 sub process {


### PR DESCRIPTION
Block recursion warnings in a few places where we traverse the XML tree from top-to-bottom, which can be deep, but without cycles.  Also increase the XSLT recursion limit.  These are mostly due to redundant `svg:g` elements, which we'll want to fix, but the results are often acceptable anyway.

Probably will be following up with a couple of semi-related patches.