### PR TITLE
add stubs for @float and @dblfloat from LaTeX

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3065,6 +3065,18 @@ DefMacro('\fnum@font@table',          '\fnum@font@float');
 DefMacro('\format@title@font@figure', '\format@title@font@float');
 DefMacro('\format@title@font@table',  '\format@title@font@float');
 
+# stubs for the latex float internals
+for my $float (qw(@float @dblfloat)) {
+  DefEnvironment('{' . $float . '}[]{}',
+    "<ltx:float xml:id='#id' inlist='#inlist' ?#1(placement='#1') class='ltx_float_#2'>"
+      . "#body"
+      . "</ltx:float>",
+    afterDigestBegin => sub {
+      DefMacroI('\@captype', undef, ToString($_[1]->getArg(2)));
+      return; },
+    afterDigest => sub {
+      RescueCaptionCounters(ToString(Expand(T_CS('\@captype'))), $_[1]);
+      return; }); }
 # Could perhaps parameterize further with a separator?
 DefMacro('\format@title@figure{}', '\lx@tag[][: ]{\lx@fnum@@{figure}}#1');
 DefMacro('\format@title@table{}',  '\lx@tag[][: ]{\lx@fnum@@{table}}#1');


### PR DESCRIPTION
A new common undefined report over arXiv comes from us interpreting local `.sty` files raw, which at times define/redefine environments using the internal boilerplate from latex.ltx.

I thought there may be an easy win in this regard, where we preserve the new name of the float, and use the generic `ltx:float` from latexml.

A self-contained example one can try to validate the PR is:

```tex
\documentclass{article}

% originally defined in a local chart.sty
\makeatletter
\newcounter{chart}
\renewcommand\thechart{\@Roman\c@chart}
\def\fps@chart{tbp}
\def\ftype@chart{1}
\def\ext@chart{loc}
\def\fnum@chart{\chartname~\thechart}
\newenvironment{chart}
               {\@float{chart}}
               {\end@float}
\newenvironment{chart*}
               {\@dblfloat{chart}}
               {\end@dblfloat}

\newcommand\listofcharts{%
    \section*{\listchartname
      \@mkboth{\MakeUppercase\listchartname}%
              {\MakeUppercase\listchartname}}%
    \@starttoc{loc}%
    }
\newcommand*\l@chart{\@dottedtocline{1}{1.5em}{2.3em}}
\newcommand\listchartname{List of Charts}
\newcommand\chartname{Chart}
\makeatother

\begin{document}
start

\begin{chart}
chart
\caption{chart caption}
\end{chart}

\begin{chart*}
star
\caption{star caption}
\end{chart*}

end
\end{document}
```