### PR TITLE
fix \endinput

### DIFF
--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -77,11 +77,14 @@ sub mouthIsOpen {
     || grep { $_ && ($$_[0] eq $mouth) } @{ $$self{mouthstack} }; }
 
 # This flushes a mouth so that it will be automatically closed, next time it's read
-# Corresponds (I think) to TeX's \endinput
+# Corresponds to TeX's \endinput
 sub flushMouth {
   my ($self) = @_;
-  $$self{mouth}->finish;     # but not close!
-  $$self{pushback}  = [];    # And don't read anytyhing more from it.
+  my $mouth = $$self{mouth};
+  # Put the remainder of Mouth's current line at the END of the pushback stack, to be read
+  while (!$mouth->isEOL) {
+    push(@{ $$self{pushback} }, $mouth->readToken); }
+  $mouth->finish;    # then finish the mouth (it'll get closed on next read)
   $$self{autoclose} = 1;
   return; }
 

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -979,17 +979,7 @@ DefMacro('\input TeXFileName', sub { Input($_[1]); });
 
 # Note that TeX doesn't actually close the mouth;
 # it just flushes it so that it will close the next time it's read!
-DefMacroI('\endinput', undef, sub {
-    my ($gullet) = @_;
-    my $mouth = $gullet->getMouth;
-    my $line;
-    if (!$mouth->isEOL) {
-      $line = $gullet->readRawLine; }
-    $gullet->flushMouth;
-    if ($line) {
-      $gullet->unread(Tokenize($line)); }
-    return;
-});
+DefMacroI('\endinput', undef, sub { $_[0]->flushMouth; });
 
 # \the<internal quantity>
 DefMacro('\the Register', sub {


### PR DESCRIPTION
fix \endinput to preserve pushback'd tokens; update gullet->flushMouth to do that job.

Fixes #1481 