### PR TITLE
espcrc2.sty and Safe use of subs in bindings

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -445,6 +445,7 @@ lib/LaTeXML/Package/epsf.tex.ltxml
 lib/LaTeXML/Package/epsfig.sty.ltxml
 lib/LaTeXML/Package/epstopdf.sty.ltxml
 lib/LaTeXML/Package/esint.sty.ltxml
+lib/LaTeXML/Package/espcrc.sty.ltxml
 lib/LaTeXML/Package/etex.sty.ltxml
 lib/LaTeXML/Package/etoolbox.sty.ltxml
 lib/LaTeXML/Package/eucal.sty.ltxml

--- a/lib/LaTeXML/Core/Definition/Constructor.pm
+++ b/lib/LaTeXML/Core/Definition/Constructor.pm
@@ -102,10 +102,10 @@ sub invoke {
     my $value = $props{$key};
     if (ref $value eq 'CODE') {
       $props{$key} = &$value($stomach, @args); } }
-  $props{font}    = $font                           unless defined $props{font};
-  $props{locator} = $stomach->getGullet->getLocator unless defined $props{locator};
-  $props{isMath}  = $ismath                         unless defined $props{isMath};
-  $props{level}   = $stomach->getBoxingLevel;
+  $props{font}        = $font                           unless defined $props{font};
+  $props{locator}     = $stomach->getGullet->getLocator unless defined $props{locator};
+  $props{isMath}      = $ismath                         unless defined $props{isMath};
+  $props{level}       = $stomach->getBoxingLevel;
   $props{scriptlevel} = $stomach->getScriptLevel if $ismath;
   # Now create the Whatsit, itself.
   my $whatsit = LaTeXML::Core::Whatsit->new($self, [@args], %props);
@@ -122,8 +122,8 @@ sub invoke {
 sub executeAfterDigestBody {
   my ($self, $stomach, @whatever) = @_;
   local $LaTeXML::Core::State::UNLOCKED = 1;
-  my $post = $$self{afterDigestBody};
-  return ($post ? map { &$_($stomach, @whatever) } @$post : ()); }
+  my @post = grep { defined } @{ $$self{afterDigestBody} || [] };
+  return (map { &$_($stomach, @whatever) } @post); }
 
 sub doAbsorbtion {
   my ($self, $document, $whatsit) = @_;
@@ -144,7 +144,7 @@ sub doAbsorbtion {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -154,7 +154,7 @@ C<LaTeXML::Core::Definition::Constructor>  - Control sequence definitions.
 
 
 This class represents control sequences that contribute arbitrary XML fragments
-to the document tree.  During digestion, a C<LaTeXML::Core::Definition::Constuctor> records the arguments 
+to the document tree.  During digestion, a C<LaTeXML::Core::Definition::Constuctor> records the arguments
 used in the invocation to produce a L<LaTeXML::Core::Whatsit>.  The resulting L<LaTeXML::Core::Whatsit>
 (usually) generates an XML document fragment when absorbed by an instance of L<LaTeXML::Core::Document>.
 Additionally, a C<LaTeXML::Core::Definition::Constructor> may have beforeDigest and afterDigest daemons

--- a/lib/LaTeXML/Core/Definition/Primitive.pm
+++ b/lib/LaTeXML/Core/Definition/Primitive.pm
@@ -37,22 +37,22 @@ sub isPrefix {
 sub executeBeforeDigest {
   my ($self, $stomach) = @_;
   local $LaTeXML::Core::State::UNLOCKED = 1;
-  my $pre = $$self{beforeDigest};
-  return ($pre ? map { &$_($stomach) } grep { defined $_ } @$pre : ()); }
+  my @pre = grep { defined } @{ $$self{beforeDigest} || [] };
+  return (map { &$_($stomach) } @pre); }
 
 sub executeAfterDigest {
   my ($self, $stomach, @whatever) = @_;
   local $LaTeXML::Core::State::UNLOCKED = 1;
-  my $post = $$self{afterDigest};
-  return ($post ? map { &$_($stomach, @whatever) } grep { defined $_ } @$post : ()); }
+  my @post = grep { defined } @{ $$self{afterDigest} || [] };
+  return (map { &$_($stomach, @whatever) } @post); }
 
 # Digest the primitive; this should occur in the stomach.
 sub invoke {
   my ($self, $stomach) = @_;
   my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
-  my $tracing = $STATE->lookupValue('TRACINGCOMMANDS');
+  my $tracing  = $STATE->lookupValue('TRACINGCOMMANDS');
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
-  print STDERR '{' . $self->tracingCSName . "}\n" if $tracing;
+  print STDERR '{' . $self->tracingCSName . "}\n"                if $tracing;
   my @result = ($self->executeBeforeDigest($stomach));
   my @args   = $self->readArguments($stomach->getGullet);
   print STDERR $self->tracingArgs(@args) . "\n" if $tracing && @args;
@@ -77,7 +77,7 @@ sub equals {
 
 __END__
 
-=pod 
+=pod
 
 =head1 NAME
 
@@ -96,7 +96,7 @@ It extends L<LaTeXML::Core::Definition>.
 
 Primitive definitions may have lists of daemon subroutines, C<beforeDigest> and C<afterDigest>,
 that are executed before (and before the arguments are read) and after digestion.
-These should either end with C<return;>, C<()>, or return a list of digested 
+These should either end with C<return;>, C<()>, or return a list of digested
 objects (L<LaTeXML::Core::Box>, etc) that will be contributed to the current list.
 
 =head1 AUTHOR

--- a/lib/LaTeXML/Package/espcrc.sty.ltxml
+++ b/lib/LaTeXML/Package/espcrc.sty.ltxml
@@ -1,0 +1,31 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# | espcrc2.sty                                                         | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+# Can handle both espcrc1 and espcrc2
+# Source: https://arxiv.org/macros/espcrc2.sty
+
+DefConstructor('\@@@address{}', "^ <ltx:contact role='address'>#1</ltx:contact>");
+DefMacro('\address[]{}',     '\@add@to@frontmatter{ltx:creator}{\@@@address{#2}}');
+DefMacro('\addressmark',     Tokens());
+DefMacro('\addresstext{}{}', '#2');
+DefMacro('\filedate',        '24 November 1993');
+DefMacro('\fileversion',     'v2.6');
+NewCounter('address');
+DefMacro('\theaddress', '\alph{address}');
+
+#======================================================================
+1;


### PR DESCRIPTION
The `espcrc` (1 and 2) part of the PR is easy, just a very old style used by arXiv that adds `\address`. 

The second part of the PR hit a phenomenally sinister bug, which hopefully was freshly introduced by "better" use of `RequirePackage`. Though I am _still_ not sure if it is fresh or old, and the exact mechanics behind the last steps of it.

A very good testing file is [cs/0309037](https://corpora.mathweb.org/entry/import/2272595) ran with includestyles, e.g.
```
latexmlc test.zip --dest=test.html --includestyles
```

If you observe the log and the raw loaded `aadebug.cls`, you will see a report of only **the first** of the following calls to `\RequirePackage`:
```tex
\RequirePackage[latin1]{inputenc}
\RequirePackage[T1]{fontenc}
\RequirePackage{palatino}
\RequirePackage[dvips]{graphicx}
\RequirePackage[usenames,dvipsnames]{color}
%\RequirePackage[pdftex]{hyperref}
\RequirePackage{hyperref}
```

Jumping in the code and debugging for a while with prints, I can also report the other macros are indeed correctly processed, called, their `beforeDigest` is called, but crucially their `afterDigest` subroutine _isn't_.

In particular the two lines you will see changed in the diff of this PR related to
```perl
my $post = $$self{afterDigest};
```

Printing a `Dumper` of the post variable (in master) revealed that while the first call to `\RequirePackage`'s afterDigest was perfect, in the second call (and all following), the post variable contained `[ undef ]` as its content.

I tried tinkering around some more and tried to isolate a minimal example, but the code is actually robust in isolation. My best theory right now is that because in the case of this paper we have a nested call to InputDefinitions (inputenc.sty -> latin1.def), the nested interplay _somehow_ leads to that afterDigest value getting erased from the Primitive definition. This could be completely off the mark and wrong.

However, by serendipity and chance, fixing this is actually much easier than understanding the bug. If one avoids using the `$$self` field directly but instead moves the subroutine items into a new array, as in:
```perl
my @post = @{ $$self{afterDigest} || [] };
```

This error never occurs. Which makes sense because replacing the sub with `undef` in `@post` will **not** propagate to the Primitive definition itself, it will just locally modify that array.

Bizarre and complicated. I will try hunting down the exact line that erases the field tomorrow, but the patch seems very solid when testing.