### PR TITLE
Ensure empty dates dont deposit any content in HTML

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -649,7 +649,7 @@
   <xsl:template name="dates">
     <xsl:param name="context"/>
     <xsl:param name="dates" select="ltx:date"/>
-    <xsl:if test="$dates">
+    <xsl:if test="$dates and string($dates)">
       <xsl:text>&#x0A;</xsl:text>
       <!-- Originally, html5 seemed to suggest we might use h2 here, but that is retracted-->
       <xsl:element name="div" namespace="{$html_ns}">


### PR DESCRIPTION
I finally felt brave enough to open a `no_problem` article in arXiv, namely [the HTML of 1504.05855](https://corpora.mathweb.org/preview/arxmliv/tex_to_html/1504.05855?style=simple), and spotted a cosmetic oversight.

The current XSLT allows a `\date{}` to propagate into the HTML as `<div class="ltx_dates">()</div>`, due to a test which checks only if a node exists, but not whether it is empty.

Not my most notable PR ... 