### PR TITLE
Enable fontenc-aware lower/uppercase for cyrillic

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -5096,20 +5096,47 @@ Let('\@sptoken', T_SPACE);
 
 DefMacroI('\@uclclist', undef, '\oe\OE\o\O\ae\AE\dh\DH\dj\DJ\l\L\ng\NG\ss\SS\th\TH');
 
-DefMacro('\MakeUppercase{}', sub {
-    my @t = LookupDefinition(T_CS('\@uclclist'))->getExpansion->unlist;
-    my @x = (T_CS('\def'), T_CS('\i'), T_BEGIN, T_LETTER('I'), T_END,
-      T_CS('\def'), T_CS('\j'), T_BEGIN, T_LETTER('J'), T_END);
-    while (@t) { push(@x, T_CS('\let'), shift(@t), shift(@t)); }
-    my $arg = Expand(Tokens(T_BEGIN, @x, $_[1]->unlist, T_END));
-    (T_CS('\uppercase'), T_BEGIN, $arg->unlist, T_END); });
+sub ltx_adjust_case {
+  my ($arg, $flag_lower) = @_;
+  my @adjusted = ();
+  for my $token ($arg->unlist) {
+    if ($$token[1] == CC_OTHER) {
+      my $letter = $$token[0];
+      my $cased  = $flag_lower ? lc($letter) : uc($letter);
+      if ($letter ne $cased) {
+        push(@adjusted, T_OTHER($cased)); }
+      else {
+        push(@adjusted, $token); } }
+    else {
+      push(@adjusted, $token); } }
+  return @adjusted;
+}
+DefMacro('\ltx@uppercase Expanded', sub { return ltx_adjust_case($_[1], 0); });
+DefMacro('\ltx@lowercase Expanded', sub { return ltx_adjust_case($_[1], 1); });
 
-DefMacro('\MakeLowercase{}', sub {
-    my @t = LookupDefinition(T_CS('\@uclclist'))->getExpansion->unlist;
-    my @x = ();
-    while (@t) { my $y = shift(@t); push(@x, T_CS('\let'), shift(@t), $y); }
-    my $arg = Expand(Tokens(T_BEGIN, @x, $_[1]->unlist, T_END));
-    (T_CS('\lowercase'), T_BEGIN, $arg->unlist, T_END); });
+RawTeX(<<'EOL');
+\DeclareRobustCommand{\MakeUppercase}[1]{{%
+      \def\i{I}\def\j{J}%
+      \def\reserved@a##1##2{\let##1##2\reserved@a}%
+      \expandafter\reserved@a\@uclclist\reserved@b{\reserved@b\@gobble}%
+      \let\UTF@two@octets@noexpand\@empty
+      \let\UTF@three@octets@noexpand\@empty
+      \let\UTF@four@octets@noexpand\@empty
+      \protected@edef\reserved@a{\uppercase{#1}}%
+      \ltx@uppercase{\reserved@a}
+   }}
+\DeclareRobustCommand{\MakeLowercase}[1]{{%
+      \def\reserved@a##1##2{\let##2##1\reserved@a}%
+      \expandafter\reserved@a\@uclclist\reserved@b{\reserved@b\@gobble}%
+      \let\UTF@two@octets@noexpand\@empty
+      \let\UTF@three@octets@noexpand\@empty
+      \let\UTF@four@octets@noexpand\@empty
+      \protected@edef\reserved@a{\lowercase{#1}}%
+      \ltx@lowercase{\reserved@a}
+   }}
+\protected@edef\MakeUppercase#1{\MakeUppercase{#1}}
+\protected@edef\MakeLowercase#1{\MakeLowercase{#1}}
+EOL
 
 #======================================================================
 

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2666,10 +2666,15 @@ DefPrimitive('\DeclareFontEncoding{}{}{}', sub {
       T_BEGIN, T_CS('\default@family'), T_END,
       T_BEGIN, T_CS('\default@series'), T_END,
       T_BEGIN, T_CS('\default@shape'),  T_END);
-    my $e = Expand($encoding);
-    DefMacroI('\LastDeclaredEncoding', undef, $e);
-    DefMacroI('\T@' . ToString($e),    undef, $x);
-    DefMacroI('\M@' . ToString($e),    undef, Tokens(T_CS('\default@M'), $y->unlist));
+    my $encoding_expanded = Expand($encoding);
+    my $encoding_str      = ToString($encoding_expanded);
+    DefMacroI('\LastDeclaredEncoding', undef, $encoding_expanded);
+    DefMacroI('\T@' . $encoding_str,   undef, $x);
+    DefMacroI('\M@' . $encoding_str,   undef, Tokens(T_CS('\default@M'), $y->unlist));
+    if (my $path = $encoding_str && FindFile(lc($encoding_str) . "enc", type => "dfu")) {
+      InputDefinitions($path);
+    }
+    return;
 });
 DefMacroI('\LastDeclaredEncoding', undef, '');
 DefPrimitive('\DeclareFontSubstitution{}{}{}{}', undef);
@@ -5096,24 +5101,6 @@ Let('\@sptoken', T_SPACE);
 
 DefMacroI('\@uclclist', undef, '\oe\OE\o\O\ae\AE\dh\DH\dj\DJ\l\L\ng\NG\ss\SS\th\TH');
 
-sub ltx_adjust_case {
-  my ($arg, $flag_lower) = @_;
-  my @adjusted = ();
-  for my $token ($arg->unlist) {
-    if ($$token[1] == CC_OTHER) {
-      my $letter = $$token[0];
-      my $cased  = $flag_lower ? lc($letter) : uc($letter);
-      if ($letter ne $cased) {
-        push(@adjusted, T_OTHER($cased)); }
-      else {
-        push(@adjusted, $token); } }
-    else {
-      push(@adjusted, $token); } }
-  return @adjusted;
-}
-DefMacro('\ltx@uppercase Expanded', sub { return ltx_adjust_case($_[1], 0); });
-DefMacro('\ltx@lowercase Expanded', sub { return ltx_adjust_case($_[1], 1); });
-
 RawTeX(<<'EOL');
 \DeclareRobustCommand{\MakeUppercase}[1]{{%
       \def\i{I}\def\j{J}%
@@ -5123,7 +5110,7 @@ RawTeX(<<'EOL');
       \let\UTF@three@octets@noexpand\@empty
       \let\UTF@four@octets@noexpand\@empty
       \protected@edef\reserved@a{\uppercase{#1}}%
-      \ltx@uppercase{\reserved@a}
+      \reserved@a
    }}
 \DeclareRobustCommand{\MakeLowercase}[1]{{%
       \def\reserved@a##1##2{\let##2##1\reserved@a}%
@@ -5132,7 +5119,7 @@ RawTeX(<<'EOL');
       \let\UTF@three@octets@noexpand\@empty
       \let\UTF@four@octets@noexpand\@empty
       \protected@edef\reserved@a{\lowercase{#1}}%
-      \ltx@lowercase{\reserved@a}
+      \reserved@a
    }}
 \protected@edef\MakeUppercase#1{\MakeUppercase{#1}}
 \protected@edef\MakeLowercase#1{\MakeLowercase{#1}}
@@ -5806,6 +5793,22 @@ DefConstructor('\textsubscript{}', "<ltx:sub>#1</ltx:sub>",
   mode => 'text');
 
 #**********************************************************************
+# We need this bit from utf8.def for textcomp
+DefPrimitive('\DeclareUnicodeCharacter Expanded {}', sub {
+    my ($stomach, $hexcode, $expansion) = @_;
+    my $char = $hexcode->toString();
+    if ($char =~ /^[0-9a-fA-F]+$/) {
+      if ((my $cp = hex($char)) <= 0x10FFFF) {
+        $char = UTF($cp);
+        AssignCatcode($char, CC_ACTIVE);
+        DefMacroI(T_ACTIVE($char), undef, $expansion); }
+      else {
+        Error('unexpected', $char, $stomach,
+          "$char too large for Unicode. Values between 0 and 10FFFF are permitted."); } }
+    else {
+      Error('unexpected', $char, $stomach,
+        "'$char' is not a hexadecimal number."); } });
+
 # LaTeX now includes textcomp by default.
 RequirePackage('textcomp');
 

--- a/lib/LaTeXML/Package/utf8.def.ltxml
+++ b/lib/LaTeXML/Package/utf8.def.ltxml
@@ -29,21 +29,6 @@ AssignValue(INPUT_ENCODING => undef);
 # And set the Mouth to simply pass-thru the utf8.
 AssignValue(PERL_INPUT_ENCODING => 'UTF8');
 
-DefPrimitive('\DeclareUnicodeCharacter Expanded {}', sub {
-    my ($stomach, $hexcode, $expansion) = @_;
-    my $char = $hexcode->toString();
-    if ($char =~ /^[0-9a-fA-F]+$/) {
-      if ((my $cp = hex($char)) <= 0x10FFFF) {
-        $char = UTF($cp);
-        AssignCatcode($char, CC_ACTIVE);
-        DefMacroI(T_ACTIVE($char), undef, $expansion); }
-      else {
-        Error('unexpected', $char, $stomach,
-          "$char too large for Unicode. Values between 0 and 10FFFF are permitted."); } }
-    else {
-      Error('unexpected', $char, $stomach,
-        "'$char' is not a hexadecimal number."); } });
-
 # Also add the uc and lc code definitions:
 our @PRECOMPUTED_UC_LC = (
   ["\x{00C1}",   193,  "\x{00E1}",   225],


### PR DESCRIPTION
Fixes #1508 

A bit of a "request for comments" PR, since I am unsure what the best general strategy would be for latexml, given how the unicode situation is dramatically different between pdflatex and perl.

First, some good news:
 1. The native definitions of `\MakeUppercase` and `\MakeLowercase` seem to work like a charm. I refactored to them to play around, leaving them in for effect.
 2. A restricted attempt to use perl's `uc` and `lc` commands for these macros achieves the desired effect for cyrillic -- seemingly without currently known side effects?

Then the tricky bits:
 - fontenc itself is a bit of a mixed bag... We are defining only a core set of the cyrillic macros, and indeed another way to get rid of the errors mentioned in the issue is to define the advanced/rarer macros directly. In latex, those are actually loaded in through the definition files, namely any of `x2enc.dfu`, `t2cenc.dfu` or `utf8enc.dfu`, from what I can see.
 - I did not address the macros directly since it's also safe to say no one is realistically using them directly - people type in cyrillic characters, and pdftex maps into these macros internally. But latexml doesn't, as unicode letters haven't been mapped into active characters - which has its upsides.

So for now I just validated that the issue is composed of these pieces, and validated the simple fix of running perl's `uc` or `lc` on tokens with the `other` catcode that pass through these macros solves the general problem as far as latexml is concerned. So a new minimal example that works with this PR is:

```tex
\documentclass{article}
\usepackage[T2A]{fontenc}
\usepackage[utf8]{inputenc}
\begin{document}
\MakeLowercase{Б}
\MakeUppercase{я}
\end{document}
```

Feedback welcome.