### PR TITLE
Suggestion for hinting for maketests

### DIFF
--- a/t/expansion/utflettercase.tex
+++ b/t/expansion/utflettercase.tex
@@ -1,3 +1,6 @@
+%+++
+% tex = xelatex
+%+++
 \documentclass{article}
 \usepackage[utf8]{inputenc}
 \begin{document}

--- a/t/expansion/utflettercase.tex
+++ b/t/expansion/utflettercase.tex
@@ -1,6 +1,6 @@
-%+++
-% tex = xelatex
-%+++
+%%%
+%%% TeX-engine: xelatex
+%%%
 \documentclass{article}
 \usepackage[utf8]{inputenc}
 \begin{document}

--- a/tools/maketests
+++ b/tools/maketests
@@ -277,9 +277,9 @@ sub gen_pdf {
     if (/documentclass/) {
         $program = 'pdflatex';
         last; }
-    # recognize %tex = "xelatex"  or %tex = xelatex in preamble
-    if (/^%\s*(la)*tex\s*=\s*\"*(\w+)\"*\s*/) {
-        $program = $2;
+    # recognize %%% TeX-engine: xelatex  or %%%tex-engine: "xelatex" in preamble
+    if (/^%%%\s*tex-engine:\s*"*(\w+)"*/i) {
+        $program = $1;
         last; }
   }
   close($IN);

--- a/tools/maketests
+++ b/tools/maketests
@@ -284,7 +284,6 @@ sub gen_pdf {
   }
   close($IN);
   local $ENV{TEXINPUTS} = "$FindBin::RealBin/../lib/LaTeXML/texmf/::" . ($ENV{TEXINPUTS} || '');
-  print "Program:$program\n";
   system($program, '-interaction=batchmode', $name) == 0 or die "Couldn't run $program $name: $!";
   system($program, '-interaction=batchmode', $name) == 0 or die "Couldn't run $program $name: $!";
 

--- a/tools/maketests
+++ b/tools/maketests
@@ -274,9 +274,17 @@ sub gen_pdf {
   open($IN, '<', "$name.tex") or die "Cannot scanTeX file $name.tex: $!";
 
   while (<$IN>) {
-    $program = 'pdflatex' if /documentclass/; }
+    if (/documentclass/) {
+        $program = 'pdflatex';
+        last; }
+    # recognize %tex = "xelatex"  or %tex = xelatex in preamble
+    if (/^%\s*(la)*tex\s*=\s*\"*(\w+)\"*\s*/) {
+        $program = $2;
+        last; }
+  }
   close($IN);
   local $ENV{TEXINPUTS} = "$FindBin::RealBin/../lib/LaTeXML/texmf/::" . ($ENV{TEXINPUTS} || '');
+  print "Program:$program\n";
   system($program, '-interaction=batchmode', $name) == 0 or die "Couldn't run $program $name: $!";
   system($program, '-interaction=batchmode', $name) == 0 or die "Couldn't run $program $name: $!";
 


### PR DESCRIPTION
Here is one suggestion to provide a hint to compile a testcase. It solves the problem that t/expansion/uflettercase.tex needs xelatex to successfully compile. But maketests tries to either pdftex or pdflatex if called with --pdf option. Use a simple hinting (compatible to llmk) to find out which compiler should be used. 

t/expansion/utflettercase contains `% tex = xelatex`. This is detected and xelatex is used to successfully compile the testcase to pdf. If no hint is given, previous detection for pdflatex is used.
