### PR TITLE
fixup tei stylesheet for tabular with and without thead/tbody

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3400,7 +3400,8 @@ DefRegister('\lx@default@tabcolsep', Dimension('6pt'));
 DefRegister('\tabcolsep',            Dimension('6pt'));
 DefMacroI('\arraystretch', undef, "1");
 
-AssignValue(GUESS_TABULAR_HEADERS => 1);    # Defaults to yes
+AssignValue(GUESS_TABULAR_HEADERS => 1)    # Defaults to yes
+  unless defined LookupValue('GUESS_TABULAR_HEADERS');
 
 sub tabularBindings {
   my ($template, %properties) = @_;

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-tei.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-tei.xsl
@@ -781,11 +781,11 @@
         </table>
     </xsl:template>
 
-    <xsl:template match="ltx:tabular/*">
+    <xsl:template match="ltx:tabular">
             <xsl:apply-templates select="@*|node()"/>
     </xsl:template>
 
-    <xsl:template match="ltx:tbody">
+    <xsl:template match="ltx:thead | ltx:tbody">
             <xsl:apply-templates select="@*|node()"/>
     </xsl:template>
 


### PR DESCRIPTION
As it says; this should make the TEI stylesheet work correctly on tabulars with and with `ltx:thead` and `ltx:tbody` (which are produced either by extra markup, or `GUESS_TABULAR_HEADERS`)

This was discovered on a tangent to #1518