### PR TITLE
add proof support in OmniBus

### DIFF
--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -123,13 +123,14 @@ DefMacro('\doi{}',
     . '\else\lx@doi{#1}\fi');
 DefConstructor('\lx@doi{}', '<ltx:ref href="https:/doi.org/#1">#1</ltx:ref>');
 
-for my $env (qw(conjecture proposition lemma corollary example definition)) {
+for my $env (qw(conjecture proposition lemma corollary example definition proof)) {
   my $beginenv = "\\begin{$env}";
   DefMacroI(T_CS($beginenv), undef, sub {
       RequirePackage('amsthm');
       return Tokenize("\\newtheorem{theorem}{Theorem}[section]
   \\newtheorem{conjecture}[theorem]{Conjecture}
   \\newtheorem{proposition}[theorem]{Proposition}
+  \\newtheorem{proof}[theorem]{Proof}
   \\newtheorem{lemma}[theorem]{Lemma}
   \\newtheorem{corollary}[theorem]{Corollary}
   \\newtheorem{example}[theorem]{Example}

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -123,7 +123,9 @@ DefMacro('\doi{}',
     . '\else\lx@doi{#1}\fi');
 DefConstructor('\lx@doi{}', '<ltx:ref href="https:/doi.org/#1">#1</ltx:ref>');
 
-for my $env (qw(conjecture proposition lemma corollary example definition proof)) {
+for my $env (qw(
+  conjecture theorem corollary definition example exercise lemma
+  note problem proof proposition question remark solution)) {
   my $beginenv = "\\begin{$env}";
   DefMacroI(T_CS($beginenv), undef, sub {
       RequirePackage('amsthm');
@@ -134,7 +136,13 @@ for my $env (qw(conjecture proposition lemma corollary example definition proof)
   \\newtheorem{lemma}[theorem]{Lemma}
   \\newtheorem{corollary}[theorem]{Corollary}
   \\newtheorem{example}[theorem]{Example}
+  \\newtheorem{exercise}[theorem]{Exercise}
   \\newtheorem{definition}[theorem]{Definition}
+  \\newtheorem{problem}[theorem]{Problem}
+  \\newtheorem{question}[theorem]{Question}
+  \\newtheorem{remark}[theorem]{Remark}
+  \\newtheorem{solution}[theorem]{Solution}
+  \\newtheorem{note}[theorem]{Note}
   $beginenv")->unlist; }); }
 
 # \abstracts

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -42,6 +42,7 @@ RequirePackage('epsf');
 # by random cls files by over 10 to 1, so we'll just load graphicx and hope for the best.
 # The alternative would be to write a version that sniffed the arguments...
 RequirePackage('graphicx');
+RequirePackage('aas_macros');
 
 # natbib is also often used, but reportedly clashes with cite.sty
 # We'll autoload natbib if it hasn't already been loaded, and if any of its obvious macros are used.


### PR DESCRIPTION
Oversight on my part last time I extended OmniBus, I missed {proof}, which has 0.53% reported at arXiv. Still checking if other packages need it, but the two papers I double-checked were falling back exactly on OmniBus.