### PR TITLE
more infra in OmniBus; improve multi script Error message

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2742,13 +2742,17 @@ DefPrimitive('\newenvironment OptionalMatch:* {}[Number][]{}{}', sub {
         || LookupValue('\\begin{' . $name . '}:locked'));
       return; }
     DefMacroI(T_CS("\\$name"),    convertLaTeXArgs($nargs, $opt), $begin);
-    DefMacroI(T_CS("\\end$name"), undef,                          $end); });
+    DefMacroI(T_CS("\\end$name"), undef,                          $end);
+    return; });
 
 DefPrimitive('\renewenvironment OptionalMatch:* {}[Number][]{}{}', sub {
     my ($stomach, $star, $name, $nargs, $opt, $begin, $end) = @_;
     $name = ToString(Expand($name));
-    DefMacroI(T_CS("\\$name"),    convertLaTeXArgs($nargs, $opt), $begin);
-    DefMacroI(T_CS("\\end$name"), undef,                          $end); });
+    if (!LookupValue("\\$name:locked")
+      && !LookupValue("\\begin{$name}:locked")) {
+      DefMacroI(T_CS("\\$name"),    convertLaTeXArgs($nargs, $opt), $begin);
+      DefMacroI(T_CS("\\end$name"), undef,                          $end); }
+    return; });
 
 #======================================================================
 # C.8.3 Theorem-like Environments
@@ -3812,7 +3816,7 @@ DefMacroI('\fnum@@bibitem', undef, '{\@biblabel{\the@bibitem}}');
 # Hack for abused bibliographies; see below
 DefMacro('\bibitem',
   '\if@lx@inbibliography\else\expandafter\lx@mung@bibliography\expandafter{\@currenvir}\fi'
-    . '\lx@bibitem');
+    . '\lx@bibitem', locked => 1);
 DefConstructor('\lx@bibitem[] Semiverbatim',
   "<ltx:bibitem key='#key' xml:id='#id'>"
     . "#tags"

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -94,10 +94,31 @@ DefConstructor('\@@@address{}', "^ <ltx:contact role='address'>#1</ltx:contact>"
 DefMacro('\address[]{}',   '\@add@to@frontmatter{ltx:creator}{\@@@address{#2}}');
 DefMacro('\affiliation{}', '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
 
+# some rarer name macros that are functionally no-ops for latexml
+DefMacro('\prefix{}',         '#1');
+DefMacro('\suffix{}',         '#1');
+DefMacro('\fnms{}',           '#1');
+DefMacro('\snm{}',            '#1');
+DefMacro('\inits{}',          '#1');
+DefMacro('\printaddresses{}', '#1');
+DefMacro('\printead{}',       Tokens());
+DefMacro('\firstpage{}',      Tokens());
+DefMacro('\lastpage{}',       Tokens());
+DefMacro('\runauthor{}',      Tokens());
+DefMacro('\runtitle{}',       Tokens());
+DefMacro('\corref{}',         Tokens());
+DefMacro('\preface',          Tokens());
+DefMacro('\thankstext',       Tokens());
+Let(T_CS('\smonth'), T_CS('\month'));
+Let(T_CS('\syear'),  T_CS('\year'));
+
 # Comes as both macro with arg, and environment! w/ or w/o "s"!
 DefMacro('\keyword{}',  '\@add@frontmatter{ltx:keywords}{#1}');
 DefMacro('\keywords{}', '\@add@frontmatter{ltx:keywords}{#1}');
 DefMacro('\kword{}',    '\@add@frontmatter{ltx:keywords}{#1}');
+DefMacro('\kwd[]{}',    '\@add@frontmatter{ltx:keywords}{#2, }');
+Let(T_CS('\addto@keywords@list'), T_CS('\keyword'));
+
 # {keyword}, {keywords}
 DefEnvironment('{keywords}', '',
   afterDigest => sub {
@@ -130,21 +151,28 @@ for my $env (qw(
   my $beginenv = "\\begin{$env}";
   DefMacroI(T_CS($beginenv), undef, sub {
       RequirePackage('amsthm');
-      return Tokenize("\\newtheorem{theorem}{Theorem}[section]
-  \\newtheorem{conjecture}[theorem]{Conjecture}
-  \\newtheorem{proposition}[theorem]{Proposition}
-  \\newtheorem{proof}[theorem]{Proof}
-  \\newtheorem{lemma}[theorem]{Lemma}
-  \\newtheorem{corollary}[theorem]{Corollary}
-  \\newtheorem{example}[theorem]{Example}
-  \\newtheorem{exercise}[theorem]{Exercise}
-  \\newtheorem{definition}[theorem]{Definition}
-  \\newtheorem{problem}[theorem]{Problem}
-  \\newtheorem{question}[theorem]{Question}
-  \\newtheorem{remark}[theorem]{Remark}
-  \\newtheorem{solution}[theorem]{Solution}
-  \\newtheorem{note}[theorem]{Note}
-  $beginenv")->unlist; }); }
+      return Tokenize(<<"EOL"
+\\newtheorem{theorem}{Theorem}[section]
+\\newtheorem{conjecture}[theorem]{Conjecture}
+\\newtheorem{proposition}[theorem]{Proposition}
+\\newtheorem{proof}[theorem]{Proof}
+\\newtheorem{lemma}[theorem]{Lemma}
+\\newtheorem{corollary}[theorem]{Corollary}
+\\newtheorem{example}[theorem]{Example}
+\\newtheorem{exercise}[theorem]{Exercise}
+\\newtheorem{definition}[theorem]{Definition}
+\\newtheorem{problem}[theorem]{Problem}
+\\newtheorem{question}[theorem]{Question}
+\\newtheorem{remark}[theorem]{Remark}
+\\newtheorem{solution}[theorem]{Solution}
+\\newtheorem{step}[theorem]{Step}
+\\newtheorem{note}[theorem]{Note}
+$beginenv
+EOL
+)->unlist; }); }
+DefMacroI(T_CS('\newproclaim'), undef, sub {
+    RequirePackage('amsthm');
+    return T_CS('\newtheorem'); });
 
 # \abstracts
 Let('\abst', '\abstract');

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -107,10 +107,15 @@ DefMacro('\lastpage{}',       Tokens());
 DefMacro('\runauthor{}',      Tokens());
 DefMacro('\runtitle{}',       Tokens());
 DefMacro('\corref{}',         Tokens());
+DefMacro('\listofauthors{}',  Tokens());
+DefMacro('\indexauthor{}',    Tokens());
 DefMacro('\preface',          Tokens());
 DefMacro('\thankstext',       Tokens());
-Let(T_CS('\smonth'), T_CS('\month'));
-Let(T_CS('\syear'),  T_CS('\year'));
+DefMacro('\resumen{}',        '\@add@frontmatter{ltx:abstract}{#1}');
+DefMacro('\ion{}{}',          '{#1 \textsc{#2}}');
+Let(T_CS('\fulladdresses'), T_CS('\address'));
+Let(T_CS('\smonth'),        T_CS('\month'));
+Let(T_CS('\syear'),         T_CS('\year'));
 
 # Comes as both macro with arg, and environment! w/ or w/o "s"!
 DefMacro('\keyword{}',  '\@add@frontmatter{ltx:keywords}{#1}');

--- a/lib/LaTeXML/Package/inst_support.sty.ltxml
+++ b/lib/LaTeXML/Package/inst_support.sty.ltxml
@@ -56,6 +56,7 @@ Let('\at',      '\and');    # Actually this is different than \and, but...
 Let('\iand',    '\and');
 Let('\nand',    '\and');
 Let('\lastand', '\and');
+Let('\AND',     '\and');
 
 NewCounter('inst', 'document');
 DefMacro('\institute{}',
@@ -117,4 +118,3 @@ sub relocateInstitute {
   return; }
 
 1;
-

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -985,7 +985,8 @@ sub pmml_script_mid_layout {
     return $base; }
   else {
     if (scalar(@$midscripts) > 1) {
-      Error("unexpected", 'multiple-mid-level-scripts', "Multiple mid-level (limit) scripts; extras are DROPPED!", $base,
+      Error("unexpected", 'multiple-mid-level-scripts', undef,
+        "Multiple mid-level (limit) scripts; extras are DROPPED!", "base: " . $base->toString(),
         map { @$_ } @$midscripts); }
     { local $LaTeXML::MathML::NOMOVABLELIMITS = 1;
       ##### TRY this to block an extra mstyle

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -985,7 +985,7 @@ sub pmml_script_mid_layout {
     return $base; }
   else {
     if (scalar(@$midscripts) > 1) {
-      Error("unexpected", $base, "Multiple mid-level (limit) scripts; extras are DROPPED!",
+      Error("unexpected", 'multiple-mid-level-scripts', "Multiple mid-level (limit) scripts; extras are DROPPED!", $base,
         map { @$_ } @$midscripts); }
     { local $LaTeXML::MathML::NOMOVABLELIMITS = 1;
       ##### TRY this to block an extra mstyle


### PR DESCRIPTION
A "caring for the wounded" PR, while examining the high-up entries in the "Error:undefined" arXiv report. I spotted [\snm](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/undefined/%5Csnm?all=false) pretty high up and there were also some related shorthand macros pertaining to doc metadata in non-standard .cls files. 

Some of the errors really require adding new bindings (e.g. `bbook`-related), or  reading the class file (e.g. local `\tfrac` definition), but others felt addressable directly in OmniBus, when there was hope for standard metadata infrastructure, or standard usage of amsthm.

This PR is testing on a single paper, [0709.3896](https://arxiv.org/abs/0709.3896), 

The conversion summary from a master run:
> Status:conversion:2 
>
> 178 warnings; 46 errors; 44 undefined macros[\baddress, \bbooktitle, {bbook}, \bseries, {pf*}, {longlist}, \bpublisher, \AND, \fnms, \runtitle, \thankstext, \bsnm, \corref, {bmisc}, \smonth, \snm, \qed, \syear, \byear, \binits, \lastpage, \endbibitem, \tfrac, \newproclaim, {step}, {bincollection}, {barticle}, \bedition, \noqed, \bvolume, \bmrnumber, \firstpage, \bhowpublished, \thanksref, \printead, \kwd, \bpages, \bfnm, \printaddresses, {aug}, \btitle, {pf}, \bauthor, \bjournal]; 1 missing file[arximspdf.cls]
>
> 6 errors

Improves to:
>Status:conversion:2 
>
>182 warnings; 30 errors; 28 undefined macros[\noqed, \bpublisher, {barticle}, \bseries, \bsnm, \thanksref, {bmisc}, \bjournal, \byear, {bincollection}, {bbook}, \binits, \bpages, \bedition, \bmrnumber, \bhowpublished, \tfrac, \bfnm, {pf*}, {longlist}, {pf}, \btitle, {aug}, \bauthor, \bvolume, \baddress, \endbibitem, \bbooktitle]; 1 missing file[arximspdf.cls]
>
>6 errors

I additionally improved a rather obscure post-processing error from reporting a formula in the summary:
![image](https://user-images.githubusercontent.com/348975/101936117-253c7700-3bae-11eb-922a-d6aa19329517.png)

to reporting a summary in the summary (see comments)