### PR TITLE
Improve SVG accessibility

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
@@ -144,38 +144,10 @@
     <xsl:element name="img" namespace="{$html_ns}">
       <xsl:attribute name="src"><xsl:value-of select="f:url(@imagesrc)"/></xsl:attribute>
       <xsl:call-template name="add_id"/>
-      <xsl:call-template name="add_attributes">
-        <xsl:with-param name="extra_style">
-          <xsl:if test="@imagedepth">
-            <xsl:value-of select="concat('vertical-align:-',@imagedepth,'px')"/>
-          </xsl:if>
-        </xsl:with-param>
-      </xsl:call-template>
-      <xsl:if test="@imagewidth">
-        <xsl:attribute name='width'>
-          <xsl:value-of select="@imagewidth"/>
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@imageheight">
-        <xsl:attribute name='height'>
-          <xsl:value-of select="@imageheight"/>
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:choose>
-        <xsl:when test="@description">
-          <xsl:attribute name='alt'>
-            <xsl:value-of select="@description"/>
-          </xsl:attribute>
-        </xsl:when>
-        <xsl:when test="ancestor::ltx:figure/ltx:caption">
-          <xsl:attribute name='alt'>
-            <xsl:value-of select="ancestor::ltx:figure/ltx:caption/text()"/>
-          </xsl:attribute>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:attribute name='alt'></xsl:attribute> <!--required; what else? -->
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:apply-templates select="." mode="graphics-attributes"/>
+      <xsl:attribute name='alt'>
+        <xsl:apply-templates select="." mode="graphics-description"/>
+      </xsl:attribute>
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>
@@ -190,37 +162,13 @@
   <xsl:template match="ltx:graphics[f:ends-with(@imagesrc,'.svg')='true']">
     <xsl:param name="context"/>
     <xsl:variable name="description">
-      <xsl:choose>
-        <xsl:when test="@description">
-          <xsl:value-of select="@description"/>
-        </xsl:when>
-        <xsl:when test="ancestor::ltx:figure/ltx:caption">
-            <xsl:value-of select="ancestor::ltx:figure/ltx:caption/text()"/>
-        </xsl:when>
-        <xsl:otherwise/>
-      </xsl:choose>
+      <xsl:apply-templates select="." mode="graphics-description"/>
     </xsl:variable>
     <xsl:element name="object" namespace="{$html_ns}">
       <xsl:attribute name="type">image/svg+xml</xsl:attribute>
       <xsl:attribute name="data"><xsl:value-of select="f:url(@imagesrc)"/></xsl:attribute>
       <xsl:call-template name="add_id"/>
-      <xsl:call-template name="add_attributes">
-        <xsl:with-param name="extra_style">
-          <xsl:if test="@imagedepth">
-            <xsl:value-of select="concat('vertical-align:-',@imagedepth,'px')"/>
-          </xsl:if>
-        </xsl:with-param>
-      </xsl:call-template>
-      <xsl:if test="@imagewidth">
-        <xsl:attribute name='width'>
-          <xsl:value-of select="@imagewidth"/>
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@imageheight">
-        <xsl:attribute name='height'>
-          <xsl:value-of select="@imageheight"/>
-        </xsl:attribute>
-      </xsl:if>
+      <xsl:apply-templates select="." mode="graphics-attributes"/>
       <!-- the object tag does not support alt, so use
            aria-label instead -->
       <xsl:if test="$description!=''">
@@ -231,8 +179,8 @@
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>
-      <!-- fallback text for screen reader/browser combinations
-           which do not accept the aria-label -->
+      <!-- fallback text for user agents which do not accept
+            the aria-label -->
       <xsl:if test="$description!=''">
         <xsl:element name="{f:blockelement($context,'p')}" namespace="{$html_ns}">
           <xsl:value-of select="$description"/>
@@ -242,6 +190,38 @@
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>
     </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="ltx:graphics" mode="graphics-attributes">
+    <xsl:call-template name="add_attributes">
+      <xsl:with-param name="extra_style">
+        <xsl:if test="@imagedepth">
+          <xsl:value-of select="concat('vertical-align:-',@imagedepth,'px')"/>
+        </xsl:if>
+      </xsl:with-param>
+    </xsl:call-template>
+    <xsl:if test="@imagewidth">
+      <xsl:attribute name='width'>
+        <xsl:value-of select="@imagewidth"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="@imageheight">
+      <xsl:attribute name='height'>
+        <xsl:value-of select="@imageheight"/>
+      </xsl:attribute>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="ltx:graphics" mode="graphics-description">
+    <xsl:choose>
+      <xsl:when test="@description">
+        <xsl:value-of select="@description"/>
+      </xsl:when>
+      <xsl:when test="ancestor::ltx:figure/ltx:caption">
+          <xsl:value-of select="ancestor::ltx:figure/ltx:caption/text()"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
   </xsl:template>
 
   <!-- ======================================================================

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
@@ -179,13 +179,21 @@
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>
-      <!-- fallback text for user agents which do not accept
-            the aria-label -->
-      <xsl:if test="$description!=''">
-        <xsl:element name="{f:blockelement($context,'p')}" namespace="{$html_ns}">
+      <!-- fallback img for user agents which do not process
+           the object tag properly -->
+      <xsl:element name="img" namespace="{$html_ns}">
+        <xsl:attribute name="src"><xsl:value-of select="f:url(@imagesrc)"/></xsl:attribute>
+        <xsl:apply-templates select="." mode="graphics-attributes"/>
+        <xsl:attribute name='alt'>
           <xsl:value-of select="$description"/>
-        </xsl:element>
-      </xsl:if>
+        </xsl:attribute>
+        <xsl:apply-templates select="." mode="begin">
+          <xsl:with-param name="context" select="$context"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="." mode="end">
+          <xsl:with-param name="context" select="$context"/>
+        </xsl:apply-templates>
+      </xsl:element>
       <xsl:apply-templates select="." mode="end">
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
@@ -189,6 +189,17 @@
        to preserve any interactivity. -->
   <xsl:template match="ltx:graphics[f:ends-with(@imagesrc,'.svg')='true']">
     <xsl:param name="context"/>
+    <xsl:variable name="description">
+      <xsl:choose>
+        <xsl:when test="@description">
+          <xsl:value-of select="@description"/>
+        </xsl:when>
+        <xsl:when test="ancestor::ltx:figure/ltx:caption">
+            <xsl:value-of select="ancestor::ltx:figure/ltx:caption/text()"/>
+        </xsl:when>
+        <xsl:otherwise/>
+      </xsl:choose>
+    </xsl:variable>
     <xsl:element name="object" namespace="{$html_ns}">
       <xsl:attribute name="type">image/svg+xml</xsl:attribute>
       <xsl:attribute name="data"><xsl:value-of select="f:url(@imagesrc)"/></xsl:attribute>
@@ -210,23 +221,23 @@
           <xsl:value-of select="@imageheight"/>
         </xsl:attribute>
       </xsl:if>
-      <!-- the object tag does not support alt, so use aria-label instead -->
-      <xsl:choose>
-        <xsl:when test="@description">
-          <xsl:attribute name='aria-label'>
-            <xsl:value-of select="@description"/>
-          </xsl:attribute>
-        </xsl:when>
-        <xsl:when test="ancestor::ltx:figure/ltx:caption">
-          <xsl:attribute name='aria-label'>
-            <xsl:value-of select="ancestor::ltx:figure/ltx:caption/text()"/>
-          </xsl:attribute>
-        </xsl:when>
-        <xsl:otherwise/>
-      </xsl:choose>
+      <!-- the object tag does not support alt, so use
+           aria-label instead -->
+      <xsl:if test="$description!=''">
+        <xsl:attribute name='aria-label'>
+          <xsl:value-of select="$description"/>
+        </xsl:attribute>
+      </xsl:if>
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>
+      <!-- fallback text for screen reader/browser combinations
+           which do not accept the aria-label -->
+      <xsl:if test="$description!=''">
+        <xsl:element name="{f:blockelement($context,'p')}" namespace="{$html_ns}">
+          <xsl:value-of select="$description"/>
+        </xsl:element>
+      </xsl:if>
       <xsl:apply-templates select="." mode="end">
         <xsl:with-param name="context" select="$context"/>
       </xsl:apply-templates>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
@@ -210,20 +210,19 @@
           <xsl:value-of select="@imageheight"/>
         </xsl:attribute>
       </xsl:if>
+      <!-- the object tag does not support alt, so use aria-label instead -->
       <xsl:choose>
         <xsl:when test="@description">
-          <xsl:attribute name='alt'>
+          <xsl:attribute name='aria-label'>
             <xsl:value-of select="@description"/>
           </xsl:attribute>
         </xsl:when>
         <xsl:when test="ancestor::ltx:figure/ltx:caption">
-          <xsl:attribute name='alt'>
+          <xsl:attribute name='aria-label'>
             <xsl:value-of select="ancestor::ltx:figure/ltx:caption/text()"/>
           </xsl:attribute>
         </xsl:when>
-        <xsl:otherwise>
-          <xsl:attribute name='alt'></xsl:attribute> <!--required; what else? -->
-        </xsl:otherwise>
+        <xsl:otherwise/>
       </xsl:choose>
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$context"/>


### PR DESCRIPTION
The current way to include external SVG images (via the `<object>` tag) has accessibility issues, see e.g. [1].

This PR replaces the `alt` attribute with `aria-label`, and uses the normal `<img>` tag as fallback content (without duplicating the `id`, of course!), which seems to be better for screen readers, although still not very good. This should also fix part of #1440.

To reduce the amount of duplication, I have moved the code generating the `description` and common attributes (`height`, `width`, ...) into new modes of templates matching `ltx:graphics`.

[1] https://www.powermapper.com/tests/screen-readers/elements/#object