### PR TITLE
add exception guards to \meaning for some primitives

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -864,12 +864,17 @@ DefMacro('\meaning Token', sub {
         # Should we be more careful to distinguish between latex and tex counters?
         $meaning = $prefix . $literal_value; }
       elsif ($type =~ /expandable$/i) {
+# short-circuit some troublesome discrepancies with TeX, which end up macros on LaTeXML's end, but \meaning expects as primitives in the CTAN ecosystem.
+        my $cs = ToString($definition->getCSorAlias);
+        # These exceptions could be extended further, as we add more .sty/.cls support
+        return Explode($cs) if $cs =~ /^\\(?:(?:un)?expanded|detokenize)$/;
         my $expansion  = $definition->getExpansion;
         my $ltxps      = $definition->getParameters;
         my $arg_index  = 0;
         my @spec_parts = ();
         my @params     = $ltxps ? $ltxps->getParameters : ();
         my $p_trailer  = '';
+
         for my $param (@params) {
           my $p_spec = $$param{spec};
           if ($p_spec eq 'RequireBrace') {


### PR DESCRIPTION
Fixes #1455 

A bit of a losing battle, but since there is only a finite number of primitives, might as well fight another round. I excepted 3 command sequences that are TeX primitives and used as such via `\meaning`, but are currently defined via `DefMacro` in latexml.

It is starting to dawn on me that `\meaning` is a bit of an information bottleneck for this distinction - in most (all?) instances where the primitive vs macro difference is relevant to a module developer or tex author, it is accessed through `\meaning`. So ensuring pdftex parity in the definition of `\meaning` itself is viable, and much easier than refactoring all `DefMacro`s into equivalent `DefPrimitive`s.

Expedient suggestion, but maybe expedience is appropriate? 