### PR TITLE
[arXiv patches] be able to find paper.tex.tex

### DIFF
--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -344,9 +344,9 @@ sub candidate_pathnames {
       if    ($ext eq '') { push(@exts, ''); }
       elsif ($ext eq '*') {
         push(@exts, '.*', ''); }
-      elsif ($pathname =~ /\.\Q$ext\E$/i) {
-        push(@exts, ''); }
       else {
+        if ($pathname =~ /\.\Q$ext\E$/i) {
+          push(@exts, ''); }
         push(@exts, '.' . $ext); } } }
   push(@exts, '') unless @exts;
 


### PR DESCRIPTION
So, `paper.tex.tex` is something used as a main source file in arXiv at times. And I assume other variations of double extensions may exist... Paper in question is [cond-mat/0411005](https://arxiv.org/abs/cond-mat/0411005).

Fix is easy, and should only fire in specific cases where a search has a `file.ext` and also requests the same extension via `type=>'ext'` or `types=>['ext']`, when this PR will now also search for `file.ext.ext`. I was wondering why we were getting Fatals failing to find `.tex` files, now it makes sense:

https://corpora.mathweb.org/corpus/arxiv%5Ftestbench/tex%5Fto%5Fhtml/fatal/missing%5Ffile/%2Fdev%2Fshm%2F91FiBpkiy1%2Fpaper%2Etex?all=false