### PR TITLE
Allow smooth loading of cleveref with listings

### DIFF
--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -1526,5 +1526,13 @@ sub lstLoadConfiguration {
 
 lstLoadConfiguration();
 
+# Also allow some internal macros which get used from sibling bindings e.g. cleveref
+DefMacro('\lst@UseHook{}','\csname\@lst hk@#1\endcsname');
+DefMacro('\lst@AddToHook{}{}',''); # ignore
+DefMacro('\lst@AddToHookExe{}{}',''); # ignore
+DefMacro('\lst@AddTo {}{}',
+    '\expandafter\gdef\expandafter#1\expandafter{#1#2}',
+    long=>1);
+DefMacro('\@lst','lst');
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;


### PR DESCRIPTION
Fixes #1400 with a simple patch that allows cleveref and listings to co-exist.

![image](https://user-images.githubusercontent.com/348975/103313898-6971a900-49ef-11eb-8574-ea6dc79c8ca2.png)
