### PR TITLE
Basic support for standalone.sty

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -457,6 +457,7 @@ lib/LaTeXML/Package/euscript.sty.ltxml
 lib/LaTeXML/Package/exscale.sty.ltxml
 lib/LaTeXML/Package/fancyhdr.sty.ltxml
 lib/LaTeXML/Package/fancyheadings.sty.ltxml
+lib/LaTeXML/Package/filehook.sty.ltxml
 lib/LaTeXML/Package/fix-cm.sty.ltxml
 lib/LaTeXML/Package/fixltx2e.sty.ltxml
 lib/LaTeXML/Package/flafter.sty.ltxml
@@ -619,6 +620,7 @@ lib/LaTeXML/Package/slides.cls.ltxml
 lib/LaTeXML/Package/soul.sty.ltxml
 lib/LaTeXML/Package/srcltx.sty.ltxml
 lib/LaTeXML/Package/standalone.cls.ltxml
+lib/LaTeXML/Package/standalone.sty.ltxml
 lib/LaTeXML/Package/stfloats.sty.ltxml
 lib/LaTeXML/Package/stmaryrd.sty.ltxml
 lib/LaTeXML/Package/subcaption.sty.ltxml

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -41,6 +41,7 @@ DefMacro('\@compatibilitytrue',  '');
 DefMacro('\@compatibilityfalse', '');
 
 Let('\@currentlabel', '\@empty');
+DefMacro('\@currdir', './');
 
 # Let's try just starting with this set (since we've loaded LaTeX)
 AssignValue(inPreamble => 1);    # \begin{document} will clear this.
@@ -4654,6 +4655,8 @@ DefEnvironment('{picture} Pair OptionalPair',
       picProperties(size => picScale($_[1]))); },
   afterDigest => \&after_picture);
 
+DefMacroI(T_CS('\Gin@driver'), undef, Tokens());
+
 DefMacro('\put Until:){}', '\lx@pic@put#1){#2\relax}');
 DefConstructor('\lx@pic@put Pair{}',
   "<ltx:g transform='#pos'>#2</ltx:g>",
@@ -5070,12 +5073,13 @@ DefMacro('\@rc@ifdefinable DefToken {}', sub {
     Let('\@ifdefinable', '\@@ifdefinable');
     return $if->unlist; });
 
-DefMacroI('\@notdefinable', undef,
-  '\@latex@error{%
-   Command \@backslashchar\reserved@a\space
-   already defined.
-   Or name \@backslashchar\@qend... illegal,
-   see p.192 of the manual}');
+DefMacroI('\@notdefinable', undef, <<'EOL');
+\@latex@error{%
+  Command \@backslashchar\reserved@a\space
+  already defined.
+  Or name \@backslashchar\@qend... illegal,
+  see p.192 of the manual}
+EOL
 
 DefMacroI('\@qend',   undef, Tokens(Explode('end')));
 DefMacroI('\@qrelax', undef, Tokens(Explode('relax')));

--- a/lib/LaTeXML/Package/filehook.sty.ltxml
+++ b/lib/LaTeXML/Package/filehook.sty.ltxml
@@ -1,0 +1,29 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  filehook.sty                                                           | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@nist.gov>                          #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+
+# this comparison can't reliably work with latexml's subroutine
+# macro definitions,
+# so default it to *true* to avoid needless warnings
+DefMacro('\filehook@cmp{}{}', '\@firstoftwo', locked => 1);
+
+InputDefinitions('filehook', type => 'sty', noltxml => 1);
+
+#**********************************************************************
+
+1;

--- a/lib/LaTeXML/Package/standalone.sty.ltxml
+++ b/lib/LaTeXML/Package/standalone.sty.ltxml
@@ -32,7 +32,8 @@ DefPrimitive('\@standalone@documentclass[]{}', sub {
     Let(T_CS('\end{document}'),   T_CS('\@standalone@end@input'));
     return; });
 
-Let('\documentclass', '\@standalone@documentclass');
+AtBeginDocument(sub {
+    Let('\documentclass', '\@standalone@documentclass'); });
 
 #**********************************************************************
 

--- a/lib/LaTeXML/Package/standalone.sty.ltxml
+++ b/lib/LaTeXML/Package/standalone.sty.ltxml
@@ -1,0 +1,39 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  standalone.sty                                                           | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@nist.gov>                          #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+
+DefMacro('\@standalone@end@input', '\egroup\endinput');
+DefPrimitiveI(T_CS('\@standalone@start@input'), undef, sub {
+    AssignValue(inPreamble => 0);
+    return; });
+DefPrimitive('\@standalone@documentclass[]{}', sub {
+    my ($stomach, $packages) = @_;
+    $stomach->bgroup;
+    AssignValue(inPreamble => 1);
+    for my $package (split(",", ToString($packages))) {
+      RequirePackage($package);
+    }
+    Let(T_CS('\begin{document}'), T_CS('\@standalone@start@input'));
+    Let(T_CS('\end{document}'),   T_CS('\@standalone@end@input'));
+    return; });
+
+Let('\documentclass', '\@standalone@documentclass');
+
+#**********************************************************************
+
+1;


### PR DESCRIPTION
Fixes #678

At least a basic use of standalone.sty should be supported now.

Example [from the docs](https://ctan.math.illinois.edu/macros/latex/contrib/standalone/standalone.pdf), if you have two files:

- main.tex
```tex
% Main file
% Real document class:
\documentclass{article}
% Use the ’standalone’ package:
\usepackage{standalone}
% Load all packages needed for all sub−files:
\usepackage{tikz}
% Inside the real ’document’ environment
% read the sub−file with ’\input’
\begin{document}
% ...
\begin{figure}
  \input{fig}
  \caption{A subfile}
\end{figure}
% ...
\end{document}
```

- fig.tex
```tex
\documentclass[tikz]{standalone}
\usetikzlibrary{calc}
\begin{document}
\begin{tikzpicture}
  \draw (0,0) rectangle (2,1) node [midway] {Example};
\end{tikzpicture}
% Further ’tikzpicture’ environments are possible which will create further pages.
\end{document}
```

For the basic use a simple binding ended up more manageable than the convoluted TeX internals that we can't support fully yet. I added a few minor pieces that get us a little closer to a raw interpretation of `standalone.sty`, but to get everything correctly I'd need to enable shellescapes, and emulate them accurately - which is more work than the feature itself is worth. Relaxing the usual latex macros in a local scope from a perl binding works just fine for this basic use.