### PR TITLE
[arXiv patches] Maintain the empty () hack for revtex4-1 bibs with no year

### DIFF
--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -559,10 +559,10 @@ sub make_bibcite {
           # HACK! Avoid empty () from situations where we've set the show (CITE_STYLE) too early
           # and don't actually have author-year information!
           my $n = $1;
-          if (($n == 1) && ($show =~ /^\s*year\s*phrase2/i) && !scalar(@{ $$datum{year} })
+          if (($n == 1) && ($show =~ /^\{\}year\{\}phrase2/i) && !scalar(@{ $$datum{year} })
             && (!$phrases[0] || (length($phrases[0]->textContent) <= 1))
             && (!$phrases[1] || (length($phrases[1]->textContent) <= 1))) {
-            $show =~ s/^\s*year\s*phrase2//i; }
+            $show =~ s/^\{\}year\{\}phrase2//i; }
           else {
             push(@stuff, $phrases[$n - 1]->childNodes) if $phrases[$n - 1]; } }
         elsif ($role eq 'year') {
@@ -907,4 +907,3 @@ sub copy_resources {
 
 # ================================================================================
 1;
-


### PR DESCRIPTION
I looked at the warning documents quickly and spotted a visual regression that we had addressed, before in #1150 , the empty `()` in citations without a year, mostly in the arXiv case of bbl-only information.

At some point the delimiter changed from ` year phrase2` to `{}year{}phrase2` and the guard wasn't migrated, so it didn't take effect. I've updated that regex and the following minimal-ish example converts more acceptably again:

```tex
\documentclass{revtex4-1}
\begin{document}

Abdul-Rahman et al. in arXiv:1901.09297~\cite{Abdul-Rahman2019} provided an elegant approach and proved analytically ...

\begin{thebibliography}
\bibitem{Abdul-Rahman2019}
 H. Abdul-Rahman, M. Lemm, A. Lucia, B. Nachtergaele, and A. Young,  A Class of Two-Dimensional AKLT Models with a Gap, arXiv:1901.09297.
\end{thebibliography}
\end{document}
```