### PR TITLE
add \unicode extension from MathJax to texvc.sty

### DIFF
--- a/lib/LaTeXML/Package/texvc.sty.ltxml
+++ b/lib/LaTeXML/Package/texvc.sty.ltxml
@@ -56,7 +56,7 @@ DefPrimitive('\unicode[][]{}', sub {
       $code = hex $code }
     else {
       $code = int($code); }
-    my $code_char = chr($code);
+    my $code_char = UTF($code);
     return Box($code_char, undef, undef,
       T_OTHER($code_char)); });
 

--- a/lib/LaTeXML/Package/texvc.sty.ltxml
+++ b/lib/LaTeXML/Package/texvc.sty.ltxml
@@ -50,9 +50,15 @@ Let('\@equationgroup@number', '\nonumber');
 # λ (\unicode{x00C5}) for λ (Å)
 # Documentation:
 # http://docs.mathjax.org/en/latest/input/tex/extensions/unicode.html
-DefMacro('\unicode[][]{}', sub {
-    my $code = hex ToString($_[3]);
-    return T_OTHER(chr($code)); });
+DefPrimitive('\unicode[][]{}', sub {
+    my $code = ToString($_[3]);
+    if ($code =~ /^x/) {
+      $code = hex $code }
+    else {
+      $code = int($code); }
+    my $code_char = chr($code);
+    return Box($code_char, undef, undef,
+      T_OTHER($code_char)); });
 
 #======================================================================
 # Uppercase Greek (the ones not already defined in TeX)

--- a/lib/LaTeXML/Package/texvc.sty.ltxml
+++ b/lib/LaTeXML/Package/texvc.sty.ltxml
@@ -46,6 +46,14 @@ Let('\and',  '\land');       # Normally for frontmatter
 #AssignValue(EQUATIONROW_NUMBER=>0);
 Let('\@equationgroup@number', '\nonumber');
 
+# MathJax allows an explicit \unicode character specification, as seen in StackExchange:
+# λ (\unicode{x00C5}) for λ (Å)
+# Documentation:
+# http://docs.mathjax.org/en/latest/input/tex/extensions/unicode.html
+DefMacro('\unicode[][]{}', sub {
+    my $code = hex ToString($_[3]);
+    return T_OTHER(chr($code)); });
+
 #======================================================================
 # Uppercase Greek (the ones not already defined in TeX)
 DefMathI('\Alpha', undef, "\x{0391}");


### PR DESCRIPTION
Thanks for merging #1466 ! It unlocked another debugging round for me, which led to my seeing a construct that had previously dodged my attention - the MathJax-postulated `\unicode` macro. Thankfully that is incredibly simple, docs here:

http://docs.mathjax.org/en/latest/input/tex/extensions/unicode.html

It's used in StackExchange, which relies heavily on texvc.sty, and I think it is a rather good location to unify all not-quite-tex extensions. But if you'd like a stranger `mathjax.sty.ltxml` contribution, I could also refactor to that... 