### PR TITLE
Ignore spaces in args for package and class loader macros

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -51,7 +51,9 @@ DefConstructor('\documentclass OptionalSemiverbatim SkipSpaces Semiverbatim []',
   afterDigest  => sub {
     my ($stomach, $whatsit) = @_;
     my $options = $whatsit->getArg(1);
-    LoadClass(ToString($whatsit->getArg(2)),
+    my $class   = ToString($whatsit->getArg(2));
+    $class =~ s/\s+//g;
+    LoadClass($class,
       options => [($options ? split(/\s*,\s*/, ToString($options)) : ())],
       after   => Tokens(T_CS('\AtBeginDocument'), T_CS('\warn@unusedclassoptions')));
     return; });
@@ -71,7 +73,8 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
     onlyPreamble('\documentstyle'); },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
-    my $class   = ToString($whatsit->getArg(2));
+    my $class = ToString($whatsit->getArg(2));
+    $class =~ s/\s+//g;
     my $options = $whatsit->getArg(1);
     $options = [($options ? split(/\s*,\s*/, ToString($options)) : ())];
 # Watch out; In principle, compatibility mode wants a .sty, not a .cls!!!
@@ -792,9 +795,11 @@ DefConstructor('\usepackage OptionalSemiverbatim Semiverbatim []',
   afterDigest  => sub { my ($stomach, $whatsit) = @_;
     my $options  = $whatsit->getArg(1);
     my $packages = $whatsit->getArg(2);
-    my @pkgs     = grep { $_ } grep { !/^\s*%/ } split(/\s*,\s*/, ToString($packages));
     $options = [($options ? split(/\s*,\s*/, (ToString($options))) : ())];
-    map { RequirePackage($_, options => $options) } @pkgs;
+    for my $pkg (split(',', ToString($packages))) {
+      $pkg =~ s/\s+//g;
+      next if !$pkg || $pkg =~ /^%/;
+      RequirePackage($pkg, options => $options); }
     return });
 
 DefConstructor('\RequirePackage OptionalSemiverbatim Semiverbatim []',
@@ -803,9 +808,11 @@ DefConstructor('\RequirePackage OptionalSemiverbatim Semiverbatim []',
   afterDigest  => sub { my ($stomach, $whatsit) = @_;
     my $options  = $whatsit->getArg(1);
     my $packages = $whatsit->getArg(2);
-    my @pkgs     = grep { $_ } grep { !/^\s*%/ } split(/\s*,\s*/, ToString($packages));
     $options = [($options ? split(/\s*,\s*/, (ToString($options))) : ())];
-    map { RequirePackage($_, options => $options) } @pkgs;
+    for my $pkg (split(',', ToString($packages))) {
+      $pkg =~ s/\s+//g;
+      next if !$pkg || $pkg =~ /^%/;
+      RequirePackage($pkg, options => $options); }
     return });
 
 DefConstructor('\LoadClass OptionalSemiverbatim Semiverbatim []',
@@ -813,9 +820,10 @@ DefConstructor('\LoadClass OptionalSemiverbatim Semiverbatim []',
   beforeDigest => sub { onlyPreamble('\LoadClass'); },
   afterDigest  => sub { my ($stomach, $whatsit) = @_;
     my $options = $whatsit->getArg(1);
-    my $class   = $whatsit->getArg(2);
+    my $class   = ToString($whatsit->getArg(2));
+    $class =~ s/\s+//g;
     $options = [($options ? split(/\s*,\s*/, (ToString($options))) : ())];
-    LoadClass(ToString($class), options => $options);
+    LoadClass($class, options => $options);
     return; });
 
 # Related internal macros for package definition
@@ -846,26 +854,32 @@ DefPrimitive('\DeclareOption{}{}', sub {
 
 DefPrimitive('\PassOptionsToPackage{}{}', sub {
     my ($stomach, $name, $options) = @_;
+    $name = ToString($name);
+    $name =~ s/\s+//g;
     PassOptions($name, 'sty', split(/\s*,\s*/, ToString(Expand($options)))); });
 
 DefPrimitive('\PassOptionsToClass{}{}', sub {
     my ($stomach, $name, $options) = @_;
+    $name = ToString($name);
+    $name =~ s/\s+//g;
     PassOptions($name, 'cls', split(/\s*,\s*/, ToString(Expand($options)))); });
 
 DefConstructor('\RequirePackageWithOptions Semiverbatim []',
   "<?latexml package='#1'?>",
   beforeDigest => sub { onlyPreamble('\RequirePackage'); },
   afterDigest  => sub { my ($stomach, $whatsit) = @_;
-    my $package = $whatsit->getArg(1);
-    RequirePackage(ToString($package), withoptions => 1);
+    my $package = ToString($whatsit->getArg(1));
+    $package =~ s/\s+//g;
+    RequirePackage($package, withoptions => 1);
     return; });
 
 DefConstructor('\LoadClassWithOptions Semiverbatim []',
   "<?latexml class='#1'?>",
   beforeDigest => sub { onlyPreamble('\LoadClassWithOptions'); },
   afterDigest  => sub { my ($stomach, $whatsit) = @_;
-    my $class = $whatsit->getArg(1);
-    LoadClass(ToString($class), withoptions => 1);
+    my $class = ToString($whatsit->getArg(1));
+    $class =~ s/\s+//g;
+    LoadClass($class, withoptions => 1);
     return; });
 
 DefPrimitive('\@onefilewithoptions {} [][] {}', sub {


### PR DESCRIPTION
This is fundamentally very simple, but still kind of icky, since I am not sure where the perfect patch would be located.

The minimal example (found in arXiv) is the following valid use of `\usepackage`:
```tex
\documentclass{article}
\usepackage{ams thm}
\begin{document}
test
\end{document}
```

Turns out the arguments ignore/discard the spaces. Since we are handling the argument parsing for package and class loading macros in the `afterDigest` perl subroutines, I went ahead and changed a bunch of them to actively discard spaces before passing the names on into the Package.pm loader machinery. Could fix a number of weird missing style files? And ideally is a no-op for anything else.

I also used a tight imperative for loop instead of the multiple grep/map calls, since I keep remembering that `map` is much slower than `for` in Perl.