### PR TITLE
Error logging

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,7 +33,7 @@ our ($KPSEV, $TEXMF);
 my ($texmfspec) = grep { /^TEXMF/ } @ARGV;
 if ($texmfspec && $texmfspec =~ /^TEXMF\s*=(.*)$/) {
   $TEXMF = $1;
-  @ARGV  = grep { $_ ne $texmfspec } @ARGV; }    # Remove so MakeMaker doesn't fret.
+  local @ARGV = grep { $_ ne $texmfspec } @ARGV; }    # Remove so MakeMaker doesn't fret.
 our @EXCLUSIONS     = ();
 our $MORE_MACROS    = {};
 our $MORE_MAKERULES = '';
@@ -63,6 +63,7 @@ WriteMakefile(NAME => 'LaTeXML',
     'Getopt::Long'      => 2.37,
     'Image::Size'       => 0,
     'IO::String'        => 0,
+    'IO::Handle'        => 0,
     'JSON::XS'          => 0,
     'LWP'               => 0,
     'MIME::Base64'      => 0,      # Core
@@ -84,7 +85,7 @@ WriteMakefile(NAME => 'LaTeXML',
     'XML::LibXSLT' => 1.58,
   },
   EXE_FILES => ['bin/latexml', 'bin/latexmlpost', 'bin/latexmlfind', 'bin/latexmlmath', 'bin/latexmlc'],
-  macro => $MORE_MACROS,
+  macro     => $MORE_MACROS,
   # link to  github location to newer MakeMaker
   (eval { ExtUtils::MakeMaker->VERSION(6.46) } ? (META_MERGE => {
         'meta-spec' => { version => 2 },
@@ -93,8 +94,8 @@ WriteMakefile(NAME => 'LaTeXML',
             type => 'git',
             url  => 'https://github.com/brucemiller/LaTeXML.git',
             web  => 'https://github.com/brucemiller/LaTeXML' },
-         bugtracker => {
-             web => 'https://github.com/brucemiller/LaTeXML/issues' } } })
+          bugtracker => {
+            web => 'https://github.com/brucemiller/LaTeXML/issues' } } })
     : ()),
 );
 

--- a/bin/latexml
+++ b/bin/latexml
@@ -71,10 +71,10 @@ if (my @baddirs = grep { !-d $_ } @paths) {
 if (!pathname_is_literaldata($source)) {
   my ($dir, $name, $ext) = pathname_split($source);
   if ($name) {
-    my $path = pathname_make(dir => pathname_cwd(), name => $name, type => 'lxlog');
+    my $path = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log');
     OpenLog($path); } }
-NoteStatus(0, "$LaTeXML::IDENTITY");
-NoteStatus(1, "processing started " . localtime());    # Probably a NoteBegin???
+NoteStatus("$LaTeXML::IDENTITY");
+Progress("processing started " . localtime());    # Probably a NoteBegin???
 
 my $latexml = LaTeXML::Core->new(
   preload         => [@preload],
@@ -129,8 +129,8 @@ if ($@) {    # Fatal error?
   Debug($@); }
 $latexml->showProfile();    # Show profile (if any)
 
-NoteStatus(0, "Conversion complete: " . $latexml->getStatusMessage);
-NoteStatus(1, "processing finished " . localtime());                   # NoteEnd?
+NoteStatus("Conversion complete: " . $latexml->getStatusMessage);
+Progress("processing finished " . localtime());    # NoteEnd?
 CloseLog();
 
 if    (!$serialized) { }

--- a/bin/latexml
+++ b/bin/latexml
@@ -19,6 +19,7 @@ use Pod::Usage;
 use LaTeXML::Core;
 use LaTeXML;    # Currently, just for version information.
 use LaTeXML::Util::Pathname;
+use LaTeXML::Common::Error;
 use Encode;
 
 #**********************************************************************
@@ -49,7 +50,7 @@ GetOptions("destination=s" => \$destination,
   "inputencoding=s" => \$inputencoding,
   "comments!"       => \$comments,
   "VERSION"         => \$showversion,
-  "debug=s"         => sub { no strict 'refs'; ${ 'LaTeXML::' . $_[1] . '::DEBUG' } = 1; },
+  "debug=s"         => sub { no strict 'refs'; $LaTeXML::DEBUG{ lc($_[1]) } = 1; },
   "documentid=s"    => \$documentid,
   "help"            => \$help,
 ) or pod2usage(-message => $LaTeXML::IDENTITY,
@@ -63,12 +64,17 @@ my $source = $ARGV[0];
 
 #**********************************************************************
 # Set up the processing.
-print STDERR "$LaTeXML::IDENTITY\n"                     if $verbosity > -1;
-print STDERR "processing started " . localtime() . "\n" if $verbosity > -1;
-
 @paths = map { pathname_canonical($_) } @paths;
 if (my @baddirs = grep { !-d $_ } @paths) {
   warn "These path directories do not exist: " . join(', ', @baddirs) . "\n"; }
+
+if (!pathname_is_literaldata($source)) {
+  my ($dir, $name, $ext) = pathname_split($source);
+  if ($name) {
+    my $path = pathname_make(dir => pathname_cwd(), name => $name, type => 'lxlog');
+    OpenLog($path); } }
+NoteStatus(0, "$LaTeXML::IDENTITY");
+NoteStatus(1, "processing started " . localtime());    # Probably a NoteBegin???
 
 my $latexml = LaTeXML::Core->new(
   preload         => [@preload],
@@ -84,8 +90,6 @@ if ($destination) {
   $destination = pathname_canonical($destination);
   if (my $dir = pathname_directory($destination)) {
     pathname_mkdir($dir) or die "Couldn't create destination directory $dir: $!"; } }
-
-binmode(STDERR, ":encoding(UTF-8)");
 
 $mode = 'BibTeX' if !defined $mode && ($source =~ /\.bib$/);
 $mode = 'TeX' unless defined $mode;
@@ -122,11 +126,12 @@ eval {
     }); }
 };
 if ($@) {    # Fatal error?
-  print STDERR $@; }
+  Debug($@); }
 $latexml->showProfile();    # Show profile (if any)
 
-print STDERR "\nConversion complete: " . $latexml->getStatusMessage . ".\n";
-print STDERR "processing finished " . localtime() . "\n" if $verbosity > -1;
+NoteStatus(0, "Conversion complete: " . $latexml->getStatusMessage);
+NoteStatus(1, "processing finished " . localtime());                   # NoteEnd?
+CloseLog();
 
 if    (!$serialized) { }
 elsif ($destination) {
@@ -142,6 +147,8 @@ else {
 $latexml    = undef;
 $digested   = undef;
 $serialized = undef;
+
+CheckDebuggable();
 
 if ($@) {    # non-zero exit code for fatal conversions
   exit 1;

--- a/bin/latexml
+++ b/bin/latexml
@@ -20,8 +20,6 @@ use LaTeXML::Core;
 use LaTeXML;    # Currently, just for version information.
 use LaTeXML::Util::Pathname;
 use LaTeXML::Common::Error;
-AllowTerminalLogs();
-
 use Encode;
 
 #**********************************************************************
@@ -67,6 +65,7 @@ my $source = $ARGV[0];
 
 #**********************************************************************
 # Set up the processing.
+OpenSTDERR();
 @paths = map { pathname_canonical($_) } @paths;
 if (my @baddirs = grep { !-d $_ } @paths) {
   warn "These path directories do not exist: " . join(', ', @baddirs) . "\n"; }
@@ -77,8 +76,8 @@ if (!pathname_is_literaldata($source)) {
     if ($name) {
       $logfile = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); } }
   OpenLog($logfile) if $logfile; }
-NoteStatus("$LaTeXML::IDENTITY");
-Progress("processing started " . localtime());    # Probably a NoteBegin???
+NoteLog("$LaTeXML::IDENTITY");
+Note("processing $source started " . localtime());    # Probably a NoteBegin???
 
 my $latexml = LaTeXML::Core->new(
   preload         => [@preload],
@@ -133,8 +132,8 @@ if ($@) {    # Fatal error?
   Debug($@); }
 $latexml->showProfile();    # Show profile (if any)
 
-NoteStatus("Conversion complete: " . $latexml->getStatusMessage);
-Progress("processing finished " . localtime());    # NoteEnd?
+Note("Conversion complete: " . $latexml->getStatusMessage);
+NoteLog("processing finished " . localtime());    # NoteEnd?
 CloseLog();
 
 if    (!$serialized) { }

--- a/bin/latexml
+++ b/bin/latexml
@@ -65,7 +65,8 @@ my $source = $ARGV[0];
 
 #**********************************************************************
 # Set up the processing.
-OpenSTDERR();
+SetVerbosity($verbosity);
+UseSTDERR();
 @paths = map { pathname_canonical($_) } @paths;
 if (my @baddirs = grep { !-d $_ } @paths) {
   warn "These path directories do not exist: " . join(', ', @baddirs) . "\n"; }
@@ -75,10 +76,10 @@ if (!pathname_is_literaldata($source)) {
     my ($dir, $name, $ext) = pathname_split($source);
     if ($name) {
       $logfile = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); } }
-  OpenLog($logfile) if $logfile; }
+  UseLog($logfile) if $logfile; }
 NoteLog("$LaTeXML::IDENTITY");
 my $starttime = StartTime();
-NoteTerminal("$LaTeXML::IDENTITY processing $source ...");
+NoteSTDERR("$LaTeXML::IDENTITY processing $source ...");
 
 my $latexml = LaTeXML::Core->new(
   preload         => [@preload],
@@ -136,8 +137,8 @@ $latexml->showProfile();    # Show profile (if any)
 my $status  = $latexml->getStatusMessage;
 my $runtime = RunTime($starttime);
 NoteLog("Conversion complete: " . $status);
-NoteTerminal("Conversion complete: " . $status . " (reqd. $runtime)");
-CloseLog();
+NoteSTDERR("Conversion complete: " . $status . " (reqd. $runtime)");
+UseLog(undef);
 
 if    (!$serialized) { }
 elsif ($destination) {

--- a/bin/latexml
+++ b/bin/latexml
@@ -26,7 +26,7 @@ use Encode;
 # Parse command line
 my ($verbosity, $strict, $comments, $noparse, $includestyles) = (0, 0, 1, 0, 0);
 my ($format, $destination, $help, $showversion)               = ('xml', '');
-my ($preamble, $postamble)                                    = (undef, undef);
+my ($preamble, $postamble, $logfile)                          = (undef, undef, undef);
 my ($documentid);
 my $inputencoding;
 my $mode  = undef;
@@ -41,6 +41,7 @@ GetOptions("destination=s" => \$destination,
   "quiet"           => sub { $verbosity--; },
   "verbose"         => sub { $verbosity++; },
   "strict"          => \$strict,
+  "log=s"           => \$logfile,
   "xml"             => sub { $format = 'xml'; },
   "tex"             => sub { $format = 'tex'; },
   "box"             => sub { $format = 'box'; },
@@ -69,10 +70,11 @@ if (my @baddirs = grep { !-d $_ } @paths) {
   warn "These path directories do not exist: " . join(', ', @baddirs) . "\n"; }
 
 if (!pathname_is_literaldata($source)) {
-  my ($dir, $name, $ext) = pathname_split($source);
-  if ($name) {
-    my $path = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log');
-    OpenLog($path); } }
+  if (!$logfile) {
+    my ($dir, $name, $ext) = pathname_split($source);
+    if ($name) {
+      $logfile = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); } }
+  OpenLog($logfile) if $logfile; }
 NoteStatus("$LaTeXML::IDENTITY");
 Progress("processing started " . localtime());    # Probably a NoteBegin???
 

--- a/bin/latexml
+++ b/bin/latexml
@@ -77,7 +77,8 @@ if (!pathname_is_literaldata($source)) {
       $logfile = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); } }
   OpenLog($logfile) if $logfile; }
 NoteLog("$LaTeXML::IDENTITY");
-Note("processing $source started " . localtime());    # Probably a NoteBegin???
+my $starttime = StartTime();
+NoteTerminal("$LaTeXML::IDENTITY processing $source ...");
 
 my $latexml = LaTeXML::Core->new(
   preload         => [@preload],
@@ -132,8 +133,10 @@ if ($@) {    # Fatal error?
   Debug($@); }
 $latexml->showProfile();    # Show profile (if any)
 
-Note("Conversion complete: " . $latexml->getStatusMessage);
-NoteLog("processing finished " . localtime());    # NoteEnd?
+my $status  = $latexml->getStatusMessage;
+my $runtime = RunTime($starttime);
+NoteLog("Conversion complete: " . $status);
+NoteTerminal("Conversion complete: " . $status . " (reqd. $runtime)");
 CloseLog();
 
 if    (!$serialized) { }

--- a/bin/latexml
+++ b/bin/latexml
@@ -20,6 +20,8 @@ use LaTeXML::Core;
 use LaTeXML;    # Currently, just for version information.
 use LaTeXML::Util::Pathname;
 use LaTeXML::Common::Error;
+AllowTerminalLogs();
+
 use Encode;
 
 #**********************************************************************

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -114,6 +114,8 @@ if ((!$sock) && $local && ($expire == -1)) {
   my $response = $converter->convert($source);
   ($result, $status, $log) = map { $$response{$_} } qw(result status log) if defined $response;
 } else {
+  # TODO: May need to check the options even in the remote cases, e.g. to fish out "whatsout"
+  # $opts->check;
   my $message = q{};
   foreach my $entry (@$keyvals) {
     my ($key, $value) = ($$entry[0], $$entry[1]);

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -56,15 +56,15 @@ my $keyvals = $opts->scan_to_keyvals(\@ARGV);
 # Client-side options:
 my ($port, $address, $expire, $local) = map { $opts->get($_) } qw(port address expire);
 $address = '127.0.0.1' if !$address || ($address eq 'localhost');
-$address =~ s/^(\w+)\:\/\///;    # strip away any protocol
+$address =~ s/^(\w+)\:\/\///;     # strip away any protocol
 my $route = '/';
 if ($address =~ s/\/(.+)$//) {    # strip away route
   $route = '/' . $1;
 }
 # Local if peerhost is localhost:
-$local = ($expire && ($expire == -1)) || ($address eq '127.0.0.1');
-$expire = -1 unless ((defined $expire) && $latexmls);
-$port = ($local ? 3334 : 80) unless $port;    #Fall back if all fails...
+$local  = ($expire && ($expire == -1)) || ($address eq '127.0.0.1');
+$expire = -1                   unless ((defined $expire) && $latexmls);
+$port   = ($local ? 3334 : 80) unless $port;    #Fall back if all fails...
 #***************************************************************************
 #Add some base, so that relative paths work
 my $cdir = abs_path(cwd());
@@ -106,8 +106,9 @@ my $sock = $latexmls && IO::Socket::INET->new(
 if ((!$sock) && $local && ($expire == -1)) {
   # Don't boot a server, single job requested:
   require LaTeXML;
+  use LaTeXML::Common::Error qw(AllowTerminalLogs);
+  AllowTerminalLogs();
   $opts->set('local', 1);
-  $opts->push('debug', 'LaTeXML') unless $opts->get('log'); # If we don't request log, print to STDERR
   my $converter = LaTeXML->get_converter($opts);
   $converter->prepare_session($opts);
   my $response = $converter->convert($source);
@@ -137,7 +138,7 @@ if ((!$sock) && $local && ($expire == -1)) {
 ### Common treatment of output:
 
 # Special features for latexmls:
-my $whatsout = $opts->get('whatsout');
+my $whatsout   = $opts->get('whatsout');
 my $is_archive = $whatsout && ($whatsout =~ /^archive/);
 if ($log) {
   if ($opts->get('log')) {
@@ -151,7 +152,7 @@ if ($log) {
       print $log_handle $log;
       close $log_handle;
     }
-  } else { print STDERR $log, "\n"; }    #STDERR log otherwise
+  } else { print STDERR "\n", $log, "\n"; }    #STDERR log otherwise
 }
 
 if ($result) {
@@ -177,7 +178,7 @@ if ($opts->get('destination')) {
   print STDERR summary($opts->get('destination'), $deststat);
 }
 
-if ($status =~ /fatal error/) {      # non-zero exit code for fatal conversions
+if ($status =~ /fatal error/) {    # non-zero exit code for fatal conversions
   exit 1;
 }
 
@@ -186,8 +187,7 @@ sub summary {
   my ($destination, $prior_stat) = @_;
   my $new_stat = (stat($destination))[9] || 0;
   return ($new_stat && ($prior_stat != $new_stat)) ? "\nWrote $destination\n" :
-    "\nError! Did not write file $destination\n";
-}
+    "\nError! Did not write file $destination\n"; }
 
 sub process_local {
   my ($req_address, $req_port, $req_route, $req_message, $req_sock) = @_;

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -107,7 +107,8 @@ if ((!$sock) && $local && ($expire == -1)) {
   # Don't boot a server, single job requested:
   require LaTeXML;
   use LaTeXML::Common::Error;
-  OpenSTDERR();
+  SetVerbosity($$opts{verbosity});
+  UseSTDERR();
   $opts->set('local', 1);
   my $converter = LaTeXML->get_converter($opts);
   $converter->prepare_session($opts);

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -106,8 +106,8 @@ my $sock = $latexmls && IO::Socket::INET->new(
 if ((!$sock) && $local && ($expire == -1)) {
   # Don't boot a server, single job requested:
   require LaTeXML;
-  use LaTeXML::Common::Error qw(AllowTerminalLogs);
-  AllowTerminalLogs();
+  use LaTeXML::Common::Error qw(EnableLogToSTDERR);
+  EnableLogToSTDERR();
   $opts->set('local', 1);
   my $converter = LaTeXML->get_converter($opts);
   $converter->prepare_session($opts);

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -63,7 +63,7 @@ if ($address =~ s/\/(.+)$//) {    # strip away route
 }
 # Local if peerhost is localhost:
 $local  = ($expire && ($expire == -1)) || ($address eq '127.0.0.1');
-$expire = -1                   unless ((defined $expire) && $latexmls);
+$expire = -1 unless ((defined $expire) && $latexmls);
 $port   = ($local ? 3334 : 80) unless $port;    #Fall back if all fails...
 #***************************************************************************
 #Add some base, so that relative paths work
@@ -106,8 +106,8 @@ my $sock = $latexmls && IO::Socket::INET->new(
 if ((!$sock) && $local && ($expire == -1)) {
   # Don't boot a server, single job requested:
   require LaTeXML;
-  use LaTeXML::Common::Error qw(EnableLogToSTDERR);
-  EnableLogToSTDERR();
+  use LaTeXML::Common::Error;
+  OpenSTDERR();
   $opts->set('local', 1);
   my $converter = LaTeXML->get_converter($opts);
   $converter->prepare_session($opts);

--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -30,7 +30,7 @@ use LaTeXML::Common::Error;
 #**********************************************************************
 # Parse command line
 
-my ($verbosity, $strict, $noparse, $includestyles) = (-1, 0, 0, 0);
+my ($verbosity, $strict, $noparse, $includestyles, $logfile) = (-1, 0, 0, 0, undef);
 my ($destination, $help, $showversion) = ('', '');
 my ($documentid);
 my ($mathimage, $mathsvg, $mag) = (undef, undef, 1.75);
@@ -53,20 +53,19 @@ GetOptions(
   "contentmathml|cmml=s"      => \$cmml,
   "openmath|om=s"             => \$om,
   "XMath=s"                   => \$xmath,
-
-  "noparse" => \$noparse,
-
-  "preload=s"       => \@preload,
-  "includestyles"   => \$includestyles,
-  "inputencoding=s" => \$inputencoding,
-  "path=s"          => \@paths,
-  "quiet"           => sub { $verbosity--; },
-  "verbose"         => sub { $verbosity++; },
-  "strict"          => \$strict,
-  "VERSION"         => \$showversion,
-  "debug=s"         => sub { no strict 'refs'; ${ 'LaTeXML::' . $_[1] . '::DEBUG' } = 1; },
-  "documentid=s"    => \$documentid,
-  "help"            => \$help,
+  "noparse"                   => \$noparse,
+  "preload=s"                 => \@preload,
+  "includestyles"             => \$includestyles,
+  "inputencoding=s"           => \$inputencoding,
+  "path=s"                    => \@paths,
+  "quiet"                     => sub { $verbosity--; },
+  "verbose"                   => sub { $verbosity++; },
+  "log=s"                     => \$logfile,
+  "strict"                    => \$strict,
+  "VERSION"                   => \$showversion,
+  "debug=s"                   => sub { no strict 'refs'; ${ 'LaTeXML::' . $_[1] . '::DEBUG' } = 1; },
+  "documentid=s"              => \$documentid,
+  "help"                      => \$help,
 ) or pod2usage(-message => $LaTeXML::IDENTITY,
   -exitval => 1, -verbose => 0, -output => \*STDERR);
 pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 2, -output => \*STDOUT)
@@ -75,9 +74,6 @@ if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(0); }
 pod2usage(-message => "$LaTeXML::IDENTITY\nMissing input TeX file",
   -exitval => 1, -verbose => 0, -output => \*STDERR) unless @ARGV;
 
-binmode(STDERR, ":encoding(UTF-8)");
-print STDERR "$LaTeXML::IDENTITY\n" if $verbosity > -1;
-
 #======================================================================
 # TeX Source
 #======================================================================
@@ -85,6 +81,13 @@ print STDERR "$LaTeXML::IDENTITY\n" if $verbosity > -1;
 my $tex = join(' ', @ARGV);
 if ($tex eq '-') {
   { local $/ = undef; $tex = <>; } }
+
+SetVerbosity($verbosity);
+UseSTDERR();
+UseLog($logfile) if $logfile;    # None, by default
+NoteLog("$LaTeXML::IDENTITY");
+my $starttime = StartTime();
+NoteSTDERR("$LaTeXML::IDENTITY processing $tex ...");
 
 # We need to determine whether the TeX we're given needs to be wrapped in \[...\]
 # Does it have $'s around it? Does it have a display math environment?
@@ -236,7 +239,13 @@ if ($xmath) {
   my ($result) = $post->ProcessChain(cloneDoc($document));
   outputXML($result->findnode('//ltx:XMath'), $xmath); }
 
-print STDERR "\nConversion complete\n" if $verbosity > -1;
+my $status = $latexml->getStatusMessage;
+# Should be combined with $post's status!
+# But better approach will be to manage all through LaTeXML.pm!!
+my $runtime = RunTime($starttime);
+NoteLog("Conversion complete: " . $status);
+NoteSTDERR("Conversion complete: " . $status . " (reqd. $runtime)");
+UseLog(undef);
 
 #======================================================================
 # Helpers

--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -24,8 +24,9 @@ use File::Temp qw(tempfile);
 use LaTeXML::Post;
 use LaTeXML::Post::Scan;
 use LaTeXML::Post::CrossRef;
-#use LaTeXML::Post::Writer;
 use LaTeXML::Util::ObjectDB;
+use LaTeXML::Common::Error qw(AllowTerminalLogs);
+AllowTerminalLogs();
 
 #**********************************************************************
 # Parse command line

--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -25,8 +25,7 @@ use LaTeXML::Post;
 use LaTeXML::Post::Scan;
 use LaTeXML::Post::CrossRef;
 use LaTeXML::Util::ObjectDB;
-use LaTeXML::Common::Error qw(AllowTerminalLogs);
-AllowTerminalLogs();
+use LaTeXML::Common::Error;
 
 #**********************************************************************
 # Parse command line

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -175,7 +175,7 @@ if ($xmlfile ne '-') {
 
   my ($dir, $name, $ext) = pathname_split($xmlfile);
   if ($name) {
-    my $path = pathname_make(dir => pathname_cwd(), name => $name, type => 'lxlog');
+    my $path = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log');
     OpenLog($path, 1); } }
 
 if (@ARGV) {
@@ -308,8 +308,8 @@ if ((!defined $destination)
 # Do the processing.
 #======================================================================
 
-NoteStatus(0, "$LaTeXML::IDENTITY ????");
-NoteStatus(1, "processing started " . localtime());
+NoteStatus("$LaTeXML::IDENTITY ????");
+Progress("processing started " . localtime());
 
 # Default options/parameters for each post processor
 our %OPTIONS = ();
@@ -465,8 +465,8 @@ eval {
   $DB->finish; };
 Debug($@) if $@;
 my $code = $latexmlpost->getStatusCode;
-NoteStatus(0, "Postprocessing " . ($code == 3 ? 'failed' : 'complete') . ": " . $latexmlpost->getStatusMessage);
-NoteStatus(1, "processing " . ($code == 3 ? 'abandoned' : 'finished') . " " . localtime());
+NoteStatus("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . ": " . $latexmlpost->getStatusMessage);
+Progress("processing " . ($code == 3 ? 'abandoned' : 'finished') . " " . localtime());
 
 CloseLog();
 CheckDebuggable();

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -18,6 +18,7 @@ use File::Spec;
 use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 use LaTeXML;    # Currently, just for version information.
+use LaTeXML::Common::Error;
 use LaTeXML::Post;
 use LaTeXML::Post::Writer;
 use LaTeXML::Post::Scan;
@@ -77,6 +78,7 @@ GetOptions("quiet" => sub { $verbosity--; },
   "verbose" => sub { $verbosity++; },
   "VERSION" => \$showversion,
   "help|?"  => \$help,
+  "debug=s" => sub { no strict 'refs'; $LaTeXML::DEBUG{ lc($_[1]) } = 1; },
   # Source Options
   "sourcedirectory=s" => \$sourcedir,
   "validate!"         => \$validate,
@@ -168,8 +170,13 @@ if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(0); }
 xError("Missing input xmlfile") unless @ARGV;
 my $xmlfile = shift(@ARGV);
 if ($xmlfile ne '-') {
-  $xmlfile .= '.xml' unless -f $xmlfile;
-  xError("The input file \"$xmlfile\" was not found") unless -f $xmlfile; }
+  $xmlfile .= '.xml'                                  unless -f $xmlfile;
+  xError("The input file \"$xmlfile\" was not found") unless -f $xmlfile;
+
+  my ($dir, $name, $ext) = pathname_split($xmlfile);
+  if ($name) {
+    my $path = pathname_make(dir => pathname_cwd(), name => $name, type => 'lxlog');
+    OpenLog($path, 1); } }
 
 if (@ARGV) {
   xError("Extra unrecognized arguments " . join(' ', @ARGV)); }
@@ -289,7 +296,7 @@ else {
 if ((!defined $destination)
   && ($dographics || $picimages
     || checkMathFormat('images') || checkMathFormat('svg'))) {
-  LaTeXML::Post::Warn("expected", "options", undef,
+  Warn("expected", "options", undef,
 "must supply --destination to support auxilliary files disabling: --nomathimages --nographicimages --nopictureimages");
   # default resources is sorta ok: we might not copy, but we'll still have the links/script/etc
   $dographics = $picimages = 0;
@@ -301,9 +308,8 @@ if ((!defined $destination)
 # Do the processing.
 #======================================================================
 
-binmode(STDERR, ":encoding(UTF-8)");
-print STDERR "$LaTeXML::IDENTITY\n"              if $verbosity > -1;
-print STDERR "processing started " . localtime() if $verbosity > -1;
+NoteStatus(0, "$LaTeXML::IDENTITY ????");
+NoteStatus(1, "processing started " . localtime());
 
 # Default options/parameters for each post processor
 our %OPTIONS = ();
@@ -457,10 +463,13 @@ my $latexmlpost = LaTeXML::Post->new(verbosity => $verbosity || 0);
 eval {
   $latexmlpost->ProcessChain($DOCUMENT, @procs);
   $DB->finish; };
-print STDERR $@ if $@;
+Debug($@) if $@;
 my $code = $latexmlpost->getStatusCode;
-print STDERR "\nPostprocessing " . ($code == 3 ? 'failed' : 'complete') . ": " . $latexmlpost->getStatusMessage . "\n";
-print STDERR "processing " . ($code == 3 ? 'abandoned' : 'finished') . " " . localtime() . "\n" if $verbosity > -1;
+NoteStatus(0, "Postprocessing " . ($code == 3 ? 'failed' : 'complete') . ": " . $latexmlpost->getStatusMessage);
+NoteStatus(1, "processing " . ($code == 3 ? 'abandoned' : 'finished') . " " . localtime());
+
+CloseLog();
+CheckDebuggable();
 
 #======================================================================
 # helpers

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -167,7 +167,8 @@ GetOptions("quiet" => sub { $verbosity--; },
 pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 2, -output => \*STDOUT) if $help;
 if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(0); }
 
-OpenSTDERR();
+SetVerbosity($verbosity);
+UseSTDERR();
 # Get the requested XML file
 xError("Missing input xmlfile") unless @ARGV;
 my $xmlfile = shift(@ARGV);
@@ -180,7 +181,7 @@ if ($xmlfile ne '-') {
     if ($name) {
       $appendlog = 1;
       $logfile   = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); } }
-  OpenLog($logfile, $appendlog); }
+  UseLog($logfile, $appendlog); }
 
 if (@ARGV) {
   xError("Extra unrecognized arguments " . join(' ', @ARGV)); }
@@ -471,8 +472,8 @@ my $code    = $latexmlpost->getStatusCode;
 my $status  = $latexmlpost->getStatusMessage;
 my $runtime = RunTime($starttime);
 NoteLog("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . ": " . $status);
-NoteTerminal("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . " " . $status . " (reqd. $runtime)");
-CloseLog();
+NoteSTDERR("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . " " . $status . " (reqd. $runtime)");
+UseLog(undef);
 CheckDebuggable();
 
 #======================================================================

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -19,7 +19,6 @@ use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 use LaTeXML;    # Currently, just for version information.
 use LaTeXML::Common::Error;
-AllowTerminalLogs();
 use LaTeXML::Post;
 use LaTeXML::Post::Writer;
 use LaTeXML::Post::Scan;
@@ -168,6 +167,7 @@ GetOptions("quiet" => sub { $verbosity--; },
 pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 2, -output => \*STDOUT) if $help;
 if ($showversion) { print STDERR "$LaTeXML::IDENTITY\n"; exit(0); }
 
+OpenSTDERR();
 # Get the requested XML file
 xError("Missing input xmlfile") unless @ARGV;
 my $xmlfile = shift(@ARGV);
@@ -312,8 +312,8 @@ if ((!defined $destination)
 # Do the processing.
 #======================================================================
 
-NoteStatus("$LaTeXML::IDENTITY ????");
-Progress("processing started " . localtime());
+NoteLog("$LaTeXML::IDENTITY");
+Note("processing started " . localtime());
 
 # Default options/parameters for each post processor
 our %OPTIONS = ();
@@ -469,8 +469,8 @@ eval {
   $DB->finish; };
 Debug($@) if $@;
 my $code = $latexmlpost->getStatusCode;
-NoteStatus("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . ": " . $latexmlpost->getStatusMessage);
-Progress("processing " . ($code == 3 ? 'abandoned' : 'finished') . " " . localtime());
+Note("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . ": " . $latexmlpost->getStatusMessage);
+NoteLog("processing " . ($code == 3 ? 'abandoned' : 'finished') . " " . localtime());
 
 CloseLog();
 CheckDebuggable();

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -30,7 +30,7 @@ use LaTeXML::Util::ObjectDB;
 #======================================================================
 # undef => unspecified; 0 = NO, 1 = YES
 my ($help, $showversion, $verbosity, $validate, $omit_doctype) = (0, 0, 0, 1, 0);
-my ($sourcedir, $destination) = (undef, undef);
+my ($sourcedir, $destination, $logfile) = (undef, undef, undef);
 my @paths = ();
 my ($format, $extension, $is_html, $urlstyle) = (undef, undef, undef, 'server');
 my ($numbersections) = (1);
@@ -78,6 +78,7 @@ GetOptions("quiet" => sub { $verbosity--; },
   "verbose" => sub { $verbosity++; },
   "VERSION" => \$showversion,
   "help|?"  => \$help,
+  "log=s"   => \$logfile,
   "debug=s" => sub { no strict 'refs'; $LaTeXML::DEBUG{ lc($_[1]) } = 1; },
   # Source Options
   "sourcedirectory=s" => \$sourcedir,
@@ -172,11 +173,13 @@ my $xmlfile = shift(@ARGV);
 if ($xmlfile ne '-') {
   $xmlfile .= '.xml'                                  unless -f $xmlfile;
   xError("The input file \"$xmlfile\" was not found") unless -f $xmlfile;
-
-  my ($dir, $name, $ext) = pathname_split($xmlfile);
-  if ($name) {
-    my $path = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log');
-    OpenLog($path, 1); } }
+  my $appendlog = 0;
+  if (!$logfile) {
+    my ($dir, $name, $ext) = pathname_split($xmlfile);
+    if ($name) {
+      $appendlog = 1;
+      $logfile   = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); } }
+  OpenLog($logfile, $appendlog); }
 
 if (@ARGV) {
   xError("Extra unrecognized arguments " . join(' ', @ARGV)); }

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -19,6 +19,7 @@ use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 use LaTeXML;    # Currently, just for version information.
 use LaTeXML::Common::Error;
+AllowTerminalLogs();
 use LaTeXML::Post;
 use LaTeXML::Post::Writer;
 use LaTeXML::Post::Scan;

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -311,9 +311,8 @@ if ((!defined $destination)
 #======================================================================
 # Do the processing.
 #======================================================================
-
-NoteLog("$LaTeXML::IDENTITY");
-Note("processing started " . localtime());
+my $starttime = StartTime();
+Note($LaTeXML::IDENTITY . ($prescan ? " scanning " : " paginating ") . $xmlfile);
 
 # Default options/parameters for each post processor
 our %OPTIONS = ();
@@ -468,10 +467,11 @@ eval {
   $latexmlpost->ProcessChain($DOCUMENT, @procs);
   $DB->finish; };
 Debug($@) if $@;
-my $code = $latexmlpost->getStatusCode;
-Note("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . ": " . $latexmlpost->getStatusMessage);
-NoteLog("processing " . ($code == 3 ? 'abandoned' : 'finished') . " " . localtime());
-
+my $code    = $latexmlpost->getStatusCode;
+my $status  = $latexmlpost->getStatusMessage;
+my $runtime = RunTime($starttime);
+NoteLog("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . ": " . $status);
+NoteTerminal("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . " " . $status . " (reqd. $runtime)");
 CloseLog();
 CheckDebuggable();
 

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -175,13 +175,11 @@ my $xmlfile = shift(@ARGV);
 if ($xmlfile ne '-') {
   $xmlfile .= '.xml'                                  unless -f $xmlfile;
   xError("The input file \"$xmlfile\" was not found") unless -f $xmlfile;
-  my $appendlog = 0;
   if (!$logfile) {
     my ($dir, $name, $ext) = pathname_split($xmlfile);
     if ($name) {
-      $appendlog = 1;
-      $logfile   = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); } }
-  UseLog($logfile, $appendlog); }
+      $logfile = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexmlpost.log'); } }
+  UseLog($logfile); }
 
 if (@ARGV) {
   xError("Extra unrecognized arguments " . join(' ', @ARGV)); }

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -19,7 +19,8 @@
      T_BEGIN,T_END,T_MATH,T_ALIGN,T_PARAM,T_SUB,T_SUPER,T_SPACE,T_LETTER,T_OTHER,T_ACTIVE,T_COMMENT,T_CS,T_CR,%
      Token,Tokens,Tokenize,TokenizeInternal,Explode,UnTeX,StartSemiverbatim,EndSemiverbatim,%
      Number,Float,Dimension,MuDimension,Glue,MuGlue,Pair,PairList,%
-     NoteProgress,NoteBegin,NoteEnd,Fatal,Error,Warn,Info,%
+     NoteStatus,Progress,ProgressDetailed,ProgressSpinup,ProgressSpindown,ProgressStep,%
+     Fatal,Error,Warn,Info,%
      Stringify,ToString,Equals,%
      DefExpandable,DefMacro,DefMacroI,DefPrimitive,DefPrimitiveI,DefRegister,DefRegisterI,%
      DefConstructor,DefConstructorI,dualize_arglist,

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -148,9 +148,9 @@ sub convert {
   my $runtime = $$self{runtime};
   ($$runtime{status}, $$runtime{status_code}) = (undef, undef);
 ###   if($LaTeXML::STATE){ $LaTeXML::STATE->assignValue(verbosity => $$opts{verbosity}); }
-  NoteStatus(0, "$LaTeXML::IDENTITY")                       if $$opts{verbosity} >= 0;
-  NoteStatus(1, "invoked as [$0 " . join(' ', @ARGV) . "]") if $$opts{verbosity} >= 1;
-  NoteStatus(1, ($$opts{recursive} ? "recursive " : "") . "processing started " . localtime()) if $$opts{verbosity} >= 1;
+  NoteStatus("$LaTeXML::IDENTITY")                       if $$opts{verbosity} >= 0;
+  NoteStatus("invoked as [$0 " . join(' ', @ARGV) . "]") if $$opts{verbosity} >= 1;
+  NoteStatus(($$opts{recursive} ? "recursive " : "") . "processing started " . localtime()) if $$opts{verbosity} >= 1;
 
   # 1.3 Prepare for What's IN:
   # We use a new temporary variable to avoid confusion with daemon caching
@@ -285,9 +285,9 @@ sub convert {
     # Terminate immediately on Fatal errors
     $$runtime{status_code} = 3;
 
-    NoteStatus(0, $eval_report) if $eval_report && ($$opts{verbosity} >= 0);
-    NoteStatus(0, ($$opts{recursive} ? "recursive " : "") . "Conversion complete: " . $$runtime{status}) if ($$opts{verbosity} >= 0);
-    NoteStatus(0, ($$opts{recursive} ? "recursive " : "") . "Status:conversion:" . ($$runtime{status_code} || '0')) if ($$opts{verbosity} >= 0);
+    NoteStatus($eval_report) if $eval_report && ($$opts{verbosity} >= 0);
+    NoteStatus(($$opts{recursive} ? "recursive " : "") . "Conversion complete: " . $$runtime{status}) if ($$opts{verbosity} >= 0);
+    NoteStatus(($$opts{recursive} ? "recursive " : "") . "Status:conversion:" . ($$runtime{status_code} || '0')) if ($$opts{verbosity} >= 0);
 
     # If we just processed an archive, clean up sandbox directory.
     if ($$opts{whatsin} =~ /^archive/) {
@@ -304,7 +304,7 @@ sub convert {
     return { result => $serialized, log => $log, status => $$runtime{status}, status_code => $$runtime{status_code} }; }
   else {
     # Standard report, if we're not in a Fatal case
-    NoteStatus(0, ($$opts{recursive} ? "recursive " : "") . "Conversion complete: " . $$runtime{status}) if ($$opts{verbosity} >= 0);
+    NoteStatus(($$opts{recursive} ? "recursive " : "") . "Conversion complete: " . $$runtime{status}) if ($$opts{verbosity} >= 0);
   }
   # 2.3 Clean up and exit if we only wanted the serialization of the core conversion
   if ($serialized) {
@@ -378,7 +378,7 @@ sub convert {
   else { $serialized = $result; }
 
   # 5.2 Finalize logging and return a response containing the document result, log and status
-  NoteStatus(0, "Status:conversion:" . ($$runtime{status_code} || '0')) if ($$opts{verbosity} >= 0);
+  NoteStatus("Status:conversion:" . ($$runtime{status_code} || '0')) if ($$opts{verbosity} >= 0);
   my $log = $self->flush_log;
   return { result => $serialized, log => $log, status => $$runtime{status}, 'status_code' => $$runtime{status_code} };
 }
@@ -622,10 +622,10 @@ sub convert_post {
     my $destination_directory = $PostOPS{destinationDirectory};
     my $log_file              = pathname_absolute($$opts{log}, $destination_directory);
     if (pathname_is_contained($log_file, $destination_directory)) {
-      NoteStatus(0, ($$opts{recursive} ? "recursive " : "") . "Post-processing complete: " . $latexmlpost->getStatusMessage) if ($$opts{verbosity} >= 0);
-      NoteStatus(1, ($$opts{recursive} ? "recursive " : "") . "processing finished " . localtime()) if ($$opts{verbosity} >= 1);
+      NoteStatus(($$opts{recursive} ? "recursive " : "") . "Post-processing complete: " . $latexmlpost->getStatusMessage) if ($$opts{verbosity} >= 0);
+      NoteStatus(($$opts{recursive} ? "recursive " : "") . "processing finished " . localtime()) if ($$opts{verbosity} >= 1);
       my $archive_log_status_code = max($$runtime{status_code}, $latexmlpost->getStatusCode);
-      NoteStatus(1, "Status:conversion:" . $archive_log_status_code) if ($$opts{verbosity} >= 1);
+      NoteStatus("Status:conversion:" . $archive_log_status_code) if ($$opts{verbosity} >= 1);
       open my $log_fh, '>', $log_file;
       print $log_fh $self->flush_log;
       close $log_fh;
@@ -646,8 +646,8 @@ sub convert_post {
   $$runtime{status_code} = max($$runtime{status_code}, $latexmlpost->getStatusCode);
   ### HACKY END
 
-  NoteStatus(0, ($$opts{recursive} ? "recursive " : "") . "Post-processing complete: " . $latexmlpost->getStatusMessage) if ($$opts{verbosity} >= 0);
-  NoteStatus(1, ($$opts{recursive} ? "recursive " : "") . "processing finished " . localtime()) if ($$opts{verbosity} >= 1);
+  NoteStatus(($$opts{recursive} ? "recursive " : "") . "Post-processing complete: " . $latexmlpost->getStatusMessage) if ($$opts{verbosity} >= 0);
+  NoteStatus(($$opts{recursive} ? "recursive " : "") . "processing finished " . localtime()) if ($$opts{verbosity} >= 1);
 
   # Avoid writing the main file twice (non-archive documents):
   if ($$opts{destination} && $$opts{local} && ($$opts{whatsout} eq 'document')) {
@@ -693,7 +693,7 @@ sub new_latexml {
   # TODO: Do again, need to do this in a GOOD way as well:
   $latexml->digestFile($_, noinitialize => 1) foreach (@str_pre);
   ## Still needed???
-  ## NoteStatus(0, "\n\n");    # Flush a pair of newlines to delimit the initalization
+  ## NoteStatus("\n\n");    # Flush a pair of newlines to delimit the initalization
   return $latexml;
 }
 

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -21,7 +21,6 @@ use File::Path qw(rmtree);
 use File::Spec;
 use List::Util qw(max);
 use LaTeXML::Common::Config;
-##use LaTeXML::Common::Error qw(generateMessage colorizeString);
 use LaTeXML::Common::Error;
 use LaTeXML::Core;
 use LaTeXML::Util::Pack;
@@ -205,9 +204,9 @@ sub convert {
   #       to this time, where we can be certain if a user has run a local job without --dest
   if ((!$$opts{destination})
     && ($$opts{dographics} || $$opts{picimages} || grep { $_ eq 'images' or $_ eq 'svg' } @{ $$opts{math_formats} })) {
-    Debug(generateMessage("Warning:expected:options", undef,
-        "must supply --destination to support auxilliary files", 0,
-        "  disabling: --nomathimages --nographicimages --nopictureimages"));
+    Warn("expected", "options", undef,
+      "must supply --destination to support auxilliary files",
+      "  disabling: --nomathimages --nographicimages --nopictureimages");
     # default resources is sorta ok: we might not copy, but we'll still have the links/script/etc
     $$opts{dographics} = 0;
     $$opts{picimages}  = 0;

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -422,9 +422,9 @@ sub convert_post {
   my $runtime = $$self{runtime};
   my ($xslt, $parallel, $math_formats, $format, $verbosity, $defaultresources, $embed) =
     map { $$opts{$_} } qw(stylesheet parallelmath math_formats format verbosity defaultresources embed);
-  $verbosity = $verbosity || 0;
-
-  my %PostOPS = (verbosity => $verbosity,
+##  $verbosity = $verbosity || 0;
+  SetVerbosity($verbosity) if defined $verbosity;
+  my %PostOPS = (    ####verbosity => $verbosity,
     validate           => $$opts{validate},
     sourceDirectory    => $$opts{sourcedirectory},
     siteDirectory      => $$opts{sitedirectory},
@@ -589,7 +589,8 @@ sub convert_post {
 
   # Do the actual post-processing:
   my @postdocs;
-  my $latexmlpost      = LaTeXML::Post->new(verbosity => $verbosity || 0);
+##  my $latexmlpost      = LaTeXML::Post->new(verbosity => $verbosity || 0);
+  my $latexmlpost      = LaTeXML::Post->new();
   my $post_eval_return = eval {
     local $SIG{'ALRM'} = sub { die "Fatal:conversion:post-processing timed out.\n" };
     alarm($$opts{timeout});
@@ -669,9 +670,10 @@ sub new_latexml {
   my $includepathpis = !(exists $$opts{xsltparameters} &&
     (grep { $_ eq 'LATEXML_VERSION:TEST' } @{ $$opts{xsltparameters} }));
   require LaTeXML;
+  SetVerbosity($$opts{verbosity}) if defined $$opts{verbosity};
   my $latexml = LaTeXML::Core->new(preload => [@pre], searchpaths => [@{ $$opts{paths} }],
-    graphicspaths   => ['.'],
-    verbosity       => $$opts{verbosity}, strict => $$opts{strict},
+    graphicspaths => ['.'],
+###    verbosity       => $$opts{verbosity}, strict => $$opts{strict},
     includecomments => $$opts{comments},
     includepathpis  => $includepathpis,
     inputencoding   => $$opts{inputencoding},

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -630,7 +630,8 @@ sub convert_post {
       print $log_fh $self->flush_log;
       close $log_fh;
       $self->bind_log; }
-    else { print STDERR "Error:I/O:log The target log file isn't contained in the destination directory!\n"; } }
+# TODO: This needs a bit of rethinking, likely a fallback.log file should be created and returned with the archive
+    else { Error("I/O", "log", "The target log file isn't contained in the destination directory!"); } }
   # Handle the output packaging
 
   my ($postdoc) = pack_collection(collection => [@postdocs], whatsout => $$opts{whatsout}, format => $format, %PostOPS);

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -205,7 +205,7 @@ sub convert {
   #       to this time, where we can be certain if a user has run a local job without --dest
   if ((!$$opts{destination})
     && ($$opts{dographics} || $$opts{picimages} || grep { $_ eq 'images' or $_ eq 'svg' } @{ $$opts{math_formats} })) {
-    Debug(generateMessage(colorizeString("Warning:expected:options", 'warning'), undef,
+    Debug(generateMessage("Warning:expected:options", undef,
         "must supply --destination to support auxilliary files", 0,
         "  disabling: --nomathimages --nographicimages --nopictureimages"));
     # default resources is sorta ok: we might not copy, but we'll still have the links/script/etc
@@ -363,7 +363,7 @@ sub convert {
       if ($ref_result =~ /Document$/) {
         $serialized = $result->toString(1);
         $serialized = Encode::encode('UTF-8', $serialized) if $serialized;
-      } else {                      # fragment case
+      } else {    # fragment case
         $serialized = $result->toString(1, 1);
     } }
     elsif ($$opts{format} =~ /^html/) {
@@ -371,7 +371,7 @@ sub convert {
         # Needs explicit encode call, toStringHTML returns Perl byte strings
         $serialized = $result->getDocument->toStringHTML;
         $serialized = Encode::encode('UTF-8', $serialized) if $serialized; }
-      else {                        # fragment case
+      else {      # fragment case
         local $XML::LibXML::setTagCompression = 1;
         $serialized = $result->toString(1, 1); } } }
   # Compressed/archive/other case, just pass on
@@ -475,7 +475,7 @@ sub convert_post {
     if ($$opts{crossref}) {
       require LaTeXML::Post::CrossRef;
       push(@procs, LaTeXML::Post::CrossRef->new(
-          db => $DB, urlstyle => $$opts{urlstyle},
+          db        => $DB, urlstyle => $$opts{urlstyle},
           extension => $$opts{extension},
           ($$opts{numbersections} ? (number_sections => 1)              : ()),
           ($$opts{navtoc}         ? (navigation_toc  => $$opts{navtoc}) : ()),
@@ -699,45 +699,18 @@ sub new_latexml {
 
 sub bind_log {
   my ($self) = @_;
-  # HACK HACK HACK !!! Refactor with proplery scoped logging !!!
-  $LaTeXML::LOG_STACK++;    # May the modern Perl community forgive me for this hack...
+  $LaTeXML::LOG_STACK++;    # Only bind once
   return if $LaTeXML::LOG_STACK > 1;
-  # TODO: Move away from global file handles, they will inevitably end up causing problems..
-##  my ($destdir) = pathname_split($$self{opts}{destination});
-##  my $logfile              = pathname_absolute($$self{opts}{log}, $destdir);
-
-##print STDERR "Bind log\n";
-  if (!$LaTeXML::DEBUG{latexml}) {    # Debug will use STDERR for logs
-        #                                     # Tie STDERR to log:
-        #   my $log_handle;
-        #   open($log_handle, ">>", \$$self{log}) or croak "Can't redirect STDERR to log! Dying...";
-    OpenLog(\$$self{log}, 1);
-##print STDERR "Opening log\n";
-    #   *STDERR_SAVED = *STDERR;
-    #   *STDERR       = *$log_handle;
-    #   binmode(STDERR, ':encoding(UTF-8)');
-    #   $LaTeXML::Common::Error::COLORIZED_LOGGING = -t STDERR;
-    #   $$self{log_handle} = $log_handle;
-  }
+  OpenLog(\$$self{log}, 1);
   return; }
 
 sub flush_log {
   my ($self) = @_;
-  # HACK HACK HACK !!! Refactor with proplery scoped logging !!!
   $LaTeXML::LOG_STACK--;    # May the modern Perl community forgive me for this hack...
   return '' if $LaTeXML::LOG_STACK > 0;
-##  my ($destdir) = pathname_split($$self{opts}{destination});
-##  my $logfile              = pathname_absolute($$self{opts}{log}, $destdir);
-##print STDERR "Flush log\n";
-  # Close and restore STDERR to original condition.
-  if (!$LaTeXML::DEBUG{latexml}) {
-    #   close $$self{log_handle};
-    #   delete $$self{log_handle};
-    #   *STDERR                                    = *STDERR_SAVED;
-    #   $LaTeXML::Common::Error::COLORIZED_LOGGING = -t STDERR;
-##print STDERR "Closing log\n";
-    CloseLog();
-  }
+
+  CloseLog();
+
   my $log = $$self{log};
   $$self{log} = q{};
   return $log; }

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -699,7 +699,7 @@ sub bind_log {
   my ($self) = @_;
   $LaTeXML::LOG_STACK++;    # Only bind once
   return if $LaTeXML::LOG_STACK > 1;
-  OpenLog(\$$self{log}, 1);
+  UseLog(\$$self{log}, 1);
   return; }
 
 sub flush_log {
@@ -707,7 +707,7 @@ sub flush_log {
   $LaTeXML::LOG_STACK--;    # May the modern Perl community forgive me for this hack...
   return '' if $LaTeXML::LOG_STACK > 0;
 
-  CloseLog();
+  UseLog(undef);
 
   my $log = $$self{log};
   $$self{log} = q{};

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -287,7 +287,7 @@ sub convert {
 
     NoteStatus($eval_report) if $eval_report && ($$opts{verbosity} >= 0);
     NoteStatus(($$opts{recursive} ? "recursive " : "") . "Conversion complete: " . $$runtime{status}) if ($$opts{verbosity} >= 0);
-    NoteStatus(($$opts{recursive} ? "recursive " : "") . "Status:conversion:" . ($$runtime{status_code} || '0')) if ($$opts{verbosity} >= 0);
+    NoteStatus(($$opts{recursive} ? "recursive " : "") . "Status:conversion:" . ($$runtime{status_code} || '0'));
 
     # If we just processed an archive, clean up sandbox directory.
     if ($$opts{whatsin} =~ /^archive/) {
@@ -378,7 +378,7 @@ sub convert {
   else { $serialized = $result; }
 
   # 5.2 Finalize logging and return a response containing the document result, log and status
-  NoteStatus("Status:conversion:" . ($$runtime{status_code} || '0')) if ($$opts{verbosity} >= 0);
+  NoteStatus("Status:conversion:" . ($$runtime{status_code} || '0'));
   my $log = $self->flush_log;
   return { result => $serialized, log => $log, status => $$runtime{status}, 'status_code' => $$runtime{status_code} };
 }
@@ -625,7 +625,7 @@ sub convert_post {
       NoteStatus(($$opts{recursive} ? "recursive " : "") . "Post-processing complete: " . $latexmlpost->getStatusMessage) if ($$opts{verbosity} >= 0);
       NoteStatus(($$opts{recursive} ? "recursive " : "") . "processing finished " . localtime()) if ($$opts{verbosity} >= 1);
       my $archive_log_status_code = max($$runtime{status_code}, $latexmlpost->getStatusCode);
-      NoteStatus("Status:conversion:" . $archive_log_status_code) if ($$opts{verbosity} >= 1);
+      NoteStatus("Status:conversion:" . $archive_log_status_code);
       open my $log_fh, '>', $log_file;
       print $log_fh $self->flush_log;
       close $log_fh;

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -365,12 +365,11 @@ sub _prepare_options {
   #======================================================================
   # "safe" and semi-perlcrtic acceptable way to set DEBUG inside arbitrary modules.
   # Note: 'LaTeXML' refers to the top-level class
-  { no strict 'refs';
-    foreach my $ltx_class (@{ $$opts{debug} || [] }) {
-      if ($ltx_class eq 'LaTeXML') {
-        ${'LaTeXML::DEBUG'} = 1; }
-      else {
-        ${ 'LaTeXML::' . $ltx_class . '::DEBUG' } = 1; } } }
+  foreach my $ltx_class (@{ $$opts{debug} || [] }) {
+    if ($ltx_class eq 'LaTeXML') {
+      $LaTeXML::DEBUG{LaTeXML} = 1; }
+    else {
+      $LaTeXML::DEBUG{$ltx_class} = 1; } }
 
   $$opts{input_limit}   = 100          unless defined $$opts{input_limit}; # 100 jobs until restart
   $$opts{timeout}       = 600          unless defined $$opts{timeout};     # 10 minute timeout default
@@ -619,7 +618,7 @@ sub _read_options_file {
   my $opts = [];
   my $OPT;
 #### Now can we report status to right places before we've gotten configuration??? (verbosity, logfile...)
-####  NoteBegin("Loading profile $file");
+####  ProgressSpinup("Loading profile $file");
   unless (open($OPT, "<", $file)) {
     Error('expected', $file, "Could not open options file '$file'");
     return; }
@@ -660,7 +659,7 @@ sub _read_options_file {
         "Unrecognized configuration data '$line'"); }
   }
   close $OPT;
-####  NoteEnd("Loading profile $file");
+####  ProgressSpindown("Loading profile $file");
   return $opts; }
 
 1;

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -618,7 +618,8 @@ sub _read_options_file {
   my ($file) = @_;
   my $opts = [];
   my $OPT;
-  print STDERR "(Loading profile $file...";
+#### Now can we report status to right places before we've gotten configuration??? (verbosity, logfile...)
+####  NoteBegin("Loading profile $file");
   unless (open($OPT, "<", $file)) {
     Error('expected', $file, "Could not open options file '$file'");
     return; }
@@ -659,7 +660,7 @@ sub _read_options_file {
         "Unrecognized configuration data '$line'"); }
   }
   close $OPT;
-  print STDERR " )\n";
+####  NoteEnd("Loading profile $file");
   return $opts; }
 
 1;

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -187,12 +187,12 @@ sub read {
   my $getOptions_success = GetOptions(%{$spec});
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   if (!$silent && $$opts{help}) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 99,
-      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', output => \*STDOUT);
   }
 
@@ -238,7 +238,7 @@ sub scan_to_keyvals {
   my $getOptions_success = GetOptions(%$spec);
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   CORE::push @$keyvals, ['source', $ARGV[0]] if $ARGV[0];
@@ -379,9 +379,9 @@ sub _prepare_options {
   if ($$opts{mathparse} eq 'no') {
     $$opts{mathparse}   = 0;
     $$opts{nomathparse} = 1; }                                             #Backwards compatible
-  $$opts{verbosity} = 0     unless defined $$opts{verbosity};
-  $$opts{preload}   = []    unless defined $$opts{preload};
-  $$opts{paths}     = ['.'] unless defined $$opts{paths};
+##  $$opts{verbosity} = 0     unless defined $$opts{verbosity};
+  $$opts{preload} = []    unless defined $$opts{preload};
+  $$opts{paths}   = ['.'] unless defined $$opts{paths};
   @{ $$opts{paths} } = map { pathname_canonical($_) } @{ $$opts{paths} };
   foreach (('destination', 'dbfile', 'sourcedirectory', 'sitedirectory')) {
     $$opts{$_} = pathname_canonical($$opts{$_}) if defined $$opts{$_};
@@ -550,7 +550,7 @@ sub _prepare_options {
       $$opts{math_formats} = [];
       maybeAddMathFormat($opts, 'images');
     }
-    $$opts{svg} = 1 unless defined $$opts{svg};    # If we're not making HTML, SVG is on by default
+    $$opts{svg} = 1 unless defined $$opts{svg};      # If we're not making HTML, SVG is on by default
         # PMML default if we're HTMLy and all else fails and no mathimages:
     if (((!defined $$opts{math_formats}) || (!scalar(@{ $$opts{math_formats} })))
       && ($$opts{is_html} || $$opts{is_xhtml} || ($$opts{format} eq 'jats'))) {

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -187,12 +187,12 @@ sub read {
   my $getOptions_success = GetOptions(%{$spec});
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   if (!$silent && $$opts{help}) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 0, -verbose => 99,
-      -input => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', output => \*STDOUT);
   }
 
@@ -238,7 +238,7 @@ sub scan_to_keyvals {
   my $getOptions_success = GetOptions(%$spec);
   if (!$getOptions_success && !$silent) {
     pod2usage(-message => $LaTeXML::IDENTITY, -exitval => 1, -verbose => 99,
-      -input => pod_where({ -inc => 1 }, __PACKAGE__),
+      -input    => pod_where({ -inc => 1 }, __PACKAGE__),
       -sections => 'OPTION SYNOPSIS', -output => \*STDERR);
   }
   CORE::push @$keyvals, ['source', $ARGV[0]] if $ARGV[0];
@@ -418,12 +418,13 @@ sub _prepare_options {
   if ($$opts{format}) {
     # Lower-case for sanity's sake
     $$opts{format} = lc($$opts{format});
-    $$opts{format} = 'html5' if $$opts{format} eq 'html';    # Default is 5
     if ($$opts{format} eq 'zip') {
       # Not encouraged! But try to produce something sensible anyway...
       $$opts{format}   = 'html5';
-      $$opts{whatsout} = 'archive';
-    }
+      $$opts{whatsout} = 'archive'; }
+    else {    # Default HTML is 5
+      $$opts{format} = 'html5' if $$opts{format} eq 'html'; }
+
     $$opts{is_html}  = ($$opts{format} =~ /^html/);
     $$opts{is_xhtml} = ($$opts{format} =~ /^(xhtml5?|epub|mobi)$/);
     $$opts{whatsout} = 'archive' if (($$opts{format} eq 'epub') || ($$opts{format} eq 'mobi'));
@@ -549,7 +550,7 @@ sub _prepare_options {
       $$opts{math_formats} = [];
       maybeAddMathFormat($opts, 'images');
     }
-    $$opts{svg} = 1 unless defined $$opts{svg};      # If we're not making HTML, SVG is on by default
+    $$opts{svg} = 1 unless defined $$opts{svg};    # If we're not making HTML, SVG is on by default
         # PMML default if we're HTMLy and all else fails and no mathimages:
     if (((!defined $$opts{math_formats}) || (!scalar(@{ $$opts{math_formats} })))
       && ($$opts{is_html} || $$opts{is_xhtml} || ($$opts{format} eq 'jats'))) {

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -166,7 +166,6 @@ sub _spinnerrestore {    # Restore the spinner line (if any)
   return; }
 
 sub _spinnerstep {    # Increment stepper
-  my () = @_;
   my $verbosity = $STATE && $STATE->lookupValue('VERBOSITY') || 0;
   if ($IS_TERMINAL && ($verbosity >= 0) && @spinnerstack) {
     my ($stage, $count, $start) = @{ $spinnerstack[-1] };

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -216,7 +216,7 @@ sub _spinnerpush {    # New spinner level
 sub _spinnerpop {    # Finished with spinner level
   my ($stage) = @_;
   if (@spinnerstack && ($stage eq $spinnerstack[-1][0])) {
-    my ($stage, $short, $start) = @{ pop(@spinnerstack) };
+    my ($xstage, $short, $start) = @{ pop(@spinnerstack) };
     return Time::HiRes::tv_interval($start, [Time::HiRes::gettimeofday]); }
   elsif ($USE_STDERR && ($VERBOSITY >= 0)) {    # What else to do about mis-matched begin/end ??
     print STDERR "SPINNER is " . ((@spinnerstack && $spinnerstack[-1][0]) || 'undef') . " not $stage\n"; }
@@ -769,6 +769,7 @@ from L<LaTeXML::Global>, namely C<Warn>, C<Error> and C<Fatal>.
 The general idea is that a minimal amount should be printed to STDERR (possibly with
 colors, spinners, etc if it is a terminal), and more complete information is printed to
 a log file. Neither of these are enabled, by default; see below.
+
 =over 4
 
 =item C<< SetVerbosity($verbosity); >>

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -39,6 +39,8 @@ our @EXPORT = (
   qw(&generateMessage),
   # Status management
   qw(&MergeStatus),
+  # Run time reporting
+  qw(&StartTime &RunTime),
 );
 
 our $VERBOSITY = 0;
@@ -171,6 +173,18 @@ sub strip_ansi {
   my ($string) = @_;
   $string =~ s/\e\[[0-9;]*[a-zA-Z]//g;
   return $string; }
+
+#======================================================================
+sub StartTime {
+  return [Time::HiRes::gettimeofday]; }
+
+sub RunTime {
+  my ($starttime) = @_;
+  my $s = Time::HiRes::tv_interval($starttime, [Time::HiRes::gettimeofday]);
+  my ($h, $m);
+  $m = int($s / 60); $s -= 60 * $m;
+  $h = int($m / 60); $m -= 60 * $h;
+  return ($h ? $h . 'h ' : '') . ($m ? $m . 'm ' : '') . sprintf("%.2fs", $s); }
 
 #======================================================================
 # Spinner support
@@ -351,12 +365,6 @@ sub NoteTerminal {
 sub NoteLog {
   my (@stuff) = @_;
   print $LOG _freshline($LOG), strip_ansi(join('', @stuff)), "\n" if $LOG && ($VERBOSITY >= 0); # verbosity???
-  return; }
-
-# NOTE: Make this OBSOLETE!
-sub NoteStatus {
-  my (@stuff) = @_;
-  _printline(0, 0, join('', @stuff));
   return; }
 
 # Progress reporting.

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -40,9 +40,10 @@ our @EXPORT = (
 );
 
 our $VERBOSITY = 0;
+
 sub SetVerbosity {
   # Validate?
-  $VERBOSITY = $_[0]; }
+  return $VERBOSITY = $_[0]; }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Terminal setup
@@ -220,7 +221,7 @@ sub Fatal {
   # This seemingly should be "local", but that doesn't seem to help with timeout/alarm/term?
   # It should be safe so long as the caller has bound it and rebinds it if necessary.
   local $SIG{__DIE__} = 'DEFAULT';    # Avoid recursion while preparing the message.
-  my $state     = $STATE;
+  my $state = $STATE;
 
   if (!$inhandler) {
     local $LaTeXML::BAILOUT = $LaTeXML::BAILOUT;
@@ -257,7 +258,7 @@ sub checkRecursiveError {
 sub Error {
   my ($category, $object, $where, $message, @details) = @_;
   return if $LaTeXML::IGNORE_ERRORS;
-  my $state     = $STATE;
+  my $state = $STATE;
   if ($state && $state->lookupValue('STRICT')) {
     Fatal($category, $object, $where, $message, @details); }
   else {
@@ -275,7 +276,7 @@ sub Error {
 sub Warn {
   my ($category, $object, $where, $message, @details) = @_;
   return if $LaTeXML::IGNORE_ERRORS;
-  my $state     = $STATE;
+  my $state = $STATE;
   $state && $state->noteStatus('warning');
   my $formatted = generateMessage(colorizeString("Warning:" . $category . ":" . ToString($object), 'warning'),
     $where, $message, 0, @details);
@@ -287,7 +288,7 @@ sub Warn {
 sub Info {
   my ($category, $object, $where, $message, @details) = @_;
   return if $LaTeXML::IGNORE_ERRORS;
-  my $state     = $STATE;
+  my $state = $STATE;
   $state && $state->noteStatus('info');
   my $formatted = generateMessage(colorizeString("Info:" . $category . ":" . ToString($object), 'info'),
     $where, $message, -1, @details);
@@ -321,8 +322,8 @@ sub ProgressStep {
   return; }
 
 sub ProgressSpinup {
-  my ($stage)   = @_;
-  my $state     = $STATE;
+  my ($stage) = @_;
+  my $state = $STATE;
   if ($VERBOSITY >= 0) {
     _spinnerclear();
     _spinnerpush($stage);
@@ -336,8 +337,8 @@ sub ProgressSpinup {
   return; }
 
 sub ProgressSpindown {
-  my ($stage)   = @_;
-  my $state     = $STATE;
+  my ($stage) = @_;
+  my $state = $STATE;
   if ($VERBOSITY >= 0) {
     _spinnerclear();
     my $elapsed = _spinnerpop($stage);

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -130,6 +130,9 @@ sub _printline {
   $message = $clean_message unless $IS_TERMINAL;
   print $LOG _freshline($LOG), $clean_message, "\n" if $LOG && ($VERBOSITY >= $loglevel);
 
+  # Spinner logic only for terminal-enabled applications
+  return unless $IS_TERMINAL;
+
   _spinnerclear();
   if ($VERBOSITY > $termlevel) {
     print STDERR _freshline(\*STDERR), $message, "\n"; }
@@ -337,6 +340,7 @@ sub ProgressSpinup {
     my $message = "($stage...";
     print $LOG _freshline($LOG), $message if $LOG;
     $NEEDSFRESHLINE{$LOG} = 1 if $LOG;
+    # TODO: Is this dead code? We now only print to STDERR when IS_TERMINAL=1
     if (!$IS_TERMINAL) {
       print STDERR _freshline(\*STDERR), $message;
       $NEEDSFRESHLINE{ \*STDERR } = 1; } }
@@ -352,6 +356,7 @@ sub ProgressSpindown {
     my $message = ($elapsed ? sprintf(" %.2f sec)", $elapsed) : '?');
     print $LOG $message       if $LOG;
     $NEEDSFRESHLINE{$LOG} = 1 if $LOG;
+    # TODO: Is this dead code? We now only print to STDERR when IS_TERMINAL=1
     if (!$IS_TERMINAL) {
       print STDERR $message;
       $NEEDSFRESHLINE{ \*STDERR } = 1; } }

--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -396,7 +396,6 @@ sub match_font {
       my $re   = '^Font\['
         . join(',', map { ($_ eq '*' ? "[^,]+" : "\Q$_\E") } @comp)
         . '\]$';
-      print STDERR "\nCreating re for \"$font1\" => $re\n";
       $regexp = $FONT_REGEXP_CACHE{$font1} = qr/$re/; } }
   return $font2 =~ /$regexp/; }
 

--- a/lib/LaTeXML/Common/Model.pm
+++ b/lib/LaTeXML/Common/Model.pm
@@ -107,7 +107,7 @@ sub compileSchema {
 
 sub loadCompiledSchema {
   my ($self, $file) = @_;
-  NoteBegin("Loading compiled schema $file");
+  ProgressSpinup("Loading compiled schema $file");
   my $MODEL;
   open($MODEL, '<', $file) or Fatal('I/O', $file, undef, "Cannot open Compiled Model $file for reading", $!);
   my $line;
@@ -127,7 +127,7 @@ sub loadCompiledSchema {
       Fatal('internal', $file, undef, "Compiled model '$file' is malformatted at \"$line\""); }
   }
   close($MODEL);
-  NoteEnd("Loading compiled schema $file");
+  ProgressSpindown("Loading compiled schema $file");
   return; }
 
 #**********************************************************************

--- a/lib/LaTeXML/Common/Model.pm
+++ b/lib/LaTeXML/Common/Model.pm
@@ -429,13 +429,13 @@ sub isInSchemaClass {
 #**********************************************************************
 sub describeModel {
   my ($self) = @_;
-  print STDERR "Doctype\n";
+  Debug("Doctype");
   foreach my $tag (sort keys %{ $$self{tagprop} }) {
     if (my $model = $$self{tagprop}{$tag}{model}) {
       if (keys %$model) {
-        print STDERR "$tag can contain " . join(', ', sort keys %{ $$self{tagprop}{$tag}{model} }) . "\n"; } }
+        Debug("$tag can contain " . join(', ', sort keys %{ $$self{tagprop}{$tag}{model} })); } }
     else {
-      print STDERR "$tag is empty\n"; }
+      Debug("$tag is empty"); }
   }
   return; }
 

--- a/lib/LaTeXML/Common/Model/DTD.pm
+++ b/lib/LaTeXML/Common/Model/DTD.pm
@@ -105,20 +105,20 @@ sub loadSchema {
 sub readDTD {
   my ($self) = @_;
   LaTeXML::Common::XML::initialize_catalogs();
-
-  NoteBegin("Loading DTD for $$self{public_id} $$self{system_id}");
+  my $message = "Loading DTD for $$self{public_id} $$self{system_id}";
+  my $how;
+  NoteBegin($message);
   # NOTE: setting XML_DEBUG_CATALOG makes this Fail!!!
   my $dtd = XML::LibXML::Dtd->new($$self{public_id}, $$self{system_id});
   if ($dtd) {
-    NoteProgress(" via catalog "); }
+    $how = " via catalog "; }
   else {    # Couldn't find dtd in catalog, try finding the file. (search path?)
     my $dtdfile = pathname_find($$self{system_id},
       paths               => $STATE->lookupValue('SEARCHPATHS'),
       installation_subdir => 'resources/DTD');
     if ($dtdfile) {
-      NoteProgress(" from $dtdfile ");
       $dtd = XML::LibXML::Dtd->new($$self{public_id}, $dtdfile);
-      NoteProgress(" from $dtdfile ") if $dtd;
+      $how = " from $dtdfile ";
       Error('misdefined', $$self{system_id}, undef,
         "Parsing of DTD \"$$self{public_id}\" \"$$self{system_id}\" failed")
         unless $dtd;
@@ -126,6 +126,8 @@ sub readDTD {
     else {
       Error('missing_file', $$self{system_id}, undef,
         "Can't find DTD \"$$self{public_id}\" \"$$self{system_id}\""); } }
+  NoteEnd($message);
+  NoteStatus(1, "Read dtd $how") if $how && $dtd;
   return $dtd; }
 
 #======================================================================

--- a/lib/LaTeXML/Common/Model/DTD.pm
+++ b/lib/LaTeXML/Common/Model/DTD.pm
@@ -53,14 +53,14 @@ my $NAME_re = qr/[a-zA-Z0-9\-\_\:]+/;    # [CONSTANT]
 sub loadSchema {
   my ($self) = @_;
   $$self{schema_loaded} = 1;
-  NoteBegin("Loading DTD " . $$self{public_id} || $$self{system_id});
+  ProgressSpinup("Loading DTD " . $$self{public_id} || $$self{system_id});
   my $model = $$self{model};
   $model->addTagContent('#Document', $$self{roottag}) if $$self{roottag};
   # Parse the DTD
   my $dtd = $self->readDTD;
   return unless $dtd;
 
-  NoteBegin("Analyzing DTD");
+  ProgressSpinup("Analyzing DTD");
   # Extract all possible namespace attributes
   foreach my $node ($dtd->childNodes()) {
     if ($node->nodeType() == XML_ATTRIBUTE_DECL) {
@@ -98,8 +98,8 @@ sub loadSchema {
             ($attr =~ /:/ ? $model->recodeDocumentQName($attr) : $attr));
     } } }
   }
-  NoteEnd("Analyzing DTD");    # Done analyzing
-  NoteEnd("Loading DTD " . $$self{public_id} || $$self{system_id});
+  ProgressSpinup("Analyzing DTD");    # Done analyzing
+  ProgressSpindown("Loading DTD " . $$self{public_id} || $$self{system_id});
   return; }
 
 sub readDTD {
@@ -107,7 +107,7 @@ sub readDTD {
   LaTeXML::Common::XML::initialize_catalogs();
   my $message = "Loading DTD for $$self{public_id} $$self{system_id}";
   my $how;
-  NoteBegin($message);
+  ProgressSpinup($message);
   # NOTE: setting XML_DEBUG_CATALOG makes this Fail!!!
   my $dtd = XML::LibXML::Dtd->new($$self{public_id}, $$self{system_id});
   if ($dtd) {
@@ -126,8 +126,8 @@ sub readDTD {
     else {
       Error('missing_file', $$self{system_id}, undef,
         "Can't find DTD \"$$self{public_id}\" \"$$self{system_id}\""); } }
-  NoteEnd($message);
-  NoteStatus(1, "Read dtd $how") if $how && $dtd;
+  ProgressSpindown($message);
+  Progress("Read dtd $how") if $how && $dtd;
   return $dtd; }
 
 #======================================================================

--- a/lib/LaTeXML/Common/Model/DTD.pm
+++ b/lib/LaTeXML/Common/Model/DTD.pm
@@ -98,7 +98,7 @@ sub loadSchema {
             ($attr =~ /:/ ? $model->recodeDocumentQName($attr) : $attr));
     } } }
   }
-  ProgressSpinup("Analyzing DTD");    # Done analyzing
+  ProgressSpindown("Analyzing DTD");    # Done analyzing
   ProgressSpindown("Loading DTD " . $$self{public_id} || $$self{system_id});
   return; }
 
@@ -127,7 +127,7 @@ sub readDTD {
       Error('missing_file', $$self{system_id}, undef,
         "Can't find DTD \"$$self{public_id}\" \"$$self{system_id}\""); } }
   ProgressSpindown($message);
-  Progress("Read dtd $how") if $how && $dtd;
+  NoteLog("Read dtd $how") if $how && $dtd;
   return $dtd; }
 
 #======================================================================

--- a/lib/LaTeXML/Common/Model/RelaxNG.pm
+++ b/lib/LaTeXML/Common/Model/RelaxNG.pm
@@ -50,7 +50,7 @@ sub addSchemaDeclaration {
 
 sub loadSchema {
   my ($self) = @_;
-  NoteBegin("Loading RelaxNG $$self{name}");
+  ProgressSpinup("Loading RelaxNG $$self{name}");
   # Scan the schema file(s), and extract the info
   my @schema = $self->scanExternal($$self{name});
   if ($LaTeXML::DEBUG{relaxng}) {
@@ -93,7 +93,7 @@ sub loadSchema {
       my $name = $1;
       my ($content, $attributes) = $self->extractContent($symbol, $$self{defs}{$symbol});
       $$self{model}->setSchemaClass($name, $content); } }
-  NoteEnd("Loading RelaxNG $$self{name}");
+  ProgressSpindown("Loading RelaxNG $$self{name}");
   return; }
 
 # Return two hashrefs for content & attributes
@@ -185,7 +185,7 @@ sub scanExternal {
   my $paths   = [@LaTeXML::Common::Model::RelaxNG::PATHS, @{ $STATE->lookupValue('SEARCHPATHS') }];
   if (my $schemadoc = LaTeXML::Common::XML::RelaxNG->new($name, searchpaths => $paths)) {
     my $uri = $schemadoc->URI;
-    NoteBegin("Loading RelaxNG schema from $uri");
+    ProgressSpinup("Loading RelaxNG schema from $uri");
     local @LaTeXML::Common::Model::RelaxNG::PATHS
       = (pathname_directory($schemadoc->URI), @LaTeXML::Common::Model::RelaxNG::PATHS);
     my $node = $schemadoc->documentElement;
@@ -195,7 +195,7 @@ sub scanExternal {
       next if $nsuri =~ m|^http://relaxng.org|;    # Ignore RelaxNG namespaces(!!)
       $$self{model}->registerDocumentNamespace($prefix, $nsuri); }
     my $mod = (['module', $modname, $self->scanPattern($node, $inherit_ns)]);
-    NoteEnd("Loading RelaxNG schema from $uri");
+    ProgressSpindown("Loading RelaxNG schema from $uri");
     return $mod; }
   else {
     Warn('expected', $name, undef, "Failed to find RelaxNG schema for name '$name'");

--- a/lib/LaTeXML/Common/XML.pm
+++ b/lib/LaTeXML/Common/XML.pm
@@ -163,7 +163,7 @@ sub append_nodes {
 sub clear_node {
   my ($node) = @_;
   return map { $node->removeChild($_) }
-    grep { ($_->nodeType == XML_ELEMENT_NODE) || ($_->nodeType == XML_TEXT_NODE) }
+    grep     { ($_->nodeType == XML_ELEMENT_NODE) || ($_->nodeType == XML_TEXT_NODE) }
     $node->childNodes; }
 
 # We have to be _extremely_ careful when rearranging trees when using XML::LibXML!!!
@@ -215,79 +215,6 @@ sub initialize_catalogs {
   foreach my $catalog (pathname_findall('LaTeXML.catalog', installation_subdir => '.')) {
     XML::LibXML->load_catalog($catalog); }
   return; }
-
-# FINISH THIS EXPERIMENT LATER....
-
-# We need to be able to find various XML resources: XSLT, RelaxNG and other random xml.
-# Catalogs provide one means to provide a level of abstraction in pathname location.
-# But at least at the top level, files ought to be searched for according to the current
-# search paths (being command line arguments, relative to source files, etc);
-# Possibly files might be referred to within XML files that libxml is already parsing
-# and these could benefit from the searchpath approach?
-#
-# We can also provide InputCallbacks to the various XML::LibXML objects that allow
-# us to programatically find & read these XML items according to the searchpaths.
-# One problem is that we don't have (from this level of the API)
-# a clean method of accessing the current search paths!
-# Another problem is that embedded references to oddly-located relative files will usually
-# get turned into paths relative to the top-level document that libxml is currently reading!
-# So, we'll be given an absolute path before we have a chance to search the searchpaths for it!
-#
-# Perhaps we should even handle the catalog functionality here?
-#
-# How should we find the searchpaths?????
-# Note also that if you use relative pathnames to refer to xml objects from within another,
-# that libxml2 will already have _assumed_ that it is relative to the base document!
-# That is, we're getting an absolute path, here.  Of course, the original request
-# could have been an absolute path, so we probably shouldn't be blithely rewriting abs paths!!!
-# We could take over the whole catalog business, however...
-# sub initialize_input_callbacks {
-#   my($object,%options) = @_;
-# #  return;
-#   # THIS IS TOTALLY WRONG!!!! Figure out how we'll find out about search paths!
-#   my $paths = $LaTeXML::SEARCHPATHS;
-#   # options might be installation_subdirs, or such pathname_find things.
-#   my $cb = XML::LibXML::InputCallback->new();
-#   $cb->register_callbacks([
-#      sub {                      # Matcher
-#        my($uri)=@_;
-#        print STDERR "INPUT CHECK: $uri\n";
-#        # We don't want to do the search here, 'cause we'll have to do it again in open!
-#        return 0 if $uri =~ m|^file://|;                 # pass on absolute pathnames
-#        return 0 if pathname_is_absolute($uri);          # a
-# #       if($uri =~ /^urn:x-LaTeXML:([^:]*):(.*)$/){
-#        print STDERR "INPUT ACCEPT: $uri\n";
-#        return 1; },
-#      sub {                      # Opener
-#        my($uri)=@_;
-#        my $handle;
-#        $uri =~ s|^file://||;
-#        # WARNING!!! Kludge alert!
-#        my @paths = ('.');
-#        push(@paths, @$LaTeXML::SEARCHPATHS) if $LaTeXML::SEARCHPATHS;
-#        push(@paths, @{$LaTeXML::POST{searchpaths}}) if $LaTeXML::POST;
-#        push(@paths, $LaTeXML::DOCUMENT->getSearchPaths) if $LaTeXML::DOCUMENT;
-#        if(my $pathname =  pathname_find($uri,
-#                                         # types => ['xsl'], installation_subdir => 'resources/XSLT',
-#                                         paths=>[@paths])){
-#          open($handle,$pathname);
-#          return $handle; }
-#        else {
-#          Error('missing-file',$uri,undef,
-#                "Couldn't find file '$uri' in search paths",
-#                "Search paths were ".join(',',@paths));
-#          return; }},
-#      sub {                      # Reader
-#        my($handle,$length)=@_;
-#        my $buffer;
-#        read($handle,$buffer,$length);
-#        return $buffer; },
-#      sub {                      # Closer
-#        my($handle)=@_;
-#        close($handle);
-#        return; }]);
-#   $object->input_callbacks($cb);
-#   return; }
 
 #======================================================================
 # Odd place for this utility, but it is needed in both conversion & post
@@ -391,8 +318,6 @@ our $xml_libxml_version;    # [CONFIGURATION]
 BEGIN {
   $xml_libxml_version = $XML::LibXML::VERSION;
   $xml_libxml_version =~ s/_\d+$//;
-###  print STDERR "XML::LibXML Version $XML::LibXML::VERSION => $xml_libxml_version\n";
-
   if ($xml_libxml_version < 1.63) {
     *XML::LibXML::Document::toString = *encoding_XML_LibXML_Document_toString; }
   if ($xml_libxml_version < 1.59) {

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -135,7 +135,7 @@ sub digestFile {
   return
     $self->withState(sub {
       my ($state) = @_;
-      NoteBegin("Digesting $mode $name");
+      ProgressSpinup("Digesting $mode $name");
       $self->initializeState($mode . ".pool", @{ $$self{preload} || [] }) unless $options{noinitialize};
       $state->assignValue(SOURCEFILE      => $request) if (!pathname_is_literaldata($request));
       $state->assignValue(SOURCEDIRECTORY => $dir)     if defined $dir;
@@ -157,7 +157,7 @@ sub digestFile {
         my $bib = LaTeXML::Pre::BibTeX->newFromGullet($name, $state->getStomach->getGullet);
         LaTeXML::Package::InputContent("literal:" . $bib->toTeX); }
       my $list = $self->finishDigestion;
-      NoteEnd("Digesting $mode $name");
+      ProgressSpindown("Digesting $mode $name");
       return $list; });
 }
 
@@ -202,7 +202,7 @@ sub convertDocument {
       my $model    = $state->getModel;                       # The document model.
       my $document = LaTeXML::Core::Document->new($model);
       local $LaTeXML::DOCUMENT = $document;
-      NoteBegin("Building");
+      ProgressSpinup("Building");
       $model->loadSchema();                                  # If needed?
       if (my $paths = $state->lookupValue('SEARCHPATHS')) {
         if ($state->lookupValue('INCLUDE_PATH_PIS')) {
@@ -219,19 +219,19 @@ sub convertDocument {
           $document->insertPI('latexml', package => $preload, ($options ? (options => $options) : ())); } }
       { no warnings 'recursion';
         $document->absorb($digested); }
-      NoteEnd("Building");
+      ProgressSpindown("Building");
 
       if (my $rules = $state->lookupValue('DOCUMENT_REWRITE_RULES')) {
-        NoteBegin("Rewriting");
+        ProgressSpinup("Rewriting");
         $document->markXMNodeVisibility;
         foreach my $rule (@$rules) {
           $rule->rewrite($document, $document->getDocument->documentElement); }
-        NoteEnd("Rewriting"); }
+        ProgressSpindown("Rewriting"); }
 
       LaTeXML::MathParser->new(lexematize => $state->lookupValue('LEXEMATIZE_MATH'))->parseMath($document) unless $$self{nomathparse};
-      NoteBegin("Finalizing");
+      ProgressSpinup("Finalizing");
       my $xmldoc = $document->finalize();
-      NoteEnd("Finalizing");
+      ProgressSpindown("Finalizing");
       return $xmldoc; }); }
 
 sub withState {

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -39,8 +39,7 @@ sub new {
   my $state     = LaTeXML::Core::State->new(catcodes => 'standard',
     stomach => LaTeXML::Core::Stomach->new(verbosity => $verbosity),
     model   => $options{model} || LaTeXML::Common::Model->new());
-  $state->assignValue(VERBOSITY => $verbosity,
-    'global');
+  SetVerbosity($verbosity);
   $state->assignValue(STRICT => (defined $options{strict} ? $options{strict} : 0),
     'global');
   $state->assignValue(INCLUDE_COMMENTS => (defined $options{includecomments} ? $options{includecomments} : 1),

--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -35,11 +35,11 @@ use base qw(LaTeXML::Common::Object);
 
 sub new {
   my ($class, %options) = @_;
-  my $verbosity = defined $options{verbosity} ? $options{verbosity} : 0;
-  my $state     = LaTeXML::Core::State->new(catcodes => 'standard',
-    stomach => LaTeXML::Core::Stomach->new(verbosity => $verbosity),
+###  my $verbosity = defined $options{verbosity} ? $options{verbosity} : 0;
+  my $state = LaTeXML::Core::State->new(catcodes => 'standard',
+    stomach => LaTeXML::Core::Stomach->new(),                       ###verbosity => $verbosity),
     model   => $options{model} || LaTeXML::Common::Model->new());
-  SetVerbosity($verbosity);
+  SetVerbosity($options{verbosity}) if defined $options{verbosity};
   $state->assignValue(STRICT => (defined $options{strict} ? $options{strict} : 0),
     'global');
   $state->assignValue(INCLUDE_COMMENTS => (defined $options{includecomments} ? $options{includecomments} : 1),

--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -194,10 +194,8 @@ sub getColumnBefore {
   my ($self) = @_;
   my $column;
   if (($column = $self->currentColumn) && !$$column{omitted}) {
-    #print STDERR "COLUMN FETCH BEFORE\n";
     return Tokens(T_CS('\@column@before'), @{ $$column{before} }); }
   else {
-    #print STDERR "COLUMN FETCH BEFORE Omitted\n";
     return Tokens(); } }
 
 sub getColumnAfter {
@@ -207,7 +205,6 @@ sub getColumnAfter {
     # Possible \@@eat@space ??? (if LaTeX style???)
     return Tokens(@{ $$column{after} }, T_CS('\@column@after')); }
   else {
-    #print STDERR "COLUMN FETCH AFTER Omitted\n";
     return Tokens(); } }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -633,8 +630,8 @@ sub normalize_prune_columns {
 
 sub show_row {
   my ($i, $row) = @_;
-  print STDERR "\nRow[$i]:" . join(', ', map { $_ . '=' . ToString($$row{$_}); }
-      grep { $_ ne 'columns'; } sort keys %$row) . "\n";
+  Debug("\nRow[$i]:" . join(', ', map { $_ . '=' . ToString($$row{$_}); }
+        grep { $_ ne 'columns'; } sort keys %$row));
   my @c = @{ $$row{columns} };
   for (my $j = 1 ; @c ; $j++) {
     show_col($i, $j, shift(@c)); }
@@ -642,7 +639,7 @@ sub show_row {
 
 sub show_col {
   my ($i, $j, $col) = @_;
-  print STDERR "Column[$i,$j]:" . join(', ', map { $_ . '=' . ToString($$col{$_}); } sort keys %$col) . "\n";
+  Debug("Column[$i,$j]:" . join(', ', map { $_ . '=' . ToString($$col{$_}); } sort keys %$col));
   return; }
 
 sub preservedBoxes {

--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -48,6 +48,7 @@ our @EXPORT = (qw(
 # because an Alignment currently doesn't know what CS created it (debugging!);
 # Also, it would better connect the things being constructed, reversion, etc.
 #======================================================================
+DebuggableFeature('alignment', "Debug guessing headers of alignments/tables");
 
 # Create a new Alignment.
 # %data can contain:
@@ -710,9 +711,9 @@ sub guess_alignment_headers {
 
   my $tag = $document->getModel->getNodeQName($table);
   my $x;
-  print STDERR "\n" . ('=' x 50) . "\nGuessing alignment headers for "
-    . (($x = $document->findnode('ancestor-or-self::*[@xml:id]', $table)) ? $x->getAttribute('xml:id') : $tag) . "\n"
-    if $LaTeXML::Core::Alignment::DEBUG;
+  Debug(('=' x 50) . "\nGuessing alignment headers for "
+      . (($x = $document->findnode('ancestor-or-self::*[@xml:id]', $table)) ? $x->getAttribute('xml:id') : $tag))
+    if $LaTeXML::DEBUG{alignment};
 
   my $ismath = $tag eq 'ltx:XMArray';
   local $LaTeXML::TR = ($ismath ? 'ltx:XMRow'  : 'ltx:tr');
@@ -730,7 +731,7 @@ sub guess_alignment_headers {
   if (alignment_characterize_lines($document, 0, 0, @rows)) { }
   # This usually does something unpleasant
 ##  else {
-##    print STDERR "Retry characterizing lines in reverse\n" if $LaTeXML::Core::Alignment::DEBUG;
+##    Debug("Retry characterizing lines in reverse") if $LaTeXML::DEBUG{alignment};
 ##    $reversed=alignment_characterize_lines(0,1,reverse(@rows)); }
   alignment_characterize_lines($document, 1, 0, @cols);
   # Did we go overboard?
@@ -738,7 +739,7 @@ sub guess_alignment_headers {
   foreach my $r (@rows) {
     foreach my $c (@$r) {
       $n{ $$c{cell_type} }++; } }
-  print STDERR "$n{h} header, $n{d} data cells\n" if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("$n{h} header, $n{d} data cells") if $LaTeXML::DEBUG{alignment};
   if ($n{d} == 1) {    # Or any other heuristic?
     $n{h} = 0;
     foreach my $r (@rows) {
@@ -753,7 +754,7 @@ sub guess_alignment_headers {
     $document->addClass($table, 'ltx_guessed_headers'); }
 
   # Debugging report!
-  summarize_alignment([@rows], [@cols]) if $LaTeXML::Core::Alignment::DEBUG;
+  summarize_alignment([@rows], [@cols]) if $LaTeXML::DEBUG{alignment};
   return; }
 
 #======================================================================
@@ -871,19 +872,18 @@ sub collect_alignment_rows {
       $rows[$r][$c]{b} = $rows[$r + 1][$c]{t} if $rows[$r + 1][$c]{t};
       $rows[$r][$c]{l} = $rows[$r][$c - 1]{r} if $rows[$r][$c - 1]{r};
       $rows[$r][$c]{r} = $rows[$r][$c + 1]{l} if $rows[$r][$c + 1]{l}; } }
-  if ($LaTeXML::Core::Alignment::DEBUG) {
-    print STDERR "\nCell characterizations:\n";
+  if ($LaTeXML::DEBUG{alignment}) {
+    Debug("Cell characterizations:");
     for (my $r = 0 ; $r < $nrows ; $r++) {
       for (my $c = 0 ; $c < $ncols ; $c++) {
         my $col = $rows[$r][$c];
-        print STDERR "[$r,$c]=>" . ($$col{cell_type} || '?')
-          . ($$col{align} ? $ALIGNMENT_CODE{ $$col{align} } : ' ')
-          . ($$col{content_class} || '?')
-          . ' ' . $$col{content_length}
-          . ' ' . $$col{border} . "=>" . join('', grep { $$col{$_} } qw(t r b l))
-          . (($$col{rowspan} || 1) > 1 ? " rowspan=" . $$col{rowspan} : '')
-          . (($$col{colspan} || 1) > 1 ? " colspan=" . $$col{colspan} : '')
-          . "\n"; } } }
+        Debug("[$r,$c]=>" . ($$col{cell_type} || '?')
+            . ($$col{align} ? $ALIGNMENT_CODE{ $$col{align} } : ' ')
+            . ($$col{content_class} || '?')
+            . ' ' . $$col{content_length}
+            . ' ' . $$col{border} . "=>" . join('', grep { $$col{$_} } qw(t r b l))
+            . (($$col{rowspan} || 1) > 1 ? " rowspan=" . $$col{rowspan} : '')
+            . (($$col{colspan} || 1) > 1 ? " colspan=" . $$col{colspan} : '')); } } }
   return @rows; }
 
 # Return one of: i(nteger), t(ext), m(ath), ? (unknown) or '_' (empty) (or some combination)
@@ -944,8 +944,8 @@ sub alignment_characterize_lines {
   my $n = scalar(@lines);
   return if $n < 2;
   local @::TABLINES = @lines;
-  print STDERR "\nCharacterizing $n " . ($axis ? "columns" : "rows") . "\n   "
-    if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Characterizing $n " . ($axis ? "columns" : "rows"))
+    if $LaTeXML::DEBUG{alignment};
 
   # Establish a scale of differences for the table.
   my ($diffhi, $difflo, $diffavg) = (0, 99999999, 0);
@@ -956,21 +956,21 @@ sub alignment_characterize_lines {
     $difflo = $d if $d < $difflo; }
   $diffavg = $diffavg / ($n - 1);
   if ($diffhi < 0.05) {    # virtually no differences.
-    print STDERR "Lines are almost identical => Fail\n" if $LaTeXML::Core::Alignment::DEBUG;
+    Debug("Lines are almost identical => Fail") if $LaTeXML::DEBUG{alignment};
     return; }
   if (($n > 2) && (($diffhi - $difflo) < $diffhi * 0.5)) { # differences too similar to establish pattern
-    print STDERR "Differences between lines are almost identical => Fail\n"
-      if $LaTeXML::Core::Alignment::DEBUG;
+    Debug("Differences between lines are almost identical => Fail")
+      if $LaTeXML::DEBUG{alignment};
     return; }
   #  local $::TAB_THRESHOLD = $difflo + 0.4*($diffhi-$difflo);
   local $::TAB_THRESHOLD = $difflo + 0.3 * ($diffhi - $difflo);
   #  local $::TAB_THRESHOLD = $difflo + 0.2*($diffhi-$difflo);
   #  local $::TAB_THRESHOLD = $diffavg;
   local $::TAB_AXIS = $axis;
-  print STDERR "\nDifferences $difflo -- $diffhi => threshold = $::TAB_THRESHOLD\n"
-    if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Differences $difflo -- $diffhi => threshold = $::TAB_THRESHOLD")
+    if $LaTeXML::DEBUG{alignment};
   # Find the first hump in differences. These are candidates for header lines.
-  print STDERR "Scanning for headers\n   " if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Scanning for headers") if $LaTeXML::DEBUG{alignment};
   my $diff;
   my ($minh, $maxh) = (1, 1);
   while (($diff = alignment_compare($axis, 1, $reversed, $maxh - 1, $maxh)) < $::TAB_THRESHOLD) {
@@ -979,8 +979,8 @@ sub alignment_characterize_lines {
       #  while( alignment_compare($axis,1,$reversed,$maxh,$maxh+1) > $difflo + ($diff-$difflo)/6){
   while (alignment_compare($axis, 1, $reversed, $maxh, $maxh + 1) > $::TAB_THRESHOLD) {
     $maxh++; }
-  $maxh = $MAX_ALIGNMENT_HEADER_LINES                          if $maxh > $MAX_ALIGNMENT_HEADER_LINES;
-  print STDERR "\nFound from $minh--$maxh potential headers\n" if $LaTeXML::Core::Alignment::DEBUG;
+  $maxh = $MAX_ALIGNMENT_HEADER_LINES                if $maxh > $MAX_ALIGNMENT_HEADER_LINES;
+  Debug("Found from $minh--$maxh potential headers") if $LaTeXML::DEBUG{alignment};
 
   my $nn = scalar(@{ $lines[0] }) - 1;
   # The sets of lines 1--$minh, .. 1--$maxh are potential headers.
@@ -1006,7 +1006,7 @@ sub alignment_characterize_lines {
 # Test whether $nhead lines makes a good fit for the headers
 sub alignment_test_headers {
   my ($nhead) = @_;
-  print STDERR "Testing $nhead headers\n" if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Testing $nhead headers") if $LaTeXML::DEBUG{alignment};
   my ($headlength, $datalength) = (0, 0);
   my @heads = (0 .. $nhead - 1);    # The indices of heading lines.
   $headlength = alignment_max_content_length($headlength, 0, $nhead - 1);
@@ -1015,11 +1015,11 @@ sub alignment_test_headers {
   # Watch out for the assumed header being really data that is a repeated pattern.
   my $nrep = scalar(@::TABLINES) / $nhead;
   if (($nhead > 1) && ($nrep == int($nrep))) {
-    print STDERR "Check for apparent header repeated $nrep times\n" if $LaTeXML::Core::Alignment::DEBUG;
+    Debug("Check for apparent header repeated $nrep times") if $LaTeXML::DEBUG{alignment};
     my $matched = 1;
     for (my $r = 1 ; $r < $nrep ; $r++) {
       $matched &&= alignment_match_head(0, $r * $nhead, $nhead); }
-    print STDERR "Repeated headers: " . ($matched ? "Matched=> Fail" : "Nomatch => Succeed") . "\n" if $LaTeXML::Core::Alignment::DEBUG;
+    Debug("Repeated headers: " . ($matched ? "Matched=> Fail" : "Nomatch => Succeed")) if $LaTeXML::DEBUG{alignment};
     return if $matched; }
 
   # And find a following grouping of data lines.
@@ -1054,38 +1054,38 @@ sub alignment_test_headers {
       $nextline += $nd; }
     else { return; } }
   # Header content seems too large relative to data?
-  print STDERR "header content = $headlength; data content = $datalength\n"
-    if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("header content = $headlength; data content = $datalength")
+    if $LaTeXML::DEBUG{alignment};
 ##  if(($headlength > 10) && (0.3*$headlength > $datalength)){
   if (($headlength > 10) && (0.25 * $headlength > $datalength)) {
-    print STDERR "header content too much longer than data content\n"
-      if $LaTeXML::Core::Alignment::DEBUG;
+    Debug("header content too much longer than data content")
+      if $LaTeXML::DEBUG{alignment};
     return; }
   # Or if a header cell has "large" content?
   if ($headlength >= 1000) {    # Or if a header cell has "large" content?
-    print STDERR "header content too large\n"
-      if $LaTeXML::Core::Alignment::DEBUG;
+    Debug("header content too large")
+      if $LaTeXML::DEBUG{alignment};
     return; }
 
-  print STDERR "Succeeded with $nhead headers\n" if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Succeeded with $nhead headers") if $LaTeXML::DEBUG{alignment};
   return @heads; }
 
 sub alignment_match_head {
   my ($p1, $p2, $nhead) = @_;
-  print STDERR "Try match $nhead header lines from $p1 to $p2\n   " if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Try match $nhead header lines from $p1 to $p2") if $LaTeXML::DEBUG{alignment};
   my $nh = alignment_match_lines($p1, $p2, $nhead);
   my $ok = $nhead == $nh;
-  print STDERR "\nMatched $nh header lines => " . ($ok ? "Succeed" : "Failed") . "\n" if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Matched $nh header lines => " . ($ok ? "Succeed" : "Failed")) if $LaTeXML::DEBUG{alignment};
   return ($ok ? $nhead : 0); }
 
 sub alignment_match_data {
   my ($p1, $p2, $ndata) = @_;
-  print STDERR "Try match $ndata data lines from $p1 to $p2\n   "
-    if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Try match $ndata data lines from $p1 to $p2")
+    if $LaTeXML::DEBUG{alignment};
   my $nd = alignment_match_lines($p1, $p2, $ndata);
   my $ok = ($nd * 1.0) / $ndata > 0.66;
-  print STDERR "\nMatched $nd data lines => " . ($ok ? "Succeed" : "Failed") . "\n"
-    if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Matched $nd data lines => " . ($ok ? "Succeed" : "Failed"))
+    if $LaTeXML::DEBUG{alignment};
   return ($ok ? $nd : 0); }
 
 # Match the $n lines starting at $i2 to those starting at $i1.
@@ -1101,8 +1101,8 @@ sub alignment_match_lines {
 # but also accept `continuation' data lines.
 sub alignment_skip_data {
   my ($i) = @_;
-  return 0                              if $i >= scalar(@::TABLINES);
-  print STDERR "Scanning for data\n   " if $LaTeXML::Core::Alignment::DEBUG;
+  return 0                   if $i >= scalar(@::TABLINES);
+  Debug("Scanning for data") if $LaTeXML::DEBUG{alignment};
   my $n = 1;
   while ($i + $n < scalar(@::TABLINES)) {
     last if (alignment_compare($::TAB_AXIS, 1, 0, $i + $n - 1, $i + $n) >= $::TAB_THRESHOLD)
@@ -1110,7 +1110,7 @@ sub alignment_skip_data {
       && (($n < 2)
       || (scalar(grep { $$_{content_class} eq '_' } @{ $::TABLINES[$i + $n] }) <= 0.4 * scalar($::TABLINES[0])));
     $n++; }
-  print STDERR "\nFound $n data lines at $i\n" if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("Found $n data lines at $i") if $LaTeXML::DEBUG{alignment};
   return ($n >= $MIN_ALIGNMENT_DATA_LINES ? $n : 0); }
 
 sub XXXalignment_max_content_length {
@@ -1189,7 +1189,7 @@ sub alignment_compare {
       $diff += 0.3 * scalar(grep { $$cell1{$_} != $$cell2{$_} } qw(r l t b)); }
   }
   $diff /= $ncells;
-  print STDERR "$p1-$p2 => $diff; " if $LaTeXML::Core::Alignment::DEBUG;
+  Debug("$p1-$p2 => $diff; ") if $LaTeXML::DEBUG{alignment};
   return $diff; }
 
 #======================================================================
@@ -1198,31 +1198,25 @@ sub summarize_alignment {
   my ($rows, $cols) = @_;
   my $r = 0;
   my ($nrows, $ncols) = (scalar(@$rows), scalar(@{ $$rows[0] }));
-  print STDERR "\n";
   foreach my $cell (@{ $$rows[0] }) {
-    print STDERR ' ' . ($$cell{t} ? ('-' x 6) : (' ' x 6)); }
-  print STDERR "\n";
+    Debug(' ' . ($$cell{t} ? ('-' x 6) : (' ' x 6))); }
   foreach my $row (@$rows) {
     my $maxb = 0;
-    print STDERR ($$row[0]{l} ? ('|' x $$row[0]{l}) : ' ');
+    Debug(($$row[0]{l} ? ('|' x $$row[0]{l}) : ' '));
     foreach my $cell (@$row) {
-      print STDERR sprintf(" %4s ",
-        ($$cell{cell_type} || '?')
-          . ($$cell{align} ? $ALIGNMENT_CODE{ $$cell{align} } : ' ')
-          . ($$cell{content_class} || '?')
-          . ($$cell{r} ? ('|' x $$cell{r}) : ' '));
+      Debug(sprintf(" %4s ",
+          ($$cell{cell_type} || '?')
+            . ($$cell{align} ? $ALIGNMENT_CODE{ $$cell{align} } : ' ')
+            . ($$cell{content_class} || '?')
+            . ($$cell{r} ? ('|' x $$cell{r}) : ' ')));
       $maxb = $$cell{b} if $$cell{b} > $maxb; }
-    #    print STDERR sprintf("%.3f",alignment_compare(0,1,$$rows[$r],$$rows[$r+1])) if ($r < $nrows-1);
-    print STDERR "\n";
+    #    Debug(sprintf("%.3f",alignment_compare(0,1,$$rows[$r],$$rows[$r+1])) if ($r < $nrows-1));
     for (my $b = 0 ; $b < $maxb ; $b++) {
       foreach my $cell (@$row) {
-        print STDERR ' ' . ($b < $$cell{b} ? ('-' x 6) : (' ' x 6)); }
-      print STDERR "\n"; }
+        Debug(' ' . ($b < $$cell{b} ? ('-' x 6) : (' ' x 6))); } }
     $r++; }
-  print STDERR "   ";
   #  for(my $c = 0; $c < $ncols-1; $c++){
-  #    print STDERR sprintf(" %.3f ",alignment_compare(1,1,$$cols[$c],$$cols[$c+1])); }
-  print STDERR "\n";
+  #    Debug(sprintf(" %.3f ",alignment_compare(1,1,$$cols[$c],$$cols[$c+1]))); }
   return; }
 
 #======================================================================

--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -210,12 +210,12 @@ sub getSize {
     unless (defined $$props{cwidth})
     && (defined $$props{cheight})
     && (defined $$props{cdepth});
-  print STDERR "SIZE of $self"
-    . "\n opt:" . _showsize($options{width}, $options{height}, $options{depth})
-    . "\n set: " . _showsize($$props{width}, $$props{height}, $$props{depth})
-    . "\n calc: " . _showsize($$props{cwidth}, $$props{cheight}, $$props{cdepth})
-    . "\n =>: " . _showsize($$props{width} || $$props{cwidth}, $$props{height} || $$props{cheight}, $$props{depth} || $$props{cdepth})
-    . "\n   Of " . Stringify($self) . "\n" if $LaTeXML::size::DEBUG;
+  Debug("SIZE of $self"
+      . "\n opt:" . _showsize($options{width}, $options{height}, $options{depth})
+      . "\n set: " . _showsize($$props{width}, $$props{height}, $$props{depth})
+      . "\n calc: " . _showsize($$props{cwidth}, $$props{cheight}, $$props{cdepth})
+      . "\n =>: " . _showsize($$props{width} || $$props{cwidth}, $$props{height} || $$props{cheight}, $$props{depth} || $$props{cdepth})
+      . "\n   Of " . Stringify($self)) if $LaTeXML::DEBUG{size};
   return ($$props{width} || $$props{cwidth},
     $$props{height}  || $$props{cheight},
     $$props{depth}   || $$props{cdepth},

--- a/lib/LaTeXML/Core/Definition.pm
+++ b/lib/LaTeXML/Core/Definition.pm
@@ -148,9 +148,9 @@ sub startProfiling {
   #   starts of pending calls...]
   if (!defined $entry) {
     $entry = [0, 0, 0, 0, 0]; $STATE->assignMapping('runtime_profile', $name, $entry); }
-  $$entry[0]++ unless $mode eq 'absorb';   # One more call.
-  $$entry[4]++;                            # One more pending...
-                                           #print STDERR "START PROFILE $mode of ".ToString($cs)."\n";
+  $$entry[0]++ unless $mode eq 'absorb';    # One more call.
+  $$entry[4]++;                             # One more pending...
+                                            #Debug("START PROFILE $mode of ".ToString($cs));
   $STATE->pushValue('runtime_stack', [$name, $mode, [Time::HiRes::gettimeofday], $entry]);
   return; }
 
@@ -173,8 +173,8 @@ sub stopProfiling {
     my ($top, $topmode, $t0, $entry) = @{ $$stack[-1] };
     if ((($top ne $name) || ($topmode ne $mode)) && ($topmode ne 'expand')) {
       return if $mode eq 'expand';                         # No error (yet) if this is a macro end marker.
-      print STDERR "\nPROFILE Error: ending $mode of $name but stack holds "
-        . join(',', map { $$_[0] . '(' . $$_[1] . ')' } @$stack) . ", $top ($topmode)\n";
+      Debug("PROFILE Error: ending $mode of $name but stack holds "
+          . join(',', map { $$_[0] . '(' . $$_[1] . ')' } @$stack) . ", $top ($topmode)");
       return; }
     pop(@$stack);
     my $duration = Time::HiRes::tv_interval($t0, [Time::HiRes::gettimeofday]);
@@ -188,7 +188,7 @@ sub stopProfiling {
       my ($callername, $callermode, $callerstart, $callerentry) = @$caller;
       $$callerentry[3] -= $duration; }         # Remove our cost from caller's exclusive time.
     return if $top eq $name; }
-  print STDERR "\nPROFILE Error: ending $mode of $name but stack is empty\n"
+  Debug("PROFILE Error: ending $mode of $name but stack is empty")
     unless $mode eq 'expand';
   return; }
 
@@ -209,21 +209,21 @@ sub showProfile {
     @inclusive = @inclusive[0 .. $MAX_PROFILE_ENTRIES];
     my @exclusive = sort { $$profile{$b}[3] <=> $$profile{$a}[3] } @cs;
     @exclusive = @exclusive[0 .. $MAX_PROFILE_ENTRIES];
-    print STDERR "\nProfiling results:\n";
-    print STDERR "Total calls: $calls; Maximum depth: $depth\n";
-    print STDERR "Most frequent:\n   "
-      . join(', ', map { $_ . ':' . $$profile{$_}[0] } @frequent) . "\n";
-    print STDERR "Deepest :\n   "
-      . join(', ', map { $_ . ':' . $$profile{$_}[1] } @deepest) . "\n";
-    print STDERR "Most expensive inclusive:\n   "
-      . join(', ', map { $_ . ':' . sprintf("%.2fs", $$profile{$_}[2]) } @inclusive) . "\n";
-    print STDERR "Most expensive exclusive:\n   "
-      . join(', ', map { $_ . ':' . sprintf("%.2fs", $$profile{$_}[3]) } @exclusive) . "\n";
+    Debug("Profiling results:");
+    Debug("Total calls: $calls; Maximum depth: $depth");
+    Debug("Most frequent:\n   "
+        . join(', ', map { $_ . ':' . $$profile{$_}[0] } @frequent));
+    Debug("Deepest :\n   "
+        . join(', ', map { $_ . ':' . $$profile{$_}[1] } @deepest));
+    Debug("Most expensive inclusive:\n   "
+        . join(', ', map { $_ . ':' . sprintf("%.2fs", $$profile{$_}[2]) } @inclusive));
+    Debug("Most expensive exclusive:\n   "
+        . join(', ', map { $_ . ':' . sprintf("%.2fs", $$profile{$_}[3]) } @exclusive));
 
     my $stack = $STATE->lookupValue('runtime_stack');
     if (@$stack) {
-      print STDERR "The following were never marked as done:\n  "
-        . join(', ', map { $$_[0] . '(' . $$_[1] . ')' } @$stack) . "\n"; } }
+      Debug("The following were never marked as done:\n  "
+          . join(', ', map { $$_[0] . '(' . $$_[1] . ')' } @$stack)); } }
   return; }
 
 #===============================================================================

--- a/lib/LaTeXML/Core/Definition/Conditional.pm
+++ b/lib/LaTeXML/Core/Definition/Conditional.pm
@@ -63,22 +63,23 @@ sub invoke_conditional {
   my $parms = $$self{parameters};
   my @args  = ($parms ? $parms->readArguments($gullet) : ());
   $$LaTeXML::IFFRAME{parsing} = 0;    # Now, we're done parsing the Test clause.
-  my $tracing = $STATE->lookupValue('TRACINGCOMMANDS');
-  Message('{' . $self->tracingCSName . "} [#$ifid]") if $tracing;
-  Message($self->tracingArgs(@args))                 if $tracing && @args;
+  my $tracing = $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
+  if ($tracing) {
+    Debug('{' . $self->tracingCSName . "} [#$ifid]");
+    Debug($self->tracingArgs(@args)) if @args; }
   if (my $test = $self->getTest) {
     my $result = &$test($gullet, @args);
     if ($result) {
-      Message("{true}") if $tracing; }
+      Debug("{true}") if $tracing; }
     else {
       my $to = skipConditionalBody($gullet, -1);
-      Message("{false} [skipped to " . ToString($to) . "]") if $tracing; } }
+      Debug("{false} [skipped to " . ToString($to) . "]") if $tracing; } }
   # If there's no test, it must be the Special Case, \ifcase
   else {
     my $num = $args[0]->valueOf;
     if ($num > 0) {
       my $to = skipConditionalBody($gullet, $num);
-      Message("{$num} [skipped to " . ToString($to) . "]") if $tracing; } }
+      Debug("{$num} [skipped to " . ToString($to) . "]") if $tracing; } }
   return; }
 
 #======================================================================
@@ -162,10 +163,10 @@ sub invoke_else {
   else {
     local $LaTeXML::IFFRAME = $$stack[0];
     my $t = skipConditionalBody($gullet, 0);
-    Message('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
+    Debug('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
         . " [for " . ToString($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid}
         . " skipping to " . ToString($t) . "]")
-      if $STATE->lookupValue('TRACINGCOMMANDS');
+      if $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
     return; } }
 
 sub invoke_fi {
@@ -181,9 +182,9 @@ sub invoke_fi {
   else {                            # "expand" by removing the stack entry for this level
     local $LaTeXML::IFFRAME = $$stack[0];
     $STATE->shiftValue('if_stack');    # Done with this frame
-    Message('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
+    Debug('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
         . " [for " . Stringify($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid} . "]")
-      if $STATE->lookupValue('TRACINGCOMMANDS');
+      if $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
     return; } }
 
 #===============================================================================

--- a/lib/LaTeXML/Core/Definition/Conditional.pm
+++ b/lib/LaTeXML/Core/Definition/Conditional.pm
@@ -64,21 +64,21 @@ sub invoke_conditional {
   my @args  = ($parms ? $parms->readArguments($gullet) : ());
   $$LaTeXML::IFFRAME{parsing} = 0;    # Now, we're done parsing the Test clause.
   my $tracing = $STATE->lookupValue('TRACINGCOMMANDS');
-  print STDERR '{' . $self->tracingCSName . "} [#$ifid]\n" if $tracing;
-  print STDERR $self->tracingArgs(@args) . "\n"            if $tracing && @args;
+  Message('{' . $self->tracingCSName . "} [#$ifid]") if $tracing;
+  Message($self->tracingArgs(@args))                 if $tracing && @args;
   if (my $test = $self->getTest) {
     my $result = &$test($gullet, @args);
     if ($result) {
-      print STDERR "{true}\n" if $tracing; }
+      Message("{true}") if $tracing; }
     else {
       my $to = skipConditionalBody($gullet, -1);
-      print STDERR "{false} [skipped to " . ToString($to) . "]\n" if $tracing; } }
+      Message("{false} [skipped to " . ToString($to) . "]") if $tracing; } }
   # If there's no test, it must be the Special Case, \ifcase
   else {
     my $num = $args[0]->valueOf;
     if ($num > 0) {
       my $to = skipConditionalBody($gullet, $num);
-      print STDERR "{$num} [skipped to " . ToString($to) . "]\n" if $tracing; } }
+      Message("{$num} [skipped to " . ToString($to) . "]") if $tracing; } }
   return; }
 
 #======================================================================
@@ -162,9 +162,9 @@ sub invoke_else {
   else {
     local $LaTeXML::IFFRAME = $$stack[0];
     my $t = skipConditionalBody($gullet, 0);
-    print STDERR '{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
-      . " [for " . ToString($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid}
-      . " skipping to " . ToString($t) . "]\n"
+    Message('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
+        . " [for " . ToString($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid}
+        . " skipping to " . ToString($t) . "]")
       if $STATE->lookupValue('TRACINGCOMMANDS');
     return; } }
 
@@ -181,8 +181,8 @@ sub invoke_fi {
   else {                            # "expand" by removing the stack entry for this level
     local $LaTeXML::IFFRAME = $$stack[0];
     $STATE->shiftValue('if_stack');    # Done with this frame
-    print STDERR '{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
-      . " [for " . Stringify($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid} . "]\n"
+    Message('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
+        . " [for " . Stringify($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid} . "]")
       if $STATE->lookupValue('TRACINGCOMMANDS');
     return; } }
 

--- a/lib/LaTeXML/Core/Definition/Constructor.pm
+++ b/lib/LaTeXML/Core/Definition/Constructor.pm
@@ -77,19 +77,19 @@ sub invoke {
   my ($self, $stomach) = @_;
   # Call any `Before' code.
   my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
-  my $tracing  = $STATE->lookupValue('TRACINGCOMMANDS');
+  my $tracing  = $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
 
   my @pre = $self->executeBeforeDigest($stomach);
 
-  Message('{' . $self->tracingCSName . '}') if $tracing;
+  Debug('{' . $self->tracingCSName . '}') if $tracing;
   # Get some info before we process arguments...
   my $font   = $STATE->lookupValue('font');
   my $ismath = $STATE->lookupValue('IN_MATH');
   # Parse AND digest the arguments to the Constructor
   my $parms = $$self{parameters};
   my @args  = ($parms ? $parms->readArgumentsAndDigest($stomach, $self) : ());
-  Message($self->tracingArgs(@args)) if $tracing && @args;
+  Debug($self->tracingArgs(@args)) if $tracing && @args;
   my $nargs = $self->getNumArgs;
   @args = @args[0 .. $nargs - 1];
 

--- a/lib/LaTeXML/Core/Definition/Constructor.pm
+++ b/lib/LaTeXML/Core/Definition/Constructor.pm
@@ -82,14 +82,14 @@ sub invoke {
 
   my @pre = $self->executeBeforeDigest($stomach);
 
-  print STDERR '{' . $self->tracingCSName . "}\n" if $tracing;
+  Message('{' . $self->tracingCSName . '}') if $tracing;
   # Get some info before we process arguments...
   my $font   = $STATE->lookupValue('font');
   my $ismath = $STATE->lookupValue('IN_MATH');
   # Parse AND digest the arguments to the Constructor
   my $parms = $$self{parameters};
   my @args  = ($parms ? $parms->readArgumentsAndDigest($stomach, $self) : ());
-  print STDERR $self->tracingArgs(@args) . " [for " . Stringify($$self{cs}) . "]\n" if $tracing && @args;
+  Message($self->tracingArgs(@args)) if $tracing && @args;
   my $nargs = $self->getNumArgs;
   @args = @args[0 .. $nargs - 1];
 

--- a/lib/LaTeXML/Core/Definition/Expandable.pm
+++ b/lib/LaTeXML/Core/Definition/Expandable.pm
@@ -71,7 +71,7 @@ sub invoke {
     LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     $result = Tokens(&$expansion($gullet, @args));
     if ($tracing) {    # More involved...
-      Message("\n" . $self->tracingCSName . ' ==> ' . tracetoString(Tokens(@result)));
+      Message("\n" . $self->tracingCSName . ' ==> ' . tracetoString($result));
       Message($self->tracingArgs(@args)) if @args; } }
   elsif (!$$self{parameters}) {    # Trivial macro
     LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;

--- a/lib/LaTeXML/Core/Definition/Expandable.pm
+++ b/lib/LaTeXML/Core/Definition/Expandable.pm
@@ -71,8 +71,8 @@ sub invoke {
     LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     $result = Tokens(&$expansion($gullet, @args));
     if ($tracing) {    # More involved...
-      print STDERR "\n" . $self->tracingCSName . ' ==> ' . tracetoString($result) . "\n";
-      print STDERR $self->tracingArgs(@args) . "\n" if @args; } }
+      Message("\n" . $self->tracingCSName . ' ==> ' . tracetoString(Tokens(@result)));
+      Message($self->tracingArgs(@args)) if @args; } }
   elsif (!$$self{parameters}) {    # Trivial macro
     LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     if ($tracing) {                # More involved...
@@ -96,8 +96,8 @@ sub invoke {
           && (($r eq 'LaTeXML::Core::Token') || ($r eq 'LaTeXML::Core::Tokens'))
         ? $_ : Tokens(Revert($_))); } @args;
     if ($tracing) {    # More involved...
-      print STDERR "\n" . $self->tracingCSName . ' -> ' . tracetoString($expansion) . "\n";
-      print STDERR $self->tracingArgs(@targs) . "\n" if @args; }
+      Message("\n" . $self->tracingCSName . ' -> ' . tracetoString($expansion));
+      Message($self->tracingArgs(@targs)) if @args; }
     LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     $result = $expansion->substituteParameters(@targs); }
   # Getting exclusive requires dubious Gullet support!

--- a/lib/LaTeXML/Core/Definition/Expandable.pm
+++ b/lib/LaTeXML/Core/Definition/Expandable.pm
@@ -70,13 +70,13 @@ sub invoke {
     my @args = ($parms ? $parms->readArguments($gullet, $self) : ());
     LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     $result = Tokens(&$expansion($gullet, @args));
-    if ($tracing) {    # More involved...
-      Message("\n" . $self->tracingCSName . ' ==> ' . tracetoString($result));
-      Message($self->tracingArgs(@args)) if @args; } }
-  elsif (!$$self{parameters}) {    # Trivial macro
+    if ($tracing || $LaTeXML::DEBUG{tracing}) {    # More involved...
+      Debug($self->tracingCSName . ' ==> ' . tracetoString($result));
+      Debug($self->tracingArgs(@args)) if @args; } }
+  elsif (!$$self{parameters}) {                    # Trivial macro
     LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
-    if ($tracing) {                # More involved...
-      print STDERR "\n" . $self->tracingCSName . ' -> ' . tracetoString($expansion) . "\n"; }
+    Debug($self->tracingCSName . ' -> ' . tracetoString($expansion))
+      if $tracing || $LaTeXML::DEBUG{tracing};
     # For trivial expansion, make sure we don't get \cs or \relax\cs direct recursion!
     if (!$onceonly && $$self{cs}) {
       my ($t0, $t1) = ($etype eq 'LaTeXML::Core::Tokens'
@@ -95,9 +95,9 @@ sub invoke {
     my @targs = map { ($_ && ($r = ref $_)
           && (($r eq 'LaTeXML::Core::Token') || ($r eq 'LaTeXML::Core::Tokens'))
         ? $_ : Tokens(Revert($_))); } @args;
-    if ($tracing) {    # More involved...
-      Message("\n" . $self->tracingCSName . ' -> ' . tracetoString($expansion));
-      Message($self->tracingArgs(@targs)) if @args; }
+    if ($tracing || $LaTeXML::DEBUG{tracing}) {    # More involved...
+      Debug($self->tracingCSName . ' -> ' . tracetoString($expansion));
+      Debug($self->tracingArgs(@targs)) if @args; }
     LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     $result = $expansion->substituteParameters(@targs); }
   # Getting exclusive requires dubious Gullet support!

--- a/lib/LaTeXML/Core/Definition/Primitive.pm
+++ b/lib/LaTeXML/Core/Definition/Primitive.pm
@@ -52,11 +52,11 @@ sub invoke {
   my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
   my $tracing  = $STATE->lookupValue('TRACINGCOMMANDS');
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
-  print STDERR '{' . $self->tracingCSName . "}\n"                if $tracing;
+  Message('{' . $self->tracingCSName . '}')                      if $tracing;
   my @result = ($self->executeBeforeDigest($stomach));
   my $parms  = $$self{parameters};
   my @args   = ($parms ? $parms->readArguments($stomach->getGullet, $self) : ());
-  print STDERR $self->tracingArgs(@args) . "\n" if $tracing && @args;
+  Message($self->tracingArgs(@args)) if $tracing && @args;
   push(@result,
     &{ $$self{replacement} }($stomach, @args),
     $self->executeAfterDigest($stomach));

--- a/lib/LaTeXML/Core/Definition/Primitive.pm
+++ b/lib/LaTeXML/Core/Definition/Primitive.pm
@@ -50,13 +50,13 @@ sub executeAfterDigest {
 sub invoke {
   my ($self, $stomach) = @_;
   my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
-  my $tracing  = $STATE->lookupValue('TRACINGCOMMANDS');
+  my $tracing  = $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
-  Message('{' . $self->tracingCSName . '}')                      if $tracing;
+  Debug('{' . $self->tracingCSName . '}')                        if $tracing;
   my @result = ($self->executeBeforeDigest($stomach));
   my $parms  = $$self{parameters};
   my @args   = ($parms ? $parms->readArguments($stomach->getGullet, $self) : ());
-  Message($self->tracingArgs(@args)) if $tracing && @args;
+  Debug($self->tracingArgs(@args)) if $tracing && @args;
   push(@result,
     &{ $$self{replacement} }($stomach, @args),
     $self->executeAfterDigest($stomach));

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -767,7 +767,7 @@ sub openText {
 #  When relativizing, should it depend on font attribute on element and/or DTD allowed attribute?
 sub openElement {
   my ($self, $qname, %attributes) = @_;
-  NoteProgress() if ($$self{progress}++ % $CONSTRUCTION_PROGRESS_QUANTUM) == 0;
+  ProgressStep() if ($$self{progress}++ % $CONSTRUCTION_PROGRESS_QUANTUM) == 0;
   Debug("openElement $qname at " . Stringify($$self{node})) if $LaTeXML::DEBUG{document};
   my $point = $self->find_insertion_point($qname);
   $attributes{_box} = $LaTeXML::BOX unless $attributes{_box};

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -52,7 +52,7 @@ sub new {
     node_fonts => {}, node_boxes => {}, node_properties => {},
     pending    => [], progress   => 0 }, $class; }
 
-our $CONSTRUCTION_PROGRESS_QUANTUM = 50;
+our $CONSTRUCTION_PROGRESS_QUANTUM = 500;
 
 #**********************************************************************
 # Basic Accessors

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -841,7 +841,7 @@ sub isCloseable {
 # Close $qname, if it is closeable.
 sub maybeCloseElement {
   my ($self, $qname) = @_;
-  print STDERR "maybeCloseNode(int) $qname\n" if $LaTeXML::Core::Document::DEBUG;
+  Debug("maybeCloseNode(int) $qname") if $LaTeXML::DEBUG{document};
   if (my $node = $self->isCloseable($qname)) {
     $self->closeNode_internal($node);
     return $node; } }
@@ -877,7 +877,7 @@ sub closeNode {
   my $model = $$self{model};
   my ($t, @cant_close) = ();
   my $n = $$self{node};
-  print STDERR "To closeNode " . Stringify($node) . "\n" if $LaTeXML::Core::Document::DEBUG;
+  Debug("To closeNode " . Stringify($node)) if $LaTeXML::DEBUG{document};
   while ((($t = $n->getType) != XML_DOCUMENT_NODE) && !$n->isSameNode($node)) {
     push(@cant_close, $n) unless $self->canAutoClose($n);
     $n = $n->parentNode; }
@@ -917,8 +917,7 @@ sub addAttribute {
 sub getInsertionContext {
   my ($self, $levels) = @_;
   if (!defined $levels) {    # Default depth is based on verbosity
-    my $verbosity = $STATE && $STATE->lookupValue('VERBOSITY') || 0;
-    $levels = 5 if ($verbosity <= 1); }
+    $levels = 5 if ($LaTeXML::Common::Error::VERBOSITY <= 1); }
   my $node = $$self{node};
   my $type = $node->nodeType;
   if (($type != XML_TEXT_NODE) && ($type != XML_ELEMENT_NODE) && ($type != XML_DOCUMENT_NODE)) {
@@ -945,7 +944,7 @@ sub find_insertion_point {
   # Else, if we can create an intermediate node that accepts $qname, we'll do that.
   elsif (($inter = $self->canContainIndirect($cur_qname, $qname))
     && ($inter ne $qname) && ($inter ne $cur_qname)) {
-    print STDERR "Need intermediate $inter to open $qname\n" if $LaTeXML::Core::Document::DEBUG;
+    Debug("Need intermediate $inter to open $qname") if $LaTeXML::DEBUG{document};
     $self->openElement($inter, _autoopened => 1,
       font => $self->getNodeFont($$self{node}));
     return $self->find_insertion_point($qname, $inter); }    # And retry insertion (should work now).
@@ -1094,7 +1093,6 @@ sub openText_internal {
   my $qname;
   if ($$self{node}->nodeType == XML_TEXT_NODE) {    # current node already is a text node.
     Debug("Appending text \"$text\" to " . Stringify($$self{node})) if $LaTeXML::DEBUG{document};
-    print STDERR "Appending text \"$text\" to " . Stringify($$self{node}) . "\n" if $LaTeXML::Core::Document::DEBUG;
     my $parent = $$self{node}->parentNode;
     if ($LaTeXML::BOX && $parent->getAttribute('_autoopened')) {
       $self->appendTextBox($parent, $LaTeXML::BOX); }
@@ -1219,7 +1217,7 @@ sub closeNode_internal {
     $self->autoCollapseChildren($n);
     last if $node->isSameNode($n);
     $n = $n->parentNode; }
-  print STDERR "closeNode(int) " . Stringify($$self{node}) . "\n" if $LaTeXML::Core::Document::DEBUG;
+  Debug("closeNode(int) " . Stringify($$self{node})) if $LaTeXML::DEBUG{document};
   $self->setNode($closeto);
   #  $self->autoCollapseChildren($node);
   return $$self{node}; }

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -289,6 +289,7 @@ sub readToken {
           push(@{ $$self{pending_comments} }, $token); }    # What to do with comments???
         elsif ($cc == CC_MARKER) {
           $self->handleMarker($token); } } }
+    ProgressStep() if ($$self{progress}++ % $TOKEN_PROGRESS_QUANTUM) == 0;
     # Wow!!!!! See TeX the Program \S 309
     if ((defined $token)
       && !$LaTeXML::ALIGN_STATE    # SHOULD count nesting of { }!!! when SCANNED (not digested)
@@ -336,7 +337,7 @@ sub readXToken {
           push(@{ $$self{pending_comments} }, $token); }
         elsif ($cc == CC_MARKER) {
           $self->handleMarker($token); } } }
-    NoteProgress() if ($$self{progress}++ % $TOKEN_PROGRESS_QUANTUM) == 0;
+    ProgressStep() if ($$self{progress}++ % $TOKEN_PROGRESS_QUANTUM) == 0;
     if (!defined $token) {
       return unless $$self{autoclose} && $toplevel && @{ $$self{mouthstack} };
       $self->closeMouth; }    # Next input stream.

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -36,7 +36,7 @@ sub new {
     progress  => 0,
   }, $class; }
 
-our $TOKEN_PROGRESS_QUANTUM = 10000;
+our $TOKEN_PROGRESS_QUANTUM = 30000;
 
 #**********************************************************************
 # Start reading tokens from a new Mouth.

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -211,25 +211,24 @@ our @CATCODE_HOLD = (
 sub handleMarker {
   my ($self, $markertoken) = @_;
   my $arg = $$markertoken[0];
-  #print STDERR "GULLET detected marker: ".Stringify($arg)."\n";
   if (ref $arg) {
     LaTeXML::Core::Definition::stopProfiling($markertoken, 'expand'); }
   elsif ($arg eq 'before-column') {    # Were in before-column template
     my $alignment = $STATE->lookupValue('Alignment');
-    print STDERR "Halign $alignment: alignment state => 0\n" if $LaTeXML::halign::DEBUG;
+    Debug("Halign $alignment: alignment state => 0") if $LaTeXML::DEBUG{halign};
     $LaTeXML::ALIGN_STATE = 0; }       # switch to column proper!
   elsif ($arg eq 'after-column') {     # Were in before-column template
     my $alignment = $STATE->lookupValue('Alignment');
-    print STDERR "Halign $alignment: alignment state: after column\n" if $LaTeXML::halign::DEBUG;
+    Debug("Halign $alignment: alignment state: after column") if $LaTeXML::DEBUG{halign};
   }
   return; }
 
 sub handleTemplate {
   my ($self, $alignment, $token, $type, $hidden) = @_;
-  print STDERR "Halign $alignment: ALIGNMENT Column ended at " . Stringify($token)
-    . " type $type [" . Stringify($STATE->lookupMeaning($token)) . "]"
-    . "@ " . ToString($self->getLocator) . "\n"
-    if $LaTeXML::halign::DEBUG;
+  Debug("Halign $alignment: ALIGNMENT Column ended at " . Stringify($token)
+      . " type $type [" . Stringify($STATE->lookupMeaning($token)) . "]"
+      . "@ " . ToString($self->getLocator))
+    if $LaTeXML::DEBUG{halign};
   #  Append expansion to end!?!?!?!
   local $LaTeXML::CURRENT_TOKEN = $token;
   my $post = $alignment->getColumnAfter;
@@ -238,7 +237,7 @@ sub handleTemplate {
   my $arg;
   if (($type eq 'cr') && $hidden) {    # \hidden@cr gets an argument as payload!!!!!
     $arg = $self->readArg(); }
-  print STDERR "Halign $alignment: column after " . ToString($post) . "\n" if $LaTeXML::halign::DEBUG;
+  Debug("Halign $alignment: column after " . ToString($post)) if $LaTeXML::DEBUG{halign};
   if ((($type eq 'cr') || ($type eq 'crcr'))
     && $$alignment{in_row} && !$alignment->currentRow->{pseudorow}) {
     unshift(@{ $$self{pushback} }, T_CS('\@row@after')); }

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -31,9 +31,12 @@ use base qw(LaTeXML::Common::Object);
 sub new {
   my ($class, %options) = @_;
   return bless {
-    mouth => undef, mouthstack => [], pushback => [], autoclose => 1, pending_comments => [],
-    verbosity => $options{verbosity} || 0
+    mouth     => undef, mouthstack => [], pushback => [], autoclose => 1, pending_comments => [],
+    verbosity => $options{verbosity} || 0,
+    progress  => 0,
   }, $class; }
+
+our $TOKEN_PROGRESS_QUANTUM = 10000;
 
 #**********************************************************************
 # Start reading tokens from a new Mouth.
@@ -333,6 +336,7 @@ sub readXToken {
           push(@{ $$self{pending_comments} }, $token); }
         elsif ($cc == CC_MARKER) {
           $self->handleMarker($token); } } }
+    NoteProgress() if ($$self{progress}++ % $TOKEN_PROGRESS_QUANTUM) == 0;
     if (!defined $token) {
       return unless $$self{autoclose} && $toplevel && @{ $$self{mouthstack} };
       $self->closeMouth; }    # Next input stream.

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -89,7 +89,7 @@ sub initialize {
     my $source = defined($$self{source}) ? ($$self{source} || 'Literal String') : 'Anonymous String';
     $$self{note_message} = "Processing " . ($$self{fordefinitions} ? "definitions" : "content")
       . " " . $source;
-    NoteBegin($$self{note_message}); }
+    ProgressSpinup($$self{note_message}); }
   if ($$self{fordefinitions}) {
     $$self{saved_at_cc}            = $STATE->lookupCatcode('@');
     $$self{SAVED_INCLUDE_COMMENTS} = $STATE->lookupValue('INCLUDE_COMMENTS');
@@ -111,7 +111,7 @@ sub finish {
     $STATE->assignCatcode('@' => $$self{saved_at_cc});
     $STATE->assignValue(INCLUDE_COMMENTS => $$self{SAVED_INCLUDE_COMMENTS}); }
   if ($$self{notes}) {
-    NoteEnd($$self{note_message}); }
+    ProgressSpindown($$self{note_message}); }
   return; }
 
 # This is (hopefully) a platform independent way of splitting a string

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -22,7 +22,7 @@ use LaTeXML::Util::Pathname;
 use Encode qw(decode);
 use base qw(LaTeXML::Common::Object);
 
-our $TOKEN_PROGRESS_QUANTUM = 25;
+our $READLINE_PROGRESS_QUANTUM = 25;
 
 # Factory method;
 # Create an appropriate Mouth
@@ -321,7 +321,7 @@ sub readToken {
       return T_MARKER('EOL') if $read_mode
         && ($$self{colno} >= $$self{nchars}) && ((!defined $eolch) || ($eolch ne "\r"));
       # Sneak a comment out, every so often.
-      if ((($$self{lineno} % $TOKEN_PROGRESS_QUANTUM) == 0) && $STATE->lookupValue('INCLUDE_COMMENTS')) {
+      if ((($$self{lineno} % $READLINE_PROGRESS_QUANTUM) == 0) && $STATE->lookupValue('INCLUDE_COMMENTS')) {
         return T_COMMENT("**** " . ($$self{shortsource} || 'String') . " Line $$self{lineno} ****"); }
     }
     if ($$self{skipping_spaces}) {    # In state S, skip spaces

--- a/lib/LaTeXML/Core/Mouth/Binding.pm
+++ b/lib/LaTeXML/Core/Mouth/Binding.pm
@@ -27,13 +27,13 @@ sub new {
   my ($class, $pathname) = @_;
   my ($dir, $name, $ext) = pathname_split($pathname);
   my $self = bless { source => $pathname, shortsource => "$name.$ext" }, $class;
-  NoteBegin("Loading $$self{source}");
+  ProgressSpinup("Loading $$self{source}");
   return $self; }
 
 sub finish {
   my ($self) = @_;
   return if $$self{finished};
-  NoteEnd("Loading $$self{source}");
+  ProgressSpindown("Loading $$self{source}");
   $$self{finished} = 1;
   return; }
 

--- a/lib/LaTeXML/Core/Mouth/Binding.pm
+++ b/lib/LaTeXML/Core/Mouth/Binding.pm
@@ -32,7 +32,9 @@ sub new {
 
 sub finish {
   my ($self) = @_;
+  return if $$self{finished};
   NoteEnd("Loading $$self{source}");
+  $$self{finished} = 1;
   return; }
 
 # Evolve to figure out if this gets dynamic location!

--- a/lib/LaTeXML/Core/Mouth/file.pm
+++ b/lib/LaTeXML/Core/Mouth/file.pm
@@ -75,9 +75,6 @@ sub getNextLine {
         Info('misdefined', $encoding, $self, "input isn't valid under encoding $encoding"); } } }
   else {
     $line = ''; }
-
-  if (!($$self{lineno} % 25)) {
-    NoteProgressDetailed("[#$$self{lineno}]"); }
   return $line; }
 
 sub stringify {

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -130,8 +130,8 @@ sub assign_internal {
   my ($self, $table, $key, $value, $scope) = @_;
   $scope = ($$self{prefixes}{global} ? 'global' : 'local') unless defined $scope;
   if (exists $$self{tracing_definitions}{$key}) {
-    print STDERR "ASSIGN $key in $table " . ($scope ? "($scope)" : '') . " => " .
-      (ref $value ? $value->stringify : $value) . "\n"; }
+    Debug("ASSIGN $key in $table " . ($scope ? "($scope)" : '') . " => " .
+        (ref $value ? $value->stringify : $value)); }
   if ($scope eq 'global') {
     # Remove bindings made in all frames down-to & including the next lower locked frame
     my $frame;
@@ -152,7 +152,6 @@ sub assign_internal {
       $$self{undo}[0]{$table}{$key} = 1;
       unshift(@{ $$self{$table}{$key} }, $value); } }    # And push new binding.
   else {
-    # print STDERR "Assigning $key in stash $stash\n";
     assign_internal($self, 'stash', $scope, [], 'global') unless $$self{stash}{$scope}[0];
     push(@{ $$self{stash}{$scope}[0] }, [$table, $key, $value]);
     assign_internal($self, $table, $key, $value, 'local')

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -89,15 +89,15 @@ sub new {
   my ($class, %options) = @_;
   my $self = bless {    # table => {},
     value   => {}, meaning  => {}, stash  => {}, stash_active => {},
-    catcode => {}, mathcode => {}, sfcode => {}, lccode       => {}, uccode => {}, delcode => {},
+    catcode => {}, mathcode => {}, sfcode => {}, lccode => {}, uccode => {}, delcode => {},
     undo    => [{ _FRAME_LOCK_ => 1 }], prefixes => {}, status => {},
-    stomach => $options{stomach},       model    => $options{model} }, $class;
+    stomach => $options{stomach}, model => $options{model} }, $class;
   # Note that "100" is hardwired into TeX, The Program!!!
   $$self{value}{MAX_ERRORS} = [100];
   # Standard TeX units, in scaled points
   $$self{value}{UNITS} = [{
-      pt => 65536,                    pc => 12 * 65536, in => 72.27 * 65536, bp => 72.27 * 65536 / 72,
-      cm => 72.27 * 65536 / 2.54,     mm => 72.27 * 65536 / 2.54 / 10, dd => 1238 * 65536 / 1157,
+      pt => 65536, pc => 12 * 65536, in => 72.27 * 65536, bp => 72.27 * 65536 / 72,
+      cm => 72.27 * 65536 / 2.54, mm => 72.27 * 65536 / 2.54 / 10, dd => 1238 * 65536 / 1157,
       cc => 12 * 1238 * 65536 / 1157, sp => 1,
       px => 72.27 * 65536 / 72,    # Assume px=bp ?
   }];
@@ -734,7 +734,12 @@ sub getStatusMessage {
   push(@report, $undef_status)   if $undef_status;
   push(@report, $missing_status) if $missing_status;
 
-  return join('; ', @report) || $success_status; }
+  #  return join('; ', @report) || $success_status; }
+  my $message = join('; ', @report) || $success_status;
+  $message .= " (See $LaTeXML::Common::Error::LOG_PATH)"
+    if ($$status{fatal} || $$status{error} || $$status{warning})
+    && $LaTeXML::Common::Error::LOG && !ref $LaTeXML::Common::Error::LOG_PATH;
+  return $message; }
 
 sub getStatusCode {
   my ($self) = @_;

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -94,7 +94,6 @@ sub new {
     stomach => $options{stomach}, model => $options{model} }, $class;
   # Note that "100" is hardwired into TeX, The Program!!!
   $$self{value}{MAX_ERRORS} = [100];
-  $$self{value}{VERBOSITY}  = [0];
   # Standard TeX units, in scaled points
   $$self{value}{UNITS} = [{
       pt => 65536, pc => 12 * 65536, in => 72.27 * 65536, bp => 72.27 * 65536 / 72,
@@ -822,8 +821,6 @@ to the given scoping rule.
 Values are also used to specify most configuration parameters (which can
 therefore also be scoped).  The recognized configuration parameters are:
 
- VERBOSITY         : the level of verbosity for debugging
-                     output, with 0 being default.
  STRICT            : whether errors (eg. undefined macros)
                      are fatal.
  INCLUDE_COMMENTS  : whether to preserve comments in the

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -156,7 +156,7 @@ sub invokeToken {
   my ($self, $token) = @_;
   no warnings 'recursion';
 INVOKE:
-  NoteProgress() if ($$self{progress}++ % $DIGESTION_PROGRESS_QUANTUM) == 0;
+  ProgressStep() if ($$self{progress}++ % $DIGESTION_PROGRESS_QUANTUM) == 0;
   push(@{ $$self{token_stack} }, $token);
   if (scalar(@{ $$self{token_stack} }) > $MAXSTACK) {
     Fatal('internal', '<recursion>', $self,

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -53,7 +53,7 @@ sub initialize {
   $STATE->assignValue(mathfont => LaTeXML::Common::Font->mathDefault(), 'global');
   return; }
 
-our $DIGESTION_PROGRESS_QUANTUM = 10000;
+our $DIGESTION_PROGRESS_QUANTUM = 30000;
 
 #**********************************************************************
 sub getGullet {

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -41,6 +41,7 @@ sub initialize {
   my ($self) = @_;
   $$self{boxing}      = [];
   $$self{token_stack} = [];
+  $$self{progress}    = 0;
   $STATE->assignValue(MODE              => 'text',           'global');
   $STATE->assignValue(IN_MATH           => 0,                'global');
   $STATE->assignValue(PRESERVE_NEWLINES => 1,                'global');
@@ -51,6 +52,8 @@ sub initialize {
   $STATE->assignValue(font     => LaTeXML::Common::Font->textDefault(), 'global');
   $STATE->assignValue(mathfont => LaTeXML::Common::Font->mathDefault(), 'global');
   return; }
+
+our $DIGESTION_PROGRESS_QUANTUM = 10000;
 
 #**********************************************************************
 sub getGullet {
@@ -153,6 +156,7 @@ sub invokeToken {
   my ($self, $token) = @_;
   no warnings 'recursion';
 INVOKE:
+  NoteProgress() if ($$self{progress}++ % $DIGESTION_PROGRESS_QUANTUM) == 0;
   push(@{ $$self{token_stack} }, $token);
   if (scalar(@{ $$self{token_stack} }) > $MAXSTACK) {
     Fatal('internal', '<recursion>', $self,

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -109,8 +109,6 @@ sub revert {
 ##  elsif($alignment = $$self{properties}{alignment}) {
   elsif ((!$defn->getReversionSpec)
     && ($alignment = $$self{properties}{alignment})) {
-    print STDERR "REVERT ALIGNMENT for " . Stringify($defn)
-      . "(" . $defn->getReversionSpec . "): $alignment\n";
     return $alignment->revert; }
   else {
     my $props = $$self{properties};

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -850,7 +850,7 @@ my $FAILURE_POSTTOKENS = 1;    # [CONSTANT]
 
 sub failureReport {
   my ($self, $document, $mathnode, $rule, $unparsed, @nodes) = @_;
-  if ($LaTeXML::MathParser::STRICT || (($STATE->lookupValue('VERBOSITY') || 0) > 1)) {
+  if ($LaTeXML::MathParser::STRICT || (($LaTeXML::Common::Error::VERBOSITY || 0) > 1)) {
     my $loc = "";
     # If we haven't already done it for this formula, show the original TeX.
     if (!$LaTeXML::MathParser::WARNED) {

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -72,18 +72,18 @@ sub parseMath {
       $self->parse($math, $document); }
     ProgressSpindown($proc);
 
-    Progress("Math parsing succeeded:"
+    NoteLog("Math parsing succeeded:"
         . join('', map { "\n   $_: "
             . colorizeString($$self{passed}{$_} . "/" . ($$self{passed}{$_} + $$self{failed}{$_}), ($$self{failed}{$_} == 0 ? 'success' : 'warning')) }
           grep { $$self{passed}{$_} + $$self{failed}{$_} }
           keys %{ $$self{passed} }));
     if (my @unk = keys %{ $$self{unknowns} }) {
-      Progress("Symbols assumed as simple identifiers (with # of occurences):\n   "
+      NoteLog("Symbols assumed as simple identifiers (with # of occurences):\n   "
           . join(', ', map { "'" . colorizeString("$_", 'warning') . "' ($$self{unknowns}{$_})" } sort @unk));
       if (!$STATE->lookupValue('MATHPARSER_SPECULATE')) {
-        Progress("Set MATHPARSER_SPECULATE to speculate on possible notations."); } }
+        NoteLog("Set MATHPARSER_SPECULATE to speculate on possible notations."); } }
     if (my @funcs = keys %{ $$self{maybe_functions} }) {
-      Progress("Possibly used as functions?\n  "
+      NoteLog("Possibly used as functions?\n  "
           . join(', ', map { "'$_' ($$self{maybe_functions}{$_}/$$self{unknowns}{$_} usages)" }
             sort @funcs)); }
   }

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -4347,8 +4347,6 @@ to the given scoping rule.
 Values are also used to specify most configuration parameters (which can
 therefore also be scoped).  The recognized configuration parameters are:
 
- VERBOSITY         : the level of verbosity for debugging
-                     output, with 0 being default.
  STRICT            : whether errors (eg. undefined macros)
                      are fatal.
  INCLUDE_COMMENTS  : whether to preserve comments in the

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -785,7 +785,6 @@ sub MaybeNoteLabel {
 
 sub deactivateCounterScope {
   my ($ctr) = @_;
-  #  print STDERR "Unusing scopes for $ctr\n";
   if (my $scopes = LookupValue('scopes_for_counter:' . $ctr)) {
     map { $STATE->deactivateScope($_) } @$scopes; }
   foreach my $inner_ctr (@{ LookupValue('nested_counters_' . $ctr) || [] }) {
@@ -1458,6 +1457,8 @@ sub DefMath {
   DefMathI(parsePrototype($proto), $presentation, %options);
   return; }
 
+DebuggableFeature('defmath', 'DefMath definitions');
+
 sub DefMathI {
   my ($cs, $paramlist, $presentation, %options) = @_;
   $cs        = coerceCS($cs);
@@ -1485,7 +1486,7 @@ sub DefMathI {
 
   # If single character, handle with a rewrite rule
   if (length($csname) == 1) {
-    ###print STDERR "Defining ".Stringify($cs)." as rewrite\n";
+    Debug("Defining " . Stringify($cs) . " as rewrite") if $LaTeXML::DEBUG{defmath};
     if ($csname ne ToString($presentation)) {
       $options{replace} = $presentation;
       delete $options{name}; }
@@ -1496,21 +1497,21 @@ sub DefMathI {
   elsif ((ref $presentation eq 'CODE')
     || ((ref $presentation)  && grep { $$_[1] == CC_ARG || $_->equals(T_PARAM) } $presentation->unlist)
     || (!(ref $presentation) && ($presentation =~ /\#\d|\\./))) {
-    ###print STDERR "Defining ".Stringify($cs)." as dual\n";
+    Debug("Defining " . Stringify($cs) . " as dual") if $LaTeXML::DEBUG{defmath};
     defmath_dual($cs, $paramlist, $presentation, %options); }
   # If no arguments, but the presentation involves macros, presumably with internal structure,
   # we'll wrap the presentation in ordet to capture the various semantic attributes
   elsif ((ref $presentation) && (grep { $_->isExecutable } $presentation->unlist)) {
-    ###print STDERR "Defining ".Stringify($cs)." as wrapped\n";
+    Debug("Defining " . Stringify($cs) . " as wrapped") if $LaTeXML::DEBUG{defmath};
     defmath_wrapped($cs, $presentation, %options); }
 
   # EXPERIMENT: Introduce an intermediate case for simple symbols
   # Define a primitive that will create a Box with the appropriate set of XMTok attributes.
   elsif (($nargs == 0) && !grep { !$$simpletoken_options{$_} } keys %options) {
-    ###print STDERR "Defining ".Stringify($cs)." as primitive\n";
+    Debug("Defining " . Stringify($cs) . " as primitive") if $LaTeXML::DEBUG{defmath};
     defmath_prim($cs, $paramlist, $presentation, %options); }
   else {
-    ###print STDERR "Defining ".Stringify($cs)." as constructor\n";
+    Debug("Defining " . Stringify($cs) . " as constructor") if $LaTeXML::DEBUG{defmath};
     defmath_cons($cs, $paramlist, $presentation, %options); }
   AssignValue($csname . ":locked" => 1) if $options{locked};
   return; }
@@ -2164,12 +2165,14 @@ sub loadTeXContent {
 # $code can be a sub (as a primitive), or a string to be expanded.
 # (effectively a macro)
 
+DebuggableFeature('packageoptions', 'Processing package & class options');
+
 sub DeclareOption {
   my ($option, $code) = @_;
   $option = ToString($option) if ref $option;
   PushValue('@declaredoptions', $option) if $option;
   my $cs = ($option ? '\ds@' . $option : '\default@ds');
-  # print STDERR "Declaring option: ".($option ? $option : '<default>')."\n";
+  Debug("Declaring option: " . ($option ? $option : '<default>')) if $LaTeXML::DEBUG{packageoptions};
   if ((!defined $code) || (ref $code eq 'CODE')) {
     DefPrimitiveI($cs, undef, $code); }
   else {
@@ -2181,7 +2184,7 @@ sub DeclareOption {
 sub PassOptions {
   my ($name, $ext, @options) = @_;
   PushValue('opt@' . $name . '.' . $ext, map { ToString($_) } @options);
-  # print STDERR "Passing to $name.$ext options: " . join(', ', @options) . "\n";
+  Debug("Passing to $name.$ext options: " . join(', ', @options)) if $LaTeXML::DEBUG{packageoptions};
   return; }
 
 # Process the options passed to the currently loading package or class.
@@ -2201,10 +2204,10 @@ sub ProcessOptions {
   my @curroptions     = @{ (defined($name) && defined($ext)
         && LookupValue('opt@' . $name . '.' . $ext)) || [] };
   my @classoptions = @{ LookupValue('class_options') || [] };
-  # print STDERR "\nProcessOptions for $name.$ext\n"
-  #   . "  declared: " . join(',', @declaredoptions) . "\n"
-  #   . "  provided: " . join(',', @curroptions) . "\n"
-  #   . "  class: " . join(',', @classoptions) . "\n";
+  Debug("ProcessOptions for $name.$ext\n"
+      . "  declared: " . join(',', @declaredoptions) . "\n"
+      . "  provided: " . join(',', @curroptions) . "\n"
+      . "  class: " . join(',', @classoptions)) if $LaTeXML::DEBUG{packageoptions};
 
   my $defaultcs = T_CS('\default@ds');
   # Execute options in declared order (unless \ProcessOptions*)
@@ -2233,7 +2236,7 @@ sub executeOption_internal {
   my ($option) = @_;
   my $cs = T_CS('\ds@' . $option);
   if ($STATE->lookupDefinition($cs)) {
-    # print STDERR "\nPROCESS OPTION $option\n";
+    Debug("PROCESS OPTION $option") if $LaTeXML::DEBUG{packageoptions};
     DefMacroI('\CurrentOption', undef, $option);
     AssignValue('@unusedoptionlist',
       [grep { $_ ne $option } @{ LookupValue('@unusedoptionlist') || [] }]);
@@ -2244,7 +2247,7 @@ sub executeOption_internal {
 
 sub executeDefaultOption_internal {
   my ($option) = @_;
-  # print STDERR "\nPROCESS DEFAULT OPTION $option\n";
+  Debug("PROCESS DEFAULT OPTION $option") if $LaTeXML::DEBUG{packageoptions};
   # presumably should NOT remove from @unusedoptionlist ?
   DefMacroI('\CurrentOption', undef, $option);
   Digest(T_CS('\default@ds'));
@@ -2626,7 +2629,6 @@ sub LookupColor {
 
 sub DefColor {
   my ($name, $color, $scope) = @_;
-  #print STDERR "DEFINE ".ToString($name)." => ".join(',',@$color)."\n";
   return unless ref $color;
   my ($model, @spec) = @$color;
   $scope = 'global' if $STATE->lookupDefinition(T_CS('\ifglobalcolors')) && IfCondition(T_CS('\ifglobalcolors'));

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -357,15 +357,6 @@ DefConstructorI(T_CS('\end{document}'), undef, sub {
     # It is common for unclosed { or even environments
     # and we want to at least compress & avoid unnecessary errors & warnings.
     my $nframes = $STATE->getFrameDepth;
-# Expect 0 frames, top with environment document.
-# print STDERR "\n\nEND DOCUMENT; $nframes frames\n";
-# for(my $i=0; $i <= $nframes; $i++){
-#   my $nonbox = $STATE->valueInFrame('groupNonBoxing',$i) || 0;
-#   my $tok = $STATE->valueInFrame('groupInitiator',        $i) || '<unknown>';
-#   my $loc = $STATE->valueInFrame('groupInitiatorLocator', $i) || '<unknown>';
-#   my $env = $STATE->isValueBound('current_environment', $i)
-#       && $STATE->valueInFrame('current_environment', $i);
-#   print STDERR "Frame $i: nonboxing=$nonbox; tok=".ToString($tok).' '.$loc." env=".($env||'none')."\n"; }
     my $ifstack;
     if ($STATE->isValueBound('current_environment', 0)
       && ($STATE->valueInFrame('current_environment', 0) eq 'document')
@@ -3865,14 +3856,13 @@ DefMacro('\lx@mung@bibliography{}', sub {
     my @tokens = ();
     # If we're in some sort of list environment, maybe we can recover
     if (($tag eq 'enumerate') || ($tag eq 'itemize') || ($tag eq 'description')) {
-      print STDERR "\nDamn! We're in a list {$tag}; try to close it!\n";
+      # nDamn! We're in a list {$tag}; try to close it!
       push(@tokens, Invocation('\end', $env),
         T_CS('\let'), T_CS('\end' . $tag), T_CS('\endthebibliography'),
         T_CS('\let'), T_CS('\end{' . $tag . '}'), T_CS('\end{thebibliography}')); }
     # else ? it probably isn't going to work??
-    print STDERR "Now, try to open {thebibliography}\n";
+    # Now, try to open {thebibliography}
     push(@tokens, Invocation('\begin', Tokenize('thebibliography'), Tokens()));
-    print STDERR "PATCHING with " . ToString(Tokens(@tokens)) . "\n";
     return Tokens(@tokens); });
 
 DefConstructorI('\lx@bibnewblock', undef, "<ltx:bibblock>");
@@ -4000,7 +3990,7 @@ DefConstructorI(T_CS("\\begin{filecontents}"), "Semiverbatim",
       while (defined($line = $gullet->readRawLine) && ($line ne '\end{filecontents}')) {
         push(@lines, $line); }
       AssignValue($filename . '_contents' => join("\n", @lines), 'global');
-      NoteProgress("[Cached filecontents for $filename (" . scalar(@lines) . " lines)]"); }]);
+      NoteStatus(1, "Cached filecontents for $filename (" . scalar(@lines) . " lines)"); }]);
 DefConstructorI(T_CS("\\begin{filecontents*}"), "Semiverbatim",
   '',
   reversion   => '',
@@ -4013,7 +4003,7 @@ DefConstructorI(T_CS("\\begin{filecontents*}"), "Semiverbatim",
       while (defined($line = $gullet->readRawLine) && ($line ne '\end{filecontents*}')) {
         push(@lines, $line); }
       AssignValue($filename . '_contents' => join("\n", @lines), 'global');
-      NoteProgress("[Cached filecontents* for $filename (" . scalar(@lines) . " lines)]"); }]);
+      NoteStatus(1, "Cached filecontents* for $filename (" . scalar(@lines) . " lines)"); }]);
 DefMacro('\endfilecontents', '');
 DefPrimitive('\listfiles', undef);
 
@@ -4220,7 +4210,7 @@ DefPrimitiveI('\makeglossary', undef, undef);
 
 DefPrimitive('\typeout{}', sub {
     my ($stomach, $stuff) = @_;
-    print STDERR ToString(Expand($stuff)) . "\n" if LookupValue('VERBOSITY') > -1;
+    Message(ToString(Expand($stuff))) if LookupValue('VERBOSITY') > -1;
     return; });
 
 DefPrimitive('\typein[]{}', undef);
@@ -5775,7 +5765,7 @@ DefPrimitive('\protected@write Number {}{}', sub {
       my $contents = LookupValue($handle);
       AssignValue($handle => $contents . UnTeX($tokens) . "\n", 'global'); }
     else {
-      print STDERR UnTeX($tokens) . "\n"; }
+      Message(UnTeX($tokens)); }
     $stomach->egroup;
     return @stuff; });
 

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3983,7 +3983,7 @@ DefConstructorI(T_CS("\\begin{filecontents}"), "Semiverbatim",
       while (defined($line = $gullet->readRawLine) && ($line ne '\end{filecontents}')) {
         push(@lines, $line); }
       AssignValue($filename . '_contents' => join("\n", @lines), 'global');
-      Progress("Cached filecontents for $filename (" . scalar(@lines) . " lines)"); }]);
+      NoteLog("Cached filecontents for $filename (" . scalar(@lines) . " lines)"); }]);
 DefConstructorI(T_CS("\\begin{filecontents*}"), "Semiverbatim",
   '',
   reversion   => '',
@@ -3996,7 +3996,7 @@ DefConstructorI(T_CS("\\begin{filecontents*}"), "Semiverbatim",
       while (defined($line = $gullet->readRawLine) && ($line ne '\end{filecontents*}')) {
         push(@lines, $line); }
       AssignValue($filename . '_contents' => join("\n", @lines), 'global');
-      Progress("Cached filecontents* for $filename (" . scalar(@lines) . " lines)"); }]);
+      NoteLog("Cached filecontents* for $filename (" . scalar(@lines) . " lines)"); }]);
 DefMacro('\endfilecontents', '');
 DefPrimitive('\listfiles', undef);
 
@@ -4203,7 +4203,7 @@ DefPrimitiveI('\makeglossary', undef, undef);
 
 DefPrimitive('\typeout{}', sub {
     my ($stomach, $stuff) = @_;
-    Message(ToString(Expand($stuff)));
+    Note(ToString(Expand($stuff)));
     return; });
 
 DefPrimitive('\typein[]{}', undef);
@@ -5758,7 +5758,7 @@ DefPrimitive('\protected@write Number {}{}', sub {
       my $contents = LookupValue($handle);
       AssignValue($handle => $contents . UnTeX($tokens) . "\n", 'global'); }
     else {
-      Message(UnTeX($tokens)); }
+      Note(UnTeX($tokens)); }
     $stomach->egroup;
     return @stuff; });
 

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3535,14 +3535,7 @@ DefConstructor('\@@array[] Undigested DigestedBody',
   '#3',
   beforeDigest => sub { $_[0]->bgroup; },
   reversion    => '\begin{array}[#1]{#2}#3\end{array}');
-# reversion => sub {
-#   my($whatsit,$op,$pat,$body)=@_;
-#   print STDERR "REVERT ARRAY"
-#     ."  options: ".Stringify($op)."\n"
-#     ."  pattern: ".Stringify($pat)."\n"
-#     ."  body: ".Stringify($body)."\n";
-#   (); }
-#   );
+
 #**********************************************************************
 # C.11 Moving Information Around
 #**********************************************************************
@@ -4210,7 +4203,7 @@ DefPrimitiveI('\makeglossary', undef, undef);
 
 DefPrimitive('\typeout{}', sub {
     my ($stomach, $stuff) = @_;
-    Message(ToString(Expand($stuff))) if LookupValue('VERBOSITY') > -1;
+    Message(ToString(Expand($stuff)));
     return; });
 
 DefPrimitive('\typein[]{}', undef);

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3990,7 +3990,7 @@ DefConstructorI(T_CS("\\begin{filecontents}"), "Semiverbatim",
       while (defined($line = $gullet->readRawLine) && ($line ne '\end{filecontents}')) {
         push(@lines, $line); }
       AssignValue($filename . '_contents' => join("\n", @lines), 'global');
-      NoteStatus(1, "Cached filecontents for $filename (" . scalar(@lines) . " lines)"); }]);
+      Progress("Cached filecontents for $filename (" . scalar(@lines) . " lines)"); }]);
 DefConstructorI(T_CS("\\begin{filecontents*}"), "Semiverbatim",
   '',
   reversion   => '',
@@ -4003,7 +4003,7 @@ DefConstructorI(T_CS("\\begin{filecontents*}"), "Semiverbatim",
       while (defined($line = $gullet->readRawLine) && ($line ne '\end{filecontents*}')) {
         push(@lines, $line); }
       AssignValue($filename . '_contents' => join("\n", @lines), 'global');
-      NoteStatus(1, "Cached filecontents* for $filename (" . scalar(@lines) . " lines)"); }]);
+      Progress("Cached filecontents* for $filename (" . scalar(@lines) . " lines)"); }]);
 DefMacro('\endfilecontents', '');
 DefPrimitive('\listfiles', undef);
 

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1852,7 +1852,6 @@ DefPrimitive('\setbox Number SkipMatch:=', sub {
     $STATE->clearPrefixes;    # before invoke, below; we've saved the only relevant one (global)
     my ($stuff, @rest) = $stomach->invokeToken($stomach->getGullet->readXToken);
     AssignValue('box' . $_[1]->valueOf => $stuff, $scope);
-##print STDERR "ASSIGN BOX ".$_[1]->valueOf." => ".Stringify($stuff)."\n";
     @rest; });
 
 DefPrimitive('\box Number', sub {
@@ -2174,9 +2173,8 @@ DefPrimitive('{', sub {
     my $open   = Box(undef, undef, undef, T_BEGIN);
     my $ismath = $STATE->lookupValue('IN_MATH');
     my @body   = $stomach->digestNextBody();
-####print STDERR "BEGIN => ".join("\n--",map { Stringify($_); } @body)."\n";
     List($open, @body, mode => ($ismath ? 'math' : 'text')); });
-#DefConstructor('}',  '',    beforeDigest=>sub{$_[0]->egroup;});
+
 DefPrimitive('}', sub { my $f = LookupValue('font'); $_[0]->egroup; Box(undef, $f, undef, T_END); });
 
 # These are for those screwy cases where you need to create a group like box,
@@ -2263,7 +2261,6 @@ sub writableTokens {
 
 DefPrimitive('\message{}', sub {
     my ($stomach, $stuff) = @_;
-    return if LookupValue('VERBOSITY') <= -1;
     Message(writableTokens(Expand($stuff)));
     return; });
 
@@ -2345,7 +2342,7 @@ DefPrimitive('\write Number {}', sub {
       my $handle   = $filename . '_contents';
       my $contents = LookupValue($handle);
       AssignValue($handle => $contents . UnTeX(Expand($tokens)) . "\n", 'global'); }
-    elsif (LookupValue('VERBOSITY') > -1) {
+    else {
       Message(UnTeX(Expand($tokens))); }
     return; });
 
@@ -2671,7 +2668,6 @@ DefMacro('\@multicolumn {Number}  AlignmentTemplate {}', sub {
     my ($gullet, $span, $template, $tokens) = @_;
     my $column = $template->column(1);
     $span = $span->valueOf;
-####    print STDERR "ALIGNMENT MULTICOLUMN $span @ ".ToString($gullet->getLocator)."; ".ToString($$column{before})." THEN ".ToString($$column{after})."\n";
     # First part, like \multispan
     (T_CS('\omit'), (map { (T_CS('\span'), T_CS('\omit')) } 1 .. $span - 1),
       # Next part, just put the template in-line, since it's only used once.
@@ -2836,7 +2832,7 @@ sub alignmentBindings {
     isMath         => $ismath,
     properties     => {%properties});
   AssignValue(Alignment => $alignment);
-  print STDERR "\nHalign $alignment: New " . $template->show . "\n" if $LaTeXML::halign::DEBUG;
+  Debug("Halign $alignment: New " . $template->show) if $LaTeXML::DEBUG{halign};
   Let('\hline', '\@alignment@hline');
   Let(T_MATH,   ($ismath ? '\@dollar@in@mathmode' : '\@dollar@in@textmode'));
   return; }
@@ -2860,7 +2856,6 @@ sub digestAlignmentBody {
   my ($stomach, $whatsit) = @_;
   my $gullet = $stomach->getGullet;
   local $LaTeXML::ALIGN_STATE = 0;
-  #  print STDERR "Template = ".Stringify(Tokens(@template))."\n => ".$template->show."\n";
   # Now read & digest the body.
   # Note that the body MUST end with a \cr, and that we've made Special Arrangments
   # with \alignment@cr to recognize the end of the \halign
@@ -2871,17 +2866,17 @@ sub digestAlignmentBody {
     return; }
   $whatsit->setProperty(alignment => $alignment);
   $alignment->setBody($whatsit);
-  print STDERR "Halign $alignment: BODY Processing...\n" if $LaTeXML::halign::DEBUG;
+  Debug("Halign $alignment: BODY Processing...") if $LaTeXML::DEBUG{halign};
   my $lastwascr  = undef;
   my @reversion  = ();
   my @creversion = ();
   while (1) {
     my ($cell, $next, $type, $hidden) = digestAlignmentColumn($stomach, $alignment, $lastwascr);
-    print STDERR "Halign $alignment: BODY got CELL"
-      . "[" . $alignment->currentRowNumber . "," . $alignment->currentColumnNumber . "]"
-      . ToString($cell) . " ended at " . Stringify($next) . "\n" if $LaTeXML::halign::DEBUG;
+    Debug("Halign $alignment: BODY got CELL"
+        . "[" . $alignment->currentRowNumber . "," . $alignment->currentColumnNumber . "]"
+        . ToString($cell) . " ended at " . Stringify($next)) if $LaTeXML::DEBUG{halign};
     if (!$cell) {
-      print STDERR "Halign $alignment: BODY DONE!\n" if $LaTeXML::halign::DEBUG;
+      Debug("Halign $alignment: BODY DONE!") if $LaTeXML::DEBUG{halign};
       last; }
     if ($cell) {
       push(@reversion,  trimColumnTemplate($alignment, pRevert($cell)));
@@ -2916,8 +2911,8 @@ sub digestAlignmentBody {
   $alignment->endRow();
   $alignment->setReversion(Tokens(@reversion));
   $alignment->setContentReversion(Tokens(@creversion));
-  print STDERR "Halign $alignment: BODY DONE!\n"
-    . "=> " . join(',', map { Stringify($_); } @reversion) . "\n" if $LaTeXML::halign::DEBUG;
+  Debug("Halign $alignment: BODY DONE!\n"
+      . "=> " . join(',', map { Stringify($_); } @reversion)) if $LaTeXML::DEBUG{halign};
   return; }
 
 # Read & digest an alignment column's data,
@@ -2929,8 +2924,8 @@ sub digestAlignmentColumn {
   my $ismath = $STATE->lookupValue('IN_MATH');
   local @LaTeXML::LIST = ();
   # Scan for leading \omit, skipping over (& saving) \hline.
-  print STDERR "Halign $alignment: COLUMN starting scan "
-    . "(" . ($ismath ? " math" : " text") . ")\n" if $LaTeXML::halign::DEBUG;
+  Debug("Halign $alignment: COLUMN starting scan "
+      . "(" . ($ismath ? " math" : " text") . ")") if $LaTeXML::DEBUG{halign};
   my $token;
   my $spanning = 0;
   while (1) {    # Outer loop; collects 1 column (possibly multiple spans) return from within!
@@ -2942,26 +2937,23 @@ sub digestAlignmentColumn {
           (Equals($token, T_CS('\crcr')) || Equals($token, T_CS('\hidden@crcr'))))) {
       }
       elsif (Equals($token, T_CS('\omit'))) {    # \omit removes template for this column.
-        print STDERR "Halign $alignment: OMIT at " . Stringify($token) . "\n"
-          if $LaTeXML::halign::DEBUG;
+        Debug("Halign $alignment: OMIT at " . Stringify($token)) if $LaTeXML::DEBUG{halign};
         $alignment->startRow() unless $$alignment{in_row};
         $alignment->omitNextColumn; }
       elsif (Equals($token, T_CS('\noalign'))) {    # \puts something in vertical list
-        print STDERR "Halign $alignment: noalign at " . Stringify($token) . "\n"
-          if $LaTeXML::halign::DEBUG;
-        $alignment->endRow() if $$alignment{in_row};
+        Debug("Halign $alignment: noalign at " . Stringify($token)) if $LaTeXML::DEBUG{halign};
+        $alignment->endRow()                                        if $$alignment{in_row};
         $alignment->startColumn(1);
         $alignment->lastColumn;
         my $r = $stomach->digest($gullet->readArg);
         $alignment->endRow();
         return ($r, T_CS('\cr'), 'cr'), undef; }    # Pretend this is a whole row???
       elsif (Equals($token, T_CS('\hidden@noalign'))) {    # \puts something in vertical list
-        print STDERR "Halign $alignment: COLUMN invisible noalign\n" if $LaTeXML::halign::DEBUG;
+        Debug("Halign $alignment: COLUMN invisible noalign") if $LaTeXML::DEBUG{halign};
         $stomach->digest($gullet->readArg); }              # Purely for side effect!
       else {
         last; } }
-    print STDERR "Halign $alignment: COLUMN end scan at " . Stringify($token) . "\n"
-      if $LaTeXML::halign::DEBUG;
+    Debug("Halign $alignment: COLUMN end scan at " . Stringify($token)) if $LaTeXML::DEBUG{halign};
     if (!$token || Equals($token, T_END) || Equals($token, T_CS('\@close@alignment'))) {
       return (undef, $token, undef, undef); }
     # Next column, unless spanning (then combine columns)
@@ -2971,32 +2963,30 @@ sub digestAlignmentColumn {
     else {
       $alignment->startColumn(); }
     # Push before template,  Marker and put the token back
-    print STDERR "Halign $alignment: COLUMN preload at "
-      . Stringify(Tokens($alignment->getColumnBefore, T_MARKER('before-column'), $token)) . "\n"
-      if $LaTeXML::halign::DEBUG;
+    Debug("Halign $alignment: COLUMN preload at "
+        . Stringify(Tokens($alignment->getColumnBefore, T_MARKER('before-column'), $token)))
+      if $LaTeXML::DEBUG{halign};
     $gullet->unread($alignment->getColumnBefore, T_MARKER('before-column'), $token);
     while ($token = $gullet->readXToken(0)) {
       my ($atoken, $type, $hidden) = $gullet->isColumnEnd($token);
       if ($atoken) {
         if ($type eq 'span') {    # next column, but continue accumulating
-          print STDERR "Halign $alignment: COLUMN span\n" if $LaTeXML::halign::DEBUG;
+          Debug("Halign $alignment: COLUMN span") if $LaTeXML::DEBUG{halign};
           $spanning = 1;
           last; }
         else {
-          print STDERR "Halign $alignment: COLUMN ended with " . Stringify($token) . "\n"
-            . "  => " . ToString(List(@LaTeXML::LIST)) . "\n"
-            if $LaTeXML::halign::DEBUG;
+          Debug("Halign $alignment: COLUMN ended with " . Stringify($token) . "\n"
+              . "  => " . ToString(List(@LaTeXML::LIST))) if $LaTeXML::DEBUG{halign};
           return (List(@LaTeXML::LIST, mode => ($ismath ? 'math' : 'text')),
             $token, $type, $hidden); } }
       elsif (Equals($token, T_CS('\hidden@noalign'))) {    # \puts something in vertical list
-        print STDERR "Halign $alignment: COLUMN invisible noalign\n" if $LaTeXML::halign::DEBUG;
+        Debug("Halign $alignment: COLUMN invisible noalign") if $LaTeXML::DEBUG{halign};
         $stomach->digest($gullet->readArg); }
       else {    # Else, we're getting some actual content for the column
-        print STDERR "Halign $alignment: COLUMN invoking " . Stringify($token) . "\n"
-          if $LaTeXML::halign::DEBUG;
+        Debug("Halign $alignment: COLUMN invoking " . Stringify($token)) if $LaTeXML::DEBUG{halign};
         push(@LaTeXML::LIST, $stomach->invokeToken($token));
-        print STDERR "Halign $alignment: COLUMN " . Stringify($token) . " ==> " . Stringify(List(@LaTeXML::LIST)) . "\n"
-          if $LaTeXML::halign::DEBUG;
+        Debug("Halign $alignment: COLUMN " . Stringify($token) . " ==> " . Stringify(List(@LaTeXML::LIST)))
+          if $LaTeXML::DEBUG{halign};
   } } }
   return; }
 
@@ -3011,12 +3001,10 @@ sub trimColumnTemplate {
   return Tokens(@tokens) if $alignment->currentRow->{pseudorow};
   my @pre  = $alignment->getColumnBefore->unlist;
   my @post = $alignment->getColumnAfter->unlist;
-  print STDERR "\nHalign $alignment: COLUMN Compare:\n"
-    . "  Column: " . ToString(Tokens(@tokens)) . "\n"
-    . "  Before: " . ToString(Tokens(@pre)) . "\n"
-    . "  After : " . ToString(Tokens(@post)) . "\n"
-
-    if $LaTeXML::halign::DEBUG;
+  Debug("Halign $alignment: COLUMN Compare:\n"
+      . "  Column: " . ToString(Tokens(@tokens)) . "\n"
+      . "  Before: " . ToString(Tokens(@pre)) . "\n"
+      . "  After : " . ToString(Tokens(@post)) . "\n") if $LaTeXML::DEBUG{halign};
   while (scalar(@pre) && scalar(@tokens)) {
     my $t = shift(@pre);
     if ($t->equals($tokens[0])) {
@@ -3033,8 +3021,7 @@ sub trimColumnTemplate {
 ##        @tokens = popArg(@tokens);
 ##        @post   = popArg(@post); }
   } }
-  print STDERR "  Trimmed: " . ToString(Tokens(@tokens)) . "\n"
-    if $LaTeXML::halign::DEBUG;
+  Debug("  Trimmed: " . ToString(Tokens(@tokens))) if $LaTeXML::DEBUG{halign};
   return Tokens(@tokens); }
 
 sub shiftArg {
@@ -3110,7 +3097,6 @@ sub extractAlignmentColumn {
       || IsEmpty($boxes[-1])) {
       unshift(@saveright, pop(@boxes)); }
     else {
-      #print STDERR "End right check at ".Stringify($boxes[0])."\n";
       last; } }
   delete $$colspec{width} unless $align eq 'justify';
   # Replacing boxes with the fil padding & vertical rules stripped off
@@ -3126,7 +3112,7 @@ sub extractAlignmentColumn {
   for (my $i = $n0 + 1 ; $i <= $n1 ; $i++) {
     my $c = $alignment->getColumn($i);
     $$c{skipped} = 1 if $c; }
-  print STDERR "Halign $alignment: INSTALL column " . join(',', map { $_ . "=" . ToString($$colspec{$_}); } sort keys %$colspec) . "\n" if $LaTeXML::halign::DEBUG;
+  Debug("Halign $alignment: INSTALL column " . join(',', map { $_ . "=" . ToString($$colspec{$_}); } sort keys %$colspec)) if $LaTeXML::DEBUG{halign};
   return $boxes; }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2191,8 +2191,8 @@ DefPrimitive('\endgroup',   sub { $_[0]->endgroup; });
 # Debugging aids; Ignored!
 DefPrimitive('\show Token', sub {
     my $stuff = Invocation(T_CS('\meaning'), $_[1]);
-    Message("\n> " . ($_[1][1] == CC_CS ? ToString($_[1]) . '=' : '') . writableTokens(Expand($stuff)));
-    Message($_[0]->getLocator->toString() . "\n");
+    Note("> " . ($_[1][1] == CC_CS ? ToString($_[1]) . '=' : '') . writableTokens(Expand($stuff)));
+    Note($_[0]->getLocator->toString());
     return; });
 DefPrimitive('\showbox Number', undef);
 DefPrimitive('\showlists',      undef);
@@ -2261,13 +2261,13 @@ sub writableTokens {
 
 DefPrimitive('\message{}', sub {
     my ($stomach, $stuff) = @_;
-    Message(writableTokens(Expand($stuff)));
+    Note(writableTokens(Expand($stuff)));
     return; });
 
 DefRegister('\errhelp' => Tokens());
 DefPrimitive('\errmessage{}', sub {
     my ($stomach, $stuff) = @_;
-    Message(ToString(Expand($stuff)) . ": " . ToString(Expand(Tokens(T_CS('\the'), T_CS('\errhelp')))));
+    Note(ToString(Expand($stuff)) . ": " . ToString(Expand(Tokens(T_CS('\the'), T_CS('\errhelp')))));
     return; });
 
 # TeX I/O primitives
@@ -2343,7 +2343,7 @@ DefPrimitive('\write Number {}', sub {
       my $contents = LookupValue($handle);
       AssignValue($handle => $contents . UnTeX(Expand($tokens)) . "\n", 'global'); }
     else {
-      Message(UnTeX(Expand($tokens))); }
+      Note(UnTeX(Expand($tokens))); }
     return; });
 
 # Since we don't paginate, we're effectively always "shipping out",

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2193,8 +2193,8 @@ DefPrimitive('\endgroup',   sub { $_[0]->endgroup; });
 # Debugging aids; Ignored!
 DefPrimitive('\show Token', sub {
     my $stuff = Invocation(T_CS('\meaning'), $_[1]);
-    print STDERR "\n> " . ($_[1][1] == CC_CS ? ToString($_[1]) . '=' : '') . writableTokens(Expand($stuff)) . ".\n";
-    print STDERR $_[0]->getLocator->toString() . "\n\n";
+    Message("\n> " . ($_[1][1] == CC_CS ? ToString($_[1]) . '=' : '') . writableTokens(Expand($stuff)));
+    Message($_[0]->getLocator->toString() . "\n");
     return; });
 DefPrimitive('\showbox Number', undef);
 DefPrimitive('\showlists',      undef);
@@ -2264,13 +2264,13 @@ sub writableTokens {
 DefPrimitive('\message{}', sub {
     my ($stomach, $stuff) = @_;
     return if LookupValue('VERBOSITY') <= -1;
-    print STDERR writableTokens(Expand($stuff));
+    Message(writableTokens(Expand($stuff)));
     return; });
 
 DefRegister('\errhelp' => Tokens());
 DefPrimitive('\errmessage{}', sub {
     my ($stomach, $stuff) = @_;
-    print STDERR ToString(Expand($stuff)) . ": " . ToString(Expand(Tokens(T_CS('\the'), T_CS('\errhelp')))) . "\n";
+    Message(ToString(Expand($stuff)) . ": " . ToString(Expand(Tokens(T_CS('\the'), T_CS('\errhelp')))));
     return; });
 
 # TeX I/O primitives
@@ -2346,7 +2346,7 @@ DefPrimitive('\write Number {}', sub {
       my $contents = LookupValue($handle);
       AssignValue($handle => $contents . UnTeX(Expand($tokens)) . "\n", 'global'); }
     elsif (LookupValue('VERBOSITY') > -1) {
-      print STDERR UnTeX(Expand($tokens)) . "\n"; }
+      Message(UnTeX(Expand($tokens))); }
     return; });
 
 # Since we don't paginate, we're effectively always "shipping out",
@@ -4038,7 +4038,6 @@ sub scriptSizer {
     else {
       $d = $hs / 2 + $ds; } }
   $w = Dimension($w); $h = Dimension($h); $d = Dimension($d);
-  #  print STDERR " ==> ".ToString($w).' x '.ToString($h).' + '.ToString($d)."\n";
   return ($w, $h, $d); }
 
 # NOTE: The When reverting these, the

--- a/lib/LaTeXML/Package/algorithm2e.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithm2e.sty.ltxml
@@ -71,7 +71,7 @@ DefEnvironment('{algorithm}[]',
     Let('\strut',  '\lx@algo@strut');
     AssignCatcode("\r" => CC_SPACE);    # NOT CC_EOL, so newlines don't turn to \par!
                                         #    AssignCatcode("\r" => 13);
-         #    Let(T_ACTIVE("\r"), '\relax');    # More appropriate than \par, I think?
+        #    Let(T_ACTIVE("\r"), '\relax');    # More appropriate than \par, I think?
 
     #    Let('\vtop','\relax');      # ?
     DefMacro('\;', '\ifmmode\@mathsemicolon\else\@endalgoln\fi');
@@ -122,19 +122,9 @@ DefMacro('\@endalgocfline', '\algocf@endline\@marker{EOL}\lx@algo@par');
 # So, how to we assure that we end the line ONLY ONCE!
 DefMacro('\lx@strippar{}', sub {
     my ($gullet, $tokens) = @_;
-###print STDERR "\nCHECK PAR: ".ToString($tokens)."\n";
     my @tokens = $tokens->unlist;
     #      return (@tokens,T_CS('\lx@algo@parx'));
-    return (@tokens, T_CS('\lx@algo@parx'), T_CS('\lx@algo@parx'), T_CS('\lx@algo@parx'));
-##    pop(@tokens) if T_SPACE->equals($tokens[-1]);
-##    if    (T_CS('\;')->equals($tokens[-1]))   { }
-##    elsif (T_CS('\par')->equals($tokens[-1])) { }
-##    else {
-##      #        print STDERR "\nMissing par? " . join(' ', map { Stringify($_) } @tokens) . "\n";
-##      push(@tokens, T_CS('\lx@algo@parx')); }
-##    #   print STDERR "\nSTRIP FOUND NO PAR!\n"; }
-##    @tokens;
-});
+    return (@tokens, T_CS('\lx@algo@parx'), T_CS('\lx@algo@parx'), T_CS('\lx@algo@parx')); });
 #DefMacro('\algocf@@@block{}{}','#1\bgroup\lx@algo@startline#2\lx@algo@endline\egroup');
 #DefMacro('\algocf@@@block{}{}','BLOCK:#1ENDBLOCK END#2');
 #DefMacro('\algocf@group{}','#1\bgroup\typeout{Block:#1}\egroup');

--- a/lib/LaTeXML/Package/algorithmic.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithmic.sty.ltxml
@@ -64,5 +64,9 @@ NewCounter('algorithm', undef,       idprefix => 'alg');
 NewCounter('ALC@line',  'algorithm', idprefix => 'l');     # Assuming we're inside an {algorithm}!
 DefMacro('\fnum@ALC@line', '\ALC@lno');
 
+# Hopefully this will only get used for right justifying a comment;
+# the ltx:text should autoclose at end of line?
+DefConstructor('\lx@algorithmic@hfill',
+  "<ltx:text cssstyle='float:right'>");
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;

--- a/lib/LaTeXML/Package/comment.sty.ltxml
+++ b/lib/LaTeXML/Package/comment.sty.ltxml
@@ -31,7 +31,7 @@ sub defineExcluded {
         $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
         while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
           $nlines++; }
-        NoteProgress("[Skipped $name ($nlines lines)]"); }]);
+        NoteStatus(1, "[Skipped $name ($nlines lines)]"); }]);
   return; }
 
 sub defineIncluded {

--- a/lib/LaTeXML/Package/comment.sty.ltxml
+++ b/lib/LaTeXML/Package/comment.sty.ltxml
@@ -31,7 +31,7 @@ sub defineExcluded {
         $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
         while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
           $nlines++; }
-        NoteStatus(1, "[Skipped $name ($nlines lines)]"); }]);
+        Progress("[Skipped $name ($nlines lines)]"); }]);
   return; }
 
 sub defineIncluded {

--- a/lib/LaTeXML/Package/comment.sty.ltxml
+++ b/lib/LaTeXML/Package/comment.sty.ltxml
@@ -31,7 +31,7 @@ sub defineExcluded {
         $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
         while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
           $nlines++; }
-        Progress("[Skipped $name ($nlines lines)]"); }]);
+        NoteLog("[Skipped $name ($nlines lines)]"); }]);
   return; }
 
 sub defineIncluded {

--- a/lib/LaTeXML/Package/eTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/eTeX.pool.ltxml
@@ -121,8 +121,8 @@ DefPrimitive('\showgroups', undef);
 
 # \showtokens <generaltext>
 DefPrimitive('\showtokens GeneralText', sub {
-    print STDERR "\n> " . writableTokens($_[1]) . ".\n";
-    print STDERR $_[0]->getLocator->toString() . "\n\n";
+    Message("\n> " . writableTokens($_[1]));
+    Message($_[0]->getLocator->toString());
     return; });
 
 DefRegister('\tracingassigns'    => Number(0));    # ???

--- a/lib/LaTeXML/Package/eTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/eTeX.pool.ltxml
@@ -121,8 +121,8 @@ DefPrimitive('\showgroups', undef);
 
 # \showtokens <generaltext>
 DefPrimitive('\showtokens GeneralText', sub {
-    Message("\n> " . writableTokens($_[1]));
-    Message($_[0]->getLocator->toString());
+    Note("> " . writableTokens($_[1]));
+    Note($_[0]->getLocator->toString());
     return; });
 
 DefRegister('\tracingassigns'    => Number(0));    # ???

--- a/lib/LaTeXML/Package/graphics.sty.ltxml
+++ b/lib/LaTeXML/Package/graphics.sty.ltxml
@@ -119,11 +119,6 @@ sub rotatedProperties {
   my $cheightp = Dimension($hp);
   my $cdepthp  = Dimension($dp);
   my $widthp   = ($options{smash} ? Dimension(0) : $cwidthp);
-##  print STDERR " => ".$widthp->ptValue." x ".$heightp->ptValue." + ".$depthp->ptValue." => ".$xsh.", ".$ysh."\n";
-
-## print STDERR "\nROTATE $angle of ".ToString($box)."\n"
-##  ." == ".ToString($width).' x '.ToString($height).' + '.ToString($depth)."\n"
-##  ." => ".ToString($widthp).' x '.ToString($heightp).' + '.ToString($depthp)."\n";
   return (
     angle       => $angle,
     width       => $widthp,

--- a/lib/LaTeXML/Package/html.sty.ltxml
+++ b/lib/LaTeXML/Package/html.sty.ltxml
@@ -72,7 +72,7 @@ DefConstructorI(T_CS("\\begin{rawhtml}"), undef, '', reversion => '',
       $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
       while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
         $nlines++; }
-      NoteProgress("[Skip rawhtml ($nlines lines)]"); }]);
+      NoteStatus(1, "Skip rawhtml ($nlines lines)"); }]);
 
 DefConstructorI(T_CS("\\begin{htmlonly}"), undef, '', reversion => '',
   afterDigest => [sub {
@@ -84,7 +84,7 @@ DefConstructorI(T_CS("\\begin{htmlonly}"), undef, '', reversion => '',
       $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
       while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
         $nlines++; }
-      NoteProgress("[Skip htmlonly ($nlines lines)]"); }]);
+      NoteStatus(1, "Skip htmlonly ($nlines lines)"); }]);
 
 DefMacro('\html{}', '');
 # I assume we should go ahead and try to include this material?

--- a/lib/LaTeXML/Package/html.sty.ltxml
+++ b/lib/LaTeXML/Package/html.sty.ltxml
@@ -72,7 +72,7 @@ DefConstructorI(T_CS("\\begin{rawhtml}"), undef, '', reversion => '',
       $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
       while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
         $nlines++; }
-      NoteStatus(1, "Skip rawhtml ($nlines lines)"); }]);
+      Progress("Skip rawhtml ($nlines lines)"); }]);
 
 DefConstructorI(T_CS("\\begin{htmlonly}"), undef, '', reversion => '',
   afterDigest => [sub {
@@ -84,7 +84,7 @@ DefConstructorI(T_CS("\\begin{htmlonly}"), undef, '', reversion => '',
       $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
       while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
         $nlines++; }
-      NoteStatus(1, "Skip htmlonly ($nlines lines)"); }]);
+      Progress("Skip htmlonly ($nlines lines)"); }]);
 
 DefMacro('\html{}', '');
 # I assume we should go ahead and try to include this material?

--- a/lib/LaTeXML/Package/html.sty.ltxml
+++ b/lib/LaTeXML/Package/html.sty.ltxml
@@ -72,7 +72,7 @@ DefConstructorI(T_CS("\\begin{rawhtml}"), undef, '', reversion => '',
       $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
       while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
         $nlines++; }
-      Progress("Skip rawhtml ($nlines lines)"); }]);
+      NoteLog("Skip rawhtml ($nlines lines)"); }]);
 
 DefConstructorI(T_CS("\\begin{htmlonly}"), undef, '', reversion => '',
   afterDigest => [sub {
@@ -84,7 +84,7 @@ DefConstructorI(T_CS("\\begin{htmlonly}"), undef, '', reversion => '',
       $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
       while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
         $nlines++; }
-      Progress("Skip htmlonly ($nlines lines)"); }]);
+      NoteLog("Skip htmlonly ($nlines lines)"); }]);
 
 DefMacro('\html{}', '');
 # I assume we should go ahead and try to include this material?

--- a/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
@@ -34,7 +34,7 @@ use LaTeXML::Package;
 # __END__
 #
 #======================================================================
-my $PGFKEYS_DEBUG = 0;
+DebuggableFeature('pgfkeys', 'pgfkeys processing');
 
 # Basic accessors to keys
 sub pgfkeyCS {
@@ -274,18 +274,18 @@ sub pgfAssignKey {
       # \pgfkeys@cur@is@descendant@of@errors
       my $check = ($key =~ m|^/errors|);
       SetCondition(T_CS('\ifpgfkeysfiltercontinue'), $check);
-      print STDERR "[SPECIAL CHECK] '$key' is descendant of '/errors': " . ($check ? 'TRUE' : 'FALSE') . ".\n" if $PGFKEYS_DEBUG;
+      Debug("[SPECIAL CHECK] '$key' is descendant of '/errors': " . ($check ? 'TRUE' : 'FALSE')) if $LaTeXML::DEBUG{pgfkeys};
       if (IfCondition(T_CS('\ifpgfkeysfiltercontinue'))) {
         $filtered = 0; } }
     if ($filtered) { SetCondition(T_CS('\ifpgfkeysfiltercontinue'), 1); }
     if (pgfkeyLookup($cmdkey = $key . '/.@cmd')) {                          # Case 1
       return if $filtered && testFilterPredicate($stomach, $key, 1);
-      print STDERR "PROCESSING KEY $key (" . ($filtered ? 'filtered ' : '') . "case 1)\n" if $PGFKEYS_DEBUG;
+      Debug("PROCESSING KEY $key (" . ($filtered ? 'filtered ' : '') . "case 1)") if $LaTeXML::DEBUG{pgfkeys};
       pgfHandleValue($stomach, $cmdkey); }
     # Case 2: a normal value assignment.
     elsif (my $cs = pgfkeyLookup($key)) {
       return if $filtered && testFilterPredicate($stomach, $key, 2);
-      print STDERR "PROCESSING KEY $key (" . ($filtered ? 'filtered ' : '') . "case 2)\n" if $PGFKEYS_DEBUG;
+      Debug("PROCESSING KEY $key (" . ($filtered ? 'filtered ' : '') . "case 2)") if $LaTeXML::DEBUG{pgfkeys};
       # Case 2: "extern"
       if (XEquals(T_CS('\pgfkeyscurrentvalue'), T_CS('\pgfkeysnovalue@text'))) {    # value empty?
         $stomach->digest(pgfkeyCS($key)); }    # Just execute the STORED value!
@@ -304,28 +304,28 @@ sub pgfAssignKey {
             T_CS('\pgfkeys@ifexecutehandler@handlefullorexisting'))
           ? 'full'
           : 'all'));
-      print STDERR "PGF ASSIGN " . ToString($key) . " restricted=" . ($restricted ? 'true' : 'false')
-        . ", handle=$handle\n"
-        if $PGFKEYS_DEBUG && ($restricted || ($handle ne 'all'));
+      Debug("PGF ASSIGN " . ToString($key) . " restricted=" . ($restricted ? 'true' : 'false')
+          . ", handle=$handle")
+        if $LaTeXML::DEBUG{pgfkeys} && ($restricted || ($handle ne 'all'));
       if (pgfkeyLookup($cmdkey = '/handlers/' . $name . '/.@cmd')    # a command bound?
         && (!$restricted || ($handle eq 'all')
           || (($handle eq 'full') && !IfCondition(T_CS('\ifpgfkeysaddeddefaultpath')))
           || LookupDefinition(T_CS('\pgfkey@excpt@' . $name))
           || pgfkeyLookup($path) || pgfkeyLookup($path . '/.@cmd'))) {
         return if $filtered && testFilterPredicate($stomach, $key, 3);
-        print STDERR "PROCESSING KEY $key (" . ($filtered ? 'filtered ' : '') . "case 3)\n" if $PGFKEYS_DEBUG;
+        Debug("PROCESSING KEY $key (" . ($filtered ? 'filtered ' : '') . "case 3)") if $LaTeXML::DEBUG{pgfkeys};
         pgfHandleValue($stomach, $cmdkey); }
       else {                                                         # Handle unknown
         if ($restricted) {
           ($path, $name) = pgfReSplitPath($key);
-          print STDERR "RESPLIT '$key' => '$path' / '$name'\n" if $PGFKEYS_DEBUG; }
+          Debug("RESPLIT '$key' => '$path' / '$name'") if $LaTeXML::DEBUG{pgfkeys}; }
         return if $filtered && testFilterPredicate($stomach, $key, 0);
         # Else various handlers for unknown
         if (pgfkeyLookup($cmdkey = $path . '/.unknown/.@cmd')) {
-          print STDERR "PROCESSING KEY $key (case 0) for $cmdkey\n" if $PGFKEYS_DEBUG;
+          Debug("PROCESSING KEY $key (case 0) for $cmdkey") if $LaTeXML::DEBUG{pgfkeys};
           pgfHandleValue($stomach, $cmdkey); }
         elsif ($cmdkey = '/handlers/.unknown/.@cmd') {
-          print STDERR "PROCESSING KEY $key (case 0) for $cmdkey\n" if $PGFKEYS_DEBUG;
+          Debug("PROCESSING KEY $key (case 0) for $cmdkey") if $LaTeXML::DEBUG{pgfkeys};
           pgfHandleValue($stomach, $cmdkey); } }
   } }
   return; }
@@ -335,7 +335,7 @@ sub testFilterPredicate {
   DefMacroI('\pgfkeyscasenumber', undef, $case);
   $stomach->digest(T_CS('\pgfkeys@key@predicate'));
   if (!IfCondition(T_CS('\ifpgfkeysfiltercontinue'))) {
-    print STDERR "FILTERED OUT KEY $key (case $case)\n" if $PGFKEYS_DEBUG;
+    Debug("FILTERED OUT KEY $key (case $case)") if $LaTeXML::DEBUG{pgfkeys};
     $stomach->digest(T_CS('\pgfkeys@filtered@handler'));
     return 1; }
   return; }

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -83,7 +83,7 @@ sub pgfmathresult {
 DefMacro('\@@@show@mathresult{}', sub {
     my ($gulet, $result) = @_;
     $result = ToString(Expand($result));
-    print STDERR "RESULT $result\n";
+    Debug("RESULT $result");
     return; });
 
 #======================================================================
@@ -91,7 +91,7 @@ DefMacro('\@@@show@mathresult{}', sub {
 DefMacro('\@@@show@pgfmatharg@{}', sub {
     my ($gullet, $arg) = @_;
     $arg = ToString(Expand($arg));
-    print STDERR "MATH ARG $arg\n";
+    Debug("MATH ARG $arg");
     return; });
 
 # A plain argument that is expanded in the parameter type definition,
@@ -260,7 +260,7 @@ DefMacro('\@@@test@mathresult{}{}{}', sub {
         "PGF: '$pgfresult'",
         "LTX: '$lxresult'"); }
     else {
-      print STDERR "PGFParse OK '$input' => '$pgfresult' or '$lxresult'\n"; }
+      Debug("PGFParse OK '$input' => '$pgfresult' or '$lxresult'"); }
     return; });
 
 DefMacro('\pgfmath@smuggleone Until:\endgroup', sub {
@@ -322,14 +322,11 @@ sub pgfmathparse {
     $result         = $PGFMATHGrammar->expr(\$string); }
 
   $result = $result || 0.0;
-  #  $result = "0.0" if $result eq "0";
-  #    print STDERR "  GOT " . (defined $result ? $result : '<fail>') . "\n";
   if ($string) {
     Error('pgfparse', 'pgfparse', $gullet,
       "Parse of '$input' failed",
       "LTX: '$result'",
       "Left: $string"); }
-  #     print STDERR "  REMAINDER: $string\n" if $string;
   # There seem to be some pesky expectations for the results
   if ($result == 0.0) {
     $result = "0."; }

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -75,9 +75,6 @@ sub pgfmathfactorial {
 sub pgfmathresult {
   my ($value) = @_;
   $value = sprintf("%06f", $value);
-  #print STDERR "ASSIGNING result as $value\n";
-  #  my @v = ExplodeText($value);
-  #print STDERR " that is ".join(' ',map { Stringify($_) } @v)."\n";
   return Tokens(T_CS('\def'), T_CS('\pgfmathresult'), T_BEGIN, ExplodeText($value), T_END); }
 
 DefMacro('\@@@show@mathresult{}', sub {
@@ -335,7 +332,6 @@ sub pgfmathparse {
     $result = int($result) . '.'; }
   else {    # We don't want scientific notation output!!!
     $result = sprintf("%f", $result); }
-###  print STDERR "PGFPARSE: '$input' => '$result'\n" unless LookupValue('inPreamble');
   return $result; }
 
 DefMacro('\lx@pgfmath@parseX{}', sub {

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -532,8 +532,8 @@ sub collapseSVGGroup {
         $node->setAttribute($key => $av{$key}); }
       $nmerged++;
       $document->unwrapNodes($c); } }
-###  Debug("COLLAPSE empty=$nempty, redundant=$nredundant, merged=$nmerged, popped=$npopped, pushed=$npushed")
-###    if ($nempty || $nredundant || $nmerged || $npopped || $npushed);
+##  Debug("COLLAPSE empty=$nempty, redundant=$nredundant, merged=$nmerged, popped=$npopped, pushed=$npushed")
+##    if ($nempty || $nredundant || $nmerged || $npopped || $npushed);
   return; }
 
 #=====================================================================

--- a/lib/LaTeXML/Package/pgfutil-common.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfutil-common.tex.ltxml
@@ -33,7 +33,6 @@ DefConditional('\ifpgfutil@in@', sub {
     my $element = $$args[0];
     my $list    = $$args[1];
     my $test    = (index($list, $element) != -1);
-    # print STDERR "-- Is $element in $list ? Answer: $test\n";
     return $test; });
 
 1;

--- a/lib/LaTeXML/Package/siunitx.sty.ltxml
+++ b/lib/LaTeXML/Package/siunitx.sty.ltxml
@@ -1409,7 +1409,6 @@ DefPrimitive('\lx@si@column@end', '');
 
 DefMacro('\lx@SI@column@parse XUntil:\lx@si@column@end', sub {
     my ($gullet, $number) = @_;
-###print STDERR "COLUMN S [".ToString($kv)."] : ".ToString($number)."\n";
     my @tokens  = $number->unlist;
     my $doparse = six_getBool('parse-numbers');
     # Deal with recognizing "surrounding material"
@@ -1450,8 +1449,6 @@ DefMacro('\lx@SI@column@parse XUntil:\lx@si@column@end', sub {
 # similar to \si
 DefMacro('\lx@si@column@parse XUntil:\lx@si@column@end', sub {
     my ($gullet, $units) = @_;
-    #print STDERR "ATTEMPT ".Stringify($units)."\n";
-
     my @tokens = $units->unlist;
     my @pre    = ();
     my @post   = ();
@@ -1475,7 +1472,6 @@ DefMacro('\lx@si@column@parse XUntil:\lx@si@column@end', sub {
 ##      Info('unexpected', 'whatever', undef,
 ##           "Don't yet know how to parse non-macro unit expressions");
       $result = Tokens(@tokens); }
-    #print STDERR "==> ".Stringify($result)."\n";
     if ($color) {
       unshift(@pre, T_BEGIN, T_CS('\color'), T_BEGIN, $color, T_END);    # outside!!!
       push(@post, T_END); }

--- a/lib/LaTeXML/Package/slides.cls.ltxml
+++ b/lib/LaTeXML/Package/slides.cls.ltxml
@@ -81,7 +81,7 @@ DefPrimitiveI('\visible',   undef, undef, font => { opacity => 1 });    # ?
 
 DefPrimitive('\showfont', sub {
     my $font = LookupValue('font');
-    print STDERR "\nFONT IS: " . Stringify($font) . "\n";
+    Message("\nFONT IS: " . Stringify($font));
     return; });
 
 RequirePackage('color');           # ?

--- a/lib/LaTeXML/Package/slides.cls.ltxml
+++ b/lib/LaTeXML/Package/slides.cls.ltxml
@@ -81,7 +81,7 @@ DefPrimitiveI('\visible',   undef, undef, font => { opacity => 1 });    # ?
 
 DefPrimitive('\showfont', sub {
     my $font = LookupValue('font');
-    Message("\nFONT IS: " . Stringify($font));
+    Note("FONT IS: " . Stringify($font));
     return; });
 
 RequirePackage('color');           # ?

--- a/lib/LaTeXML/Package/tikz.sty.ltxml
+++ b/lib/LaTeXML/Package/tikz.sty.ltxml
@@ -33,7 +33,7 @@ DefPrimitive('\use@@tikzlibrary{}', sub {
     foreach my $lib (split(/,/, $libs = ToString(Expand($libs)))) {
       $lib =~ s/^\s+//; $lib =~ s/\s+$//;
       if ($lib && !LookupDefinition(T_CS('\tikz@library@' . $lib . '@loaded'))) {
-        print STDERR "\nTIKZ LIBRARY $lib\n";
+        Message("\nTIKZ LIBRARY $lib");
         Let(T_CS('\tikz@library@' . $lib . '@loaded'), T_CS('\pgfutil@empty'));
         my $barcc = LookupCatcode('|');
         AssignCatcode('|', CC_OTHER);

--- a/lib/LaTeXML/Package/tikz.sty.ltxml
+++ b/lib/LaTeXML/Package/tikz.sty.ltxml
@@ -33,7 +33,7 @@ DefPrimitive('\use@@tikzlibrary{}', sub {
     foreach my $lib (split(/,/, $libs = ToString(Expand($libs)))) {
       $lib =~ s/^\s+//; $lib =~ s/\s+$//;
       if ($lib && !LookupDefinition(T_CS('\tikz@library@' . $lib . '@loaded'))) {
-        Message("\nTIKZ LIBRARY $lib");
+        NoteLog("TIKZ LIBRARY $lib");
         Let(T_CS('\tikz@library@' . $lib . '@loaded'), T_CS('\pgfutil@empty'));
         my $barcc = LookupCatcode('|');
         AssignCatcode('|', CC_OTHER);

--- a/lib/LaTeXML/Package/utf8.def.ltxml
+++ b/lib/LaTeXML/Package/utf8.def.ltxml
@@ -380,7 +380,7 @@ for my $row (@PRECOMPUTED_UC_LC) {
 #     my $lower_code = ord($lower);
 #     my $upper_hex = sprintf("00%X", $upper_code);
 #     my $lower_hex = sprintf("00%X", $lower_code);
-#     print STDERR "[\"\\x{$upper_hex}\", $upper_code, \"\\x{$lower_hex}\", $lower_code],\n";
+#     print "[\"\\x{$upper_hex}\", $upper_code, \"\\x{$lower_hex}\", $lower_code],\n";
 #  } }
 #
 #**********************************************************************

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -48,7 +48,7 @@ sub ProcessChain_internal {
   local $LaTeXML::Post::DOCUMENT = $doc;
 
   my @docs = ($doc);
-  NoteBegin("post-processing");
+  ProgressSpinup("post-processing");
 
   foreach my $processor (@postprocessors) {
     local $LaTeXML::Post::PROCESSOR = $processor;
@@ -60,13 +60,13 @@ sub ProcessChain_internal {
         my $msg = join(' ', $processor->getName || '',
           $doc->siteRelativeDestination || '',
           ($n > 1 ? "$n to process" : 'processing'));
-        NoteBegin($msg);
+        ProgressSpinup($msg);
         push(@newdocs, $processor->process($doc, @nodes));
-        NoteEnd($msg); }
+        ProgressSpindown($msg); }
       else {
         push(@newdocs, $doc); } }
     @docs = @newdocs; }
-  NoteEnd("post-processing");
+  ProgressSpindown("post-processing");
   return @docs; }
 
 ## HACK!!!
@@ -319,7 +319,7 @@ sub process {
       # Now do cross referencing
       $proc1->addCrossrefs($doc, $proc2);
       $proc2->addCrossrefs($doc, $proc1); } }
-  NoteStatus(2, "converted $n Maths");
+  ProgressDetailed("converted $n Maths");
   return $doc; }
 
 # Make THIS MathProcessor the primary branch (of whatever parallel markup it supports),

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -319,7 +319,7 @@ sub process {
       # Now do cross referencing
       $proc1->addCrossrefs($doc, $proc2);
       $proc2->addCrossrefs($doc, $proc1); } }
-  NoteProgressDetailed(" [converted $n Maths]");
+  NoteStatus(2, "converted $n Maths");
   return $doc; }
 
 # Make THIS MathProcessor the primary branch (of whatever parallel markup it supports),

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -914,6 +914,10 @@ sub stringify {
   my ($self) = @_;
   return 'Post::Document[' . $self->siteRelativeDestination . ']'; }
 
+sub getLocator {
+  my ($self) = @_;
+  return $$self{source}; }
+
 #======================================================================
 sub validate {
   my ($self) = @_;

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -27,11 +27,9 @@ sub new {
   my ($class, %options) = @_;
   my $self = bless { status => {}, %options }, $class;
   # TEMPORARY HACK!!!!
-  # Create a State object, essentially only to hold verbosity (for now)
-  # so that Errors can be reported, managed and recorded
-  # Eventually will be a "real" State (or other configuration object)
+  # Create a State object, for config & recursive conversions;
+  # Eventually should be managed higher up.
   $$self{state} = LaTeXML::Core::State->new();
-  SetVerbosity($$self{verbosity} // 0);
   return $self; }
 
 #======================================================================
@@ -156,7 +154,6 @@ use base qw(LaTeXML::Common::Object);
 sub new {
   my ($class, %options) = @_;
   my $self = bless {%options}, $class;
-  $$self{verbosity}          = 0 unless defined $$self{verbosity};
   $$self{resource_directory} = $options{resource_directory};
   $$self{resource_prefix}    = $options{resource_prefix};
   my $name = $class; $name =~ s/^LaTeXML::Post:://;

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -26,13 +26,12 @@ our @EXPORT = (@LaTeXML::Common::Error::EXPORT);
 sub new {
   my ($class, %options) = @_;
   my $self = bless { status => {}, %options }, $class;
-  $$self{verbosity} = 0 unless defined $$self{verbosity};
   # TEMPORARY HACK!!!!
   # Create a State object, essentially only to hold verbosity (for now)
   # so that Errors can be reported, managed and recorded
   # Eventually will be a "real" State (or other configuration object)
   $$self{state} = LaTeXML::Core::State->new();
-  $$self{state}->assignValue(VERBOSITY => $$self{verbosity});
+  SetVerbosity($$self{verbosity} // 0);
   return $self; }
 
 #======================================================================

--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -318,7 +318,7 @@ sub process {
       # Now do cross referencing
       $proc1->addCrossrefs($doc, $proc2);
       $proc2->addCrossrefs($doc, $proc1); } }
-  ProgressDetailed("converted $n Maths");
+  NoteLog("converted $n Maths");
   return $doc; }
 
 # Make THIS MathProcessor the primary branch (of whatever parallel markup it supports),
@@ -412,7 +412,7 @@ sub convertNode {
 # Maybe the caller of this should check the namespaces, and call wrapper if needed?
 sub combineParallel {
   my ($self, $doc, $xmath, $primary, @secondaries) = @_;
-  LaTeXML::Post::Error('misdefined', (ref $self), undef,
+  Error('misdefined', (ref $self), undef,
     "Abstract package: combining parallel markup has not been defined for this MathProcessor",
     "dropping the extra markup from: " . join(',', map { $$_{processor} } @secondaries));
   return $primary; }
@@ -928,12 +928,12 @@ sub validate {
       $schema = $2; } }
   if ($schema) {    # Validate using rng
     my $rng = LaTeXML::Common::XML::RelaxNG->new($schema, searchpaths => [$self->getSearchPaths]);
-    LaTeXML::Post::Error('I/O', $schema, undef, "Failed to load RelaxNG schema $schema" . "Response was: $@")
+    Error('I/O', $schema, undef, "Failed to load RelaxNG schema $schema" . "Response was: $@")
       unless $rng;
     my $v = eval {
       local $LaTeXML::IGNORE_ERRORS = 1;
       $rng->validate($$self{document}); };
-    LaTeXML::Post::Error("malformed", 'document', undef,
+    Error("malformed", 'document', undef,
       "Document fails RelaxNG validation (" . $schema . ")",
       "Validation reports: " . $@,
       "(Jing may provide a more precise report; https://relaxng.org/jclark/jing.html)")
@@ -941,18 +941,18 @@ sub validate {
   elsif (my $decldtd = $$self{document}->internalSubset) {    # Else look for DTD Declaration
     my $dtd = XML::LibXML::Dtd->new($decldtd->publicId, $decldtd->systemId);
     if (!$dtd) {
-      LaTeXML::Post::Error("I/O", $decldtd->publicId, undef,
+      Error("I/O", $decldtd->publicId, undef,
         "Failed to load DTD " . $decldtd->publicId . " at " . $decldtd->systemId,
         "skipping validation"); }
     else {
       my $v = eval {
         local $LaTeXML::IGNORE_ERRORS = 1;
         $$self{document}->validate($dtd); };
-      LaTeXML::Post::Error("malformed", 'document', undef,
+      Error("malformed", 'document', undef,
         "Document failed DTD validation (" . $decldtd->systemId . ")",
         "Validation reports: " . $@) if $@ || !defined $v; } }
   else {    # Nothing found to validate with
-    LaTeXML::Post::Warn("expected", 'schema', undef,
+    Warn("expected", 'schema', undef,
       "No Schema or DTD found for this document"); }
   return; }
 
@@ -967,11 +967,11 @@ sub idcheck {
     $idcache{$id} = 1; }
   foreach my $id (keys %{ $$self{idcache} }) {
     $missing{$id} = 1 unless $idcache{$id}; }
-  LaTeXML::Post::Warn("unexpected", 'ids', undef,
+  Warn("unexpected", 'ids', undef,
     "IDs were duplicated in cache for " . $self->siteRelativeDestination,
     join(',', keys %dups))
     if keys %dups;
-  LaTeXML::Post::Warn("expected", 'ids', undef, "IDs were cached for " . $self->siteRelativeDestination
+  Warn("expected", 'ids', undef, "IDs were cached for " . $self->siteRelativeDestination
       . " but not in document",
     join(',', keys %missing))
     if keys %missing;
@@ -1061,7 +1061,7 @@ sub addNodes {
       else {
         my ($prefix, $localname) = $tag =~ /^(.*):(.*)$/;
         my $nsuri = $prefix && $$self{namespaces}{$prefix};
-        LaTeXML::Post::Warn('expected', 'namespace', undef, "No namespace on '$tag'") unless $nsuri;
+        Warn('expected', 'namespace', undef, "No namespace on '$tag'") unless $nsuri;
         my $new;
         if (ref $node eq 'LibXML::XML::Document') {
           $new = $node->createElementNS($nsuri, $localname);
@@ -1128,7 +1128,7 @@ sub addNodes {
         $node->appendTextNode($child->textContent); }
     }
     elsif (ref $child) {
-      LaTeXML::Post::Warn('misdefined', $child, undef, "Dont know how to add $child to $node; ignoring"); }
+      Warn('misdefined', $child, undef, "Dont know how to add $child to $node; ignoring"); }
     elsif (defined $child) {
       $node->appendTextNode($child); } }
   return; }

--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use LaTeXML::Util::Pathname;
 use LaTeXML::Common::XML;
+use LaTeXML::Common::Error;
 use charnames qw(:full);
 use LaTeXML::Post;
 use base qw(LaTeXML::Post::Processor);
@@ -233,7 +234,7 @@ sub fill_in_tocs {
       $lists = { toc => 1 };
       @list  = $self->gentoc_context($doc, $id, $show, $lists, $types); }
     $doc->addNodes($toc, ['ltx:toclist', {}, @list]) if @list; }
-  NoteProgressDetailed(" [Filled in $n TOCs]");
+  NoteStatus(2, "Filled in $n TOCs");
   return; }
 
 # generate TOC for $id & its children,
@@ -318,7 +319,7 @@ sub fill_in_frags {
       if (my $fragid = $entry->getValue('fragid')) {
         $n++;
         $node->parentNode->setAttribute(fragid => $fragid); } } }
-  NoteProgressDetailed(" [Filled in fragment $n ids]");
+  NoteStatus(2, "Filled in fragment $n ids");
   return; }
 
 # Fill in content text for any <... @idref..>'s or @labelref
@@ -360,7 +361,7 @@ sub fill_in_refs {
       if (my $entry = $$self{db}->lookup("ID:$id")) {
         $ref->setAttribute(stub => 1) if $entry->getValue('stub'); }
   } }
-  NoteProgressDetailed(" [Filled in $n refs]");
+  NoteStatus(2, "Filled in $n refs");
   return; }
 
 # similar sorta thing for RDF about & resource labels & ids
@@ -389,7 +390,7 @@ sub fill_in_RDFa_refs {
             $ref->setAttribute($key => '#' . $id); } }
   } } }
   set_RDFa_prefixes($doc->getDocument, {});    # what prefixes??
-  NoteProgressDetailed(" [Filled in $n RDFa refs]");
+  NoteStatus(2, "Filled in $n RDFa refs");
   return; }
 
 sub fill_in_mathlinks {
@@ -419,7 +420,7 @@ sub fill_in_mathlinks {
         if (my $tag = $entry->getValue('tag:short') || $entry->getValue('description')) {
           $sym->setAttribute(title => getTextContent($doc, $tag)); }
   } } }
-  NoteProgressDetailed(" [Filled in $n math links]");
+  NoteStatus(2, "Filled in $n math links");
   return; }
 
 # Given a declaration entry (ltx:declare, or ltx:mark or ...)
@@ -453,7 +454,7 @@ sub fill_in_bibrefs {
   foreach my $bibref ($doc->findnodes('descendant::ltx:bibref')) {
     $n++;
     $doc->replaceNode($bibref, $self->make_bibcite($doc, $bibref)); }
-  NoteProgressDetailed(" [Filled in $n bibrefs]");
+  NoteStatus(2, "Filled in $n bibrefs");
   return; }
 
 # Given a list of bibkeys, construct links to them.
@@ -593,7 +594,7 @@ sub make_bibcite {
             push(@r, $yysep, ' ', ['ltx:ref', $$next{attr}, @{ $$next{number} }]); }
           push(@stuff, ['ltx:sup', {}, @r]); }
         else {
-          print STDERR "CITE ignoring show key '$role'\n"; } }
+          Info('unexpected', $role, $doc, "CITE ignoring show key '$role'"); } }
       elsif ($show =~ s/^\{([^\}]*)\}//) {    # pass-thru literal, quoted with {}
         push(@stuff, $1) if $1; }
       elsif ($show =~ s/^~//) {               # Pass-thru spaces
@@ -863,7 +864,7 @@ sub fillInGlossaryRef {
     if (!$ref->textContent && !element_nodes($ref)) {
       $doc->addNodes($ref, $key);
       $doc->addClass($ref, 'ltx_missing'); } }
-  NoteProgressDetailed(" [Filled in $n glossaryrefs]");
+  NoteStatus(2, "Filled in $n glossaryrefs");
   return; }
 
 sub generateGlossaryRefTitle {

--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -234,7 +234,7 @@ sub fill_in_tocs {
       $lists = { toc => 1 };
       @list  = $self->gentoc_context($doc, $id, $show, $lists, $types); }
     $doc->addNodes($toc, ['ltx:toclist', {}, @list]) if @list; }
-  NoteStatus(2, "Filled in $n TOCs");
+  ProgressDetailed("Filled in $n TOCs");
   return; }
 
 # generate TOC for $id & its children,
@@ -319,7 +319,7 @@ sub fill_in_frags {
       if (my $fragid = $entry->getValue('fragid')) {
         $n++;
         $node->parentNode->setAttribute(fragid => $fragid); } } }
-  NoteStatus(2, "Filled in fragment $n ids");
+  ProgressDetailed("Filled in fragment $n ids");
   return; }
 
 # Fill in content text for any <... @idref..>'s or @labelref
@@ -361,7 +361,7 @@ sub fill_in_refs {
       if (my $entry = $$self{db}->lookup("ID:$id")) {
         $ref->setAttribute(stub => 1) if $entry->getValue('stub'); }
   } }
-  NoteStatus(2, "Filled in $n refs");
+  ProgressDetailed("Filled in $n refs");
   return; }
 
 # similar sorta thing for RDF about & resource labels & ids
@@ -390,7 +390,7 @@ sub fill_in_RDFa_refs {
             $ref->setAttribute($key => '#' . $id); } }
   } } }
   set_RDFa_prefixes($doc->getDocument, {});    # what prefixes??
-  NoteStatus(2, "Filled in $n RDFa refs");
+  ProgressDetailed("Filled in $n RDFa refs");
   return; }
 
 sub fill_in_mathlinks {
@@ -420,7 +420,7 @@ sub fill_in_mathlinks {
         if (my $tag = $entry->getValue('tag:short') || $entry->getValue('description')) {
           $sym->setAttribute(title => getTextContent($doc, $tag)); }
   } } }
-  NoteStatus(2, "Filled in $n math links");
+  ProgressDetailed("Filled in $n math links");
   return; }
 
 # Given a declaration entry (ltx:declare, or ltx:mark or ...)
@@ -454,7 +454,7 @@ sub fill_in_bibrefs {
   foreach my $bibref ($doc->findnodes('descendant::ltx:bibref')) {
     $n++;
     $doc->replaceNode($bibref, $self->make_bibcite($doc, $bibref)); }
-  NoteStatus(2, "Filled in $n bibrefs");
+  ProgressDetailed("Filled in $n bibrefs");
   return; }
 
 # Given a list of bibkeys, construct links to them.
@@ -864,7 +864,7 @@ sub fillInGlossaryRef {
     if (!$ref->textContent && !element_nodes($ref)) {
       $doc->addNodes($ref, $key);
       $doc->addClass($ref, 'ltx_missing'); } }
-  NoteStatus(2, "Filled in $n glossaryrefs");
+  ProgressDetailed("Filled in $n glossaryrefs");
   return; }
 
 sub generateGlossaryRefTitle {

--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -64,10 +64,8 @@ sub process {
       foreach my $type (sort keys %{ $LaTeXML::Post::CrossRef::MISSING{$severity} }) {
         my @items = keys %{ $LaTeXML::Post::CrossRef::MISSING{$severity}{$type} };
         $tempid ||= grep { $_ eq 'TEMPORARY_DOCUMENT_ID' } @items;
-        push(@msgs, $type . ": " . join(', ', @items)); }
-      if (@msgs) {
         my @args = ('expected', 'ids', undef,
-          "Missing items:\n  " . join(";\n  ", @msgs),
+          "Missing $type: " . join(',', @items),
           ($tempid ? "[Note TEMPORARY_DOCUMENT_ID is a stand-in ID for the main document.]" : ()));
         if    ($severity eq 'error') { Error(@args); }
         elsif ($severity eq 'warn')  { Warn(@args); }
@@ -234,7 +232,7 @@ sub fill_in_tocs {
       $lists = { toc => 1 };
       @list  = $self->gentoc_context($doc, $id, $show, $lists, $types); }
     $doc->addNodes($toc, ['ltx:toclist', {}, @list]) if @list; }
-  ProgressDetailed("Filled in $n TOCs");
+  Debug("Filled in $n TOCs") if $LaTeXML::DEBUG{crossref};
   return; }
 
 # generate TOC for $id & its children,
@@ -319,7 +317,7 @@ sub fill_in_frags {
       if (my $fragid = $entry->getValue('fragid')) {
         $n++;
         $node->parentNode->setAttribute(fragid => $fragid); } } }
-  ProgressDetailed("Filled in fragment $n ids");
+  Debug("Filled in fragment $n ids") if $LaTeXML::DEBUG{crossref};
   return; }
 
 # Fill in content text for any <... @idref..>'s or @labelref
@@ -361,7 +359,7 @@ sub fill_in_refs {
       if (my $entry = $$self{db}->lookup("ID:$id")) {
         $ref->setAttribute(stub => 1) if $entry->getValue('stub'); }
   } }
-  ProgressDetailed("Filled in $n refs");
+  Debug("Filled in $n refs") if $LaTeXML::DEBUG{crossref};
   return; }
 
 # similar sorta thing for RDF about & resource labels & ids
@@ -390,7 +388,7 @@ sub fill_in_RDFa_refs {
             $ref->setAttribute($key => '#' . $id); } }
   } } }
   set_RDFa_prefixes($doc->getDocument, {});    # what prefixes??
-  ProgressDetailed("Filled in $n RDFa refs");
+  Debug("Filled in $n RDFa refs") if $LaTeXML::DEBUG{crossref};
   return; }
 
 sub fill_in_mathlinks {
@@ -420,7 +418,7 @@ sub fill_in_mathlinks {
         if (my $tag = $entry->getValue('tag:short') || $entry->getValue('description')) {
           $sym->setAttribute(title => getTextContent($doc, $tag)); }
   } } }
-  ProgressDetailed("Filled in $n math links");
+  Debug("Filled in $n math links") if $LaTeXML::DEBUG{crossref};
   return; }
 
 # Given a declaration entry (ltx:declare, or ltx:mark or ...)
@@ -454,7 +452,7 @@ sub fill_in_bibrefs {
   foreach my $bibref ($doc->findnodes('descendant::ltx:bibref')) {
     $n++;
     $doc->replaceNode($bibref, $self->make_bibcite($doc, $bibref)); }
-  ProgressDetailed("Filled in $n bibrefs");
+  Debug("Filled in $n bibrefs") if $LaTeXML::DEBUG{crossref};
   return; }
 
 # Given a list of bibkeys, construct links to them.
@@ -864,7 +862,7 @@ sub fillInGlossaryRef {
     if (!$ref->textContent && !element_nodes($ref)) {
       $doc->addNodes($ref, $key);
       $doc->addClass($ref, 'ltx_missing'); } }
-  ProgressDetailed("Filled in $n glossaryrefs");
+  Debug("Filled in $n glossaryrefs") if $LaTeXML::DEBUG{crossref};
   return; }
 
 sub generateGlossaryRefTitle {

--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -89,8 +89,8 @@ sub process {
   my ($self, $doc, @nodes) = @_;
   local $LaTeXML::Post::Graphics::SEARCHPATHS
     = [map { pathname_canonical($_) } $self->findGraphicsPaths($doc), $doc->getSearchPaths];
-  ProgressDetailed(" [Using graphicspaths: "
-      . join(', ', @$LaTeXML::Post::Graphics::SEARCHPATHS) . "]");
+  Debug(" [Using graphicspaths: "
+      . join(', ', @$LaTeXML::Post::Graphics::SEARCHPATHS) . "]") if $LaTeXML::DEBUG{images};
   foreach my $node (@nodes) {
     $self->processGraphic($doc, $node); }
   $doc->closeCache;    # If opened.
@@ -200,7 +200,7 @@ sub transformGraphic {
   my $type = $properties{destination_type} || $srctype;
   my $key  = (ref $self) . ':' . join('|', "$reldir$name.$srctype.$type",
     map { join(' ', @$_) } @$transform);
-  Progress("Processing $source as key=$key");
+  Debug("Processing $source as key=$key") if $LaTeXML::DEBUG{images};
 
   my $dest = $self->desiredResourcePathname($doc, $node, $source, $type);
   if (my $prev = $doc->cacheLookup($key)) {                 # Image was processed on previous run?
@@ -212,7 +212,8 @@ sub transformGraphic {
       if ((!defined $dest) || ($cached eq $dest)) {
         my $absdest = pathname_absolute($cached, $doc->getDestinationDirectory);
         if (pathname_timestamp($source) <= pathname_timestamp($absdest)) {
-          ProgressDetailed(" [Reuse $cached @ " . ($width || '?') . " x " . ($height || '?') . "]");
+          Debug(" [Reuse $cached @ " . ($width || '?') . " x " . ($height || '?') . "]")
+            if $LaTeXML::DEBUG{images};
           return ($cached, $width, $height); } } } }
   # Trivial scaling case: Use original image with (at most) different width & height.
   my $triv_scaling = $$self{trivial_scaling} && ($type eq $srctype)
@@ -254,7 +255,7 @@ sub transformGraphic {
       $dest    = $self->generateResourcePathname($doc, $node, $source, $type);
       $absdest = $doc->checkDestination($dest); }
 
-    ProgressDetailed(" [Destination $absdest]");
+    Debug(" [Destination $absdest]") if $LaTeXML::DEBUG{images};
     ($width, $height) = image_graphicx_trivial($source, $transform, ddpt => $$self{ddpt});
     if (!($width && $height)) {
       if (!image_can_image()) {
@@ -267,23 +268,24 @@ sub transformGraphic {
           "Couldn't get usable image size for $source"); } }
     pathname_copy($source, $absdest)
       or Warn('I/O', $absdest, undef, "Couldn't copy $source to $absdest", "Response was: $!");
-    ProgressDetailed(" [Copied to $dest @ " . ($width || '?') . " x " . ($height || '?') . "]"); }
+    Debug(" [Copied to $dest @ " . ($width || '?') . " x " . ($height || '?') . "]")
+      if $LaTeXML::DEBUG{images}; }
   else {
     # With a complex transformation, we really needs a new name (well, don't we?)
     $dest = $self->generateResourcePathname($doc, $node, $source, $type) unless $dest;
     my $absdest = $doc->checkDestination($dest);
-    ProgressDetailed(" [Destination $absdest]");
+    Debug(" [Destination $absdest]") if $LaTeXML::DEBUG{images};
     ($image, $width, $height) = image_graphicx_complex($source, $transform,
       ddpt => $$self{ddpt}, background => $$self{background}, %properties);
     if (!($image && $width && $height)) {
       Warn('expected', 'image', undef,
         "Couldn't get usable image for $source");
       return; }
-    ProgressDetailed(" [Writing to $absdest]");
+    Debug(" [Writing to $absdest]") if $LaTeXML::DEBUG{images};
     image_write($image, $absdest) or return; }
 
   $doc->cacheStore($key, "$dest|" . ($width || '') . '|' . ($height || ''));
-  ProgressDetailed(" [done with $key]");
+  Debug(" [done with $key]") if $LaTeXML::DEBUG{images};
   return ($dest, $width, $height); }
 
 #======================================================================

--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -89,7 +89,7 @@ sub process {
   my ($self, $doc, @nodes) = @_;
   local $LaTeXML::Post::Graphics::SEARCHPATHS
     = [map { pathname_canonical($_) } $self->findGraphicsPaths($doc), $doc->getSearchPaths];
-  NoteProgressDetailed(" [Using graphicspaths: "
+  NoteStatus(2, " [Using graphicspaths: "
       . join(', ', @$LaTeXML::Post::Graphics::SEARCHPATHS) . "]");
   foreach my $node (@nodes) {
     $self->processGraphic($doc, $node); }
@@ -200,7 +200,7 @@ sub transformGraphic {
   my $type = $properties{destination_type} || $srctype;
   my $key  = (ref $self) . ':' . join('|', "$reldir$name.$srctype.$type",
     map { join(' ', @$_) } @$transform);
-  NoteProgressDetailed("\n[Processing $source as key=$key]");
+  NoteStatus(1, "Processing $source as key=$key");
 
   my $dest = $self->desiredResourcePathname($doc, $node, $source, $type);
   if (my $prev = $doc->cacheLookup($key)) {                 # Image was processed on previous run?
@@ -212,7 +212,7 @@ sub transformGraphic {
       if ((!defined $dest) || ($cached eq $dest)) {
         my $absdest = pathname_absolute($cached, $doc->getDestinationDirectory);
         if (pathname_timestamp($source) <= pathname_timestamp($absdest)) {
-          NoteProgressDetailed(" [Reuse $cached @ " . ($width || '?') . " x " . ($height || '?') . "]");
+          NoteStatus(2, " [Reuse $cached @ " . ($width || '?') . " x " . ($height || '?') . "]");
           return ($cached, $width, $height); } } } }
   # Trivial scaling case: Use original image with (at most) different width & height.
   my $triv_scaling = $$self{trivial_scaling} && ($type eq $srctype)
@@ -254,7 +254,7 @@ sub transformGraphic {
       $dest    = $self->generateResourcePathname($doc, $node, $source, $type);
       $absdest = $doc->checkDestination($dest); }
 
-    NoteProgressDetailed(" [Destination $absdest]");
+    NoteStatus(2, " [Destination $absdest]");
     ($width, $height) = image_graphicx_trivial($source, $transform, ddpt => $$self{ddpt});
     if (!($width && $height)) {
       if (!image_can_image()) {
@@ -267,23 +267,23 @@ sub transformGraphic {
           "Couldn't get usable image size for $source"); } }
     pathname_copy($source, $absdest)
       or Warn('I/O', $absdest, undef, "Couldn't copy $source to $absdest", "Response was: $!");
-    NoteProgressDetailed(" [Copied to $dest @ " . ($width || '?') . " x " . ($height || '?') . "]"); }
+    NoteStatus(2, " [Copied to $dest @ " . ($width || '?') . " x " . ($height || '?') . "]"); }
   else {
     # With a complex transformation, we really needs a new name (well, don't we?)
     $dest = $self->generateResourcePathname($doc, $node, $source, $type) unless $dest;
     my $absdest = $doc->checkDestination($dest);
-    NoteProgressDetailed(" [Destination $absdest]");
+    NoteStatus(2, " [Destination $absdest]");
     ($image, $width, $height) = image_graphicx_complex($source, $transform,
       ddpt => $$self{ddpt}, background => $$self{background}, %properties);
     if (!($image && $width && $height)) {
       Warn('expected', 'image', undef,
         "Couldn't get usable image for $source");
       return; }
-    NoteProgressDetailed(" [Writing to $absdest]");
+    NoteStatus(2, " [Writing to $absdest]");
     image_write($image, $absdest) or return; }
 
   $doc->cacheStore($key, "$dest|" . ($width || '') . '|' . ($height || ''));
-  NoteProgressDetailed(" [done with $key]");
+  NoteStatus(2, " [done with $key]");
   return ($dest, $width, $height); }
 
 #======================================================================

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -54,7 +54,7 @@ sub new {
   # Parameters for separating the clipping box from the
   # desired padding between image edge and "ink"
   $$self{padding} = $options{padding} || 2;    # pixels
-        # amount of extra space (+padding) to put between object & rules for clipping
+      # amount of extra space (+padding) to put between object & rules for clipping
   $$self{clippingfudge} = 3;       # px
   $$self{clippingrule}  = 0.90;    # pixels (< 1 to avoid antialiasing..?)
 
@@ -181,8 +181,8 @@ sub cleanTeX {
   if ($tex =~ s/^\s*(\\displaystyle|\\textstyle|\\scriptstyle|\\scriptscriptstyle)\s*//) {
     $style = $1; }
   $tex =~ s/^(?:\\\s*,|\\!\s*|\\>\s*|\\;\s*|\\:\s*|\\ \s*|\\\/\s*)*//; # Trim leading spacing (especially negative!)
-  $tex =~ s/(?:\\\s*,|\\!\s*|\\>\s*|\\;\s*|\\:\s*|\\ \s*|\\\/\s*)*$//; # and trailing spacing
-       # Strip comments, but watchout for \% (or more exactly, an ODD number of \)
+  $tex =~ s/(?:\\\s*,|\\!\s*|\\>\s*|\\;\s*|\\:\s*|\\ \s*|\\\/\s*)*$//;    # and trailing spacing
+      # Strip comments, but watchout for \% (or more exactly, an ODD number of \)
   $tex =~ s/(?<!\\)((?:\\\\)*)\%[^\n]*\n/$1/gs;
   $tex = $style . ' ' . $tex if $style;    # Put back the style, if any
   return $tex; }
@@ -253,7 +253,7 @@ sub generateImages {
       next if -f pathname_absolute($1, $destdir); }
     push(@pending, $table{$key}); }
 
-  NoteProgress(" [$nuniq unique; " . scalar(@pending) . " new]");
+  NoteStatus(2, "LaTeXImages: $nuniq unique; " . scalar(@pending) . " new");
   if (@pending) {    # if any images need processing
         # Create working directory; note TMPDIR attempts to put it in standard place (like /tmp/)
     File::Temp->safe_level(File::Temp::HIGH);
@@ -345,7 +345,6 @@ sub generateImages {
           my $d = int(0.5 + ($dd || 0) + $$self{padding});
           if ((($w == 1) && ($ww > 1)) || (($h == 1) && ($hh > 1))) {
             Warn('expected', 'image', undef, "Image for '$$entry{tex}' was cropped to nothing!"); }
-#          print STDERR "\nFor key='$$entry{key}': Image[$index] '$dest' $$entry{tex} $ww x $hh + $dd ==> $w x $h \\ $d\n";
           $doc->cacheStore($$entry{key}, "$dest;$w;$h;$d"); }
       }
       else {
@@ -378,6 +377,7 @@ sub pre_preamble {
   my $dest            = $doc->getDestination;
   my $description     = ($dest ? "% Destination $dest" : "");
   my $pts_per_pixel   = 72.27 / $$self{dpi} / $$self{magnification};
+
   foreach my $pkgdata (@classdata) {
     my ($package, $package_options) = @$pkgdata;
     $package_options = "[$package_options]" if $package_options && ($package_options !~ /^\[.*\]$/);
@@ -469,16 +469,16 @@ sub convert_image {
   $image->Border(width => 1, height => 1, fill => $bg);
   $image->Trim(fuzz => '75%');    # Fuzzy, to trim the gray tabs, as well!!
   $image->Set(fuzz => '0%');      # But, be SURE to RESET fuzz!! (It is NOT an "argument"!!!)
-       # [Also, be CAREFULL of ImageMagick's Floodfill variants, they sometimes go wild]
+      # [Also, be CAREFULL of ImageMagick's Floodfill variants, they sometimes go wild]
 
   # Finally, shave off the rule & fudge padding.
   my $fudge = int(0.5 + $$self{clippingfudge} + $$self{clippingrule});
   $image->Shave(width => $fudge, height => $fudge);
 
   my ($w, $h) = $image->Get('width', 'height');    # Get final image size
-         # ImageMagick tries to manage a "virtual" image within the image data,
-         # (whatever that means)
-         # This resets it back to the origin which avoids confusion, all 'round!
+      # ImageMagick tries to manage a "virtual" image within the image data,
+      # (whatever that means)
+      # This resets it back to the origin which avoids confusion, all 'round!
   $image->Set(page => "${w}x${h}+0+0");
 
   # Ideally, we'd make the alpha exactly opposite the ink, rather than merely 1 bit
@@ -486,7 +486,7 @@ sub convert_image {
   #  $image = $image->Fx(expression=>'(3.0-r+g+b)/3.0', channel=>'alpha');
   $image->Transparent(color => $bg);
 
-  NoteProgressDetailed(" [Converting $src => $dest ($w x $h)]");
+  NoteStatus(2, "LaTeXImages: Converting $src => $dest ($w x $h)");
 
   # Workaround bad png detection(?) in ImageMagick 6.6.5 (???)
   if ($$self{imagetype} eq 'png') {

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -253,7 +253,7 @@ sub generateImages {
       next if -f pathname_absolute($1, $destdir); }
     push(@pending, $table{$key}); }
 
-  NoteStatus(2, "LaTeXImages: $nuniq unique; " . scalar(@pending) . " new");
+  ProgressDetailed("LaTeXImages: $nuniq unique; " . scalar(@pending) . " new");
   if (@pending) {    # if any images need processing
         # Create working directory; note TMPDIR attempts to put it in standard place (like /tmp/)
     File::Temp->safe_level(File::Temp::HIGH);
@@ -486,7 +486,7 @@ sub convert_image {
   #  $image = $image->Fx(expression=>'(3.0-r+g+b)/3.0', channel=>'alpha');
   $image->Transparent(color => $bg);
 
-  NoteStatus(2, "LaTeXImages: Converting $src => $dest ($w x $h)");
+  ProgressDetailed("LaTeXImages: Converting $src => $dest ($w x $h)");
 
   # Workaround bad png detection(?) in ImageMagick 6.6.5 (???)
   if ($$self{imagetype} eq 'png') {

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -253,7 +253,7 @@ sub generateImages {
       next if -f pathname_absolute($1, $destdir); }
     push(@pending, $table{$key}); }
 
-  ProgressDetailed("LaTeXImages: $nuniq unique; " . scalar(@pending) . " new");
+  Debug("LaTeXImages: $nuniq unique; " . scalar(@pending) . " new") if $LaTeXML::DEBUG{images};
   if (@pending) {    # if any images need processing
         # Create working directory; note TMPDIR attempts to put it in standard place (like /tmp/)
     File::Temp->safe_level(File::Temp::HIGH);
@@ -486,8 +486,7 @@ sub convert_image {
   #  $image = $image->Fx(expression=>'(3.0-r+g+b)/3.0', channel=>'alpha');
   $image->Transparent(color => $bg);
 
-  ProgressDetailed("LaTeXImages: Converting $src => $dest ($w x $h)");
-
+  Debug("LaTeXImages: Converting $src => $dest ($w x $h)") if $LaTeXML::DEBUG{images};
   # Workaround bad png detection(?) in ImageMagick 6.6.5 (???)
   if ($$self{imagetype} eq 'png') {
     $dest = "png32:$dest"; }

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -286,14 +286,15 @@ sub generateImages {
     # Sometimes latex returns non-zero code, even though it apparently succeeded.
     # And sometimes it doesn't produce a dvi, even with 0 return code?
     if (($ltxerr != 0) || (!-f "$workdir/$jobname.dvi")) {
-      my $preserve = $$LaTeXML::POST{verbosity} > 0;    # preserve junk when verbosity high.
-      $workdir->unlink_on_destroy(0) if $preserve;
+      $workdir->unlink_on_destroy(0) if $LaTeXML::DEBUG{images};    # Preserve junk
       Error('shell', $LATEXCMD, undef,
         "LaTeX command '$ltxcommand' failed",
-        ($ltxerr == 0 ? "No dvi file generated"     : "returned code $ltxerr (!= 0): $@"),
-        ($preserve    ? "See $workdir/$jobname.log" : "Re-run with --verbose to see TeX log"));
+        ($ltxerr == 0 ? "No dvi file generated" : "returned code $ltxerr (!= 0): $@"),
+        ($LaTeXML::DEBUG{images}
+          ? "See $workdir/$jobname.log"
+          : "Re-run with --debug=images to see TeX log"));
       return $doc; }
-    $workdir->unlink_on_destroy(0) if $$LaTeXML::POST{verbosity} > 2;
+    ### $workdir->unlink_on_destroy(0) if $LaTeXML::DEBUG{images}; # preserve ALL junk!?!?!
 
     # Extract dimensions (width x height+depth) from each image from log file.
     my @dimensions = ();

--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -166,7 +166,7 @@ sub getBibliographies {
         $raw .= "%\n"; } }
     my $bibdoc = $self->convertBibliography($doc, $raw);
     push(@bibs, $bibdoc) if $bibdoc; }
-  NoteStatus(1, "MakeBibliography: using bibliographies "
+  Progress("MakeBibliography: using bibliographies "
       . join(',', map { (length($_) > 100 ? substr($_, 100) . '...' : $_) } @bibnames)
       . "]");
   return @bibs; }
@@ -201,7 +201,7 @@ sub convertBibliography {
     else {
       push(@preload, "$pkg.sty"); } }
   my $bibname = pathname_is_literaldata($bib) ? 'Anonymous Bib String' : $bib;
-  NoteStatus(1, "MakeBibliography: Converting bibliography $bibname ...");
+  Progress("MakeBibliography: Converting bibliography $bibname ...");
   my $bib_config = LaTeXML::Common::Config->new(
     recursive      => 1,
     verbosity      => $$self{verbosity},
@@ -240,10 +240,10 @@ sub convertBibliography {
 
   # TODO: We need to handle the logging properly, it's a bit of a mess for nested ->convert() calls
   if (my $bibdoc = $$response{result}) {
-    NoteStatus(1, "... converted!");
+    Progress("... converted!");
     return $doc->new($bibdoc, sourceDirectory => '.'); }
   else {
-    NoteStatus(1, "... Failed!");
+    Progress("... Failed!");
     return; } }
 
 # ================================================================================
@@ -345,7 +345,7 @@ sub getBibEntries {
     my $bibkey = $$entry{bibkey};
     map { $entries{ normalizeBibKey($_) }{bibreferrers}{$bibkey} = 1 } @{ $$entry{citations} }; }
 
-  NoteStatus(1, "MakeBibliography: " . (scalar keys %entries) . " bibentries, " . (scalar keys %$included) . " cited");
+  Progress("MakeBibliography: " . (scalar keys %entries) . " bibentries, " . (scalar keys %$included) . " cited");
   Warn('expected', 'bibkeys', undef,
     "Missing bibkeys " . join(', ', sort keys %missing_keys)) if keys %missing_keys;
 

--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -205,7 +205,6 @@ sub convertBibliography {
   ProgressSpinup($stage);
   my $bib_config = LaTeXML::Common::Config->new(
     recursive      => 1,
-    verbosity      => $$self{verbosity},
     cache_key      => 'BibTeX',
     type           => "BibTeX",
     post           => 0,

--- a/lib/LaTeXML/Post/MakeIndex.pm
+++ b/lib/LaTeXML/Post/MakeIndex.pm
@@ -63,11 +63,11 @@ sub build_tree {
   my $defaultlistname = 'idx';
   my $listname        = 'idx';    # Eventually customizable for different indices?
   if (my @keys = grep { /^INDEX:/ } $$self{db}->getKeys) {
-    NoteProgress(" [" . scalar(@keys) . " entries]");
+    NoteStatus(2, "MakeIndex: " . scalar(@keys) . " entries");
 
-    my $id = $index->getAttribute('xml:id');
+    my $id         = $index->getAttribute('xml:id');
     my $allphrases = {};          # Keep a hash of all phrase textContent=>id encountered (for seealso)
-    my $tree = { subtrees => {}, referrers => {}, id => $id, parent => undef };
+    my $tree       = { subtrees => {}, referrers => {}, id => $id, parent => undef };
     foreach my $key (@keys) {
       my $entry   = $$self{db}->lookup($key);
       my $phrases = $entry->getValue('phrases');
@@ -174,7 +174,7 @@ my $GREEK_RE = '(' . join('|', sort keys %GREEK_ASCII_MAP) . ')';
 sub getIndexKeyID {
   my ($key) = @_;
   $key =~ s/^\s+//s; $key =~ s/\s+$//s;    # Trim leading/trailing, in any case
-        # We don't want accented chars (do we?) but we need to decompose the accents!
+      # We don't want accented chars (do we?) but we need to decompose the accents!
   $key = NFD($key);
   $key =~ s/$GREEK_RE/$GREEK_ASCII_MAP{$1}/eg;
   $key = unidecode($key);
@@ -317,7 +317,7 @@ sub seealsoSearch {
 sub seealsoSearch_rec {
   my ($doc, $allphrases, $contexttree, @parts) = @_;
   my ($link, @links);
-  if (scalar(@parts) < 1) { return (); }
+  if    (scalar(@parts) < 1) { return (); }
   elsif (scalar(@parts) < 3) {
     # Single term? (w/ possible trailing punct) just look it up
     if ($link = lookupSeealsoPhrase($doc, $allphrases, $contexttree, $parts[0])) {
@@ -352,10 +352,10 @@ sub lookupSeealsoPhrase {
   my ($doc, $allphrases, $contexttree, $pair) = @_;
   my ($phrase, @xml) = @$pair;
   # concoct various phrases to search for
-  my $pnc   = $phrase; $pnc =~ s/,\s*/ /sg;        # Ignore punct?
-  my $ps    = $phrase; $ps =~ s/(\w+)s\b/$1/sg;    # Ignore plurals?
-  my $psnc  = $ps;     $psnc =~ s/,\s*/ /sg;       # Ignore punct AND plurals?
-  my $pnlvl = $phrase; $pnlvl =~ s/,\s*/./sg;      # Convert punct to levels?
+  my $pnc   = $phrase; $pnc   =~ s/,\s*/ /sg;         # Ignore punct?
+  my $ps    = $phrase; $ps    =~ s/(\w+)s\b/$1/sg;    # Ignore plurals?
+  my $psnc  = $ps;     $psnc  =~ s/,\s*/ /sg;         # Ignore punct AND plurals?
+  my $pnlvl = $phrase; $pnlvl =~ s/,\s*/./sg;         # Convert punct to levels?
   foreach my $trial ($phrase, lc($phrase),
     $pnc,   lc($pnc),
     $ps,    lc($ps),
@@ -387,7 +387,7 @@ sub seealsoPartition {
   while (@parts) {
     my $next    = shift(@parts);
     my $prev_is = ($result[-1][0] =~ /^,?\s*(?:,|\.|\s+|\band\s+also|\band|\bor)\s*$/);
-    my $next_is = ($$next[0] =~ /^(?:,|\.|\s+|and\b|or\b)/);
+    my $next_is = ($$next[0]      =~ /^(?:,|\.|\s+|and\b|or\b)/);
     # If either BOTH or NEITHER prev & next are delimiters, combine them.
     if (!($prev_is xor $next_is)) {
       my ($k, @x) = @$next;

--- a/lib/LaTeXML/Post/MakeIndex.pm
+++ b/lib/LaTeXML/Post/MakeIndex.pm
@@ -63,7 +63,7 @@ sub build_tree {
   my $defaultlistname = 'idx';
   my $listname        = 'idx';    # Eventually customizable for different indices?
   if (my @keys = grep { /^INDEX:/ } $$self{db}->getKeys) {
-    NoteStatus(2, "MakeIndex: " . scalar(@keys) . " entries");
+    ProgressDetailed("MakeIndex: " . scalar(@keys) . " entries");
 
     my $id         = $index->getAttribute('xml:id');
     my $allphrases = {};          # Keep a hash of all phrase textContent=>id encountered (for seealso)

--- a/lib/LaTeXML/Post/MakeIndex.pm
+++ b/lib/LaTeXML/Post/MakeIndex.pm
@@ -63,7 +63,7 @@ sub build_tree {
   my $defaultlistname = 'idx';
   my $listname        = 'idx';    # Eventually customizable for different indices?
   if (my @keys = grep { /^INDEX:/ } $$self{db}->getKeys) {
-    ProgressDetailed("MakeIndex: " . scalar(@keys) . " entries");
+    NoteLog("MakeIndex: " . scalar(@keys) . " entries");
 
     my $id         = $index->getAttribute('xml:id');
     my $allphrases = {};          # Keep a hash of all phrase textContent=>id encountered (for seealso)

--- a/lib/LaTeXML/Post/MathImages.pm
+++ b/lib/LaTeXML/Post/MathImages.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use LaTeXML::Post;
 use LaTeXML::Util::Pathname;
+use LaTeXML::Common::Error;
 use base qw(LaTeXML::Post::MathProcessor LaTeXML::Post::LaTeXImages);
 
 sub new {
@@ -72,7 +73,7 @@ sub convertNode {
     return { processor => $self, mimetype => $MIMETYPES{$type},
       src => $reldest, width => $width, height => $height, depth => $depth }; }
   else {
-    print STDERR "Couldn't find image for '$key'\n";
+    Warn('expected', 'image', $doc, "Couldn't find image for '$key'");
     return {}; } }
 
 # Definitions needed for processing inline & display math images

--- a/lib/LaTeXML/Post/MathML/Linebreaker.pm
+++ b/lib/LaTeXML/Post/MathML/Linebreaker.pm
@@ -515,7 +515,7 @@ sub layout {
     local $LaTeXML::IGNORE_ERRORS = 1;
     \&$handler; };
   if (!$handler) {
-    LaTeXML::Post::Fatal("unexpected", $name, $node,
+    Fatal("unexpected", $name, $node,
       "Can't find layout handler for $name"); }
   Debug(('  ' x $level), "layout $name: ", $node, "...") if $LaTeXML::DEBUG{linebreaking};
   # Get the handler to compute the layouts
@@ -575,7 +575,7 @@ sub asRow {
   my $type     = nodeName($node);
   my @children = nodeChildren($node);
   if (my (@invalid) = grep { ref $_ ne 'ARRAY' } @children) {
-    LaTeXML::Post::Fatal('unexpected', $invalid[0], $node,
+    Fatal('unexpected', $invalid[0], $node,
       "Math row has non-element: " . nodeName($node)); }
 
   # Since we can't vertically align independently on both sides of an mtable,

--- a/lib/LaTeXML/Post/MathML/Linebreaker.pm
+++ b/lib/LaTeXML/Post/MathML/Linebreaker.pm
@@ -517,7 +517,7 @@ sub layout {
   if (!$handler) {
     Fatal("unexpected", $name, $node,
       "Can't find layout handler for $name"); }
-  Debug(('  ' x $level), "layout $name: ", $node, "...") if $LaTeXML::DEBUG{linebreaking};
+  Debug(('  ' x $level) . "layout $name: " . $node . "...") if $LaTeXML::DEBUG{linebreaking};
   # Get the handler to compute the layouts
   my $layouts  = &$handler($node, $target, $level, $demerits || 1);
   my $nlayouts = scalar(@$layouts);
@@ -525,7 +525,7 @@ sub layout {
   # Sort & prune the layouts
   my @layouts = prunesort($target, @$layouts);
   my $pruned  = scalar(@layouts);
-  Debug(('  ' x $level), "$name: $nlayouts layouts"
+  Debug(('  ' x $level) . "$name: $nlayouts layouts"
       . ($pruned < $nlayouts ? " pruned to $pruned" : "")
       . " " . layoutDescriptor($$layouts[0])
       . ($nlayouts > 1 ? "..." . layoutDescriptor($$layouts[$nlayouts - 1]) : "")
@@ -646,9 +646,9 @@ sub asRow {
   # and quit as soon as we get reasonable layouts; Pruning is _essential_!!!
   my $nbreaks    = scalar(@breaks);
   my $nbreaksets = 2**$nbreaks;
-  Debug(("  " x $level), $type, " ",
-    join("x", map { scalar(@$_) } @child_layouts), " layouts",
-    (@breaks
+  Debug(("  " x $level) . $type . " "
+      . join("x", map { scalar(@$_) } @child_layouts) . " layouts"
+      . (@breaks
       ? ", breaks@" . join(",", map { "[" . join(',', @$_) . "]" } @breaks)
         . "(" . $nbreaksets . " sets;"
         . product((map { scalar(@$_) } @child_layouts), $nbreaksets) . " combinations"

--- a/lib/LaTeXML/Post/Scan.pm
+++ b/lib/LaTeXML/Post/Scan.pm
@@ -129,7 +129,7 @@ sub process {
       $self->addAsChild($id, $parent_id); }
     else {
       Info('expected', 'parent', undef, "No parent document found for '$id'"); } }
-  NoteStatus(2, "Scan: DBStatus: " . $$self{db}->status);
+  ProgressDetailed("Scan: DBStatus: " . $$self{db}->status);
   return $doc; }
 
 sub scan {

--- a/lib/LaTeXML/Post/Scan.pm
+++ b/lib/LaTeXML/Post/Scan.pm
@@ -129,7 +129,7 @@ sub process {
       $self->addAsChild($id, $parent_id); }
     else {
       Info('expected', 'parent', undef, "No parent document found for '$id'"); } }
-  NoteProgressDetailed(" [DBStatus: " . $$self{db}->status . "]");
+  NoteStatus(2, "Scan: DBStatus: " . $$self{db}->status);
   return $doc; }
 
 sub scan {

--- a/lib/LaTeXML/Post/Scan.pm
+++ b/lib/LaTeXML/Post/Scan.pm
@@ -129,7 +129,7 @@ sub process {
       $self->addAsChild($id, $parent_id); }
     else {
       Info('expected', 'parent', undef, "No parent document found for '$id'"); } }
-  ProgressDetailed("Scan: DBStatus: " . $$self{db}->status);
+  NoteLog("Scan: DBStatus: " . $$self{db}->status);
   return $doc; }
 
 sub scan {

--- a/lib/LaTeXML/Post/Split.pm
+++ b/lib/LaTeXML/Post/Split.pm
@@ -43,7 +43,7 @@ sub process {
     my @nav = $doc->findnodes("descendant::ltx:navigation");
     $doc->removeNodes(@nav) if @nav;
     my $tree = { node => $root, document => $doc,
-      id       => $root->getAttribute('xml:id'), name => $doc->getDestination,
+      id => $root->getAttribute('xml:id'), name => $doc->getDestination,
       children => [] };
     # Group the pages into a tree, in case they are nested.
     my $haschildren = {};
@@ -56,7 +56,7 @@ sub process {
     $self->addNavigation($tree, @nav) if @nav;
   }
   my $n = scalar(@docs);
-  NoteProgressDetailed(($n > 1 ? " [Split into in $n TOCs]" : "[not split]"));
+  NoteStatus(2, ($n > 1 ? " [Split into in $n TOCs]" : "[not split]"));
   return @docs; }
 
 # Get the nodes in the document that WILL BECOME separate "pages".
@@ -125,7 +125,7 @@ sub processPages {
       # Due to the way document building works, we remove & process children pages
       # BEFORE processing this page.
       my @childdocs = $self->processPages($doc, @{ $$entry{children} });
-      my $subdoc = $doc->newDocument($page, destination => $$entry{name},
+      my $subdoc    = $doc->newDocument($page, destination => $$entry{name},
         parentDocument => $doc, parent_id => $$entry{upid});
       $$entry{document} = $subdoc;
       push(@docs, $subdoc, @childdocs); }

--- a/lib/LaTeXML/Post/Split.pm
+++ b/lib/LaTeXML/Post/Split.pm
@@ -56,7 +56,7 @@ sub process {
     $self->addNavigation($tree, @nav) if @nav;
   }
   my $n = scalar(@docs);
-  NoteStatus(2, ($n > 1 ? " [Split into in $n TOCs]" : "[not split]"));
+  ProgressDetailed(($n > 1 ? " [Split into in $n TOCs]" : "[not split]"));
   return @docs; }
 
 # Get the nodes in the document that WILL BECOME separate "pages".

--- a/lib/LaTeXML/Post/Split.pm
+++ b/lib/LaTeXML/Post/Split.pm
@@ -56,7 +56,7 @@ sub process {
     $self->addNavigation($tree, @nav) if @nav;
   }
   my $n = scalar(@docs);
-  ProgressDetailed(($n > 1 ? " [Split into in $n TOCs]" : "[not split]"));
+  NoteLog(($n > 1 ? " [Split into in $n TOCs]" : "[not split]"));
   return @docs; }
 
 # Get the nodes in the document that WILL BECOME separate "pages".

--- a/lib/LaTeXML/Pre/BibTeX.pm
+++ b/lib/LaTeXML/Pre/BibTeX.pm
@@ -32,9 +32,9 @@ use Text::Balanced qw(extract_delimited extract_bracketed);
 # Column number is currently kinda flubbed up.
 #**********************************************************************
 my %default_macros = (    # [CONSTANT]
-  jan => "January",   feb => "February", mar => "March",    apr => "April",
-  may => "May",       jun => "June",     jul => "July",     aug => "August",
-  sep => "September", oct => "October",  nov => "November", dec => "December",
+  jan      => "January",   feb => "February", mar => "March",    apr => "April",
+  may      => "May",       jun => "June",     jul => "July",     aug => "August",
+  sep      => "September", oct => "October",  nov => "November", dec => "December",
   acmcs    => "ACM Computing Surveys",
   acta     => "Acta Informatica",
   cacm     => "Communications of the ACM",
@@ -138,7 +138,7 @@ sub getLocator {
 sub parseTopLevel {
   my ($self) = @_;
   my $note = "Preparsing Bibliography " . ($$self{source} || "<Unknown>");
-  NoteBegin($note);
+  ProgressSpinup($note);
   while ($self->skipJunk) {
     my $type = $self->parseEntryType;
     if    ($type eq 'preamble') { $self->parsePreamble; }
@@ -146,7 +146,7 @@ sub parseTopLevel {
     elsif ($type eq 'comment')  { $self->parseComment; }
     else                        { $self->parseEntry($type); }
   }
-  NoteEnd($note);
+  ProgressSpindown($note);
   $$self{parsed} = 1;
   return; }
 
@@ -256,20 +256,20 @@ sub parseString {
   if ($$self{line} =~ s/^\"//) {    # If opening " (and remove it!)
         # Note that BibTeX doesn't see a " if it is enclosed with {}, so can't use extract_delmited
     while ($$self{line} !~ s/^\"//) {    # Until we've found the closing "
-      if (!$$self{line}) { $self->extendLine; }
-      elsif ($$self{line} =~ /^\{/) {    # Starts with a brace! extract balanced {}
+      if    (!$$self{line}) { $self->extendLine; }
+      elsif ($$self{line} =~ /^\{/) {                # Starts with a brace! extract balanced {}
         $string .= $self->parseBalancedBraces; }
-      elsif ($$self{line} =~ s/^([^"\{]*)//) {    # else pull off everything except a brace or "
+      elsif ($$self{line} =~ s/^([^"\{]*)//) {       # else pull off everything except a brace or "
         $string .= $1; } }
   }
   elsif ($$self{line} =~ /^\{/) {
     $string = $self->parseBalancedBraces;
-    $string =~ s/^.//;                            # Remove the delimiters.
+    $string =~ s/^.//;                               # Remove the delimiters.
     $string =~ s/.$//; }
   else {
     Error('expected', '<delimitedstring>', undef,
       "Expected a string delimited by \"..\", (..) or {..}"); }
-  $string =~ s/^\s+//;                            # and trim
+  $string =~ s/^\s+//;                               # and trim
   $string =~ s/\s+$//;
   return $string; }
 
@@ -336,9 +336,9 @@ sub skipJunk {
   my ($self) = @_;
   $$self{line} ||= "";
   while (1) {
-    $$self{line} =~ s/^[^@%]*//;    # Skip till comment or @
-    return '@' if $$self{line} =~ s/^@//;    # Found @
-                                             # else line is empty, or a comment, so get next
+    $$self{line} =~ s/^[^@%]*//;                  # Skip till comment or @
+    return '@' if $$self{line} =~ s/^@//;         # Found @
+                                                  # else line is empty, or a comment, so get next
     my $nextline = shift(@{ $$self{lines} });
     $$self{line} = $nextline || "";
     $$self{lineno}++;

--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -312,7 +312,8 @@ sub image_graphicx_complex {
         ($w, $h) = (ceil($a1 * $dppt), ceil($a2 * $dppt)); } }
     my $X = 4;                 # Expansion factor
     my ($dx, $dy) = (int($X * 72 * $w / $w0), int($X * 72 * $h / $h0));
-    ProgressDetailed("reloading $source to desired size $w x $h (density = $dx x $dy)");
+    Debug("reloading $source to desired size $w x $h (density = $dx x $dy)")
+      if $LaTeXML::DEBUG{images};
     $image = image_read($source, antialias => 1, density => $dx . 'x' . $dy) or return;
     image_internalop($image, 'Trim') or return if $properties{autocrop};
     #    image_setvalue($image, colorspace => 'RGB') or return;
@@ -394,7 +395,7 @@ sub image_graphicx_complex {
     $notes .= " quality=$quality";
     image_setvalue($image, quality => $properties{quality}) or return; }
 
-  ProgressDetailed("Transformed $source : $notes") if $notes;
+  Debug("Transformed $source : $notes") if $notes && $LaTeXML::DEBUG{images};
   return ($image, $w, $h); }
 
 # Wrap up ImageMagick's methods to give more useful & consistent error handling.

--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -312,7 +312,7 @@ sub image_graphicx_complex {
         ($w, $h) = (ceil($a1 * $dppt), ceil($a2 * $dppt)); } }
     my $X = 4;                 # Expansion factor
     my ($dx, $dy) = (int($X * 72 * $w / $w0), int($X * 72 * $h / $h0));
-    NoteStatus(2, "reloading $source to desired size $w x $h (density = $dx x $dy)");
+    ProgressDetailed("reloading $source to desired size $w x $h (density = $dx x $dy)");
     $image = image_read($source, antialias => 1, density => $dx . 'x' . $dy) or return;
     image_internalop($image, 'Trim') or return if $properties{autocrop};
     #    image_setvalue($image, colorspace => 'RGB') or return;
@@ -394,7 +394,7 @@ sub image_graphicx_complex {
     $notes .= " quality=$quality";
     image_setvalue($image, quality => $properties{quality}) or return; }
 
-  NoteStatus(2, "Transformed $source : $notes") if $notes;
+  ProgressDetailed("Transformed $source : $notes") if $notes;
   return ($image, $w, $h); }
 
 # Wrap up ImageMagick's methods to give more useful & consistent error handling.

--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -312,7 +312,7 @@ sub image_graphicx_complex {
         ($w, $h) = (ceil($a1 * $dppt), ceil($a2 * $dppt)); } }
     my $X = 4;                 # Expansion factor
     my ($dx, $dy) = (int($X * 72 * $w / $w0), int($X * 72 * $h / $h0));
-    NoteProgressDetailed(" [reloading to desired size $w x $h (density = $dx x $dy)]");
+    NoteStatus(2, "reloading $source to desired size $w x $h (density = $dx x $dy)");
     $image = image_read($source, antialias => 1, density => $dx . 'x' . $dy) or return;
     image_internalop($image, 'Trim') or return if $properties{autocrop};
     #    image_setvalue($image, colorspace => 'RGB') or return;
@@ -394,7 +394,7 @@ sub image_graphicx_complex {
     $notes .= " quality=$quality";
     image_setvalue($image, quality => $properties{quality}) or return; }
 
-  NoteProgressDetailed(" [Transformed : $notes]") if $notes;
+  NoteStatus(2, "Transformed $source : $notes") if $notes;
   return ($image, $w, $h); }
 
 # Wrap up ImageMagick's methods to give more useful & consistent error handling.

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -82,6 +82,7 @@ sub pathname_make {
 # If pathname is absolute, dir starts with volume or '/'
 sub pathname_split {
   my ($pathname) = @_;
+  return unless defined $pathname;
   $pathname = pathname_canonical($pathname);
   my ($vol, $dir, $name) = File::Spec->splitpath($pathname);
   # Hmm, for /, we get $dir = / but we want $vol='/'  ?????
@@ -99,6 +100,7 @@ use Carp;
 # AND, care about symbolic links and collapsing ../ !!!
 sub pathname_canonical {
   my ($pathname) = @_;
+  return unless defined $pathname;
   if ($pathname =~ /^($LITERAL_RE)/) {
     return $pathname; }
   # Don't call pathname_is_absolute, etc, here, cause THEY call US!
@@ -139,6 +141,7 @@ sub pathname_type {
 # Note that this returns ONLY recognized protocols!
 sub pathname_protocol {
   my ($pathname) = @_;
+  return unless defined $pathname;
   return ($pathname =~ /^($PROTOCOL_RE|$LITERAL_RE)/ ? $1 : 'file'); }
 
 #======================================================================
@@ -196,6 +199,7 @@ sub pathname_is_reloadable {
 # we _could_ make relative...
 sub pathname_relative {
   my ($pathname, $base) = @_;
+  return unless defined $pathname;
   $pathname = pathname_canonical($pathname);
   return ($base && pathname_is_absolute($pathname) && !pathname_is_url($pathname)
     ? File::Spec->abs2rel($pathname, pathname_canonical($base))
@@ -203,13 +207,16 @@ sub pathname_relative {
 
 sub pathname_absolute {
   my ($pathname, $base) = @_;
+  return unless defined $pathname;
   $pathname = pathname_canonical($pathname);
   return (!pathname_is_absolute($pathname) && !pathname_is_url($pathname)
     ? File::Spec->rel2abs($pathname, ($base ? pathname_canonical($base) : pathname_cwd()))
     : $pathname); }
 
 sub pathname_to_url {
-  my $relative_pathname = pathname_relative($_[0]);
+  my ($pathname) = @_;
+  return unless defined $pathname;
+  my $relative_pathname = pathname_relative($pathname);
   if ($SEP ne '/') {
     $relative_pathname = join('/', split(/\Q$SEP\E/, $relative_pathname)); }
   return $relative_pathname; }

--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -237,6 +237,10 @@ sub daemon_ok {
   my $opts = read_options("$base.spec", $base);
   push @$opts, (['destination', "$localname.test.xml"],
     ['log',                "/dev/null"],
+    ['quiet',              ''],
+    ['quiet',              ''],
+    ['quiet',              ''],
+    ['quiet',              ''],
     ['timeout',            10],
     ['autoflush',          1],
     ['timestamp',          '0'],

--- a/t/002_unit_findfile.t
+++ b/t/002_unit_findfile.t
@@ -11,11 +11,13 @@ BEGIN { use_ok('LaTeXML::Core::Stomach'); }
 BEGIN { use_ok('LaTeXML::Common::Model'); }
 BEGIN { use_ok('LaTeXML::Global'); }
 BEGIN { use_ok('LaTeXML::Package'); }
+BEGIN { use_ok('LaTeXML::Common::Error'); }
 
 local $STATE = LaTeXML::Core::State->new(catcodes => 'standard',
     stomach => LaTeXML::Core::Stomach->new(),
     model   => LaTeXML::Common::Model->new());
-$STATE->assignValue("VERBOSITY", -2);
+
+SetVerbosity(-2);
 
 my @supported_filename_patterns = qw(
   amsmath2.sty amsmath3-1.sty amsmathv2.sty amsmath_v2.sty amsmath2019.sty amsmath_v2019.sty amsmath_2019.sty

--- a/t/170_grammar_coverage.t
+++ b/t/170_grammar_coverage.t
@@ -21,7 +21,7 @@ if (!$ENV{"CI"}) {
 # Obtain the rule pairs from MathGrammar, which we want to exhaustively test:
 my %grammar_dependencies = obtain_dependencies();
 
-my $opts = LaTeXML::Common::Config->new(input_limit => 100);
+my $opts = LaTeXML::Common::Config->new(input_limit => 100, verbosity=>-2);
 
 my $converter = LaTeXML->get_converter($opts);
 $converter->prepare_session($opts);
@@ -31,8 +31,16 @@ my %tested_dependencies = ();
 my @core_tests = parser_test_filenames();
 for my $test (@core_tests) {
   note("grammar coverage $test...");
-  my $response = $converter->convert($test);
-  my $regularized_log = $response->{log};
+  my $regularized_log = '';
+  my $response;
+  my $log_handle;
+  open($log_handle, ">>", \$regularized_log) or croak("Can't redirect STDERR to log! Dying...");
+  {
+    local *STDERR       = *$log_handle;
+    binmode(STDERR, ':encoding(UTF-8)');
+    $response = $converter->convert($test);
+#  my $regularized_log = $response->{log};
+    }
   # Preprocess split lines back to single lines, e.g.
   # 2|AnythingAn|>>Matched subrule:                    |
   #  |          |[modifierFormulae]<< (return value:   |

--- a/tools/maketests
+++ b/tools/maketests
@@ -108,6 +108,10 @@ sub maketest_daemon {
   my $opts = read_options($source, "$dir/$name");
   push @$opts, (['destination', "$name.test.xml"],
     ['log',                "/dev/null"],
+    ['quiet',              ''],
+    ['quiet',              ''],
+    ['quiet',              ''],
+    ['quiet',              ''],
     ['timeout',            5],
     ['autoflush',          1],
     ['timestamp',          '0'],


### PR DESCRIPTION
This PR refactors the Error module to provide more concise output on STDERR (with the benefit of some cute Terminal tricks), while also providing for a more complete separate log file. It also defines a new `Debug` function, so as to avoid using STDERR except at the lowest level.  The goal is to get predictable and complete error/progress reporting and avoid error prone tricks manipulating STDERR. 

There are several sticking points.  The major one is to tease apart the executables and `LaTeXML.pm` so as to make clear the layers of top-level executable, processing of options/configuration, processing an individual job. This is a chicken/egg problem to establish the desired verbosity and log-file (which presumably is job-specific), before starting to report (or not report) any errors or progress.  Somewhat related to that is how reliably to communicate success or failure to any calling program (with more detail that an error return code).  Related to all that is that I've attempted to keep it functioning the same as before (all tests run unchanged, but please test various server applications), but the code could be more maintainable with a bit cleaner & clearer setup.

A smaller issue is where the log file should go: command-line option; in the working directory; source directory; or destination directory (which often is a security problem).

Finally, is a stylistic issue. I started off trying to keep the API close to the existing one. But as the design started to congeal, some of the functions (particularly those starting with `Note`) began to fit thier names less well.  Since I ended up modifying just about everything anyway, some name adjustment seems allowable.