### PR TITLE
Avoid DefAutoload unless truly certain

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -978,7 +978,12 @@ sub DefAutoload {
   $cs     = T_CS($csname)  unless ref $cs;
   if ($defnfile =~ /^(.*?)\.(pool|sty|cls)\.ltxml$/) {
     my ($name, $type) = ($1, $2);
-    if (!LookupValue($name . '.' . $type . '_loaded')) {    # if already loaded, DONT redefine!
+    # if already loaded, or set, DONT redefine!
+    if (!(
+        LookupValue($name . '.' . $type . '_loaded')       ||
+        LookupValue($name . '.' . $type . '.ltxml_loaded') ||
+        LookupMeaning($cs))) {
+
       DefMacroI($cs, undef, sub {
           $STATE->assign_internal('meaning', $csname => undef, 'global');    # UNDEFINE (no recurse)
           if    ($type eq 'pool') { LoadPool($name); }                       # Load appropriate definitions


### PR DESCRIPTION
I was a bit confused by reports of undefined [\citealp](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/undefined/%5Ccitealp?all=false) and doubly so after I realized they _do_ load natbib correctly.

It turned out that in certain cases natbib would load _before_ OmniBus.cls does, which exposed an interesting conditional related to `DefAutoload`.

It seems that conditional was only checking if the raw TeXy file was loaded, but not if the `.ltxml` binding may have been loaded (as was the case for natbib). Additionally, I think that method should set a command sequence only if it was undefined so far, and never override an existing assignment - so I added a check for `LookupMeaning`.

I tested on the first doc in this report category, cond-mat/0001011