### PR TITLE
CSS tweaks

### DIFF
--- a/lib/LaTeXML/resources/CSS/LaTeXML-navbar-left.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-navbar-left.css
@@ -9,5 +9,5 @@
 .ltx_page_main {
     position:absolute; left:190px; top:0px; right:2px; 
     margin:0px; padding:1em 3em 1em 2em;
-    padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%), min(2em, 3%);
+    padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%) min(2em, 3%);
     width:70%; }

--- a/lib/LaTeXML/resources/CSS/LaTeXML-navbar-right.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-navbar-right.css
@@ -7,5 +7,5 @@
     margin-left:-2em; }
 .ltx_page_main {
     margin:0px; padding:1em 3em 1em 2em;
-    padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%), min(2em, 3%);
+    padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%) min(2em, 3%);
     width:75%; }

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -57,11 +57,10 @@
 
 .ltx_outdent { margin-left: -2em; }
 
-/* .ltx_chapter_title, etc should be in ltx-article.css etc.
- */
-.ltx_page_main { margin:0px auto; max-width: 36em; max-width: 72ch;
+/* .ltx_chapter_title, etc should be in ltx-article.css etc. */
+.ltx_page_main { margin:0px auto;
     padding:1em 3em 1em 2em;
-    padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%), min(2em, 3%); }
+    padding:min(1em,1.5%) min(3em,4.5%) min(1em,1.5%) min(2em, 3%); }
 .ltx_tocentry  { list-style-type:none; }
 
 /* support for common author block layouts.*/
@@ -244,16 +243,19 @@ span.ltx_rowspan { position:absolute; top:0; bottom:0; }
 
 /*======================================================================
   Columns */
-.ltx_page_column1 {
-    width:44%; float:left; } /* IE uses % of wrong container*/
+.ltx_page_columns {
+    display: flex; }
+.ltx_page_column1,
 .ltx_page_column2 {
-    width:44%; float:right; }
-.ltx_page_columns > .ltx_page_column1 {
-    width:48%; float:left; }
-.ltx_page_columns > .ltx_page_column2 {
-    width:48%; float:right; }
-.ltx_page_columns:after {
-    content:"."; display:block; height:0; clear:both; visibility:hidden; }
+    flex:100%; }
+@media screen and (max-width: 80em){
+  .ltx_page_columns {
+     flex-direction: column; }
+  .ltx_page_column1 > ul {
+     margin-bottom: 0; }
+  .ltx_page_column2 > ul {
+     margin-top: 0; }
+}
 
 /*======================================================================
  Borders and such */

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -251,9 +251,13 @@ span.ltx_rowspan { position:absolute; top:0; bottom:0; }
 @media screen and (max-width: 80em){
   .ltx_page_columns {
      flex-direction: column; }
-  .ltx_page_column1 > ul {
+  .ltx_page_column1 > ul,
+  .ltx_page_column1 > ol,
+  .ltx_page_column1 > dl {
      margin-bottom: 0; }
-  .ltx_page_column2 > ul {
+  .ltx_page_column2 > ul,
+  .ltx_page_column2 > ol,
+  .ltx_page_column2 > dl {
      margin-top: 0; }
 }
 

--- a/tools/xtest
+++ b/tools/xtest
@@ -29,8 +29,8 @@ my $identity = "xtest";
 my ($verbosity, $force, $help) = (-1, 0, 0);    # start off quieter
 my ($timestamp) = (undef);
 GetOptions("force" => \$force,
-  "quiet"   => sub { $verbosity--; },
-  "verbose" => sub { $verbosity++; },
+  "quiet"       => sub { $verbosity--; },
+  "verbose"     => sub { $verbosity++; },
   "timestamp=s" => \$timestamp,
   "help"        => \$help,
 ) or pod2usage(-message => $identity, -exitval => 1, -verbose => 0, -output => \*STDERR);
@@ -94,7 +94,7 @@ foreach my $set (@testsets) {
           "--format=$type",
           "--javascript=LaTeXML-maybeMathjax.js",
           (defined $timestamp ? ("--timestamp=$timestamp") : ()),
-          ($verbosity > 0 ? map { "--verbose" } 1 .. $verbosity
+          ($verbosity > 0     ? map { "--verbose" } 1 .. $verbosity
             : ($verbosity < 0 ? map { "--quiet" } 1 .. -$verbosity
               : ())),
           $srcxml)
@@ -120,8 +120,10 @@ sub copy {
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 BEGIN {
   $HEADER = <<'EOHead';
+<!DOCTYPE html>
 <html>
 <head><title>LaTeXML Tests</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
 th { font-weight:bold; }
 .testgroup { text-align:left; font-size:120%; font-style:italic; }


### PR DESCRIPTION
This makes two column layout use CSS flexbox, and adds media query to have the 2 columns unwrap when the screen is too narrow.

Also fixes a couple of minor typos from #1442.

@xworld21 Could you take a look that I've not undone anything important to your work?