### PR TITLE
Fix bigop sizes

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -5478,59 +5478,50 @@ DefMathI('\oint', undef, "\x{222E}",
   role      => 'INTOP',
   meaning   => 'contour-integral',
   mathstyle => \&doVariablesizeOp);
-DefMathI('\bigcap', undef, "\x{22C2}",
+DefMathI('\bigcap', undef, "\x{22C2}",    # versus \x{2229}
   role      => 'SUMOP',
   scriptpos => \&doScriptpos,
   meaning   => 'intersection',
-  mathstyle => \&doVariablesizeOp,
-  font      => { size => 'Big' });
-DefMathI('\bigcup', undef, "\x{22C3}",
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigcup', undef, "\x{22C3}",    # versus \x{222A}
   role      => 'SUMOP',
   scriptpos => \&doScriptpos,
   meaning   => 'union',
-  mathstyle => \&doVariablesizeOp,
-  font      => { size => 'Big' });
-DefMathI('\bigsqcup', undef, "\x{2294}",
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigsqcup', undef, "\x{2A06}",    # versus \x{2294}
   role      => 'SUMOP',
   scriptpos => \&doScriptpos,
   meaning   => 'square-union',
-  mathstyle => \&doVariablesizeOp,
-  font      => { size => 'Big' });
-DefMathI('\bigvee', undef, "\x{22C1}",
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigvee', undef, "\x{22C1}",      # versus \x{2229}
   role      => 'SUMOP',
   scriptpos => \&doScriptpos,
   meaning   => 'or',
-  mathstyle => \&doVariablesizeOp,
-  font      => { size => 'Big' });
-DefMathI('\bigwedge', undef, "\x{22C0}",
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigwedge', undef, "\x{22C0}",    # versus \x{2227}
   role      => 'SUMOP',
   scriptpos => \&doScriptpos,
   meaning   => 'and',
-  mathstyle => \&doVariablesizeOp,
-  font      => { size => 'Big' });
-DefMathI('\bigodot', undef, "\x{2299}",
-  role      => 'SUMOP',              #meaning=> ?
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigodot', undef, "\x{2A00}",     # versus \x{2299}
+  role      => 'SUMOP',                     #meaning=> ?
   scriptpos => \&doScriptpos,
-  mathstyle => \&doVariablesizeOp,
-  font      => { size => 'Big' });
-DefMathI('\bigotimes', undef, "\x{2297}",
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigotimes', undef, "\x{2A02}",    # versus \x{2297}
   role      => 'SUMOP',
   scriptpos => \&doScriptpos,
   meaning   => 'tensor-product',
-  mathstyle => \&doVariablesizeOp,
-  font      => { size => 'Big' });
-DefMathI('\bigoplus', undef, "\x{2295}",
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigoplus', undef, "\x{2A01}",     # versus \x{2295}
   role      => 'SUMOP',
   scriptpos => \&doScriptpos,
   meaning   => 'direct-sum',
-  mathstyle => \&doVariablesizeOp,
-  font      => { size => 'Big' });
-DefMathI('\biguplus', undef, "\x{228E}",
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\biguplus', undef, "\x{2A04}",     # versus \x{228e}
   role      => 'SUMOP',
   scriptpos => \&doScriptpos,
   meaning   => 'symmetric-difference',
-  mathstyle => \&doVariablesizeOp,
-  font      => { size => 'Big' });
+  mathstyle => \&doVariablesizeOp);
 DefConstructorI('\limits', undef, '',
   afterDigest => sub { mergeLimits('mid'); },
   properties  => { isSpace => 1 });

--- a/lib/LaTeXML/Package/stmaryrd.sty.ltxml
+++ b/lib/LaTeXML/Package/stmaryrd.sty.ltxml
@@ -55,27 +55,27 @@ DefMathI('\leftslice',           undef, "\x{2aa6}",                            r
 DefMathI('\merge',               undef, "\x{2a07}",                            role => 'RELOP');
 DefMathI('\minuso',              undef, "\x{29b5}",                            role => 'RELOP');
 DefMathI('\moo',                 undef, '\lx@nounicode{\moo}');
-DefMathI('\obar',                undef, "\x{29B6}",                            role => 'RELOP');
-DefMathI('\oblong',              undef, "\x{2395}",                            role => 'RELOP');
-DefMathI('\obslash',             undef, "\x{29B8}",                            role => 'RELOP');
-DefMathI('\ogreaterthan',        undef, "\x{29C1}",                            role => 'RELOP');
-DefMathI('\olessthan',           undef, "\x{29C0}",                            role => 'RELOP');
-DefMathI('\ovee',                undef, "\x{2228}\x{20DD}",                    role => 'RELOP');
-DefMathI('\owedge',              undef, "\x{2227}\x{20DD}",                    role => 'RELOP');
-DefMathI('\rightslice',          undef, "\x{2aa7}",                            role => 'RELOP');
-DefMathI('\sslash',              undef, "\x{2AFD}",                            role => 'RELOP');
-DefMathI('\talloblong',          undef, "\x{2AFF}",                            role => 'RELOP');
-DefMathI('\varbigcirc',          undef, "\x{25EF}",                            role => 'MULOP');
-DefMathI('\varcurlyvee',         undef, "\x{22CE}",                            role => 'RELOP');
-DefMathI('\varcurlywedge',       undef, "\x{22CF}",                            role => 'RELOP');
-DefMathI('\varoast',             undef, "\x{229B}",                            role => 'MULOP');
-DefMathI('\varobar',             undef, "\x{29B6}",                            role => 'RELOP');
-DefMathI('\varobslash',          undef, "\x{29B8}",                            role => 'MULOP');
-DefMathI('\varocircle',          undef, "\x{229A}",                            role => 'MULOP');
-DefMathI('\varodot',             undef, "\x{2299}",                            role => 'MULOP');
-DefMathI('\varogreaterthan',     undef, "\x{29C1}",                            role => 'RELOP');
-DefMathI('\varolessthan',        undef, "\x{29C0}",                            role => 'RELOP');
-DefMathI('\varominus',           undef, "\x{2296}",                            role => 'ADDOP');
+DefMathI('\obar',                undef, "\x{29B6}",         role => 'RELOP');
+DefMathI('\oblong',              undef, "\x{2395}",         role => 'RELOP');
+DefMathI('\obslash',             undef, "\x{29B8}",         role => 'RELOP');
+DefMathI('\ogreaterthan',        undef, "\x{29C1}",         role => 'RELOP');
+DefMathI('\olessthan',           undef, "\x{29C0}",         role => 'RELOP');
+DefMathI('\ovee',                undef, "\x{2228}\x{20DD}", role => 'RELOP');
+DefMathI('\owedge',              undef, "\x{2227}\x{20DD}", role => 'RELOP');
+DefMathI('\rightslice',          undef, "\x{2aa7}",         role => 'RELOP');
+DefMathI('\sslash',              undef, "\x{2AFD}",         role => 'RELOP');
+DefMathI('\talloblong',          undef, "\x{2AFF}",         role => 'RELOP');
+DefMathI('\varbigcirc',          undef, "\x{25EF}",         role => 'MULOP');
+DefMathI('\varcurlyvee',         undef, "\x{22CE}",         role => 'RELOP');
+DefMathI('\varcurlywedge',       undef, "\x{22CF}",         role => 'RELOP');
+DefMathI('\varoast',             undef, "\x{229B}",         role => 'MULOP');
+DefMathI('\varobar',             undef, "\x{29B6}",         role => 'RELOP');
+DefMathI('\varobslash',          undef, "\x{29B8}",         role => 'MULOP');
+DefMathI('\varocircle',          undef, "\x{229A}",         role => 'MULOP');
+DefMathI('\varodot',             undef, "\x{2299}",         role => 'MULOP');
+DefMathI('\varogreaterthan',     undef, "\x{29C1}",         role => 'RELOP');
+DefMathI('\varolessthan',        undef, "\x{29C0}",         role => 'RELOP');
+DefMathI('\varominus',           undef, "\x{2296}",         role => 'ADDOP');
 DefMathI('\varoplus', undef, "\x{2295}", role => 'ADDOP',
   meaning => 'additive-disjunction');
 DefMathI('\varoslash', undef, "\x{2298}", role => 'RELOP');
@@ -85,14 +85,38 @@ DefMathI('\varovee',   undef, "\x{2228}\x{20DD}", role => 'RELOP');
 DefMathI('\varowedge', undef, "\x{2227}\x{20DD}", role => 'RELOP');
 DefMathI('\vartimes',  undef, UTF(0xD7),          role => 'MULOP');
 
-DefMathI('\bigbox',          undef, "\x{25a1}", font => { size => 'Big' }, role => 'BIGOP');
-DefMathI('\bigcurlywedge',   undef, "\x{22CF}", font => { size => 'Big' }, role => 'BIGOP');
-DefMathI('\bigcurlyvee',     undef, "\x{22CE}", font => { size => 'Big' }, role => 'BIGOP');
-DefMathI('\biginterleave',   undef, "\x{2AFC}", font => { size => 'Big' }, role => 'BIGOP');
-DefMathI('\bigparallel',     undef, "\x{2016}", font => { size => 'Big' }, role => 'BIGOP');
-DefMathI('\bigsqcap',        undef, "\x{2293}", font => { size => 'Big' }, role => 'BIGOP');
-DefMathI('\bigtriangledown', undef, "\x{25BD}", font => { size => 'Big' }, role => 'BIGOP');
-DefMathI('\bigtriangleup',   undef, "\x{25B3}", font => { size => 'Big' }, role => 'BIGOP');
+DefMathI('\bigbox', undef, "\x{25a1}", font => { size => 'Big' },
+  role      => 'SUMOP',
+  scriptpos => \&doScriptpos,
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigcurlywedge', undef, "\x{22CF}", font => { size => 'Big' },
+  role      => 'SUMOP',
+  scriptpos => \&doScriptpos,
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigcurlyvee', undef, "\x{22CE}", font => { size => 'Big' },
+  role      => 'SUMOP',
+  scriptpos => \&doScriptpos,
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\biginterleave', undef, "\x{2AFC}",
+  role      => 'SUMOP',
+  scriptpos => \&doScriptpos,
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigparallel', undef, "\x{2016}",
+  role      => 'SUMOP',
+  scriptpos => \&doScriptpos,
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigsqcap', undef, "\x{2A05}",
+  role      => 'SUMOP',
+  scriptpos => \&doScriptpos,
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigtriangledown', undef, "\x{25BD}", font => { size => 'Big' },
+  role      => 'SUMOP',
+  scriptpos => \&doScriptpos,
+  mathstyle => \&doVariablesizeOp);
+DefMathI('\bigtriangleup', undef, "\x{25B3}", font => { size => 'Big' },
+  role      => 'SUMOP',
+  scriptpos => \&doScriptpos,
+  mathstyle => \&doVariablesizeOp);
 
 DefMathI('\inplus',                undef, "\x{2A2D}", role => 'RELOP');
 DefMathI('\niplus',                undef, "\x{2A2E}", role => 'RELOP');

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -4127,7 +4127,7 @@ Then a switch of tag forms.</p>
                   <XMTok role="PUNCT">⁣</XMTok>
                   <XMTok meaning="tensor-product" name="otimes" role="MULOP" xml:id="S7.Ex59.m1.5">⊗</XMTok>
                   <XMTok role="PUNCT">⁣</XMTok>
-                  <XMTok fontsize="160%" mathstyle="display" meaning="tensor-product" name="bigotimes" role="SUMOP" scriptpos="mid" xml:id="S7.Ex59.m1.6">⊗</XMTok>
+                  <XMTok mathstyle="display" meaning="tensor-product" name="bigotimes" role="SUMOP" scriptpos="mid" xml:id="S7.Ex59.m1.6">⨂</XMTok>
                 </XMWrap>
               </XMDual>
             </XMath>

--- a/t/fonts/stmaryrd.xml
+++ b/t/fonts/stmaryrd.xml
@@ -750,29 +750,29 @@
               <XMRef idref="S0.Ex11.m1.9"/>
             </XMApp>
             <XMWrap>
-              <XMTok fontsize="160%" name="bigbox" role="BIGOP" xml:id="S0.Ex11.m1.1">□</XMTok>
+              <XMTok fontsize="160%" mathstyle="display" name="bigbox" role="SUMOP" scriptpos="mid" xml:id="S0.Ex11.m1.1">□</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigcurlywedge" role="BIGOP" xml:id="S0.Ex11.m1.2">⋏</XMTok>
+              <XMTok fontsize="160%" mathstyle="display" name="bigcurlywedge" role="SUMOP" scriptpos="mid" xml:id="S0.Ex11.m1.2">⋏</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigcurlyvee" role="BIGOP" xml:id="S0.Ex11.m1.3">⋎</XMTok>
+              <XMTok fontsize="160%" mathstyle="display" name="bigcurlyvee" role="SUMOP" scriptpos="mid" xml:id="S0.Ex11.m1.3">⋎</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="biginterleave" role="BIGOP" xml:id="S0.Ex11.m1.4">⫼</XMTok>
+              <XMTok mathstyle="display" name="biginterleave" role="SUMOP" scriptpos="mid" xml:id="S0.Ex11.m1.4">⫼</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
               <XMDual role="ADDOP" xml:id="S0.Ex11.m1.5">
                 <XMTok mathstyle="display" meaning="intersection-plus" name="bignplus" role="ADDOP"/>
                 <XMWrap rule="kludge">
-                  <XMTok fontsize="160%" mathstyle="display" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="mid">⋂</XMTok>
+                  <XMTok mathstyle="display" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="mid">⋂</XMTok>
                   <XMTok meaning="plus" role="ADDOP" width="0pt" xoffset="-1.6em" yoffset="0.2ex">+</XMTok>
                 </XMWrap>
               </XMDual>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigparallel" role="BIGOP" xml:id="S0.Ex11.m1.6">‖</XMTok>
+              <XMTok mathstyle="display" name="bigparallel" role="SUMOP" scriptpos="mid" xml:id="S0.Ex11.m1.6">‖</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigsqcap" role="BIGOP" xml:id="S0.Ex11.m1.7">⊓</XMTok>
+              <XMTok mathstyle="display" name="bigsqcap" role="SUMOP" scriptpos="mid" xml:id="S0.Ex11.m1.7">⨅</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigtriangledown" role="BIGOP" xml:id="S0.Ex11.m1.8">▽</XMTok>
+              <XMTok fontsize="160%" mathstyle="display" name="bigtriangledown" role="SUMOP" scriptpos="mid" xml:id="S0.Ex11.m1.8">▽</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigtriangleup" role="BIGOP" xml:id="S0.Ex11.m1.9">△</XMTok>
+              <XMTok fontsize="160%" mathstyle="display" name="bigtriangleup" role="SUMOP" scriptpos="mid" xml:id="S0.Ex11.m1.9">△</XMTok>
             </XMWrap>
           </XMDual>
         </XMath>
@@ -797,29 +797,29 @@
               <XMRef idref="S0.Ex12.m1.9"/>
             </XMApp>
             <XMWrap>
-              <XMTok fontsize="160%" name="bigbox" role="BIGOP" xml:id="S0.Ex12.m1.1">□</XMTok>
+              <XMTok fontsize="160%" mathstyle="text" name="bigbox" role="SUMOP" scriptpos="post" xml:id="S0.Ex12.m1.1">□</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigcurlywedge" role="BIGOP" xml:id="S0.Ex12.m1.2">⋏</XMTok>
+              <XMTok fontsize="160%" mathstyle="text" name="bigcurlywedge" role="SUMOP" scriptpos="post" xml:id="S0.Ex12.m1.2">⋏</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigcurlyvee" role="BIGOP" xml:id="S0.Ex12.m1.3">⋎</XMTok>
+              <XMTok fontsize="160%" mathstyle="text" name="bigcurlyvee" role="SUMOP" scriptpos="post" xml:id="S0.Ex12.m1.3">⋎</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="biginterleave" role="BIGOP" xml:id="S0.Ex12.m1.4">⫼</XMTok>
+              <XMTok mathstyle="text" name="biginterleave" role="SUMOP" scriptpos="post" xml:id="S0.Ex12.m1.4">⫼</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
               <XMDual role="ADDOP" xml:id="S0.Ex12.m1.5">
                 <XMTok mathstyle="text" meaning="intersection-plus" name="bignplus" role="ADDOP"/>
                 <XMWrap rule="kludge">
-                  <XMTok fontsize="160%" mathstyle="text" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="post">⋂</XMTok>
+                  <XMTok mathstyle="text" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="post">⋂</XMTok>
                   <XMTok meaning="plus" role="ADDOP" width="0pt" xoffset="-1.3em" yoffset="0.2ex">+</XMTok>
                 </XMWrap>
               </XMDual>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigparallel" role="BIGOP" xml:id="S0.Ex12.m1.6">‖</XMTok>
+              <XMTok mathstyle="text" name="bigparallel" role="SUMOP" scriptpos="post" xml:id="S0.Ex12.m1.6">‖</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigsqcap" role="BIGOP" xml:id="S0.Ex12.m1.7">⊓</XMTok>
+              <XMTok mathstyle="text" name="bigsqcap" role="SUMOP" scriptpos="post" xml:id="S0.Ex12.m1.7">⨅</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigtriangledown" role="BIGOP" xml:id="S0.Ex12.m1.8">▽</XMTok>
+              <XMTok fontsize="160%" mathstyle="text" name="bigtriangledown" role="SUMOP" scriptpos="post" xml:id="S0.Ex12.m1.8">▽</XMTok>
               <XMTok font="italic" name="quad" role="PUNCT"> </XMTok>
-              <XMTok fontsize="160%" name="bigtriangleup" role="BIGOP" xml:id="S0.Ex12.m1.9">△</XMTok>
+              <XMTok fontsize="160%" mathstyle="text" name="bigtriangleup" role="SUMOP" scriptpos="post" xml:id="S0.Ex12.m1.9">△</XMTok>
             </XMWrap>
           </XMDual>
         </XMath>
@@ -842,7 +842,7 @@
               <XMDual role="ADDOP" xml:id="S0.Ex13.m1.1">
                 <XMTok mathstyle="display" meaning="intersection-plus" name="bignplus" role="ADDOP"/>
                 <XMWrap rule="kludge">
-                  <XMTok fontsize="160%" mathstyle="display" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="mid">⋂</XMTok>
+                  <XMTok mathstyle="display" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="mid">⋂</XMTok>
                   <XMTok meaning="plus" role="ADDOP" width="0pt" xoffset="-1.6em" yoffset="0.2ex">+</XMTok>
                 </XMWrap>
               </XMDual>
@@ -850,7 +850,7 @@
               <XMDual role="ADDOP" xml:id="S0.Ex13.m1.2">
                 <XMTok mathstyle="text" meaning="intersection-plus" name="bignplus" role="ADDOP"/>
                 <XMWrap rule="kludge">
-                  <XMTok fontsize="160%" mathstyle="text" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="post">⋂</XMTok>
+                  <XMTok mathstyle="text" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="post">⋂</XMTok>
                   <XMTok meaning="plus" role="ADDOP" width="0pt" xoffset="-1.3em" yoffset="0.2ex">+</XMTok>
                 </XMWrap>
               </XMDual>
@@ -858,7 +858,7 @@
               <XMDual role="ADDOP" xml:id="S0.Ex13.m1.3">
                 <XMTok mathstyle="text" meaning="intersection-plus" name="bignplus" role="ADDOP"/>
                 <XMWrap rule="kludge">
-                  <XMTok fontsize="160%" mathstyle="text" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="post">⋂</XMTok>
+                  <XMTok fontsize="70%" mathstyle="text" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="post">⋂</XMTok>
                   <XMTok fontsize="70%" meaning="plus" role="ADDOP" width="0pt" xoffset="-1.3em" yoffset="0.2ex">+</XMTok>
                 </XMWrap>
               </XMDual>
@@ -866,7 +866,7 @@
               <XMDual role="ADDOP" xml:id="S0.Ex13.m1.4">
                 <XMTok mathstyle="text" meaning="intersection-plus" name="bignplus" role="ADDOP"/>
                 <XMWrap rule="kludge">
-                  <XMTok fontsize="160%" mathstyle="text" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="post">⋂</XMTok>
+                  <XMTok fontsize="50%" mathstyle="text" meaning="intersection" name="bigcap" role="SUMOP" scriptpos="post">⋂</XMTok>
                   <XMTok fontsize="50%" meaning="plus" role="ADDOP" width="0pt" xoffset="-1.3em" yoffset="0.2ex">+</XMTok>
                 </XMWrap>
               </XMDual>


### PR DESCRIPTION
This PR uses the correct (I think) Unicode for various `\bigXXX` symbols in TeX and also a few in stmaryrd.  It also treats those in the latter style as having movable scripts.

I couldn't find large size Unicode for `\bigbox, \bigcurlywedge,\bigcurlyvee,\bigtriangledown,\bigtriangleup`, so I kept the Big sizing.  If you find the right codes, let me know! (Also the rendering for `\bigparallel` is dubious, but the codepoint seems to be the correct one).

Fixes #1502

Thanks, @xworld21 