### PR TITLE
Pgf cleanup

### DIFF
--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -54,9 +54,9 @@ my $FLAG_EMPH         = 0x10;
 # NOTE: This probably doesn't really belong in here...
 
 my %font_family = (
-  cmr  => { family => 'serif' },      cmss  => { family => 'sansserif' },
-  cmtt => { family => 'typewriter' }, cmvtt => { family => 'typewriter' },
-  cmti => { family => 'typewriter', shape => 'italic' },
+  cmr   => { family => 'serif' },      cmss  => { family => 'sansserif' },
+  cmtt  => { family => 'typewriter' }, cmvtt => { family => 'typewriter' },
+  cmti  => { family => 'typewriter', shape => 'italic' },
   cmfib => { family => 'serif' },      cmfr  => { family => 'serif' },
   cmdh  => { family => 'serif' },      cm    => { family => 'serif' },
   ptm   => { family => 'serif' },      ppl   => { family => 'serif' },
@@ -74,21 +74,21 @@ my %font_family = (
   pxr   => { family => 'serif' },      pxms  => { family => 'symbol' },
   pxsya => { family => 'symbol' },     pxsyb => { family => 'symbol' },
   futs  => { family => 'serif' },
-  uaq   => { family => 'serif' },      ugq   => { family => 'sansserif' },
-  eur   => { family => 'serif' },      eus   => { family => 'script' },
-  euf   => { family => 'fraktur' },    euex  => { family => 'symbol' },
+  uaq   => { family => 'serif' },   ugq  => { family => 'sansserif' },
+  eur   => { family => 'serif' },   eus  => { family => 'script' },
+  euf   => { family => 'fraktur' }, euex => { family => 'symbol' },
   # The following are actually math fonts.
   ms    => { family => 'symbol' },
-  ccm   => { family => 'serif', shape => 'italic' },
-  cmm   => { family => 'italic', encoding => 'OML' },
-  cmex  => { family => 'symbol', encoding => 'OMX' },       # Not really symbol, but...
-  cmsy  => { family => 'symbol', encoding => 'OMS' },
-  ccitt => { family => 'typewriter', shape => 'italic' },
-  cmbrm => { family => 'sansserif', shape => 'italic' },
-  futm  => { family => 'serif', shape => 'italic' },
-  futmi => { family => 'serif', shape => 'italic' },
-  txmi  => { family => 'serif', shape => 'italic' },
-  pxmi  => { family => 'serif', shape => 'italic' },
+  ccm   => { family => 'serif',      shape    => 'italic' },
+  cmm   => { family => 'italic',     encoding => 'OML' },
+  cmex  => { family => 'symbol',     encoding => 'OMX' },      # Not really symbol, but...
+  cmsy  => { family => 'symbol',     encoding => 'OMS' },
+  ccitt => { family => 'typewriter', shape    => 'italic' },
+  cmbrm => { family => 'sansserif',  shape    => 'italic' },
+  futm  => { family => 'serif',      shape    => 'italic' },
+  futmi => { family => 'serif',      shape    => 'italic' },
+  txmi  => { family => 'serif',      shape    => 'italic' },
+  pxmi  => { family => 'serif',      shape    => 'italic' },
   bbm   => { family => 'blackboard' },
   bbold => { family => 'blackboard' },
   bbmss => { family => 'blackboard' },
@@ -129,10 +129,10 @@ sub lookupFontShape {
 # extended logical font sizes, based on nominal document size of 10pts
 # Possibly should simply use absolute font point sizes, as declared in class...
 my %font_size = (
-  tiny   => 0.5, SMALL => 0.7, Small => 0.8,  small => 0.9,
-  normal => 1.0, large => 1.2, Large => 1.44, LARGE => 1.728,
-  huge => 2.074, Huge => 2.488,
-  big  => 1.2,   Big  => 1.6, bigg => 2.1, Bigg => 2.6,
+  tiny   => 0.5,   SMALL => 0.7, Small => 0.8,  small => 0.9,
+  normal => 1.0,   large => 1.2, Large => 1.44, LARGE => 1.728,
+  huge   => 2.074, Huge  => 2.488,
+  big    => 1.2,   Big   => 1.6, bigg => 2.1, Bigg => 2.6,
 );
 
 sub rationalizeFontSize {
@@ -200,6 +200,7 @@ sub new {
   my $encoding  = $options{encoding};
   my $language  = $options{language};
   my $mathstyle = $options{mathstyle};
+
   if ($options{forcebold}) {    # for compatibility
     $series = 'bold'; $options{forceseries} = 1; }
   my $flags = 0
@@ -207,8 +208,8 @@ sub new {
     | ($options{forceseries} ? $FLAG_FORCE_SERIES : 0)
     | ($options{forceshape}  ? $FLAG_FORCE_SHAPE  : 0);
   return $class->new_internal(
-    $family, $series, $shape, rationalizeFontSize($size),
-    $color, $bg, $opacity,
+    $family,    $series, $shape, rationalizeFontSize($size),
+    $color,     $bg,     $opacity,
     $encoding,  $language,
     $mathstyle, $flags); }
 
@@ -250,15 +251,15 @@ sub stringify {
   my ($fam, $ser, $shp, $siz, $col, $bkg, $opa, $enc, $lang, $mstyle, $flags) = @$self;
   $fam = 'serif' if $fam && ($fam eq 'math');
   return 'Font[' . join(',', map { Stringify($_) } grep { $_ }
-      (isDiff($fam, $DEFFAMILY) ? ($fam) : ()),
-    (isDiff($ser, $DEFSERIES)     ? ($ser) : ()),
-    (isDiff($shp, $DEFSHAPE)      ? ($shp) : ()),
-    (isDiff($siz, DEFSIZE())      ? ($siz) : ()),
-    (isDiff($col, $DEFCOLOR)      ? ($col) : ()),
-    (isDiff($bkg, $DEFBACKGROUND) ? ($bkg) : ()),
-    (isDiff($opa, $DEFOPACITY)    ? ($opa) : ()),
-    ($mstyle ? ($mstyle) : ()),
-    ($flags  ? ($flags)  : ()),
+      (isDiff($fam, $DEFFAMILY)   ? ($fam)    : ()),
+    (isDiff($ser, $DEFSERIES)     ? ($ser)    : ()),
+    (isDiff($shp, $DEFSHAPE)      ? ($shp)    : ()),
+    (isDiff($siz, DEFSIZE())      ? ($siz)    : ()),
+    (isDiff($col, $DEFCOLOR)      ? ($col)    : ()),
+    (isDiff($bkg, $DEFBACKGROUND) ? ($bkg)    : ()),
+    (isDiff($opa, $DEFOPACITY)    ? ($opa)    : ()),
+    ($mstyle                      ? ($mstyle) : ()),
+    ($flags                       ? ($flags)  : ()),
     )
     . ']'; }
 
@@ -286,9 +287,9 @@ sub makeConcrete {
   my ($family, $series, $shape, $size, $color, $bg, $opacity, $encoding, $lang, $mstyle, $flags) = @$self;
   my ($ofamily, $oseries, $oshape, $osize, $ocolor, $obg, $oopacity, $oencoding, $olang, $omstyle, $oflags) = @$concrete;
   return (ref $self)->new_internal(
-    $family || $ofamily, $series || $oseries, $shape || $oshape, $size || $osize,
-    $color || $ocolor, $bg || $obg, (defined $opacity ? $opacity : $oopacity),
-    $encoding || $oencoding, $lang || $olang, $mstyle || $omstyle,
+    $family   || $ofamily,   $series || $oseries, $shape || $oshape, $size || $osize,
+    $color    || $ocolor,    $bg     || $obg, (defined $opacity ? $opacity : $oopacity),
+    $encoding || $oencoding, $lang   || $olang, $mstyle || $omstyle,
     ($flags || 0) | ($oflags || 0)); }
 
 sub isDiff {
@@ -446,9 +447,11 @@ our %mathstylesize = (display => 1, text => 1,
 # NOTE: that we assume the size has already been adjusted for mathstyle, if necessary.
 sub computeStringSize {
   my ($self, $string) = @_;
+  if ($self->getFamily eq 'nullfont') {
+    return (Dimension(0), Dimension(0), Dimension(0)); }
   my $size = ($self->getSize || DEFSIZE() || 10); ## * $mathstylesize{ $self->getMathstyle || 'text' };
-  my $l = (defined $string ? length($string) : 0);
-  my $u = $size * 65535;
+  my $l    = (defined $string ? length($string) : 0);
+  my $u    = $size * 65535;
   return (Dimension(0.75 * $u * $l), Dimension(0.7 * $u), Dimension(0.2 * $u)); }
 
 # Get nominal width, height base ?
@@ -578,6 +581,7 @@ sub merge {
   my $encoding  = $options{encoding};
   my $language  = $options{language};
   my $mathstyle = $options{mathstyle};
+
   if ($options{forcebold}) {    # for compatibility
     $series = 'bold'; $options{forceseries} = 1; }
   my $flags = 0
@@ -587,24 +591,24 @@ sub merge {
 
   my $oflags = $$self[10];
   # Fallback to positional invocation:
-  $family = $$self[0] if (!defined $family) || ($oflags & $FLAG_FORCE_FAMILY);
-  $series = $$self[1] if (!defined $series) || ($oflags & $FLAG_FORCE_SERIES);
-  $shape  = $$self[2] if (!defined $shape)  || ($oflags & $FLAG_FORCE_SHAPE);
-  $size   = $$self[3] if (!defined $size);
-  $color  = $$self[4] if (!defined $color);
-  $bg     = $$self[5] if (!defined $bg);
+  $family    = $$self[0] if (!defined $family) || ($oflags & $FLAG_FORCE_FAMILY);
+  $series    = $$self[1] if (!defined $series) || ($oflags & $FLAG_FORCE_SERIES);
+  $shape     = $$self[2] if (!defined $shape)  || ($oflags & $FLAG_FORCE_SHAPE);
+  $size      = $$self[3] if (!defined $size);
+  $color     = $$self[4] if (!defined $color);
+  $bg        = $$self[5] if (!defined $bg);
   $opacity   = $$self[6] if (!defined $opacity);
   $encoding  = $$self[7] if (!defined $encoding);
   $language  = $$self[8] if (!defined $language);
   $mathstyle = $$self[9] if (!defined $mathstyle);
-  $flags = ($$self[10] || 0) | $flags;
+  $flags     = ($$self[10] || 0) | $flags;
 
   if (my $scale = $options{scale}) {
     $size = $scale * $size; }
   # Set the mathstyle, and also the size from the mathstyle
   # But we may need to scale that size against the existing or requested size.
   my $stylescale = ($$self[3] ? $$self[3] / $stylesize{ $$self[9] || 'display' } : 1);
-  if ($options{size}) { }    # Explicitly requested size, use it
+  if    ($options{size}) { }       # Explicitly requested size, use it
   elsif ($options{mathstyle}) {    # otherwise set the size from mathstyle
     $size = $stylescale * $stylesize{$mathstyle}; }
   elsif ($options{scripted}) {     # Or adjust both the mathstyle & size for scripts
@@ -620,7 +624,7 @@ sub merge {
   $flags &= ~$FLAG_EMPH if $mathstyle;    # Disable emph in math
 
   my $newfont = (ref $self)->new_internal($family, $series, $shape, $size,
-    $color, $bg, $opacity,
+    $color,     $bg, $opacity,
     $encoding,  $language,
     $mathstyle, $flags);
   if (my $specialize = $options{specialize}) {
@@ -702,10 +706,10 @@ sub purestyleChanges {
 sub mergePurestyle {
   my ($self, %stylechanges) = @_;
   my $new = $self->new_internal(@$self);
-  $$new[3] = $$self[3] * $stylechanges{scale} if $stylechanges{scale};
-  $$new[4] = $stylechanges{color}             if $stylechanges{color};
-  $$new[5] = $stylechanges{background}        if $stylechanges{background};
-  $$new[6] = $stylechanges{opacity}           if $stylechanges{opacity};
+  $$new[3] = $$self[3] * $stylechanges{scale}                            if $stylechanges{scale};
+  $$new[4] = $stylechanges{color}                                        if $stylechanges{color};
+  $$new[5] = $stylechanges{background}                                   if $stylechanges{background};
+  $$new[6] = $stylechanges{opacity}                                      if $stylechanges{opacity};
   $$new[9] = $stepmathstyle{ $$self[9] }{ $stylechanges{mathstylestep} } if $stylechanges{mathstylestep};
   return new; }
 

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -1815,7 +1815,6 @@ sub wrapNodes {
     if ($self->isOpen($n)) {
       $leave_open = 1;
       last; } }
-  print STDERR "WRAPPING with $qname, but keeping upen!\n" if $leave_open;
   my $model  = $$self{model};
   my $parent = $nodes[0]->parentNode;
   my ($ns, $tag) = $model->decodeQName($qname);

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -851,12 +851,12 @@ sub closeToNode {
     $n        = $n->parentNode; }
   if ($t == XML_DOCUMENT_NODE) {    # Didn't find $node at all!!
     Error('malformed', $model->getNodeQName($node), $self,
-      "Attempt to close " . Stringify($node) . ", which isn't open",
+      "Attempt to close to " . Stringify($node) . ", which isn't open",
       "Currently in " . $self->getInsertionContext()) unless $ifopen;
     return; }
   else {                            # Found node.
     Error('malformed', $model->getNodeQName($node), $self,
-      "Closing " . Stringify($node) . " whose open descendents do not auto-close",
+      "Closing to " . Stringify($node) . " whose open descendents do not auto-close",
       "Descendents are " . join(', ', map { Stringify($_) } @cant_close))
       if @cant_close;               # But found has intervening non-auto-closeable nodes!!
     $self->closeNode_internal($lastopen) if $lastopen; }

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1943,6 +1943,9 @@ DefConstructor('\hbox BoxSpecification HBoxContents', sub {
       width => $props{width});
 
     $document->absorb($contents);
+    if (!$issvg) {
+      while (!$document->getElement()->hasAttribute('_beginscope') && $document->maybeCloseElement('svg:g')) { }
+      $document->maybeCloseElement('svg:svg'); }
     $document->closeNode($node); },
 
   mode => 'text', bounded => 1,

--- a/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
@@ -260,7 +260,7 @@ sub pgfAssignKey {
   DefMacroI(T_CS('\pgfkeyscurrentvalue'), undef,
     ($value ? Tokens(map { ($_->getCatcode == CC_PARAM ? ($_, $_) : $_) } @value_toks)
       : ()));    # (or \pgfkeysnovalue ????
-  if (defined $value) { }                              # Got value? ok.
+  if    (defined $value) { }                           # Got value? ok.
   elsif (my $def = pgfkeyLookup($key . '/.@def')) {    # else if a default, let to it
     Let(T_CS('\pgfkeyscurrentvalue'), pgfkeyCS($key . '/.@def')); }
 
@@ -371,22 +371,22 @@ sub pgfHandleValue {
 our $PGF_1ARG = LaTeXML::Core::Parameters->new(
   LaTeXML::Core::Parameter->new('Until', 'Until:\pgfeov', extra => [T_CS('\pgfeov')]));
 
-DefMacro('\pgfkeysdef{}{}', sub {
-    my ($gullet, $key, $body) = @_;
+DefPrimitive('\pgfkeysdef{}{}', sub {
+    my ($stomach, $key, $body) = @_;
     $key = ToString(Expand($key));
     DefMacroI(pgfkeyCS($key . '/.@cmd'),  $PGF_1ARG, $body);
     DefMacroI(pgfkeyCS($key . '/.@body'), undef,     $body); },
   locked => 1);
 
-DefMacro('\pgfkeysedef{}{}', sub {
-    my ($gullet, $key, $body) = @_;
+DefPrimitive('\pgfkeysedef{}{}', sub {
+    my ($stomach, $key, $body) = @_;
     $key = ToString(Expand($key));
     DefMacroI(pgfkeyCS($key . '/.@cmd'),  $PGF_1ARG, Expand($body));
     DefMacroI(pgfkeyCS($key . '/.@body'), undef,     $body); },
   locked => 1);
 
-DefMacro('\pgfkeysdefargs{}{}{}', sub {
-    my ($gullet, $key, $args, $body) = @_;
+DefPrimitive('\pgfkeysdefargs{}{}{}', sub {
+    my ($stomach, $key, $args, $body) = @_;
     $key = ToString(Expand($key));
     my $vargs = Tokens($args->unlist, T_CS('\pgfeov'));
     DefMacroI(pgfkeyCS($key . '/.@cmd'),  parseDefParameters("PGF Key $key", $vargs), $body);
@@ -394,8 +394,8 @@ DefMacro('\pgfkeysdefargs{}{}{}', sub {
     DefMacroI(pgfkeyCS($key . '/.@body'), undef,                                      $body); },
   locked => 1);
 
-DefMacro('\pgfkeysedefargs{}{}{}', sub {
-    my ($gullet, $key, $args, $body) = @_;
+DefPrimitive('\pgfkeysedefargs{}{}{}', sub {
+    my ($stomach, $key, $args, $body) = @_;
     $key = ToString(Expand($key));
     my $vargs = Tokens($args->unlist, T_CS('\pgfeov'));
     DefMacroI(pgfkeyCS($key . '/.@cmd'),  parseDefParameters("PGF Key $key", $vargs), Expand($body));
@@ -410,8 +410,8 @@ if (LookupDefinition(T_CS('\pgfversiondate'))) {
 
 # called by \pgfkeysdefnargs and \pgfkeysedefnargs
 if ($pgf_version_year >= 2018) {    # Latest tikz (in texlive 2018) has a fifth argument
-  DefMacro('\pgfkeysdefnargs@{}{}{}{}{}', sub {
-      my ($gullet, $key, $nargs, $body, $def, $body_macro) = @_;
+  DefPrimitive('\pgfkeysdefnargs@{}{}{}{}{}', sub {
+      my ($stomach, $key, $nargs, $body, $def, $body_macro) = @_;
       $key   = ToString(Expand($key));
       $nargs = ToString($nargs);
       $nargs =~ s/^#//;
@@ -430,8 +430,8 @@ if ($pgf_version_year >= 2018) {    # Latest tikz (in texlive 2018) has a fifth 
         (ToString($def) eq '\edef' ? Expand($body) : $body)); },
     locked => 1); }
 else {
-  DefMacro('\pgfkeysdefnargs@{}{}{}{}', sub {
-      my ($gullet, $key, $nargs, $body, $def) = @_;
+  DefPrimitive('\pgfkeysdefnargs@{}{}{}{}', sub {
+      my ($stomach, $key, $nargs, $body, $def) = @_;
       $key   = ToString(Expand($key));
       $nargs = ToString($nargs);
       $nargs =~ s/^#//;

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -70,14 +70,15 @@ sub pgfmathfactorial {
 #   <flag>Y<mantissa>e<exponent>] !!!
 # with flag for signs, nans, etc.
 # For the moment: fixed precision!
+# NOTE: Since this is for use in macros, it returns Tokens which will set \pgfmathresult,
+# but doesn't directly set it itself.
 sub pgfmathresult {
   my ($value) = @_;
   $value = sprintf("%06f", $value);
   #print STDERR "ASSIGNING result as $value\n";
   #  my @v = ExplodeText($value);
   #print STDERR " that is ".join(' ',map { Stringify($_) } @v)."\n";
-  DefMacroI(T_CS('\pgfmathresult'), undef, Tokens(ExplodeText($value)));
-  return; }
+  return Tokens(T_CS('\def'), T_CS('\pgfmathresult'), T_BEGIN, ExplodeText($value), T_END); }
 
 DefMacro('\@@@show@mathresult{}', sub {
     my ($gulet, $result) = @_;
@@ -130,29 +131,29 @@ DefParameterType('pgfNumbers', sub {
       return [$token->getString]; } });
 
 DefMacro('\pgfmathpi@', sub {
-    pgfmathresult($PI); return; });
+    return pgfmathresult($PI); });
 DefMacro('\pgfmathe@', sub {
-    pgfmathresult($E); return; });
+    return pgfmathresult($E); });
 DefMacro('\pgfmathadd@ pgfNumber pgfNumber', sub {
-    pgfmathresult($_[1] + $_[2]); return });
+    return pgfmathresult($_[1] + $_[2]); });
 DefMacro('\pgfmathsubtract@ pgfNumber pgfNumber', sub {
-    pgfmathresult($_[1] - $_[2]); return });
+    return pgfmathresult($_[1] - $_[2]); });
 DefMacro('\pgfmathneg@ pgfNumber', sub {
-    pgfmathresult(-$_[1]); return });
+    return pgfmathresult(-$_[1]); });
 DefMacro('\pgfmathmultiply@ pgfNumber pgfNumber', sub {
-    pgfmathresult($_[1] * $_[2]); return });
+    return pgfmathresult($_[1] * $_[2]); });
 DefMacro('\pgfmathdivide@ pgfNumber pgfNumber', sub {
-    pgfmathresult($_[1] / pgfmath_divisor($_[2])); return });
+    return pgfmathresult($_[1] / pgfmath_divisor($_[2])); });
 DefMacro('\pgfmathpow@ pgfNumber pgfNumber', sub {
-    pgfmathresult($_[1]**$_[2]); return });
+    return pgfmathresult($_[1]**$_[2]); });
 DefMacro('\pgfmathabs@ pgfNumber', sub {
-    pgfmathresult(abs($_[1])); return });
+    return pgfmathresult(abs($_[1])); });
 DefMacro('\pgfmathround@ pgfNumber', sub {
-    pgfmathresult(round($_[1])); return });
+    return pgfmathresult(round($_[1])); });
 DefMacro('\pgfmathfloor@ pgfNumber', sub {
-    pgfmathresult(floor($_[1])); return });
+    return pgfmathresult(floor($_[1])); });
 DefMacro('\pgfmathceil@ pgfNumber', sub {
-    pgfmathresult(ceil($_[1])); return });
+    return pgfmathresult(ceil($_[1])); });
 #DefMacro('\pgfmathgcd@ pgfNumber pgfNumber', sub {
 
 # DefMacro('\pgfmathisprime@ pgfNumber pgfNumber', sub {
@@ -169,11 +170,11 @@ DefMacro('\pgfmathmin@ pgfNumbers', sub {
     my @args = @$args;
     return pgfmathresult(min(@args)); });
 DefMacro('\pgfmathsin@ pgfNumber', sub {
-    pgfmathresult(sin(pgfmathargradians($_[1]))); return });
+    return pgfmathresult(sin(pgfmathargradians($_[1]))); });
 DefMacro('\pgfmathcos@ pgfNumber', sub {
-    pgfmathresult(cos(pgfmathargradians($_[1]))); return });
+    return pgfmathresult(cos(pgfmathargradians($_[1]))); });
 DefMacro('\pgfmathtan@ pgfNumber', sub {
-    pgfmathresult(tan(pgfmathargradians($_[1]))); return });
+    return pgfmathresult(tan(pgfmathargradians($_[1]))); });
 # One mod is truncated (can be neg) other is floored, the latter should be capitalized?
 # Apparently mod towards 0
 sub pgfmath_mod_trunc {
@@ -196,39 +197,39 @@ DefMacro('\pgfmathmod@ pgfNumber pgfNumber', sub {
     my ($gullet, $arg1, $arg2) = @_;
     return pgfmathresult(pgfmath_mod_floor($arg1, $arg2)); });
 DefMacro('\pgfmathrad@ pgfNumber', sub {
-    pgfmathresult(deg2rad($_[1])); return });
+    return pgfmathresult(deg2rad($_[1])); });
 DefMacro('\pgfmathdeg@ pgfNumber', sub {
-    pgfmathresult(rad2deg($_[1])); return });
+    return pgfmathresult(rad2deg($_[1])); });
 DefMacro('\pgfmathatan@ pgfNumber', sub {
-    pgfmathresult(atan($_[1])); return });
+    return pgfmathresult(atan($_[1])); });
 DefMacro('\pgfmathatantwo@ pgfNumber', sub {
-    pgfmathresult(atan2($_[1], $_[2])); return });
+    return pgfmathresult(atan2($_[1], $_[2])); });
 DefMacro('\pgfmathasin@ pgfNumber', sub {
-    pgfmathresult(asin($_[1])); return });
+    return pgfmathresult(asin($_[1])); });
 DefMacro('\pgfmathacos@ pgfNumber', sub {
-    pgfmathresult(acos($_[1])); return });
+    return pgfmathresult(acos($_[1])); });
 DefMacro('\pgfmathcot@ pgfNumber', sub {
-    pgfmathresult(cot(pgfmathargradians($_[1]))); return });
+    return pgfmathresult(cot(pgfmathargradians($_[1]))); });
 DefMacro('\pgfmathsec@ pgfNumber', sub {
-    pgfmathresult(sec(pgfmathargradians($_[1]))); return });
+    return pgfmathresult(sec(pgfmathargradians($_[1]))); });
 DefMacro('\pgfmathcosec@ pgfNumber', sub {
-    pgfmathresult(cosec(pgfmathargradians($_[1]))); return });
+    return pgfmathresult(cosec(pgfmathargradians($_[1]))); });
 DefMacro('\pgfmathexp@ pgfNumber', sub {
-    pgfmathresult(exp($_[1])); return });
+    return pgfmathresult(exp($_[1])); });
 DefMacro('\pgfmathln@ pgfNumber', sub {
-    pgfmathresult(log($_[1])); return });
+    return pgfmathresult(log($_[1])); });
 DefMacro('\pgfmathlogten@ pgfNumber', sub {
-    pgfmathresult(log($_[1]) / $LOG10); return });
+    return pgfmathresult(log($_[1]) / $LOG10); });
 DefMacro('\pgfmathsqrt@ pgfNumber', sub {
-    pgfmathresult(sqrt($_[1])); return });
+    return pgfmathresult(sqrt($_[1])); });
 DefMacro('\pgfmathrnd@', sub {
-    pgfmathresult(rand()); return });
+    return pgfmathresult(rand()); });
 DefMacro('\pgfmathrand@', sub {
-    pgfmathresult(1 + rand(2)); return });
+    return pgfmathresult(1 + rand(2)); });
 DefMacro('\pgfmathfactorial@', sub {
-    pgfmathresult(pgfmathfactorial($_[1])); return });
+    return pgfmathresult(pgfmathfactorial($_[1])); });
 DefMacro('\pgfmathreciprocal@ pgfNumber', sub {
-    pgfmathresult(1 / pgfmath_divisor($_[1])); return });
+    return pgfmathresult(1 / pgfmath_divisor($_[1])); });
 
 sub pgfmath_divisor {
   my $divisor = 0.0 + $_[0];
@@ -329,10 +330,10 @@ sub pgfmathparse {
   #     print STDERR "  REMAINDER: $string\n" if $string;
   # There seem to be some pesky expectations for the results
   if ($result == 0.0) {
-    $result = "0"; }
+    $result = "0."; }
   # NOT really correct, but would like to use an internal to distinguish 1.0 from int(1.0)!!!
   elsif ($result == int($result)) {
-    $result = int($result); }
+    $result = int($result) . '.'; }
   else {    # We don't want scientific notation output!!!
     $result = sprintf("%f", $result); }
 ###  print STDERR "PGFPARSE: '$input' => '$result'\n";
@@ -340,13 +341,12 @@ sub pgfmathparse {
 
 DefMacro('\lx@pgfmath@parseX{}', sub {
     my ($gullet, $tokens) = @_;
-    DefMacroI('\lx@pgfmathresult', undef, Tokens(Explode(pgfmathparse($gullet, $tokens))));
-    return; });
+    return Tokens(T_CS('\def'), T_CS('\lx@pgfmathresult'),
+      T_BEGIN, pgfmathparse($gullet, $tokens), T_END); });
 
 DefMacro('\lx@pgfmath@parse{}', sub {
     my ($gullet, $tokens) = @_;
-    DefMacroI('\pgfmathresult', undef, Tokens(Explode(pgfmathparse($gullet, $tokens))));
-    return; });
+    return pgfmathresult(pgfmathparse($gullet, $tokens)); });
 
 DefPrimitive('\pgfmathsetlength DefToken {}', sub {
     my ($stomach, $register, $tokens) = @_;

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -201,13 +201,15 @@ DefMacro('\pgfmathrad@ pgfNumber', sub {
 DefMacro('\pgfmathdeg@ pgfNumber', sub {
     return pgfmathresult(rad2deg($_[1])); });
 DefMacro('\pgfmathatan@ pgfNumber', sub {
-    return pgfmathresult(atan($_[1])); });
-DefMacro('\pgfmathatantwo@ pgfNumber', sub {
-    return pgfmathresult(atan2($_[1], $_[2])); });
+    return pgfmathresult(rad2deg(atan($_[1]))); });
+DefMacro('\pgfmathatantwo@ pgfNumber pgfNumber', sub {
+    return pgfmathresult(rad2deg(atan2($_[1], $_[2]))); });
+# Reverse of tikz, but...
+Let(T_CS('\pgfmathatan2@'), T_CS('\pgfmathatantwo@'));
 DefMacro('\pgfmathasin@ pgfNumber', sub {
-    return pgfmathresult(asin($_[1])); });
+    return pgfmathresult(rad2deg(asin($_[1]))); });
 DefMacro('\pgfmathacos@ pgfNumber', sub {
-    return pgfmathresult(acos($_[1])); });
+    return pgfmathresult(rad2deg(acos($_[1]))); });
 DefMacro('\pgfmathcot@ pgfNumber', sub {
     return pgfmathresult(cot(pgfmathargradians($_[1]))); });
 DefMacro('\pgfmathsec@ pgfNumber', sub {
@@ -336,7 +338,7 @@ sub pgfmathparse {
     $result = int($result) . '.'; }
   else {    # We don't want scientific notation output!!!
     $result = sprintf("%f", $result); }
-###  print STDERR "PGFPARSE: '$input' => '$result'\n";
+###  print STDERR "PGFPARSE: '$input' => '$result'\n" unless LookupValue('inPreamble');
   return $result; }
 
 DefMacro('\lx@pgfmath@parseX{}', sub {

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -56,6 +56,7 @@ sub installPGFCommands {
   Let(T_CS('\raise'),  T_CS('\lxSVG@raise'));
   Let(T_CS('\hskip'),  T_CS('\lxSVG@hskip'));
   Let(T_CS('\halign'), T_CS('\lxSVG@halign'));
+  Let('\ignorespaces', '\lx@inpgf@ignorespaces');    # Use local defn
   AssignValue(TEXT_MODE_BINDINGS => []);
   return; }
 
@@ -66,9 +67,8 @@ DefPrimitive('\lxSVG@installcommands', sub { installPGFCommands(); });
 DefPrimitive('\lx@inpgf@ignorespaces SkipSpaces', sub { (); });
 # Order might matter here
 DefMacro('\lxSVG@picture', sub {
-    Let('\ignorespaces', '\lx@inpgf@ignorespaces');    # Use local defn
-    AssignValue('pgf_SVGpath' => '', 'global');
-    (T_CS('\begingroup'), T_CS('\lxSVG@installcommands'),
+    (T_CS('\lxSVG@clearpath'),
+      T_CS('\begingroup'), T_CS('\lxSVG@installcommands'),
       #        T_CS('\pgfsysprotocol@setcurrentprotocol'), T_CS('\pgfutil@empty')
     ); });
 
@@ -339,6 +339,11 @@ sub addToSVGPath {
     AssignValue(pgf_SVGpath => $newPath, 'global'); }
   return; }
 
+DefPrimitive('\lxSVG@clearpath', sub {
+    AssignValue(pgf_SVGpath => '', 'global'); });
+DefPrimitive('\lxSVG@clearclip', sub {
+    AssignValue(pgf_clipnext => 0); });
+
 #=====================================================================
 # Implementation
 
@@ -416,19 +421,21 @@ DefConstructor('\lxSVG@fillstroke', '', alias => '\pgfsys@fillstroke', sizer => 
 
 #======================================================================
 
-# Warning: assignments in Macro!!!
 DefMacro('\lxSVG@drawpath{}', sub {
     my ($gullet, $arg) = @_;
     my $path = LookupValue('pgf_SVGpath') || '';
-    AssignValue(pgf_SVGpath => '', 'global');
-    my $op;
     if (LookupValue('pgf_clipnext')) {
-      AssignValue(pgf_clipnext => 0);
-      addToCount('pgf_scopecount', 1, 'global');
-      $op = Invocation('\lxSVG@drawpath@clipped', $path, $arg); }
+      Tokens(
+        T_CS('\lxSVG@clearpath'),
+        T_CS('\lxSVG@clearclip'),
+        T_CS('\lxSVG@incrgroup'),
+        Invocation('\pgfsysprotocol@literal',
+          Invocation('\lxSVG@drawpath@clipped', $path, $arg))); }
     else {
-      $op = Invocation('\lxSVG@drawpath@unclipped', $path, $arg); }
-    Invocation('\pgfsysprotocol@literal', $op)->unlist; });
+      Tokens(
+        T_CS('\lxSVG@clearpath'),
+        Invocation('\pgfsysprotocol@literal',
+          Invocation('\lxSVG@drawpath@unclipped', $path, $arg))); } });
 
 # Seemingly can get called with no path, which is invalid
 DefConstructor('\lxSVG@drawpath@unclipped{}{}',
@@ -446,15 +453,17 @@ DefConstructor('\lxSVG@drawpath@clipped{}{}',
 
 # #======================================================================
 DefMacro('\pgfsys@discardpath', '\lxSVG@discardpath\lxSVG@@discardpath');
-DefConstructor('\lxSVG@discardpath', '', alias => '\pgfsys@discardpath', sizer => 0);
+DefConstructor('\lxSVG@discardpath', '',
+  alias => '\pgfsys@discardpath', sizer => 0);
 DefMacro('\lxSVG@@discardpath', sub {
     my $path = LookupValue('pgf_SVGpath') || '';
-    AssignValue(pgf_SVGpath => '', 'global');
     if (LookupValue('pgf_clipnext')) {
-      AssignValue(pgf_clipnext => 0);
-      addToCount('pgf_scopecount', 1, 'global');
-      Invocation('\pgfsysprotocol@literal',
-        Invocation(T_CS('\lxSVG@discardpath@clipped'), $path))->unlist; }
+      Tokens(
+        T_CS('\lxSVG@clearpath'),
+        T_CS('\lxSVG@clearclip'),
+        T_CS('\lxSVG@incrgroup'),
+        Invocation('\pgfsysprotocol@literal',
+          Invocation(T_CS('\lxSVG@discardpath@clipped'), $path))); }
     else {
       (); } });
 
@@ -672,21 +681,25 @@ DefConstructor('\lxSVG@color@gray@fill{}',    '', alias => '\pgfsys@color@gray@f
 #====================================================================#
 
 # \pgfsys@declarepattern{name}{x1}{y1}{x2}{y2}{x step}{y step}{code}{ﬂag}
-DefMacro('\pgfsys@declarepattern{}'
-    . '{Dimension}{Dimension}{Dimension}{Dimension}{Dimension}{Dimension}'
-    . '{}{Number}', sub {
+DefMacro('\pgfsys@declarepattern{} {}{}{}{}{}{} {}{Number}', sub {
     my ($gullet, $name, $x1, $y1, $x2, $y2, $x_step, $y_step, $code, $flag) = @_;
+    my $op = ($flag->valueOf == 1 ? '\lxSVG@coloredpattern' : '\lxSVG@uncoloredpattern');
+    return Invocation('\pgfsysprotocol@literal',
+      Invocation('\lxSVG@setpattern', $x1, $y1, $x2, $y2, $x_step, $y_step),
+      Invocation($op, $name, $x_step, $y_step, $code)); });
+
+DefPrimitive('\lxSVG@setpattern {Dimension}{Dimension}{Dimension}{Dimension}{Dimension}{Dimension}', sub {
+    #    my ($gullet, $x1, $y1, $x2, $y2, $x_step, $y_step) = @_;
+    my ($stomach, $x1, $y1, $x2, $y2, $x_step, $y_step) = @_;
     AssignValue('\pgf@xa' => $x1);     AssignValue('\pgf@ya' => $y1);
     AssignValue('\pgf@xb' => $x2);     AssignValue('\pgf@yb' => $y2);
     AssignValue('\pgf@xc' => $x_step); AssignValue('\pgf@yc' => $y_step);
-    my $op = ($flag->valueOf == 1 ? '\lxSVG@coloredpattern' : '\lxSVG@uncoloredpattern');
-    return Invocation('\pgfsysprotocol@literal',
-      Invocation($op, $name, $x_step, $y_step, $code)); });
+    return; });
 
 DefMacro('\pgfsys@setpatternuncolored{}{}{}{}', sub {
-    addToCount('pgf_scopecount', 1, 'global');
-    Invocation('\pgfsysprotocol@literal',
-      Invocation('\lxSVG@setpatternuncolored@', @_[1 .. $#_])); });
+    Tokens(T_CS('\lxSVG@incrgroup'),
+      Invocation('\pgfsysprotocol@literal',
+        Invocation('\lxSVG@setpatternuncolored@', @_[1 .. $#_]))); });
 
 DefMacro('\pgfsys@setpatterncolored{}',
   '\lxSVG@setcolor{fill}{url(\#pgfpat#1)}');

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -110,7 +110,7 @@ DefConstructor('\lxSVG@insertpicture{}',
     my $miny   = LookupValue('\pgf@picminy')->subtract($margin);
     my $width  = LookupValue('\pgf@picmaxx')->add($margin2);
     my $height = LookupValue('\pgf@picmaxy')->add($margin2);
-    my $w      = max($width->pxValue, 1);
+    my $w      = max($width->pxValue,  1);
     my $h      = max($height->pxValue, 1);
     # Note viewbox is minx, miny, width, height (NOT maxx,maxy!)
     $whatsit->setProperty(minx      => $minx->pxValue);
@@ -260,7 +260,7 @@ DefConstructor('\pgfsys@hbox{Number}', sub {
     # Fishing for the correct y position (maybe w/o the depth?)
     #    my $y = $h->pxValue;   # Seemingly should NOT have ->add($d)
     my $y = $h->add(($font ? $fd : $d))->pxValue;    # Seemingly should NOT have ->add($d)
-         # But if the box's height has been set to 0, still need adjustment; Use font?
+        # But if the box's height has been set to 0, still need adjustment; Use font?
     $y = $fh->add($fd)->pxValue if !$y && $font;    # Seemingly SHOULD have ->add($fd)
     $doc->openElement('svg:g',
       transform => 'matrix(1 0 0 -1 0 ' . $y . ')',
@@ -448,7 +448,7 @@ DefConstructor('\lxSVG@discardpath@clipped{}',
     . '<svg:path d="#1" />'
     . '</svg:clipPath>'
     . '<svg:g clip-path="url(##pgfcp#obj)">',
-  reversion  => '', sizer => 0,
+  reversion => '', sizer => 0,
   properties => { obj => sub { SVGNextObject(); } });
 
 #=====================================================================#
@@ -482,15 +482,8 @@ DefConstructor('\lxSVG@begingroup@ RequiredKeyVals', sub {
     my $orig_this_name = $doc->getNodeQName($this);
     # Special case check: if we are in a latexml context, the parent svg:g is acceptable
     if ($orig_this_name =~ /^ltx:/ && (my $g_ancestor = $doc->findnode("ancestor::svg:g", $this))) {
-      # Sometimes even when we have a parent g, there is an attribute conflict
-      #    and we need to open a new one. AND make it the current insertion point OR?!
-      my @needs_wrap = grep { $g_ancestor->hasAttribute($_) } @keys;
-      if (@needs_wrap) {    # incompatible, wrap with new g
-        $this = $doc->wrapNodes('svg:g', $g_ancestor->lastChild); }
-      else {                # compatible, reuse
-        $this = $g_ancestor; } }
-    else {                  # all other cases, just open a g.
-                            # TODO: Redundant g's get made, we can merge them on afterClose?
+      $this = $doc->wrapNodes('svg:g', $g_ancestor->lastChild); }    # note: this svg:g stays OPEN!
+    else {                                                           # all other cases, just open a g.
       $this = $doc->openElement('svg:g'); }
     # We have the _correct_ svg:g here, let's assign the attributes
     foreach my $key (@keys) {
@@ -502,6 +495,81 @@ DefConstructor('\lxSVG@endgroup@',
 ###  '</svg:g>',
   sub { $_[0]->maybeCloseElement('svg:g'); },
   reversion => '', sizer => 0);
+
+# Collapse redundant svg:g nodes that have only certain simple attributes
+Tag('svg:g', afterClose => \&collapseSVGGroup);
+my %collapsible_group_attributes = map { ($_ => 1); } qw(fill stroke color);
+
+# Collapse/remove/unwrap unneeded svg:g's to reduce depth of tree
+sub collapseSVGGroup {
+  my ($document, $node) = @_;
+  my ($nempty, $nredundant, $nmerged, $npopped, $npushed) = (0, 0, 0, 0, 0);
+  # Record the attributes on $node, for later use.
+  my %nodeattr = ();
+  foreach my $attr ($node->attributes) {
+    my $key = $attr->getName;
+    $nodeattr{$key} = $attr->getValue if ($key !~ /^_/); }
+  my @children = element_nodes($node);
+  # Remove empty svg:g children
+  foreach my $c (@children) {
+    if (($document->getNodeQName($c) eq 'svg:g') && !scalar(element_nodes($c))) {
+      $nempty++;
+      $document->removeNode($c); } }
+  @children = element_nodes($node) if $nempty;
+  # Move ahead, all leading children whose svg:g attributes completely mask $node's attributes.
+  # Could do same moving trailing children to back
+  my $c;
+  while (scalar(@children) && ($document->getNodeQName($c = $children[0]) eq 'svg:g')) {
+    my $nmasked = 0;
+    foreach my $attr ($c->attributes) {
+      my $key = $attr->getName;
+      if (($key !~ /^_/) && $collapsible_group_attributes{$key} && defined $nodeattr{$key}) {
+        $nmasked++; } }
+    last unless $nmasked == scalar(keys %nodeattr);              # child completely masks attr of node
+    $node->parentNode->insertBefore(shift(@children), $node);    # move it outside!
+    $npopped++; }
+  # Same story for trailing children, but move behind
+  while (scalar(@children) && ($document->getNodeQName($c = $children[-1]) eq 'svg:g')) {
+    my $nmasked = 0;
+    foreach my $attr ($c->attributes) {
+      my $key = $attr->getName;
+      if (($key !~ /^_/) && $collapsible_group_attributes{$key} && defined $nodeattr{$key}) {
+        $nmasked++; } }
+    last unless $nmasked == scalar(keys %nodeattr);              # child completely masks attr of node
+    $node->parentNode->insertAfter(pop(@children), $node);
+    $npushed++; }
+  # Now remove any redundant svg:g's (same attributes & values) [some left after above]
+  foreach my $c (@children) {
+    if ($c && ($document->getNodeQName($c) eq 'svg:g')) {        # for every nested svg:g
+      my $issame = 1;
+      foreach my $attr ($c->attributes) {
+        my $key = $attr->getName;
+        if (($key !~ /^_/) && ($attr->getValue ne ($nodeattr{$key} || ''))) {
+          $issame = 0; } }
+      if ($issame) {                                             # child is completely redundant.
+        $document->unwrapNodes($c);
+        $nredundant++; } } }
+  @children = element_nodes($node) if $nredundant;
+  # Could check if $node is empty now?
+  # Then if only one left, and it's attributes can be migrated to $node, unwrap it
+  if ((scalar(@children) == 1) && ($document->getNodeQName($c = $children[0]) eq 'svg:g')) {
+    my %av        = ();
+    my $mergeable = 1;
+    foreach my $attr ($c->attributes) {
+      my $key = $attr->getName;
+      if (($key =~ /^_/) || $collapsible_group_attributes{$key}) {
+        $av{$key} = $attr->getValue; }
+      else {
+        $mergeable = 0; } }
+    if ($mergeable) {
+      foreach my $key (sort keys %av) {
+        $nodeattr{$key} = $av{$key};
+        $node->setAttribute($key => $av{$key}); }
+      $nmerged++;
+      $document->unwrapNodes($c); } }
+###  Debug("COLLAPSE empty=$nempty, redundant=$nredundant, merged=$nmerged, popped=$npopped, pushed=$npushed")
+###    if ($nempty || $nredundant || $nmerged || $npopped || $npushed);
+  return; }
 
 #=====================================================================
 # Implementation
@@ -563,7 +631,7 @@ DefMacro('\pgfsys@color@rgb{}{}{}',
 DefMacro('\lxSVG@RGB{}{}{}',    sub { Explode(Color('rgb',  $_[1], $_[2], $_[3])->toHex); });
 DefMacro('\lxSVG@CMYK{}{}{}{}', sub { Explode(Color('cmyk', $_[1], $_[2], $_[3], $_[4])->toHex); });
 DefMacro('\lxSVG@CMY{}{}{}',    sub { Explode(Color('cmy',  $_[1], $_[2], $_[3])->toHex); });
-DefMacro('\lxSVG@GRAY{}', sub { Explode(Color('gray', $_[1])->toHex); });
+DefMacro('\lxSVG@GRAY{}',       sub { Explode(Color('gray', $_[1])->toHex); });
 
 DefMacro('\pgfsys@color@rgb@stroke{}{}{}',
   '\lxSVG@color@rgb@stroke{#1}{#2}{#3}\lxSVG@begingroup{stroke=\lxSVG@RGB{#1}{#2}{#3}}');
@@ -583,7 +651,7 @@ DefMacro('\pgfsys@color@gray@fill{}',
   '\lxSVG@color@gray@fill{#1}\lxSVG@begingroup{fill=\lxSVG@GRAY{#1}}');
 
 DefConstructor('\lxSVG@color@rgb@stroke{}{}{}', '', alias => '\pgfsys@color@rgb@stroke', sizer => 0);
-DefConstructor('\lxSVG@color@rgb@fill{}{}{}', '', alias => '\pgfsys@color@rgb@fill', sizer => 0);
+DefConstructor('\lxSVG@color@rgb@fill{}{}{}',   '', alias => '\pgfsys@color@rgb@fill', sizer => 0);
 DefConstructor('\lxSVG@color@cmyk@stroke{}{}{}{}', '', alias => '\pgfsys@color@cmyk@stroke', sizer => 0);
 DefConstructor('\lxSVG@color@cmyk@fill{}{}{}{}', '', alias => '\pgfsys@color@cmyk@fill', sizer => 0);
 DefConstructor('\lxSVG@color@cmy@stroke{}{}{}', '', alias => '\pgfsys@color@cmy@stroke', sizer => 0);
@@ -733,7 +801,7 @@ DefMacro('\lxSVG@sh@create', sub {
       T_BEGIN, T_CS('\pgf@sys@shading@end@pos'), T_END,
       T_BEGIN, T_CS('\pgf@sys@shading@end@rgb'), T_END,
       T_BEGIN, T_CS('\pgf@sys@shading@end@rgb'), T_END,
-      T_END, T_BEGIN, T_END); });
+      T_END,   T_BEGIN, T_END); });
 
 DefPrimitive('\lxSVG@sh@color{Float}{Float}{Float}', sub {
     AssignValue(pgf_sh_color => Color('rgb', map { $_->valueOf } @_[1 .. $#_]));
@@ -988,8 +1056,10 @@ DefConstructor('\lxSVG@halign BoxSpecification',
     my ($stomach, $whatsit) = @_;
     my $gullet = $stomach->getGullet;
     my $t      = $gullet->readNonSpace;
-    Error('expected', '\bgroup', $stomach, "Missing \\halign box") unless Equals($t, T_BEGIN);
-    print STDERR "\nHALIGN IN PGF!\n";
+    if (!Equals($t, T_BEGIN)) {
+      Error('expected', '\bgroup', $stomach, "Missing \\halign box"); }
+    else {
+      Warn('unexpected', 'halign', $stomach, "HALIGN IN PGF!"); }
     # Read the template up till something equivalent to \cr
     my @template = ();
     # Only expand certain things; See TeX book p.238
@@ -1031,7 +1101,6 @@ DefConstructor('\lxSVG@halign BoxSpecification',
     my $template = LaTeXML::Core::Alignment::Template->new((@nonreps ?
           (columns => [@nonreps], repeated => [@cols])
         : (columns => [@cols])));
-    #  print STDERR "Template = ".Stringify(Tokens(@template))."\n => ".$template->show."\n";
     # Now read & digest the body.
     # Note that the body MUST end with a \cr, and that we've made Special Arrangments
     # with \alignment@cr to recognize the end of the \halign

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -144,15 +144,42 @@ DefParameterType('SVGMoveableBox', sub {
     $box; });
 
 # Try to avoid errors inserting random boxes (esp. ltx:text)(Is this safe?)
-Tag('svg:switch', autoOpen => 1, autoClose => 1);    # ?
+Tag('svg:switch', autoOpen => 1, autoClose => 1,
+  afterClose => \&collapseSVGSwitch);    # ?
+
+# Remove empty <svg:switch><svg:foreignObject> or those that contain only <p/>
+# Possibly could incorporate the collapse when it contains only svg elements?
+sub collapseSVGSwitch {
+  my ($doc, $node) = @_;
+  my ($fo,  @rest) = element_nodes($node);
+  return if !$fo || ($doc->getNodeQName($fo) ne 'svg:foreignObject')
+    || scalar(@rest);    # Expect single svg:foreignObject
+  my @fo_c = element_nodes($fo);
+  if (scalar(@fo_c) == 0) {    # Empty?
+    $doc->removeNode($node); }
+  # Else, single <p> element ?
+  elsif ((scalar(@fo_c) == 1) && ($doc->getNodeQName($fo_c[0]) eq 'ltx:p')) {
+    my @p_c = element_nodes($fo_c[0]);
+    if (scalar(@p_c) == 0) {    # or Empty <p/>?
+      $doc->removeNode($node); }
+    # Else, single ltx:picture ?
+    elsif ((scalar(@p_c) == 1) && ($doc->getNodeQName($p_c[0]) eq 'ltx:picture')) {
+      my @pic_c = element_nodes($p_c[0]);
+      # With single svg:svg ?
+      if ((scalar(@pic_c) == 1) && ($doc->getNodeQName($pic_c[0]) eq 'svg:svg')) {
+        $doc->replaceNode($node, element_nodes($pic_c[0]));
+  } } }
+  return; }
+
 Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
   afterClose => sub {
     my ($document, $node, $whatsit) = @_;
     # Make sure we get a size, in case autoOpen'd
     if ($whatsit) {
       my ($w, $h, $d) = $whatsit->getSize;
-      $node->setAttribute(width  => $w->toAttribute)          unless $node->hasAttribute('width');
-      $node->setAttribute(height => $h->add($d)->toAttribute) unless $node->hasAttribute('height'); } });
+      $node->setAttribute(width    => $w->toAttribute)          unless $node->hasAttribute('width');
+      $node->setAttribute(height   => $h->add($d)->toAttribute) unless $node->hasAttribute('height');
+      $node->setAttribute(overflow => 'visible'); } });
 
 # Check whether a svg:foreignObject is open,
 # but don't check beyond an svg:svg node, in case we're nested.
@@ -285,19 +312,7 @@ DefConstructor('\pgfsys@hbox{Number}', sub {
       if ($n->isSameNode($fo)) {
         $doc->closeElement('svg:foreignObject');
         $doc->closeElement('svg:switch');
-        $doc->closeElement('svg:g');
-        # Check the children of the inserted ltx:p
-        # We should at least try to denest svg ?
-        # If svg:switch/svg:foreignObject/ltx:p/ltx:picture/svg:svg/svg:g
-        # should be replaced by just the final svg:g !!! (?)
-        my @ch = element_nodes($p);
-        if ((scalar(@ch) == 1) && ($doc->getNodeQName($ch[0]) eq 'ltx:picture')) {
-          my @gch = element_nodes($ch[0]);
-          if ((scalar(@gch) == 1) && ($doc->getNodeQName($gch[0]) eq 'svg:svg')) {
-            my ($g) = element_nodes($gch[0]);
-            $doc->replaceNode($sw, $g);
-    } } } }
-    # Could conceivably be simplifying ltx:text ???
+        $doc->closeElement('svg:g'); } }
   },
   reversion => sub {
     my $box = $_[0]->getProperty('thebox');
@@ -480,7 +495,7 @@ DefConstructor('\lxSVG@begingroup@ RequiredKeyVals', sub {
     # Special case check: if we are in a latexml context, move up to parent svg:g
     if ($doc->getNodeQName($this) =~ /^ltx:/
       && (my $g_ancestor = $doc->findnode("ancestor::svg:g[position()=1]", $this))) {
-      $doc->setNode($g_ancestor); }
+      $doc->closeToNode($g_ancestor); }
     $doc->openElement('svg:g', $kv->getHash); },
   reversion => '', sizer => 0);
 

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -24,21 +24,14 @@ use LaTeXML::Util::Image;
 use List::Util qw(min max);
 #=====================================================================
 # TODO:
-# * Need to be consistent about when things like pgf_scopecount, etc are bumped
 # * ALL \pgfsys@<drivercmd> level commands should be Constructors
 #   or expand into Constructors, which must yeild the svg
 #   AND revert into the original \pgfsys@<drivercmd>
 #   so that image generation can work.
-# * Since \pgfsys@literal CAN defer the evaluation of its argument,
-#   (or even discard it?) any such counter maintenance has to be done outside of it.
+# * Note \pgfsys@literal CAN defer the evaluation of its argument,
+#   (or even discard?), so be VERY aware of expansion/digestion/ingestion timing
 #=====================================================================
 # Utilities
-sub addToCount {
-  my ($reg, $value, $option) = @_;
-  $option = 'local' if !$option;
-  AssignValue($reg => (LookupValue($reg) || 0) + $value, $option);
-  return; }
-
 sub SVGNextObject {
   my $n = (LookupValue('svg_objcount') || 0) + 1;
   AssignValue(svg_objcount => $n, 'global');
@@ -94,8 +87,10 @@ DefConstructor('\lxSVG@insertpicture{}',
       viewBox  => "$props{minx} $props{miny} $props{pxwidth} $props{pxheight}",
       overflow => "visible");
     $document->openElement('svg:g',
-      transform => "matrix(1 0 0 -1 0 $props{flipnmove})");
+      transform   => "matrix(1 0 0 -1 0 $props{flipnmove})",
+      _scopebegin => 1);
     $document->absorb($content);
+### Handled by \lxSVG@closegroups ???
     while ($document->maybeCloseElement('svg:g')) { }
     #                 $document->closeElement('svg:g');
     $document->closeElement('svg:svg');
@@ -196,9 +191,7 @@ sub foreignObjectCheck {
 DefConstructor('\lxSVG@raise Dimension SVGMoveableBox', sub {
     my ($doc, $dim, $box) = @_;
     if (foreignObjectCheck($doc)) {
-      $doc->openElement('ltx:text',
-        yoffset      => $dim->negate->pxValue . 'px',
-        _noautoclose => '1');
+      $doc->openElement('ltx:text', yoffset => $dim->negate->pxValue . 'px');
       $doc->absorb($box);
       $doc->closeElement('ltx:text'); }
     else { $doc->absorb($box); } },
@@ -208,9 +201,7 @@ DefConstructor('\lxSVG@raise Dimension SVGMoveableBox', sub {
 DefConstructor('\lxSVG@lower Dimension SVGMoveableBox', sub {
     my ($doc, $dim, $box) = @_;
     if (foreignObjectCheck($doc)) {
-      $doc->openElement('ltx:text',
-        yoffset      => $dim->pxValue . 'px',
-        _noautoclose => '1');
+      $doc->openElement('ltx:text', yoffset => $dim->pxValue . 'px');
       $doc->absorb($box);
       $doc->closeElement('ltx:text'); }
     else { $doc->absorb($box); } },
@@ -220,9 +211,7 @@ DefConstructor('\lxSVG@lower Dimension SVGMoveableBox', sub {
 DefConstructor('\lxSVG@hskip Glue', sub {
     my ($doc, $skip) = @_;
     if (foreignObjectCheck($doc)) {
-      $doc->openElement('ltx:text',
-        'xoffset'      => $skip->pxValue . 'px',
-        '_noautoclose' => '0'); } },
+      $doc->openElement('ltx:text', 'xoffset' => $skip->pxValue . 'px'); } },
   alias => '\hskip');
 
 # Like regular \hbox, \vbox, but we don't want any extra element around it.
@@ -268,7 +257,7 @@ DefMacro('\pgfsys@typesetpicturebox{}', <<'EoTeX');
    \wd#1=\pgf@picmaxx%
    \dp#1=0pt%
    \leavevmode%\message{width: \the\pgf@picmaxx, height:\the\pgf@picmaxy}%%
-   \lxSVG@insertpicture{\box#1\lxSVG@endgroups}%
+   \lxSVG@insertpicture{\box#1\lxSVG@closescope}%
 EoTeX
 
 DefMacro('\pgfsys@beginpicture', '');
@@ -289,6 +278,7 @@ DefConstructor('\pgfsys@hbox{Number}', sub {
     my $y = $h->add(($font ? $fd : $d))->pxValue;    # Seemingly should NOT have ->add($d)
         # But if the box's height has been set to 0, still need adjustment; Use font?
     $y = $fh->add($fd)->pxValue if !$y && $font;    # Seemingly SHOULD have ->add($fd)
+    my ($ww, $hh, $dd) = map { $_->ptValue; } $w, $h, $d;
     $doc->openElement('svg:g',
       transform => 'matrix(1 0 0 -1 0 ' . $y . ')',
       class     => 'ltx_svg_fog');
@@ -312,8 +302,7 @@ DefConstructor('\pgfsys@hbox{Number}', sub {
       if ($n->isSameNode($fo)) {
         $doc->closeElement('svg:foreignObject');
         $doc->closeElement('svg:switch');
-        $doc->closeElement('svg:g'); } }
-  },
+        $doc->closeElement('svg:g'); } } },
   reversion => sub {
     my $box = $_[0]->getProperty('thebox');
     return ($box ? $box->revert : ()); },
@@ -346,22 +335,27 @@ DefPrimitive('\lxSVG@clearclip', sub {
 
 #=====================================================================
 # Implementation
+# These are listed as "protocolled", but actually only record the path
+# the path user (eg \pgfsys@stroke) is protocolled.
 
 # Start a path at a specific point (x,y) or to move the current point of the
 # current path to (x,yp) without drawing anything upon stroking (the current
 # path is 'interrupted'
 DefConstructor('\pgfsys@moveto{Dimension}{Dimension}', '',
-  afterDigest => sub { addToSVGPath('M', $_[1]->getArgs); });
+  afterDigest => sub { addToSVGPath('M', $_[1]->getArgs); },
+  sizer       => 0);
 
 # Continue the current path to (#1,#2) with a line.
 DefConstructor('\pgfsys@lineto{Dimension}{Dimension}', '',
-  afterDigest => sub { addToSVGPath('L', $_[1]->getArgs); });
+  afterDigest => sub { addToSVGPath('L', $_[1]->getArgs); },
+  sizer       => 0);
 
 # Continue the current path with a bezier curver to (#5,#6). The
 # control points of the curve are at (#1,#2) and (#3,#4).
 DefConstructor('\pgfsys@curveto{Dimension}{Dimension}{Dimension}'
     . '{Dimension}{Dimension}{Dimension}', '',
-  afterDigest => sub { addToSVGPath('C', $_[1]->getArgs); });
+  afterDigest => sub { addToSVGPath('C', $_[1]->getArgs); },
+  sizer       => 0);
 
 # Append a rectangle to the current path whose lower left corner is at
 # (#1,#2) and whose width/height is given by (#3,#4).
@@ -372,13 +366,15 @@ DefConstructor('\pgfsys@rect{Dimension}{Dimension}{Dimension}{Dimension}', '',
     addToSVGPath('h', $w);
     addToSVGPath('v', $h);
     addToSVGPath('h', $w->negate);
-    addToSVGPath('Z'); });
+    addToSVGPath('Z'); },
+  sizer => 0);
 
 # Close the current path. This results in joining the current point of
 # the path with the point specified by the last moveto
 # operation.
 DefConstructor('\pgfsys@closepath', '',
-  afterDigest => sub { addToSVGPath('Z'); });
+  afterDigest => sub { addToSVGPath('Z'); },
+  sizer       => 0);
 
 #=====================================================================#
 #= 3. Canvas transformation ==========================================#
@@ -394,7 +390,8 @@ DefMacro('\pgfsys@transformcm {Float}{Float}{Float}{Float}{Dimension}{Dimension}
     . '\lxSVG@@transformcm{#1}{#2}{#3}{#4}{#5}{#6}');
 
 DefConstructor('\lxSVG@transformcm {Float}{Float}{Float}{Float}{Dimension}{Dimension}', '',
-  alias => '\pgfsys@transformcm');
+  alias => '\pgfsys@transformcm',
+  sizer => 0);
 
 DefMacro('\lxSVG@@transformcm {Float}{Float}{Float}{Float}{Dimension}{Dimension}', sub {
     my ($gullet, @args) = @_;
@@ -409,7 +406,8 @@ DefMacro('\lxSVG@@transformcm {Float}{Float}{Float}{Float}{Dimension}{Dimension}
 #=====================================================================#
 
 DefConstructor('\pgfsys@clipnext', '',
-  afterDigest => sub { AssignValue(pgf_clipnext => 1); });
+  afterDigest => sub { AssignValue(pgf_clipnext => 1); },
+  sizer       => 0);
 
 DefMacro('\pgfsys@stroke',     '\lxSVG@stroke\lxSVG@drawpath{fill:none}');
 DefMacro('\pgfsys@fill',       '\lxSVG@fill\lxSVG@drawpath{stroke:none}');
@@ -428,7 +426,6 @@ DefMacro('\lxSVG@drawpath{}', sub {
       Tokens(
         T_CS('\lxSVG@clearpath'),
         T_CS('\lxSVG@clearclip'),
-        T_CS('\lxSVG@incrgroup'),
         Invocation('\pgfsysprotocol@literal',
           Invocation('\lxSVG@drawpath@clipped', $path, $arg))); }
     else {
@@ -440,7 +437,7 @@ DefMacro('\lxSVG@drawpath{}', sub {
 # Seemingly can get called with no path, which is invalid
 DefConstructor('\lxSVG@drawpath@unclipped{}{}',
   '?#1(<svg:path d="#1" style="#2" />)()',
-  reversion => '');
+  reversion => '', sizer => 0);
 
 DefConstructor('\lxSVG@drawpath@clipped{}{}',
   '<svg:clipPath id="pgfcp#obj">'
@@ -448,7 +445,7 @@ DefConstructor('\lxSVG@drawpath@clipped{}{}',
     . '</svg:clipPath>'
     . '<svg:use xlink:href="##pgfpath#obj" style="#2" />'
     . '<svg:g clip-path="url(##pgfcp#obj)">',
-  reversion  => '',
+  reversion => '', sizer => 0,
   properties => { obj => sub { SVGNextObject(); } });
 
 # #======================================================================
@@ -461,7 +458,6 @@ DefMacro('\lxSVG@@discardpath', sub {
       Tokens(
         T_CS('\lxSVG@clearpath'),
         T_CS('\lxSVG@clearclip'),
-        T_CS('\lxSVG@incrgroup'),
         Invocation('\pgfsysprotocol@literal',
           Invocation(T_CS('\lxSVG@discardpath@clipped'), $path))); }
     else {
@@ -480,42 +476,33 @@ DefConstructor('\lxSVG@discardpath@clipped{}',
 #=====================================================================#
 
 #=====================================================================
-# There's something fishy about counting <svg:g>'s.
-# They need to be kept track of consistently at the same level (macro, primitive..)
-DefPrimitive('\lxSVG@incrgroup{}', sub { addToCount('pgf_scopecount', +1, 'global'); });
-DefPrimitive('\lxSVG@decrgroup{}', sub { addToCount('pgf_scopecount', -1, 'global'); });
-
 # Open an <svg:g>, with some sort of options
-# keeping track of how many have been opened.
 # Note this is basically \pgf@sys@svg@gs
-# Note silliness if invoked outside picture.
+# but we mark the svg:g that initiates a "scope" using attribute _scopebegin
+# Since svg:g's always occur within a scope, the scope will handle closing them.
+# Note silliness of \ifpgfpicture if invoked outside picture(?)
+DefPrimitive('\lxSVG@stopexpansion', undef);
 DefMacro('\lxSVG@begingroup{}',
-  '\ifpgfpicture\lxSVG@incrgroup\pgfsysprotocol@literal{\lxSVG@begingroup@{#1}}\fi');
-
-DefMacro('\lxSVG@endgroup',
-  '\lxSVG@decrgroup\pgfsysprotocol@literal{\lxSVG@endgroup@}');
-
-DefMacro('\lxSVG@endgroups', sub {
-    map { T_CS('\lxSVG@endgroup') } 1 .. LookupValue('pgf_scopecount'); });
+  '\ifpgfpicture\pgfsysprotocol@literal{\lxSVG@begingroup@{#1}}\fi');
 
 DefConstructor('\lxSVG@begingroup@ RequiredKeyVals', sub {
     my ($doc, $kv) = @_;
     my $this = $doc->getElement;
     # Special case check: if we are in a latexml context, move up to parent svg:g
     if ($doc->getNodeQName($this) =~ /^ltx:/
-      && (my $g_ancestor = $doc->findnode("ancestor::svg:g[position()=1]", $this))) {
-      $doc->closeToNode($g_ancestor); }
+      && (my $g = $doc->findnode("ancestor::svg:g[position()=1]", $this))) {
+      $doc->closeToNode($g); }
     $doc->openElement('svg:g', $kv->getHash); },
   reversion => '', sizer => 0);
 
-DefConstructor('\lxSVG@endgroup@',
-###  '</svg:g>',
-  sub { $_[0]->maybeCloseElement('svg:g'); },
-  reversion => '', sizer => 0);
-
-# Collapse redundant svg:g nodes that have only certain simple attributes
+# Collapse redundant svg:g nodes that have only certain
+# non-cummulative attributes
 Tag('svg:g', afterClose => \&collapseSVGGroup);
-my %collapsible_group_attributes = map { ($_ => 1); } qw(fill stroke color);
+my %collapsible_group_attributes = map { ($_ => 1); }
+  qw(fill fill-rule fill-opacity
+  stroke stroke-width stroke-linecap stroke-linejoin stroke-miterlimit
+  stroke-dasharray stroke-dashoffset stroke-opacity
+  color);
 
 # Collapse/remove/unwrap unneeded svg:g's to reduce depth of tree
 sub collapseSVGGroup {
@@ -697,9 +684,8 @@ DefPrimitive('\lxSVG@setpattern {Dimension}{Dimension}{Dimension}{Dimension}{Dim
     return; });
 
 DefMacro('\pgfsys@setpatternuncolored{}{}{}{}', sub {
-    Tokens(T_CS('\lxSVG@incrgroup'),
-      Invocation('\pgfsysprotocol@literal',
-        Invocation('\lxSVG@setpatternuncolored@', @_[1 .. $#_]))); });
+    Invocation('\pgfsysprotocol@literal',
+      Invocation('\lxSVG@setpatternuncolored@', @_[1 .. $#_])); });
 
 DefMacro('\pgfsys@setpatterncolored{}',
   '\lxSVG@setcolor{fill}{url(\#pgfpat#1)}');
@@ -713,7 +699,8 @@ DefConstructor('\lxSVG@coloredpattern{}{Dimension}{Dimension}{}',
     '</svg:pattern></svg:defs>',
   properties => {
     x_step => sub { $_[2]->pxValue; },
-    y_step => sub { $_[3]->pxValue; } });
+    y_step => sub { $_[3]->pxValue; } },
+  sizer => 0);
 
 DefConstructor('\lxSVG@uncoloredpattern{}{Dimension}{Dimension}{}',
   '<svg:defs>' .
@@ -725,7 +712,8 @@ DefConstructor('\lxSVG@uncoloredpattern{}{Dimension}{Dimension}{}',
     . '</svg:pattern></svg:defs>',
   properties => {
     x_step => sub { $_[2]->pxValue; },
-    y_step => sub { $_[3]->pxValue; } });
+    y_step => sub { $_[3]->pxValue; } },
+  sizer => 0);
 
 DefConstructor('\lxSVG@setpatternuncolored@{}{}{}{}',
   '<svg:defs><svg:pattern id="pgfupat#obj" xlink:href="##pgfpat#1">'
@@ -736,7 +724,8 @@ DefConstructor('\lxSVG@setpatternuncolored@{}{}{}{}',
     . '<svg:g fill="url(##pgfupat#obj)">',
   properties => {
     obj   => sub { SVGNextObject(); },
-    color => sub { Color('rgb', $_[2], $_[3], $_[4]); } });
+    color => sub { Color('rgb', $_[2], $_[3], $_[4]); } },
+  sizer => 0);
 
 #====================================================================#
 #= 8. Scoping =======================================================#
@@ -748,22 +737,30 @@ DefConstructor('\lxSVG@setpatternuncolored@{}{}{}{}',
 # the old values will be restored after endscope is used.
 
 # Do we really need an <svg:g> w/no attributes???
-DefMacro('\pgfsys@beginscope', '\lxSVG@beginscope\lxSVG@begingroup{}');
-DefMacro('\pgfsys@endscope',   '\lxSVG@endgroups\lxSVG@endscope');
+DefMacro('\pgfsys@beginscope',
+  '\lxSVG@beginscope\lxSVG@begingroup{_scopebegin=1}');
+DefMacro('\pgfsys@endscope',
+  '\pgfsysprotocol@literal{\lxSVG@closescope}\lxSVG@endscope');
+
+DefConstructor('\lxSVG@closescope', sub {
+    my ($doc, %props) = @_;
+    my $n = 0;
+    while (my $node = $doc->maybeCloseElement('svg:g')) {
+      $n++;
+      last if $node->getAttribute('_scopebegin'); }
+    return; },
+  sizer => 0);
 
 DefConstructor('\lxSVG@beginscope', '',
   afterDigest => sub {
     my ($stomach) = @_;
-    AssignValue(pgf_scopecount_save => LookupValue('pgf_scopecount') || 0);
-    AssignValue(pgf_scopecount      => 0, 'global');
     $stomach->begingroup; },
   alias => '\pgfsys@beginscope', sizer => 0);
 
 DefConstructor('\lxSVG@endscope', '',
   afterDigest => sub {
     my ($stomach) = @_;
-    $stomach->endgroup;
-    AssignValue(pgf_scopecount => LookupValue('pgf_scopecount_save') || 0, 'global'); },
+    $stomach->endgroup; },
   alias => '\pgfsys@endscope', sizer => 0);
 
 #=====================================================================#
@@ -839,7 +836,8 @@ DefConstructor('\lxSVG@sh@stop{Dimension}{Dimension}',
   properties => sub {
     my ($r, $g, $b) = LookupValue('pgf_sh_color')->rgb->components;
     (offset => $_[1]->pxValue / $_[2]->pxValue,
-      stopcolor => LookupValue('pgf_sh_color')); });
+      stopcolor => LookupValue('pgf_sh_color')); },
+  sizer => 0);
 
 DefMacro('\lxSVG@sh@interval{}{}{}{}', sub {
     (T_CS('\lxSVG@sh@color'), $_[3],
@@ -867,11 +865,13 @@ DefPrimitive('\lxSVG@sh@defstripes{}{Number}', sub {
             . ($flag->valueOf == 1 ? 'gradientTransform="rotate(90)"' : '') . '>'
             . '#stops'
             . '</svg:linearGradient></svg:defs>',
-          properties => { stops => $stops }
+          properties => { stops => $stops },
+          sizer      => 0
         );
         DefConstructor('\lxSVG@sh',
           '<svg:rect width="' . $x . '" height="' . $y . '" '
-            . 'style="fill:url(##pgfsh' . $objcount . ');stroke:none" />');
+            . 'style="fill:url(##pgfsh' . $objcount . ');stroke:none" />',
+          sizer => 0);
         DefMacro('\lxSVG@pos', sub { Invocation(T_CS('\pgfpoint'), $x, $y); });
         return; }, scope => 'global');
     return; });
@@ -890,11 +890,13 @@ DefPrimitive('\lxSVG@sh@defcircles{}', sub {
             . 'fx="' . $x . '" fy="' . $y . '">'
             . '#stops'
             . '</svg:radialGradient></svg:defs>',
-          properties => { stops => $stops }
+          properties => { stops => $stops },
+          sizer      => 0
         );
         DefConstructor('\lxSVG@sh',
           '<svg:circle cx="' . $endpos . '" cy="' . $endpos . '" r="' . $endpos . '" '
-            . 'style="fill:url(##pgfsh' . $objcount . ');stroke:none" />');
+            . 'style="fill:url(##pgfsh' . $objcount . ');stroke:none" />',
+          sizer => 0);
         DefMacro('\lxSVG@pos', sub {
             Invocation(T_CS('\pgfpoint'), 2 * $endpos, 2 * $endpos) });
         return; }, scope => 'global');
@@ -908,7 +910,8 @@ DefConstructor('\lxSVG@sh@insert{Dimension}{Dimension}{}',
 #### What's going on here? Why pt's instead of px ? (what are units?)
 ### (with px shading's way off)
     x => sub { $_[1]->ptValue; },
-    y => sub { $_[2]->ptValue; } });
+    y => sub { $_[2]->ptValue; } },
+  sizer => 0);
 
 # \lxSVG@process{Dimension}{Dimension}
 DefMacro('\lxSVG@process{}{}',
@@ -1009,7 +1012,7 @@ DefConstructor('\lxSVG@definemask', '', alias => '\pgfsys@definemask', sizer => 
 #= 12. Reusable objects ==============================================#
 #=====================================================================#
 
-DefConstructor('\pgfsys@invoke{}', '#1');
+DefConstructor('\pgfsys@invoke{}', '#1', sizer => 0);
 DefMacro('\pgfsys@markposition{}', '');
 
 #=====================================================================#

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -43,8 +43,6 @@ sub SVGNextObject {
 
 sub installPGFCommands {
   # Local definitions.
-  Let(T_CS('\hbox'),   T_CS('\lxSVG@hbox'));
-  Let(T_CS('\vbox'),   T_CS('\lxSVG@vbox'));
   Let(T_CS('\lower'),  T_CS('\lxSVG@lower'));
   Let(T_CS('\raise'),  T_CS('\lxSVG@raise'));
   Let(T_CS('\hskip'),  T_CS('\lxSVG@hskip'));
@@ -135,7 +133,7 @@ DefParameterType('SVGMoveableBox', sub {
     Error(":expected:<box>  A <svghbox> was supposed to be here, got "
         . Stringify($box))
       unless $box && $box->isa('LaTeXML::Core::Whatsit')
-      && ($box->getDefinition->getCSName =~ /^(\\lxSVG\@hbox||)$/);
+      && ($box->getDefinition->getCSName =~ /^(\\hbox||)$/);
     $box; });
 
 # Try to avoid errors inserting random boxes (esp. ltx:text)(Is this safe?)
@@ -157,13 +155,15 @@ sub collapseSVGSwitch {
     my @p_c = element_nodes($fo_c[0]);
     if (scalar(@p_c) == 0) {    # or Empty <p/>?
       $doc->removeNode($node); }
-    # Else, single ltx:picture ?
-    elsif ((scalar(@p_c) == 1) && ($doc->getNodeQName($p_c[0]) eq 'ltx:picture')) {
-      my @pic_c = element_nodes($p_c[0]);
-      # With single svg:svg ?
-      if ((scalar(@pic_c) == 1) && ($doc->getNodeQName($pic_c[0]) eq 'svg:svg')) {
-        $doc->replaceNode($node, element_nodes($pic_c[0]));
-  } } }
+    # Else, single ltx:picture or ltx:text ?
+    elsif (scalar(@p_c) == 1) {
+      my $tag = $doc->getNodeQName($p_c[0]);
+      if (($tag eq 'ltx:picture') || ($tag eq 'ltx:text')) {
+        my @pic_c = element_nodes($p_c[0]);
+        # With single svg:svg ?
+        if ((scalar(@pic_c) == 1) && ($doc->getNodeQName($pic_c[0]) eq 'svg:svg')) {
+          $doc->replaceNode($node, element_nodes($pic_c[0])); } }
+  } }
   return; }
 
 Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
@@ -172,8 +172,11 @@ Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
     # Make sure we get a size, in case autoOpen'd
     if ($whatsit) {
       my ($w, $h, $d) = $whatsit->getSize;
-      $node->setAttribute(width    => $w->toAttribute)          unless $node->hasAttribute('width');
-      $node->setAttribute(height   => $h->add($d)->toAttribute) unless $node->hasAttribute('height');
+      $node->setAttribute(width  => $w->toAttribute)          unless $node->hasAttribute('width');
+      $node->setAttribute(height => $h->add($d)->toAttribute) unless $node->hasAttribute('height');
+      # Odd, sometimes needed, sometimes too much (vtop type situations?)
+      if ($d->ptValue < 10) {    # Random heuristic
+        $node->setAttribute(y => $d->negate->toAttribute) unless $node->hasAttribute('y'); }
       $node->setAttribute(overflow => 'visible'); } });
 
 # Check whether a svg:foreignObject is open,
@@ -214,38 +217,6 @@ DefConstructor('\lxSVG@hskip Glue', sub {
       $doc->openElement('ltx:text', 'xoffset' => $skip->pxValue . 'px'); } },
   alias => '\hskip');
 
-# Like regular \hbox, \vbox, but we don't want any extra element around it.
-DefConstructor('\lxSVG@hbox BoxSpecification HBoxContents', '#2',
-  mode => 'text', bounded => 1,
-  # Workaround for $ in alignment; an explicit \hbox gives us a normal $.
-  # And also things like \centerline that will end up bumping up to block level!
-  sizer        => '#2',
-  alias        => '\hbox',
-  beforeDigest => sub { reenterTextMode(); },
-  afterDigest  => sub {
-    my ($stomach, $whatsit) = @_;
-    my $spec = $whatsit->getArg(1);
-    my $box  = $whatsit->getArg(2);
-    if (my $w = GetKeyVal($spec, 'to')) {
-      $whatsit->setWidth($w); }
-    elsif (my $s = GetKeyVal($spec, 'spread')) {
-      $whatsit->setWidth($box->getWidth->add($s)); }
-    return; });
-
-DefConstructor('\lxSVG@vbox BoxSpecification VBoxContents', '#2',
-  sizer       => '#2',
-  alias       => '\vbox',
-  afterDigest => sub {
-    my ($stomach, $whatsit) = @_;
-    my $spec = $whatsit->getArg(1);
-    my $box  = $whatsit->getArg(2);
-    if (my $h = GetKeyVal($spec, 'to')) {
-      $whatsit->setHeight($h); }
-    elsif (my $s = GetKeyVal($spec, 'spread')) {
-      $whatsit->setHeight($box->getHeight->add($s)); }
-    return; },
-  mode => 'text');
-
 #=====================================================================#
 # 1. Beginning and ending a stream ===================================#
 #=====================================================================#
@@ -278,7 +249,6 @@ DefConstructor('\pgfsys@hbox{Number}', sub {
     my $y = $h->add(($font ? $fd : $d))->pxValue;    # Seemingly should NOT have ->add($d)
         # But if the box's height has been set to 0, still need adjustment; Use font?
     $y = $fh->add($fd)->pxValue if !$y && $font;    # Seemingly SHOULD have ->add($fd)
-    my ($ww, $hh, $dd) = map { $_->ptValue; } $w, $h, $d;
     $doc->openElement('svg:g',
       transform => 'matrix(1 0 0 -1 0 ' . $y . ')',
       class     => 'ltx_svg_fog');
@@ -289,7 +259,7 @@ DefConstructor('\pgfsys@hbox{Number}', sub {
       # often the size is set to 0, which inhibits display COMPLETELY!
       # Using 100% works, though, and seems apparently best to use for height all the time(?)
       width    => $w->pxValue || '100%',
-      height   => '100%',
+      height   => $H          || '100%',
       overflow => 'visible',
       color    => $strokeattr && $strokeattr->getValue);
     my $p = $doc->openElement('ltx:p');
@@ -491,7 +461,7 @@ DefConstructor('\lxSVG@begingroup@ RequiredKeyVals', sub {
     # Special case check: if we are in a latexml context, move up to parent svg:g
     if ($doc->getNodeQName($this) =~ /^ltx:/
       && (my $g = $doc->findnode("ancestor::svg:g[position()=1]", $this))) {
-      $doc->closeToNode($g); }
+      $doc->openElement('svg:svg', _autoopened => 1); }
     $doc->openElement('svg:g', $kv->getHash); },
   reversion => '', sizer => 0);
 

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -476,19 +476,12 @@ DefMacro('\lxSVG@endgroups', sub {
 
 DefConstructor('\lxSVG@begingroup@ RequiredKeyVals', sub {
     my ($doc, $kv) = @_;
-    my $g_attrs        = $kv->getKeyVals;
-    my @keys           = keys %$g_attrs;
-    my $this           = $doc->getElement;
-    my $orig_this_name = $doc->getNodeQName($this);
-    # Special case check: if we are in a latexml context, the parent svg:g is acceptable
-    if ($orig_this_name =~ /^ltx:/ && (my $g_ancestor = $doc->findnode("ancestor::svg:g", $this))) {
-      $this = $doc->wrapNodes('svg:g', $g_ancestor->lastChild); }    # note: this svg:g stays OPEN!
-    else {                                                           # all other cases, just open a g.
-      $this = $doc->openElement('svg:g'); }
-    # We have the _correct_ svg:g here, let's assign the attributes
-    foreach my $key (@keys) {
-      my $value = $kv->getValue($key);
-      $doc->setAttribute($this, $key, $value); } },
+    my $this = $doc->getElement;
+    # Special case check: if we are in a latexml context, move up to parent svg:g
+    if ($doc->getNodeQName($this) =~ /^ltx:/
+      && (my $g_ancestor = $doc->findnode("ancestor::svg:g[position()=1]", $this))) {
+      $doc->setNode($g_ancestor); }
+    $doc->openElement('svg:g', $kv->getHash); },
   reversion => '', sizer => 0);
 
 DefConstructor('\lxSVG@endgroup@',

--- a/lib/LaTeXML/Package/pgfutil-common.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfutil-common.tex.ltxml
@@ -24,7 +24,7 @@ InputDefinitions('pgfutil-common', type => 'tex', noltxml => 1)
 
 # Overwrite macros of interest
 
-DefMacro('\pgfutil@in@{}{}', sub {
+DefPrimitive('\pgfutil@in@{}{}', sub {
     AssignValue('pgfutilin_args', [ToString($_[1]), ToString($_[2])]);
     return; });
 

--- a/lib/LaTeXML/Package/tikz.sty.ltxml
+++ b/lib/LaTeXML/Package/tikz.sty.ltxml
@@ -37,7 +37,12 @@ DefPrimitive('\use@@tikzlibrary{}', sub {
         Let(T_CS('\tikz@library@' . $lib . '@loaded'), T_CS('\pgfutil@empty'));
         my $barcc = LookupCatcode('|');
         AssignCatcode('|', CC_OTHER);
-        InputDefinitions('tikzlibrary' . $lib . '.code.tex');
+        if (InputDefinitions('tikzlibrary' . $lib . '.code.tex', noerror => 1)
+          || InputDefinitions('pgflibrary' . $lib . '.code.tex', noerror => 1)) { }
+        else {
+          Warn('missing_file', $lib, $STATE->getStomach->getGullet,
+            "Can't find tikz library '$lib' (neither pgf nor tikz)",
+            "Anticipate undefined macros or environments or keys"); }
         AssignCatcode('|', $barcc);
     } }
     return; });


### PR DESCRIPTION
This PR runs a cleanup of `svg:g` elements after they close to check for redundancies, or when they are completely masked by a child, or if a child establishes a complete set of the same attributes, and so can be pulled out.  This vastly reduces both the size and depth of tikz/pgf documents, particularly when run with post-2017 texlives.

In the process, a couple of other tikz regressions were suddenly discoverable and were fixed.  More can probably be found and fixed?  Also, since this fixes some tikz regressions that didn't cause outright failure, but very poor rendering, a rerun of arXiv tikz might be in order (when this is complete).