### PR TITLE
Add latest required packages of mathtools

### DIFF
--- a/lib/LaTeXML/Package/mathtools.sty.ltxml
+++ b/lib/LaTeXML/Package/mathtools.sty.ltxml
@@ -35,7 +35,14 @@ foreach my $option (qw(fixamsmath donotfixamsmathbugs allowspaces disallowspaces
 DeclareOption(undef, sub {
     PassOptions('amsmath', 'sty', ToString(Expand(T_CS('\CurrentOption')))); });
 ProcessOptions();
+
+RequirePackage('keyval');
+RequirePackage('calc');
+# TODO: add support for mhsetup
+#RequirePackage('mhsetup');
 RequirePackage('amsmath', withoptions => 1);
+AtBeginDocument(sub {
+    RequirePackage('graphicx'); });
 
 ##########
 # Macros #
@@ -613,7 +620,7 @@ DefMacro('\csname enddrcases\endcsname',
   '\lx@end@ams@cases');
 
 DefMacro('\csname drcases*\endcsname',
-  '\lx@ams@cases{name=drcases*,meaning=cases,right=\@right\},style=\displaystyle,conditionmode=text}');
+'\lx@ams@cases{name=drcases*,meaning=cases,right=\@right\},style=\displaystyle,conditionmode=text}');
 DefMacro('\csname enddrcases*\endcsname',
   '\lx@end@ams@cases');
 
@@ -749,7 +756,7 @@ DefMacroI('\end{spreadlines}',   undef,         '\endgroup');
 DefConstructor('\@@lgathered DigestedBody',
   "#1",
   beforeDigest => sub { $_[0]->bgroup; },
-  afterDigest => sub {
+  afterDigest  => sub {
     $_[1]->setProperty('MULTIROW_ALIGNMENT_RULE' => { 'default' => 'left' });
     $_[1]->setBody($_[1]->getArg(1)->unlist, undef); },
   afterConstruct => sub {
@@ -762,7 +769,7 @@ DefMacroI('\endlgathered', undef, '\@finish@alignment\@end@gathered');
 DefConstructor('\@@rgathered DigestedBody',
   "#1",
   beforeDigest => sub { $_[0]->bgroup; },
-  afterDigest => sub {
+  afterDigest  => sub {
     $_[1]->setProperty('MULTIROW_ALIGNMENT_RULE' => { 'default' => 'right' });
     $_[1]->setBody($_[1]->getArg(1)->unlist, undef); },
   afterConstruct => sub {
@@ -774,7 +781,7 @@ DefMacroI('\endrgathered', undef, '\@finish@alignment\@end@gathered');
 
 DefConstructor('\@@newgathered@dummy DigestedBody',
   '#1',
-  beforeDigest => sub { $_[0]->bgroup; },
+  beforeDigest   => sub { $_[0]->bgroup; },
   afterConstruct => sub {
     my ($document) = @_;
     my $array = $document->getNode->lastChild;


### PR DESCRIPTION
Another minor niggle from arXiv, found that an `\includegraphics` was used undefined in a recent 2019 paper. Turns out mathtools [now depends](http://lcd-www.colorado.edu/~axbr9098/tmp/chiral-mhd/paper2/mathtools.sty) on more packages, so I added the easy ones in.

The `mhsetup` one is interesting to look into with some care on a rainy day, deferring that one for now.