### PR TITLE
remove download button from listings in EPUB3

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
@@ -57,4 +57,8 @@
   <xsl:template match="ltx:rdf">
   </xsl:template>
 
+  <!-- Linking to a text/plain data URL is invalid in EPUB3,
+       so just skip over it -->
+  <xsl:template match="ltx:listing[@data]" mode="begin"/>
+
 </xsl:stylesheet>


### PR DESCRIPTION
Quick fix for #1457 until a better solution is available.