### PR TITLE
Try out raw support for standalone.cls

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -616,6 +616,7 @@ lib/LaTeXML/Package/slashed.sty.ltxml
 lib/LaTeXML/Package/slides.cls.ltxml
 lib/LaTeXML/Package/soul.sty.ltxml
 lib/LaTeXML/Package/srcltx.sty.ltxml
+lib/LaTeXML/Package/standalone.cls.ltxml
 lib/LaTeXML/Package/stfloats.sty.ltxml
 lib/LaTeXML/Package/stmaryrd.sty.ltxml
 lib/LaTeXML/Package/subcaption.sty.ltxml

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -398,6 +398,9 @@ DefConstructorI(T_CS('\end{document}'), undef, sub {
     # Babel's expecting \bbl@pop@language
     return @boxes; });
 
+# \enddocument is used directly in e.g. standalone.cls
+Let(T_CS('\enddocument'), T_CS('\end{document}'), 'global');
+
 #**********************************************************************
 # C.3. Sentences and Paragraphs
 #**********************************************************************

--- a/lib/LaTeXML/Package/standalone.cls.ltxml
+++ b/lib/LaTeXML/Package/standalone.cls.ltxml
@@ -1,0 +1,24 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  standalone.cls                                                     | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@gmail.com>                         #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+
+InputDefinitions('standalone', type => 'cls', noltxml => 1, handleoptions => 1);
+
+#**********************************************************************
+
+1;


### PR DESCRIPTION
Fixes the easy `.cls` half of #678

I was trying out a TeX snippet from twitter (of all places) and noticed it's using standalone. Trying out `--includestyles` almost worked out of the box, and it wasn't really meant to do much, so I added a simple binding that delegates to the raw `.cls` implementation, as a quick&easy fix.

The snippet actually creates very nice HTML5 with the latest latexml master, with embedded MathML in the (neat and to the point) SVG.

```tex
\documentclass[border=1cm]{standalone}
\usepackage{tikz}
\usetikzlibrary{positioning}

\begin{document}

\begin{tikzpicture}

%draw a polygonal chain that traces the order on a tiny finite fragment of the product

\draw (0,0) -- (0,1) -- (1,0) -- (1,1) -- (0,2) -- (1,2) 
-- (2,0) -- (2,1) -- (2,2) -- (0,3) -- (1,3) -- (2,3) -- (3,0) -- (3,1) -- (3,2) -- (3,3) -- (0,4) -- (1,4) -- (2,4) -- (3,4) -- (4,0) -- (4,1) -- (4,2) -- (4,3) -- (4,4) -- (0,5)
-- (1,5) -- (2,5) -- (3,5) -- (4,5) -- (5,0) -- (5,1) -- (5,2) -- (5,3) -- (5,4) -- (5,5);

%add a slanted dotted line that indicates that the order goes ad infinitum

\draw[dotted] (5,5) -- (0,6);

%put the red dots, it is better to put them after the chain to hide it below the dots

\foreach \x in {0,1,2,3,4,5}
{
    \foreach \y in {0,1,2,3,4,5}
    {
    \fill[red] (\x,\y) circle (2pt);
    }
}

%draw a horizontal and vertical dotted lines

\draw[dotted] (5,8) -- (7.5,8) (8,5) -- (8,7.5);

%draw the lines and fill the dots at the top horizontal and right-most vertical lines

\foreach \a in {1,2,...,5}
{
\draw (\a-1,8) -- (\a,8);
\draw (8,\a-1) -- (8,\a);
\fill[red] (\a,8) circle (2pt); 
\fill[red] (8,\a) circle (2pt); 
}

\fill[red] (0,8) circle (2pt) (8,0) circle (2pt) (8,8) circle (2pt);

%decorate some points

\node[above] at (0,8) {$(0,\omega)$};
\node[above] at (8,8) {$(\omega,\omega)$};
\node[below] at (8,0) {$(\omega,0)$};
\node[below] at (0,0) {$(0,0)$};
\end{tikzpicture}

\end{document}
```


HTML output attached as [standalone_example.zip](https://github.com/brucemiller/LaTeXML/files/5753088/standalone_example.zip)
