### PR TITLE
add \everymath and \everydisplay hooks

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1865,9 +1865,15 @@ DefConstructorI('\@@BEGINDISPLAYMATH', undef,
     . "</ltx:Math>"
     . "</ltx:equation>",
   alias        => '$$',
-  beforeDigest => sub { $_[0]->beginMode('display_math'); },
-  properties   => sub { RefStepID('equation') },
-  captureBody  => 1);
+  beforeDigest => sub {
+    $_[0]->beginMode('display_math');
+    if (my @everymath_toks = LookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
+      $_[0]->getGullet->unread(@everymath_toks); }
+    if (my @everydisplay_toks = LookupDefinition(T_CS('\everydisplay'))->valueOf->unlist()) {
+      $_[0]->getGullet->unread(@everydisplay_toks); }
+    return; },
+  properties  => sub { RefStepID('equation') },
+  captureBody => 1);
 
 DefEnvironment('{displaymath}',
   "<ltx:equation xml:id='#id'>"
@@ -1888,6 +1894,8 @@ DefEnvironment('{math}',
     . "</ltx:Math>",
   mode => 'inline_math',
 );
+
+Let('\curr@math@size', '\@empty');
 
 # Equation Numbering turns out to be rather convoluted!
 # numbered equations & friends want to IMMEDIATELY increment the equation counter

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1867,9 +1867,9 @@ DefConstructorI('\@@BEGINDISPLAYMATH', undef,
   alias        => '$$',
   beforeDigest => sub {
     $_[0]->beginMode('display_math');
-    if (my @everymath_toks = LookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
+    if (my @everymath_toks = $STATE->lookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
       $_[0]->getGullet->unread(@everymath_toks); }
-    if (my @everydisplay_toks = LookupDefinition(T_CS('\everydisplay'))->valueOf->unlist()) {
+    if (my @everydisplay_toks = $STATE->lookupDefinition(T_CS('\everydisplay'))->valueOf->unlist()) {
       $_[0]->getGullet->unread(@everydisplay_toks); }
     return; },
   properties  => sub { RefStepID('equation') },

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -856,10 +856,13 @@ DefMacro('\meaning Token', sub {
         my $value         = $definition->valueOf;
         my $register_type = lc(ref $value);
         my $prefix        = '\count';
-        if ($register_type && $register_type =~ /glue/) {
-          $prefix = '\skip'; }
-        elsif ($register_type && $register_type =~ /dimension/) {
-          $prefix = '\dimen'; }
+        if ($register_type) {
+          if ($register_type =~ /glue/) {
+            $prefix = '\skip'; }
+          elsif ($register_type =~ /dimension/) {
+            $prefix = '\dimen'; }
+          elsif ($register_type =~ /tokens/) {
+            $prefix = '\toks'; } }
         my $literal_value = $register_type && $value->valueOf;
         # Should we be more careful to distinguish between latex and tex counters?
         $meaning = $prefix . $literal_value; }
@@ -3327,8 +3330,13 @@ DefConstructorI('\@@BEGINDISPLAYMATH', undef,
     . "</ltx:Math>"
     . "</ltx:equation>",
   reversion    => Tokens(T_MATH, T_MATH),
-  beforeDigest => sub { $_[0]->beginMode('display_math'); },
-  captureBody  => 1);
+  beforeDigest => sub {
+    $_[0]->beginMode('display_math');
+    if (my @everymath_toks = LookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
+      $_[0]->getGullet->unread(@everymath_toks); }
+    if (my @everydisplay_toks = LookupDefinition(T_CS('\everydisplay'))->valueOf->unlist()) {
+      $_[0]->getGullet->unread(@everydisplay_toks); }
+    return; }, captureBody => 1);
 DefConstructorI('\@@ENDDISPLAYMATH', undef, "",
   reversion    => Tokens(T_MATH, T_MATH),
   beforeDigest => sub { $_[0]->endMode('display_math'); });
@@ -3339,8 +3347,12 @@ DefConstructorI('\@@BEGININLINEMATH', undef,
     . "#body"
     . "</ltx:XMath>"
     . "</ltx:Math>",
-  reversion => Tokens(T_MATH),
-  beforeDigest => sub { $_[0]->beginMode('inline_math'); }, captureBody => 1);
+  reversion    => Tokens(T_MATH),
+  beforeDigest => sub {
+    $_[0]->beginMode('inline_math');
+    if (my @everymath_toks = LookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
+      $_[0]->getGullet->unread(@everymath_toks); }
+    return; }, captureBody => 1);
 DefConstructorI('\@@ENDINLINEMATH', undef, "",
   reversion    => Tokens(T_MATH),
   beforeDigest => sub { $_[0]->endMode('inline_math'); });

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -3332,9 +3332,9 @@ DefConstructorI('\@@BEGINDISPLAYMATH', undef,
   reversion    => Tokens(T_MATH, T_MATH),
   beforeDigest => sub {
     $_[0]->beginMode('display_math');
-    if (my @everymath_toks = LookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
+    if (my @everymath_toks = $STATE->lookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
       $_[0]->getGullet->unread(@everymath_toks); }
-    if (my @everydisplay_toks = LookupDefinition(T_CS('\everydisplay'))->valueOf->unlist()) {
+    if (my @everydisplay_toks = $STATE->lookupDefinition(T_CS('\everydisplay'))->valueOf->unlist()) {
       $_[0]->getGullet->unread(@everydisplay_toks); }
     return; }, captureBody => 1);
 DefConstructorI('\@@ENDDISPLAYMATH', undef, "",
@@ -3350,7 +3350,7 @@ DefConstructorI('\@@BEGININLINEMATH', undef,
   reversion    => Tokens(T_MATH),
   beforeDigest => sub {
     $_[0]->beginMode('inline_math');
-    if (my @everymath_toks = LookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
+    if (my @everymath_toks = $STATE->lookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
       $_[0]->getGullet->unread(@everymath_toks); }
     return; }, captureBody => 1);
 DefConstructorI('\@@ENDINLINEMATH', undef, "",


### PR DESCRIPTION
Fixes #1430 

Apparently we need to add some of the token hooks of TeXBook p.275 to their respective callers. I would assume there is more to add, but this should be a reasonable start which addresses the minimal example in the issue.

I also snuck in a tiny internal latex.ltx macro, and a small fix that properly prints the `\meaning` of a tokens register with the `\toks` prefix.