### PR TITLE
closer to native latex.ltx, add \abstracts to OmniBus

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4390,49 +4390,36 @@ DefPrimitive('\newsavebox DefToken', sub {
     DefRegisterI($_[1], undef, Number($n));
     AssignValue('box' . $n, List()); });
 
-DefPrimitive('\sbox {Register} {}', sub {
-    my ($defn) = @{ $_[1] };
-    my $value;
-    if ($defn && ref $defn) {
-      $value = $defn->valueOf();
-      if (ref $value) {
-        $value = $value->valueOf;
-      }
-    } else {
-      Error('expected', '<definition>', undef, "\\sbox expected a definition, was missing");
-    }
-    my $contents = Digest($_[2]);
-    AssignValue('box' . $value, $contents); return; });
-
-DefMacro('\savebox{}', '\@ifnextchar({\pic@savebox#1}{\@savebox#1}');
-DefPrimitive('\@savebox DefToken[][]{}', sub {
-    my ($defn, @args) = @{ LookupDefinition($_[1]) };
-    my $value = $defn->valueOf(@args);
-    AssignValue('box' . $value, Digest($_[4])); return; });
-DefPrimitive('\@savebox Register [][]{}', sub {
-    my ($defn)   = @{ $_[1] };
-    my $value    = $defn->valueOf()->valueOf;
-    my $contents = Digest($_[4]);
-    #    AssignValue('box' . $value, Digest($_[4])); return; });
-    AssignValue('box' . $value, $contents); return; });
-
-DefMacroI('\begin{lrbox}', '{Token}',
-  '\@begin@lrbox #1');
-DefPrimitiveI('\end{lrbox}', undef, sub { $_[0]->egroup; });
-DefPrimitive('\@begin@lrbox Token', sub {
-    my ($stomach, $token) = @_;
-    $stomach->bgroup;
-    #  my $font = $STATE->lookupValue('font');
-    #  my $loc  = $stomach->getGullet->getLocator;
-    #  my $box = LaTeXML::Core::Box->new($stomach->digestNextBody(),$font,$loc);
-    my $box = List($stomach->digestNextBody());
-    AssignValue('box' . ToString($token), $box); });
-
-DefPrimitive('\usebox {Register}', sub {
-    my ($defn) = @{ $_[1] };
-    return Box() unless $defn && ($defn ne 'missing');
-    my $value = $defn->valueOf()->valueOf;
-    LookupValue('box' . $value) || Box(); });
+RawTeX(<<'EOL');
+\def\newsavebox#1{\@ifdefinable{#1}{\newbox#1}}
+\DeclareRobustCommand\savebox[1]{%
+  \@ifnextchar(%)
+    {\@savepicbox#1}{\@ifnextchar[{\@savebox#1}{\sbox#1}}}%
+\DeclareRobustCommand\sbox[2]{\setbox#1\hbox{%
+  \color@setgroup#2\color@endgroup}}
+\def\@savebox#1[#2]{%
+  \@ifnextchar [{\@isavebox#1[#2]}{\@isavebox#1[#2][c]}}
+\long\def\@isavebox#1[#2][#3]#4{%
+  \sbox#1{\@imakebox[#2][#3]{#4}}}
+\def\@savepicbox#1(#2,#3){%
+  \@ifnextchar[%]
+    {\@isavepicbox#1(#2,#3)}{\@isavepicbox#1(#2,#3)[]}}
+\long\def\@isavepicbox#1(#2,#3)[#4]#5{%
+  \sbox#1{\@imakepicbox(#2,#3)[#4]{#5}}}
+\def\lrbox#1{%
+  \edef\reserved@a{%
+    \endgroup
+    \setbox#1\hbox{%
+      \begingroup\aftergroup}%
+        \def\noexpand\@currenvir{\@currenvir}%
+        \def\noexpand\@currenvline{\on@line}}%
+  \reserved@a
+    \@endpefalse
+    \color@setgroup
+      \ignorespaces}
+\def\endlrbox{\unskip\color@endgroup}
+\DeclareRobustCommand\usebox[1]{\leavevmode\copy #1\relax}
+EOL
 
 # A soft sorta \par that only closes an ltx:p, but not ltx:para
 DefConstructor('\lx@parboxnewline[]', sub {
@@ -4723,6 +4710,7 @@ DefConstructor('\pic@makebox Pair []{}',
 DefMacro('\pic@savebox DefToken Pair []{}', '\pic@@savebox{#1}{\pic@makebox #2[#3]{#4}}');
 DefPrimitive('\pic@@savebox DefToken {}', sub {
     AssignValue('box' . ToString($_[1]), Digest($_[2])); return; });
+DefMacro('\@savepicbox', '\pic@savebox');
 
 DefConstructor('\pic@raisebox{Dimension}[Dimension][Dimension]{}',
   "<ltx:g y='#1'>#4</ltx:g>",

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -5040,8 +5040,11 @@ RawTeX(<<'EoTeX');
 \def\@cdr#1#2\@nil{#2}
 \def\@carcube#1#2#3#4\@nil{#1#2#3}
 \def\nfss@text#1{{\mbox{#1}}}
+\def\@sect#1#2#3#4#5#6[#7]#8{}
 EoTeX
 
+Let('\@begindocumenthook', '\@empty');
+DefMacroI('\@preamblecmds', undef, Tokens());
 DefMacro('\@ifdefinable DefToken {}', sub {
     my ($gullet, $token, $if) = @_;
     if (isDefinable($token)) {

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -179,8 +179,8 @@ DefMacroI(T_CS('\newproclaim'), undef, sub {
     RequirePackage('amsthm');
     return T_CS('\newtheorem'); });
 
-# \abstracts
-Let('\abst', '\abstract');
+Let('\abstracts', '\abstract');
+Let('\abst',      '\abstract');
 # \editors
 
 # Seems to come in different spellings and often misused!


### PR DESCRIPTION
So, um, I hope you don't take this the wrong way...

But people are doing weird stuff with the latex.ltx primitives in arXiv! In particular, [gr-qc/0003053](https://arxiv.org/abs/gr-qc/0003053) uses `\savebox1{arg...}` and `\usebox1`, rather than the officially documented backslash-starting box name.

And.. well, it actually works, because the native latex.ltx code allows it to work!

I'm a little hestient to suggest merging here, but I am wondering what other tests one would need to be convinced the native TeX definition works well. It seems to be improving the arXiv article in question at least, but... lilkely worth discussing :> 