### PR TITLE
Windows CI via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ jobs:
           command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
               gmake
       - run:
-          name: gmake test 9
+          name: gmake test 8
           command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
-              gmake test TEST_FILES=t/9*
+              gmake test TEST_FILES=t/8*
       - run:
           name: gmake test 0
           command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
@@ -76,9 +76,9 @@ jobs:
           command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
               gmake test TEST_FILES=t/7*
       - run:
-          name: gmake test 8
+          name: gmake test 9
           command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
-              gmake test TEST_FILES=t/8*
+              gmake test TEST_FILES=t/9*
       - save_cache:
           key: chocolatey-miktex-strawberry-v4
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,6 @@ jobs:
           command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
               gmake
       - run:
-          name: gmake test 8
-          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
-              gmake test TEST_FILES=t/8*
-      - run:
           name: gmake test 0
           command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
               gmake test TEST_FILES=t/0*
@@ -75,6 +71,10 @@ jobs:
           name: gmake test 7
           command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
               gmake test TEST_FILES=t/7*
+      - run:
+          name: gmake test 8
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/8*
       - run:
           name: gmake test 9
           command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,87 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+orbs:
+  win: circleci/windows@2.4.0
+jobs:
+  build: # name of your job
+    executor:
+      name: win/default
+      size: "medium" # resource class, can be "medium", "large", "xlarge", "2xlarge", defaults to "medium" if not specified
+    steps:
+      # Commands are run in a Windows virtual machine environment
+      # Install miktex to get pdflatex, if we don't get it from the cache
+      # autoinstall latex packages (0=no, 1=autoinstall, 2=ask)
+      # this adds this to the registry!
+      - restore_cache:
+          keys:
+            - chocolatey-miktex-strawberry-v4
+      - run: choco install miktex -y --params '"/Set:essential"'
+      - run:
+          name: initexmf
+          command: $env:Path+="C:\Program Files\MiKTeX\miktex\bin\x64\;";
+              initexmf --set-config-value [MPM]AutoInstall=1
+      - run:
+          name: update miktex db
+          command: $env:Path+="C:\Program Files\MiKTeX\miktex\bin\x64\;";
+              mpm --update
+      - run: refreshenv
+      - run: choco install strawberryperl -y
+      - checkout
+      - run:
+          name: LaTeXML dependencies
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              cpanm --quiet --installdeps --with-develop --notest .
+      - run:
+          name: Makefile.PL
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              perl Makefile.PL
+      - run:
+          name: gmake
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake
+      - run:
+          name: gmake test 9
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/9*
+      - run:
+          name: gmake test 0
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/0*
+      - run:
+          name: gmake test 1
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/1*
+      - run:
+          name: gmake test 2
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/2*
+      - run:
+          name: gmake test 3
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/3*
+      - run:
+          name: gmake test 4
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/4*
+      - run:
+          name: gmake test 5
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/5*
+      - run:
+          name: gmake test 6
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/6*
+      - run:
+          name: gmake test 7
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/7*
+      - run:
+          name: gmake test 8
+          command: $env:Path="C:\Program Files\MiKTeX\miktex\bin\x64\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;$env:Path";
+              gmake test TEST_FILES=t/8*
+      - save_cache:
+          key: chocolatey-miktex-strawberry-v4
+          paths:
+            - C:\ProgramData\chocolatey
+            - C:\Program Files\MiKTeX
+            - C:\Strawberry

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,8 +26,8 @@ use FindBin;
 #     and post-uninstall stages of the build.
 #======================================================================
 
-our $OLD_LIBXML = grep { /OLD_LIBXML/ } @ARGV;
-our $NOMKTEXLSR = grep { /NOMKTEXLSR/ } @ARGV;
+our $OLD_LIBXML     = grep { /OLD_LIBXML/ } @ARGV;
+our $NOMKTEXLSR     = grep { /NOMKTEXLSR/ } @ARGV;
 our $KPSE_TOOLCHAIN = "";
 our ($KPSEV, $TEXMF);
 my ($texmfspec) = grep { /^TEXMF/ } @ARGV;
@@ -201,8 +201,6 @@ MakeGrammar
 #    embedded spaces.
 sub install_TeXStyles {
   if (!$TEXMF) {
-    if ($ENV{"APPVEYOR"}) {    # assume miktex admin on windows CI
-      $KPSE_TOOLCHAIN = "--miktex-admin"; }
     if (system("kpsewhich --version $KPSE_TOOLCHAIN") == 0) {    # can run kpsewhich?
       $TEXMF = `kpsewhich --expand-var='\$TEXMFLOCAL' $KPSE_TOOLCHAIN`;
       # Strip the quotes (they appear in windows, when spaces in pathnames(?))

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -395,9 +395,6 @@ sub build_kpse_cache {
   $kpse_cache = {};    # At least we've tried.
   return unless $kpsewhich;
   # This finds ALL the directories looked for for any purposes, including docs, fonts, etc
-  if ($ENV{"APPVEYOR"}) {
-    $kpse_toolchain = "--miktex-admin";
-  }
   my $texmf = `"$kpsewhich" --expand-var \'\\\$TEXMF\' $kpse_toolchain`; chomp($texmf);
   # These are directories which contain the tex related files we're interested in.
   # (but they're typically below where the ls-R indexes are!)

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -273,6 +273,8 @@ sub daemon_ok {
     # Compare the just generated $base.test.status to the previous $base.status
     if (my $teststatus = get_filecontent("$base.test.status", $base)) {
       if (my $status = get_filecontent("$base.status", $base)) {
+        if ($ENV{CIRCLECI}) {    # ignore windows complaining about running kpsewhich in admin mode
+          $teststatus = [grep { $_ !~ /^kpsewhich\: / } @$teststatus]; }
         is_strings($teststatus, $status, $base); } }
     unlink "$base.test.xml"    if -e "$base.test.xml";
     unlink "$base.test.status" if -e "$base.test.status";
@@ -331,7 +333,7 @@ sub texlive_version {
   if (defined $texlive_version) {
     return $texlive_version; }
   my $extra_flag = '';
-  if ($ENV{"APPVEYOR"}) {
+  if ($ENV{"CIRCLECI"}) {
     # disabled under windows for now
     return 0; }
   if (my $tex = which("tex")) {

--- a/t/81_babel.t
+++ b/t/81_babel.t
@@ -5,7 +5,7 @@
 use LaTeXML::Util::Test;
 
 latexml_tests("t/babel",
-  requires => { '*' => ['babel.sty', 'babel.def'],
+  requires => { '*' => ['babel.sty', 'babel.def', 'english.ldf'],
     csquotes => { texlive_min => 2015,
       packages => ['csquotes.sty', 'frenchb.ldf', 'germanb.ldf'] },
     numprints => 'numprint.sty',


### PR DESCRIPTION
Took me an ungodly amount of time, but I now have CircleCI passing the basic latexml tests under MikTeX on Windows.

Without caching this takes 19 minutes, and seemingly "740 credits". Since my weekly quota is 2500 credits, this would just be 3-4 builds per week, which is ... underwhelming? But we mostly care about windows regressions around release time, and having it run once a week is fine too.

Caching saves about 2 minutes of setup, but that leaves us with 17 mins of runtime... In any case, it works, with the main remaining downside of being unable to silence the ignorable warnings of miktex through kpsewhich.

Here is a link to the last build:
https://app.circleci.com/pipelines/github/dginev/LaTeXML/121/workflows/49c9f338-a001-4f4f-9ff0-8b0e61de6a9c/jobs/124

Not the most pressing of upgrades, but it's good to be done setting it up.