### PR TITLE
Change test utflettercase.tex to use \MakeLowercase und \MakeUppercase

### DIFF
--- a/t/expansion/utflettercase.tex
+++ b/t/expansion/utflettercase.tex
@@ -1,7 +1,7 @@
 \documentclass{article}
 \usepackage[utf8]{inputenc}
 \begin{document}
-\uppercase{(aou) (äöü) (ÄÖÜ)}
+\MakeUppercase{(aou) (äöü) (ÄÖÜ)}
 
-\lowercase{(aou) (ÄÖÜ) (äöü)}
+\MakeLowercase{(aou) (ÄÖÜ) (äöü)}
 \end{document}


### PR DESCRIPTION
- utflettercase.tex only compiles with error into pdf with texlive >= 2015 (previous versions not tested)
- (iso8859-1 letters are created for \lowercase)
- instead use the Latex commands \MakeLowercase and \MakeUppercase
- pdf (visual) and xml output is not changed.