### PR TITLE
fix halign hack

### DIFF
--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -312,7 +312,6 @@ sub egroup {
 sub begingroup {
   my ($self) = @_;
   pushStackFrame($self, 1);
-  $LaTeXML::ALIGN_STATE++;
   return; }
 
 sub endgroup {
@@ -323,7 +322,6 @@ sub endgroup {
       $self->currentFrameMessage); }
   else {                                         # Don't pop if there's an error; maybe we'll recover?
     popStackFrame($self, 1); }
-  $LaTeXML::ALIGN_STATE--;
   return; }
 
 #======================================================================


### PR DESCRIPTION
Fix the badfix (begin/endgroup should NOT look like braces for alignments)