### PR TITLE
don't force fallback to .ltxml if INTERPRETING_DEFINITIONS

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1940,7 +1940,8 @@ sub FindFile_aux {
   if (!$options{noltxml}) {
     if ($path = pathname_find("$file.ltxml", paths => $ltxml_paths, installation_subdir => 'Package')) {
       return $path; }
-    elsif ($path = FindFile_fallback($file, $ltxml_paths, %options)) {
+    elsif (!LookupValue('INTERPRETING_DEFINITIONS')
+      && ($path = FindFile_fallback($file, $ltxml_paths, %options))) {
       return $path; } }
   # If we're looking for TeX, look within our paths & installation first (faster than kpse)
   if (!$options{notex}


### PR DESCRIPTION
I think we're a little too zealous trying to find an ltxml fallback file in the case where we're already using `INTERPRETING_DEFINITIONS`. In the bug report `filehook.sty` tries to load `filehook-2019.sty`, but the fall back "corrects" this back into `filehook.sty`!

Hopefully, this still does all the right things in an arXiv context?

fixes #1470