### PR TITLE
Modernize HTML5: add viewport meta tag

### DIFF
--- a/lib/LaTeXML/resources/CSS/LaTeXML-navbar-left.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-navbar-left.css
@@ -9,4 +9,5 @@
 .ltx_page_main {
     position:absolute; left:190px; top:0px; right:2px; 
     margin:0px; padding:1em 3em 1em 2em;
+    padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%), min(2em, 3%);
     width:70%; }

--- a/lib/LaTeXML/resources/CSS/LaTeXML-navbar-right.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-navbar-right.css
@@ -7,4 +7,5 @@
     margin-left:-2em; }
 .ltx_page_main {
     margin:0px; padding:1em 3em 1em 2em;
+    padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%), min(2em, 3%);
     width:75%; }

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -59,7 +59,8 @@
 
 /* .ltx_chapter_title, etc should be in ltx-article.css etc.
  */
-.ltx_page_main { margin:0px; padding:1em 3em 1em 2em; }
+.ltx_page_main { margin:0px; padding:1em 3em 1em 2em;
+    padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%), min(2em, 3%); }
 .ltx_tocentry  { list-style-type:none; }
 
 /* support for common author block layouts.*/

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -59,7 +59,8 @@
 
 /* .ltx_chapter_title, etc should be in ltx-article.css etc.
  */
-.ltx_page_main { margin:0px; padding:1em 3em 1em 2em;
+.ltx_page_main { margin:0px auto; max-width: 36em; max-width: 72ch;
+    padding:1em 3em 1em 2em;
     padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%), min(2em, 3%); }
 .ltx_tocentry  { list-style-type:none; }
 

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-html5.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-html5.xsl
@@ -32,6 +32,9 @@
   <xsl:param name="USE_NAMESPACES"  ></xsl:param>
   <xsl:param name="USE_HTML5"       >true</xsl:param>
 
+  <!-- Mobile-friendly default viewport setting. -->
+  <xsl:param name="META_VIEWPORT">width=device-width, initial-scale=1, shrink-to-fit=no</xsl:param>
+
   <xsl:template match="/" mode="doctype">
     <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html></xsl:text>
   </xsl:template>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -36,6 +36,10 @@
   <xsl:param name="HEAD_TITLE_PREFIX"></xsl:param>
   <xsl:param name="HEAD_TITLE_SHOW_CONTEXT">true</xsl:param>
 
+  <!-- Use this string as meta viewport tag.
+       The tag is omitted if the string is empty. -->
+  <xsl:param name="META_VIEWPORT"></xsl:param>
+
   <!-- We don't really anticipate page structure appearing in inline contexts,
        so we pretty much ignore the $context switches.
        See the CONTEXT discussion in LaTeXML-common -->
@@ -106,6 +110,7 @@
       <xsl:apply-templates select="." mode="head-content-type"/>
       <xsl:apply-templates select="." mode="head-icon"/>
       <xsl:apply-templates select="." mode="head-resources"/>
+      <xsl:apply-templates select="." mode="head-viewport"/>
       <xsl:apply-templates select="." mode="head-css"/>
       <xsl:apply-templates select="." mode="head-javascript"/>
       <xsl:apply-templates select="." mode="head-links"/>
@@ -498,6 +503,18 @@
       <xsl:attribute name="type"><xsl:value-of select="@type"/></xsl:attribute>
       <xsl:apply-templates select="text()"/>
     </xsl:element>
+  </xsl:template>
+
+  <!-- Generate a meta configuring the viewport. -->
+  <xsl:template match="/" mode="head-viewport">
+    <xsl:if test="$META_VIEWPORT">
+      <xsl:element name="meta" namespace="{$html_ns}">
+        <xsl:attribute name="name">viewport</xsl:attribute>
+        <xsl:attribute name="content">
+          <xsl:value-of select="$META_VIEWPORT"/>
+        </xsl:attribute>
+      </xsl:element>
+    </xsl:if>
   </xsl:template>
 
   <!-- Generate CSS line & style entries for the head.


### PR DESCRIPTION
This is an attempt at modernising the generic HTML5 output.

I have added a meta viewport tag, strictly for the HTML5 output only, with default value `width=device-width, initial-scale=1, shrink-to-fit=no` (taken from [arXiv Vanity](https://www.arxiv-vanity.com/)). This should make the output mobile friendly in most cases. I think it's reasonable to turn it on by default, as the current output is generally bad on mobile, and the tag has no effect on desktop anyway.

I'd like to make a few more changes like this, so I thought of adding XSLT parameters to configure these updates. As I mentioned on the mailing list, inlining SVG images and using `<img>` instead of `<object>` would be next, and for that a parameter like `INLINE_SVG` is probably warranted to maintain compatibility with old browsers (and possibly the use cases mentioned in [`LaTeXML-xhtml-misc.xsl`](https://github.com/brucemiller/LaTeXML/blob/master/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl#L188)?).

Now for the viewport tag, one can override the `mode="head-viewport"` template, which is easy enough to do, but to get a sense of how things would look like I have added a parameter `META_VIEWPORT` to change the viewport value or remove the tag altogether.

PS: I also took the liberty of moving the content-type meta tag at the top of the head, since it is supposed to appear as early as possible [1].

[1] https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/Introduction_to_HTML5#declaring_the_character_set_with_the_%3Cmeta_charset%3E