### PR TITLE
Fix scantokens

### DIFF
--- a/lib/LaTeXML/Package/eTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/eTeX.pool.ltxml
@@ -16,6 +16,8 @@ use warnings;
 use LaTeXML::Package;
 
 # See http://tex.loria.fr/moteurs/etex_ref.html
+# Or better yet, see the full manual
+# http://texdoc.net/texmf-dist/doc/etex/base/etex_man.pdf
 # Section 3. The new features
 
 #======================================================================
@@ -45,13 +47,10 @@ DefMacro('\readline Number SkipKeyword:to SkipSpaces Token', sub {
       DefMacroI($token, undef, Tokens(Explode(($mouth->readRawLine || '') . "\r"))); }
     return; });
 
-# https://tex.loria.fr/moteurs/etex_ref.html#scantokens
-# TODO: "Parentheses and a single space representing the pseudo-file will be displayed
-#        if \tracingscantokens (q.v.) is positive and non-zero."
-#       We are currently missing a final trailing space in some uses
-#           c.f. t/tokenize/hashes.tex
 DefMacro('\scantokens GeneralText', sub {
-    LaTeXML::Core::Mouth->new(writableTokens($_[1]))->readTokens; });
+    my ($gullet, $generaltext) = @_;
+    $gullet->openMouth(LaTeXML::Core::Mouth->new(writableTokens($generaltext)), 0);
+    return; });
 
 #======================================================================
 # 3.3 Environmental enquiries

--- a/t/expansion/multi_escaped_param.xml
+++ b/t/expansion/multi_escaped_param.xml
@@ -4,6 +4,7 @@
   <resource src="LaTeXML.css" type="text/css"/>
   <para>
     <p>test returns 1: 
+
 1
 </p>
   </para>

--- a/tools/maketests
+++ b/tools/maketests
@@ -30,8 +30,8 @@ use Term::ANSIColor;
 #  make test TEST_FILES=t/sometestglob.t
 #======================================================================
 my $identity = "maketests (LaTeXML version $LaTeXML::VERSION)";
-my ($doxml,     $dopdf, $docompare)   = ();
-my ($verbosity, $help,  $showversion) = (0);
+my ($doxml, $dopdf, $docompare)      = ();
+my ($verbosity, $help, $showversion) = (0);
 my $whitespace = 1;    # keep whitespace;
 GetOptions("xml!" => \$doxml,
   "pdf!"        => \$dopdf,
@@ -233,7 +233,7 @@ sub stringifyDom {
   $parser->validation(0);
   $parser->keep_blanks(1);
   $string = $parser->parse_string($string)->toStringC14N(0);
-  return [grep { /\S/ } split("\n", $string)]; }
+  return [split("\n", $string)]; }
 
 sub gen_xml {
   my ($dir, $name, $for_comparison) = @_;
@@ -275,12 +275,12 @@ sub gen_pdf {
 
   while (<$IN>) {
     if (/documentclass/) {
-        $program = 'pdflatex';
-        last; }
+      $program = 'pdflatex';
+      last; }
     # recognize %%% TeX-engine: xelatex  or %%%tex-engine: "xelatex" in preamble
     if (/^%%%\s*tex-engine:\s*"*(\w+)"*/i) {
-        $program = $1;
-        last; }
+      $program = $1;
+      last; }
   }
   close($IN);
   local $ENV{TEXINPUTS} = "$FindBin::RealBin/../lib/LaTeXML/texmf/::" . ($ENV{TEXINPUTS} || '');


### PR DESCRIPTION
This is a more accurate implementation of `\scantokens`, which sets up a mouth for the imaginary file, but defers reading from it, so that expansion/digestion interleaving works as expected.

To make things interesting, it seems to introduce an extra space (as a newline in LaTeXML's case) in the `multi-escaped-param` test. But if you examine the pdf carefully, I think you'll find that there are 3, not 2, spaces before the result.

And even more interesting, `tools/maketests` formerly discarded blank lines, which gave different test results between `make test` and `maketests`.

What fun! Should be all better now.

Fixes #1515