### PR TITLE
add \newdefinition \newproof macros to elsart

### DIFF
--- a/lib/LaTeXML/Package/elsart_support.sty.ltxml
+++ b/lib/LaTeXML/Package/elsart_support.sty.ltxml
@@ -206,6 +206,10 @@ if (LookupValue('@seceqn')) {
 else {
   RawTeX('\newtheorem{thm}{Theorem}'); }
 
+# Section 7, https://www.elsevier.com/__data/assets/pdf_file/0008/56843/elsdoc-1.pdf
+Let(T_CS('\newdefinition'), T_CS('\newtheorem'));
+Let(T_CS('\newproof'),      T_CS('\newtheorem'));
+
 RawTeX(<<'EoTeX');
 \theoremstyle{plain}
 \newtheorem{cor}[thm]{Corollary}


### PR DESCRIPTION
In [1607.07653](https://corpora.mathweb.org/entry/import/1820146), I noticed two missing macros from Elsevier's class file, which seem to be documented in [newer versions of their manual](https://www.elsevier.com/__data/assets/pdf_file/0008/56843/elsdoc-1.pdf), Section 7.

Adding the two macros as aliases to `\newtheorem` gets that arXiv document passing nice and smooth.