### PR TITLE
Expl3 optimizatoin

### DIFF
--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -674,15 +674,8 @@ sub ReadAlignmentTemplate {
       $gullet->unread($op); }
     elsif (defined($defn = $STATE->lookupDefinition(T_CS('\NC@rewrite@' . ToString($op))))
       && $defn->isExpandable) {
-      # A variation on $defn->invoke, so we can reconstruct the reversion
-      my @args = $defn->readArguments($gullet);
-      if (my $exp = $defn->doInvocation($gullet, @args)) {    # This just expanded into other stuff
-        $gullet->unread(@{$exp}); }
-      else {
-        push(@tokens, $op);
-        if (my $param = $defn->getParameters) {
-          push(@tokens, $param->revertArguments(@args)); } } }
-    elsif ($op->equals(T_BEGIN)) {                            # Wrong, but a safety valve
+      $gullet->unread($defn->invoke($gullet, 1)); }
+    elsif ($op->equals(T_BEGIN)) {    # Wrong, but a safety valve
       $gullet->unread($gullet->readBalanced->unlist); }
     else {
       Warn('unexpected', $op, $gullet, "Unrecognized tabular template '" . Stringify($op) . "'"); }

--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -676,7 +676,7 @@ sub ReadAlignmentTemplate {
       && $defn->isExpandable) {
       $gullet->unread($defn->invoke($gullet, 1)); }
     elsif ($op->equals(T_BEGIN)) {    # Wrong, but a safety valve
-      $gullet->unread($gullet->readBalanced->unlist); }
+      $gullet->unread($gullet->readBalanced); }
     else {
       Warn('unexpected', $op, $gullet, "Unrecognized tabular template '" . Stringify($op) . "'"); }
     last unless $nopens; }

--- a/lib/LaTeXML/Core/Definition.pm
+++ b/lib/LaTeXML/Core/Definition.pm
@@ -89,15 +89,10 @@ sub getLocator {
 
 sub readArguments {
   my ($self, $gullet) = @_;
-  my $params = $self->getParameters;
-  return ($params ? $params->readArguments($gullet, $self) : ()); }
+  return ($$self{parameters} ? $$self{parameters}->readArguments($gullet, $self) : ()); }
 
 sub getParameters {
   my ($self) = @_;
-  # Allow defering these until the Definition is actually used.
-  if ((defined $$self{parameters}) && !ref $$self{parameters}) {
-    require LaTeXML::Package;
-    $$self{parameters} = LaTeXML::Package::parseParameters($$self{parameters}, $$self{cs}); }
   return $$self{parameters}; }
 
 #======================================================================
@@ -153,9 +148,9 @@ sub startProfiling {
   #   starts of pending calls...]
   if (!defined $entry) {
     $entry = [0, 0, 0, 0, 0]; $STATE->assignMapping('runtime_profile', $name, $entry); }
-  $$entry[0]++ unless $mode eq 'absorb';    # One more call.
-  $$entry[4]++;    # One more pending...
-                   #print STDERR "START PROFILE $mode of ".ToString($cs)."\n";
+  $$entry[0]++ unless $mode eq 'absorb';   # One more call.
+  $$entry[4]++;                            # One more pending...
+                                           #print STDERR "START PROFILE $mode of ".ToString($cs)."\n";
   $STATE->pushValue('runtime_stack', [$name, $mode, [Time::HiRes::gettimeofday], $entry]);
   return; }
 

--- a/lib/LaTeXML/Core/Definition/Conditional.pm
+++ b/lib/LaTeXML/Core/Definition/Conditional.pm
@@ -60,8 +60,8 @@ sub invoke_conditional {
   local $LaTeXML::IFFRAME = { token => $LaTeXML::CURRENT_TOKEN, start => $gullet->getLocator,
     parsing => 1, elses => 0, ifid => $ifid };
   $STATE->unshiftValue(if_stack => $LaTeXML::IFFRAME);
-
-  my @args = $self->readArguments($gullet);
+  my $parms = $$self{parameters};
+  my @args  = ($parms ? $parms->readArguments($gullet) : ());
   $$LaTeXML::IFFRAME{parsing} = 0;    # Now, we're done parsing the Test clause.
   my $tracing = $STATE->lookupValue('TRACINGCOMMANDS');
   print STDERR '{' . $self->tracingCSName . "} [#$ifid]\n" if $tracing;

--- a/lib/LaTeXML/Core/Definition/Conditional.pm
+++ b/lib/LaTeXML/Core/Definition/Conditional.pm
@@ -110,11 +110,16 @@ sub skipConditionalBody {
   my $level = 1;
   my $n_ors = 0;
   my $start = $gullet->getLocator;
-  # NOTE: Open-coded manipulation of if_stack!
+  # NOTE: Open-coded manipulation of if_stack!, Gullet and Token's
   # [we're only reading tokens & looking up, so State shouldn't change behind our backs]
   my $stack = $STATE->lookupValue('if_stack');
   while (1) {
-    my ($t, $cond_type) = $gullet->readNextConditional;
+    my ($t, $cond_type);
+    while ($t = shift(@{ $$gullet{pushback} }) || $$gullet{mouth}->readToken()) {
+      $t = $$t[2] if $$t[1] == CC_SMUGGLE_THE;
+      if ($LaTeXML::Core::State::CATCODE_ACTIVE_OR_CS[$$t[1]]
+        && ($cond_type = $STATE->lookupConditional($t))) {
+        last; } }
     last unless $cond_type;
     if ($cond_type eq 'if') {    #  Found a \ifxx of some sort
       $level++; }

--- a/lib/LaTeXML/Core/Definition/Constructor.pm
+++ b/lib/LaTeXML/Core/Definition/Constructor.pm
@@ -87,9 +87,9 @@ sub invoke {
   my $font   = $STATE->lookupValue('font');
   my $ismath = $STATE->lookupValue('IN_MATH');
   # Parse AND digest the arguments to the Constructor
-  my $params = $self->getParameters;
-  my @args   = ($params ? $params->readArgumentsAndDigest($stomach, $self) : ());
-  print STDERR $self->tracingArgs(@args) . " [for ".Stringify($$self{cs})."]\n" if $tracing && @args;
+  my $parms = $$self{parameters};
+  my @args  = ($parms ? $parms->readArgumentsAndDigest($stomach, $self) : ());
+  print STDERR $self->tracingArgs(@args) . " [for " . Stringify($$self{cs}) . "]\n" if $tracing && @args;
   my $nargs = $self->getNumArgs;
   @args = @args[0 .. $nargs - 1];
 

--- a/lib/LaTeXML/Core/Definition/Expandable.pm
+++ b/lib/LaTeXML/Core/Definition/Expandable.pm
@@ -57,78 +57,50 @@ sub getExpansion {
 sub invoke {
   my ($self, $gullet, $onceonly) = @_;
   # shortcut for "trivial" macros; but only if not tracing & profiling!!!!
-  my $expansion = (!$STATE->lookupValue('TRACINGMACROS') && !$$self{parameters} && $self->getExpansion);
-  if (ref $expansion eq 'LaTeXML::Core::Tokens') {
-    if (!$onceonly && recursion_check($$self{cs}, $expansion->unlist)) {
-      Error('recursion', $$self{cs}, $gullet,
-        "Token " . Stringify($$self{cs}) . " expands into itself!",
-        "defining as empty");
-      $expansion = Tokens(); }
-    return $expansion; }
-  else {
-    return $self->doInvocation($gullet, $self->readArguments($gullet)); } }
-
-sub doInvocation {
-  my ($self, $gullet, @args) = @_;
+  my $tracing   = $STATE->lookupValue('TRACINGMACROS');
+  my $profiled  = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
   my $expansion = $self->getExpansion;
-  my $r;
-  my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
-  LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
-  my @result;
-  if ($STATE->lookupValue('TRACINGMACROS')) {    # More involved...
-    if (ref $expansion eq 'CODE') {
-      # Harder to emulate \tracingmacros here.
-      @result = &$expansion($gullet, @args);
-      # CHECK @result HERE TOO!!!!
-      print STDERR "\n" . $self->tracingCSName . ' ==> ' . tracetoString(Tokens(@result)) . "\n";
-      print STDERR $self->tracingArgs(@args) . "\n" if @args; }
-    else {
-      # for "real" macros, make sure all args are Tokens
-      my @targs = map { $_ && (($r = ref $_) && ($r eq 'LaTeXML::Core::Tokens')
-          ? $_
-          : ($r && ($r eq 'LaTeXML::Core::Token')
-            ? Tokens($_)
-            : Tokens(Revert($_)))) }
-        @args;
-      print STDERR "\n" . $self->tracingCSName
-        . ' -> ' . tracetoString($expansion) . "\n";
-      print STDERR $self->tracingArgs(@targs) . "\n" if @args;
-      @result = $expansion->substituteParameters(@targs)->unlist; } }
+  my $etype     = ref $expansion;
+  my $iscode    = $etype eq 'CODE';
+  my $result;
+  if ($iscode) {
+    # Harder to emulate \tracingmacros here.
+    my @args = $self->readArguments($gullet);
+    LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
+    $result = Tokens(&$expansion($gullet, @args));
+    if ($tracing) {    # More involved...
+      print STDERR "\n" . $self->tracingCSName . ' ==> ' . tracetoString($result) . "\n";
+      print STDERR $self->tracingArgs(@args) . "\n" if @args; } }
+  elsif (!$$self{parameters}) {    # Trivial macro
+    LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
+    if ($tracing) {                # More involved...
+      print STDERR "\n" . $self->tracingCSName . ' -> ' . tracetoString($expansion) . "\n"; }
+    # For trivial expansion, make sure we don't get \cs or \relax\cs direct recursion!
+    if (!$onceonly && $$self{cs}) {
+      my ($t0, $t1) = ($etype eq 'LaTeXML::Core::Tokens'
+        ? ($$expansion[0], $$expansion[1]) : ($expansion, undef));
+      if ($t0 && ($t0->equals($$self{cs})
+          || ($t1 && $t1->equals($$self{cs}) && $t0->equals(T_CS('\protect'))))) {
+        Error('recursion', $$self{cs}, $gullet,
+          "Token " . Stringify($$self{cs}) . " expands into itself!",
+          "defining as empty");
+        $expansion = Tokens(); } }
+    $result = $expansion; }
   else {
-    if (ref $expansion eq 'CODE') {
-      my $t;
-      # Check the result from code calls.
-      @result = map { (($t = ref $_) eq 'LaTeXML::Core::Token' ? $_
-          : ($t eq 'LaTeXML::Core::Tokens' ? @$_
-            : (Error('misdefined', $self, undef,
-                "Expected a Token in expansion of " . ToString($self),
-                "got " . Stringify($_)), ()))) }
-        &$expansion($gullet, @args); }
-    else {
-      # but for tokens, make sure args are proper Tokens (lists)
-      @result = $expansion->substituteParameters(
-        map { $_ && (($r = ref $_) && ($r eq 'LaTeXML::Core::Tokens')
-            ? $_
-            : ($r && ($r eq 'LaTeXML::Core::Token')
-              ? Tokens($_)
-              : Tokens(Revert($_)))) }
-          @args)->unlist; } }
-  # Avoid simplest case of infinite-loop expansion.
-  if ((ref $expansion ne 'CODE') && !scalar(@args) && recursion_check($$self{cs}, @result)) {
-    Error('recursion', $$self{cs}, $gullet,
-      "Token " . Stringify($$self{cs}) . " expands into itself!",
-      "defining as empty");
-    @result = (); }
+    my @args = $self->readArguments($gullet);
+    # for "real" macros, make sure all args are Tokens
+    my $r;
+    my @targs = map { ($_ && ($r = ref $_)
+          && (($r eq 'LaTeXML::Core::Token') || ($r eq 'LaTeXML::Core::Tokens'))
+        ? $_ : Tokens(Revert($_))); } @args;
+    if ($tracing) {    # More involved...
+      print STDERR "\n" . $self->tracingCSName . ' -> ' . tracetoString($expansion) . "\n";
+      print STDERR $self->tracingArgs(@targs) . "\n" if @args; }
+    LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
+    $result = $expansion->substituteParameters(@targs); }
   # Getting exclusive requires dubious Gullet support!
-  push(@result, T_MARKER($profiled)) if $profiled;
-  return [@result]; }
-
-sub recursion_check {
-  my ($cs, @tokens) = @_;
-  # expect $expansion as Token, Tokens or [Token...] ! Argh !
-  return $cs &&
-    (($tokens[0] && $tokens[0]->equals($cs))
-    || ($tokens[1] && $tokens[1]->equals($cs) && $tokens[0]->equals(T_CS('\protect')))); }
+  $result = Tokens($result, T_MARKER($profiled)) if $profiled;
+  return $result; }
 
 # print a string of tokens like TeX would when tracing.
 sub tracetoString {

--- a/lib/LaTeXML/Core/Definition/Expandable.pm
+++ b/lib/LaTeXML/Core/Definition/Expandable.pm
@@ -63,9 +63,11 @@ sub invoke {
   my $etype     = ref $expansion;
   my $iscode    = $etype eq 'CODE';
   my $result;
+  my $parms = $$self{parameters};
+
   if ($iscode) {
     # Harder to emulate \tracingmacros here.
-    my @args = $self->readArguments($gullet);
+    my @args = ($parms ? $parms->readArguments($gullet, $self) : ());
     LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     $result = Tokens(&$expansion($gullet, @args));
     if ($tracing) {    # More involved...
@@ -87,7 +89,7 @@ sub invoke {
         $expansion = Tokens(); } }
     $result = $expansion; }
   else {
-    my @args = $self->readArguments($gullet);
+    my @args = ($parms ? $parms->readArguments($gullet, $self) : ());
     # for "real" macros, make sure all args are Tokens
     my $r;
     my @targs = map { ($_ && ($r = ref $_)

--- a/lib/LaTeXML/Core/Definition/Primitive.pm
+++ b/lib/LaTeXML/Core/Definition/Primitive.pm
@@ -54,7 +54,8 @@ sub invoke {
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
   print STDERR '{' . $self->tracingCSName . "}\n"                if $tracing;
   my @result = ($self->executeBeforeDigest($stomach));
-  my @args   = $self->readArguments($stomach->getGullet);
+  my $parms  = $$self{parameters};
+  my @args   = ($parms ? $parms->readArguments($stomach->getGullet, $self) : ());
   print STDERR $self->tracingArgs(@args) . "\n" if $tracing && @args;
   push(@result,
     &{ $$self{replacement} }($stomach, @args),

--- a/lib/LaTeXML/Core/Definition/Register.pm
+++ b/lib/LaTeXML/Core/Definition/Register.pm
@@ -61,7 +61,8 @@ sub invoke {
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
 
   my $gullet = $stomach->getGullet;
-  my @args   = $self->readArguments($gullet);
+  my $parms  = $$self{parameters};
+  my @args   = ($parms ? $parms->readArguments($gullet) : ());
   $gullet->readKeyword('=');    # Ignore
   my $value = $gullet->readValue($self->isRegister);
   $self->setValue($value, @args);

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -588,20 +588,6 @@ sub readUntilBrace {
     push(@tokens, $token); }
   return Tokens(@tokens); }
 
-# Skipping over conditional branches is used heavily when processing raw TeX (eg. tikz).
-# Make this efficient! Note that since we're skipping tokens, we presumably neither
-# need to note profiling end markers, nor preserve comments in the skipped sections?
-sub readNextConditional {
-  my ($self) = @_;
-  my $token;
-  my $type;
-  while ($token = shift(@{ $$self{pushback} }) || $$self{mouth}->readToken()) {
-    $token = $$token[2] if $$token[1] == CC_SMUGGLE_THE;
-    if ($LaTeXML::Core::State::CATCODE_ACTIVE_OR_CS[$$token[1]]
-      && ($type = $STATE->lookupConditional($token))) {
-      return ($token, $type); } }
-  return; }
-
 #**********************************************************************
 # Higher-level readers: Read various types of things from the input:
 #  tokens, non-expandable tokens, args, Numbers, ...

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -345,8 +345,8 @@ sub readXToken {
       && (($atoken, $atype, $ahidden) = $self->isColumnEnd($token))) {
       $self->handleTemplate($LaTeXML::READING_ALIGNMENT, $token, $atype, $ahidden); }
     ## Note: use general-purpose lookup, since we may reexamine $defn below
-    elsif ($LaTeXML::Core::State::CATCODE_ACTIVE_OR_CS[$$token[1]]
-      && defined($defn = LaTeXML::Core::State::lookupMeaning($STATE, $token))
+    elsif ($LaTeXML::Core::State::CATCODE_ACTIVE_OR_CS[$cc]
+      && defined($defn = $STATE->lookupMeaning($token))
       && ((ref $defn) ne 'LaTeXML::Core::Token')    # an actual definition
       && $$defn{isExpandable}
       && ($toplevel || !$$defn{isProtected})) {     # is this the right logic here? don't expand unless di
@@ -534,7 +534,6 @@ sub readKeyword {
 # Note that Braces on input hides the contents from matching,
 # so this assumes there wont be braces in $delim!
 # But, see readUntilBrace for that case.
-# NOTE: Add error handling, $token undef detection, etc!!!!!
 sub readUntil {
   my ($self, $delim) = @_;
   my @tokens = ();
@@ -638,7 +637,7 @@ sub readRegisterValue {
   my ($self, $type) = @_;
   my $token = $self->readXToken(0);
   return unless defined $token;
-  my $defn = LaTeXML::Core::State::lookupDefinition($STATE, $token);
+  my $defn = $STATE->lookupDefinition($token);
   if ((defined $defn) && ($defn->isRegister eq $type)) {
     my $parms = $$defn{parameters};
     return $defn->valueOf(($parms ? $parms->readArguments($self) : ())); }
@@ -654,7 +653,7 @@ sub readTokensValue {
     return; }
   elsif ($$token[1] == CC_BEGIN) {             # Inline ->getCatcode!
     return $self->readBalanced; }
-  elsif (my $defn = LaTeXML::Core::State::lookupDefinition($STATE, $token)) {
+  elsif (my $defn = $STATE->lookupDefinition($token)) {
     if ($defn->isRegister eq 'Tokens') {
       my $parms = $$defn{parameters};
       return $defn->valueOf(($parms ? $parms->readArguments($self) : ())); }

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -481,8 +481,7 @@ sub readBalanced {
     my $loc_message = $startloc ? ("Started at " . ToString($startloc)) : ("Ended at " . ToString($self->getLocator));
     Error('expected', "}", $self, "Gullet->readBalanced ran out of input in an unbalanced state.",
       $loc_message); }
-  ## Performance enhancement:
-  return (wantarray ? (Tokens(@tokens), $token) : Tokens(@tokens)); }
+  return Tokens(@tokens); }
 
 sub ifNext {
   my ($self, $token) = @_;
@@ -549,7 +548,7 @@ sub readUntil {
     push(@tokens, $token);
     $n++;
     if ($$token[1] == CC_BEGIN) {      # And if it's a BEGIN, copy till balanced END
-      push(@tokens, $self->readBalanced); } }
+      push(@tokens, $self->readBalanced, T_END); } }
   # Notice that IFF the arg looks like {balanced}, the outer braces are stripped
   # so that delimited arguments behave more similarly to simple, undelimited arguments.
   if (($n == 1) && ($tokens[0][1] == CC_BEGIN)) {
@@ -590,7 +589,7 @@ sub readArg {
   if (!defined $token) {
     return; }
   elsif ($$token[1] == CC_BEGIN) {    # Inline ->getCatcode!
-    return scalar($self->readBalanced(0)); }
+    return $self->readBalanced(0); }
   else {
     return Tokens($token); } }
 
@@ -644,7 +643,7 @@ sub readTokensValue {
   if (!defined $token) {
     return; }
   elsif ($$token[1] == CC_BEGIN) {             # Inline ->getCatcode!
-    return scalar($self->readBalanced); }
+    return $self->readBalanced; }
   elsif (my $defn = LaTeXML::Core::State::lookupDefinition($STATE, $token)) {
     if ($defn->isRegister eq 'Tokens') {
       return $defn->valueOf($defn->readArguments($self)); }

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -654,7 +654,8 @@ sub readRegisterValue {
   return unless defined $token;
   my $defn = LaTeXML::Core::State::lookupDefinition($STATE, $token);
   if ((defined $defn) && ($defn->isRegister eq $type)) {
-    return $defn->valueOf($defn->readArguments($self)); }
+    my $parms = $$defn{parameters};
+    return $defn->valueOf(($parms ? $parms->readArguments($self) : ())); }
   else {
     unshift(@{ $$self{pushback} }, $token);    # Unread
     return; } }
@@ -669,7 +670,8 @@ sub readTokensValue {
     return $self->readBalanced; }
   elsif (my $defn = LaTeXML::Core::State::lookupDefinition($STATE, $token)) {
     if ($defn->isRegister eq 'Tokens') {
-      return $defn->valueOf($defn->readArguments($self)); }
+      my $parms = $$defn{parameters};
+      return $defn->valueOf(($parms ? $parms->readArguments($self) : ())); }
     elsif ($defn->isExpandable) {
       if (my $x = $defn->invoke($self)) {
         $self->unread(@{$x}); }

--- a/lib/LaTeXML/Core/KeyVals.pm
+++ b/lib/LaTeXML/Core/KeyVals.pm
@@ -339,7 +339,7 @@ sub readFrom {
         while ((!defined($delim = $gullet->readMatch($punct, $until)))
           && (defined($tok = $gullet->readToken()))) {    # Copy next token to args
           push(@toks, $tok,
-            ($tok->getCatcode == CC_BEGIN ? $gullet->readBalanced : ())); }
+            ($tok->getCatcode == CC_BEGIN ? ($gullet->readBalanced, T_END) : ())); }
         # reparse (and expand) the tokens representing the value
         $value = Tokens(@toks)->stripBraces;
         $value = $keydef->reparse($gullet, $value) if $keydef && $value;

--- a/lib/LaTeXML/Core/Parameters.pm
+++ b/lib/LaTeXML/Core/Parameters.pm
@@ -60,10 +60,8 @@ sub readArguments {
   my ($self, $gullet, $fordefn) = @_;
   my @args = ();
   $gullet->setup_scan();
-  foreach my $parameter (@$self) {
-    my $value = $parameter->read($gullet, $fordefn);
-    push(@args, $value) unless $$parameter{novalue}; }
-  return @args; }
+  my ($p, $v);
+  return map { $p = $_; $v = $p->read($gullet, $fordefn); ($$p{novalue} ? () : $v); } @$self; }
 
 sub readArgumentsAndDigest {
   my ($self, $stomach, $fordefn) = @_;

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -391,14 +391,8 @@ sub lookupConditional {
   return unless $token;
   my $defn;
   my $entry;
-  #  my $inmath = $self->lookupValue('IN_MATH');
-  my $cc = $$token[1];
-  my $lookupname =
-    ($CATCODE_ACTIVE_OR_CS[$cc]
-    ? $$token[0]
-    : $CATCODE_EXECUTABLE_PRIMITIVE_NAME[$cc]);
-  if ($lookupname
-    && ($entry = $$self{meaning}{$lookupname})
+  if ($CATCODE_ACTIVE_OR_CS[$$token[1]]
+    && ($entry = $$self{meaning}{ $$token[0] })
     && ($defn  = $$entry[0])
     # Can only be a token or definition; we only want defns that have conditional_type
     && ((ref $defn) ne 'LaTeXML::Core::Token')) {
@@ -411,14 +405,8 @@ sub lookupExpandable {
   return unless $token;
   my $defn;
   my $entry;
-  #  my $inmath = $self->lookupValue('IN_MATH');
-  my $cc = $$token[1];
-  my $lookupname =
-    ($CATCODE_ACTIVE_OR_CS[$cc]
-    ? $$token[0]
-    : $CATCODE_EXECUTABLE_PRIMITIVE_NAME[$cc]);
-  if ($lookupname
-    && ($entry = $$self{meaning}{$lookupname})
+  if ($CATCODE_ACTIVE_OR_CS[$$token[1]]
+    && ($entry = $$self{meaning}{ $$token[0] })
     && ($defn  = $$entry[0])
     # Can only be a token or definition; we want defns!
     && ((ref $defn) ne 'LaTeXML::Core::Token')

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -178,7 +178,7 @@ INVOKE:
   # but it isn't expanded in the gullet, but later when digesting, in math mode (? I think)
   elsif ($meaning->isExpandable) {
     my $gullet = $$self{gullet};
-    $gullet->unread(@{ $meaning->invoke($gullet) || [] });
+    $gullet->unread($meaning->invoke($gullet));
     $token = $gullet->readXToken();    # replace the token by it's expansion!!!
     pop(@{ $$self{token_stack} });
     goto INVOKE if $token; }

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4557,7 +4557,9 @@ sub ReadPair {
       $gullet->readUntil(T_OTHER(')')); $gullet->skipSpaces;
       return Pair(Dimension(0), Dimension(0)); }
     my $x = &$itemreader($gullet, $xarg);
-    $gullet->skipSpaces; $gullet->readUntil(T_OTHER(','), T_OTHER(';')); $gullet->skipSpaces;
+    # This had also recognized ";" as a possible separator; if needed, will need to generalize
+    # but we want to make readUntil accept only a single match
+    $gullet->skipSpaces; $gullet->readUntil(T_OTHER(',')); $gullet->skipSpaces;
     my $y = &$itemreader($gullet, $yarg);
     $gullet->skipSpaces; $gullet->readUntil(T_OTHER(')')); $gullet->skipSpaces;
     return Pair($x, $y); }

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2782,7 +2782,7 @@ sub parseHAlignTemplate {
   my $tabskip;         # Need to use this somehow!
   ## Only expand certain things; See TeX book p.238
   local $LaTeXML::ALIGN_STATE = 1000000;
-  while ($t = $gullet->readToken(0)) {
+  while ($t = $gullet->readToken) {
     if ($t->equals(T_CS('\tabskip'))) {    # Read the tabskip assignment
       $gullet->readKeyword('=');
       $tabskip = $gullet->readGlue; }

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -953,8 +953,7 @@ DefMacro('\expandafter Token Token', sub {
       my @x = ();
       {
         local $LaTeXML::CURRENT_TOKEN = $xtok;
-        my $x = $defn->invoke($gullet, 1);
-        @x = @$x if $x;    # Expand $xtok ONCE ONLY!
+        @x = $defn->invoke($gullet, 1);    # Expand $xtok ONCE ONLY!
       }
       ($tok, @x); }
     elsif (!$STATE->lookupMeaning($xtok)) {

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -218,7 +218,8 @@ DefParameterType('XUntil', sub {
       elsif ($token->getCatcode == CC_BEGIN) {
         push(@tokens, $token, $gullet->readBalanced, T_END); }
       elsif (my $defn = LookupDefinition($token)) {
-        push(@tokens, Invocation($token, $defn->readArguments($gullet))); }
+        push(@tokens, Invocation($token,
+            ($$defn{parameters} ? $$defn{parameters}->readArguments($gullet) : ()))); }
       else {
         push(@tokens, $token); } }
     Tokens(@tokens); });
@@ -324,7 +325,7 @@ DefParameterType('Variable', sub {
     my $token    = $gullet->readXToken;
     my $defn     = $token && LookupDefinition($token);
     if ((defined $defn) && $defn->isRegister && !$defn->isReadonly) {
-      [$defn, $defn->readArguments($gullet)]; }
+      [$defn, ($$defn{parameters} ? $$defn{parameters}->readArguments($gullet) : ())]; }
     else {
       DefRegisterI($token, undef, Dimension(0));    # Don't really know what KIND of variable!
       if ($token && ($token->getCatcode == CC_CS)) {
@@ -350,7 +351,7 @@ DefParameterType('Register', sub {
     my $token    = $gullet->readXToken;
     my $defn     = $token && LookupDefinition($token);
     if ((defined $defn) && $defn->isRegister) {
-      [$defn, $defn->readArguments($gullet)]; }
+      [$defn, ($$defn{parameters} ? $$defn{parameters}->readArguments($gullet) : ())]; }
     else {
       if ($token && ($token->getCatcode == CC_CS)) {
         Error('expected', '<register>', $gullet,

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -147,7 +147,7 @@ DefParameterType('GeneralText', sub {
     my ($gullet) = @_;
     my $open = $gullet->readXToken;
     if ($open->equals(T_BEGIN)) {
-      return scalar($gullet->readBalanced); }
+      return $gullet->readBalanced; }
     else {
       Error('expected', '{', $gullet,
         "Expected <general text> here");
@@ -216,7 +216,7 @@ DefParameterType('XUntil', sub {
       if ($token->equals($until)) {
         last; }
       elsif ($token->getCatcode == CC_BEGIN) {
-        push(@tokens, $token, $gullet->readBalanced); }
+        push(@tokens, $token, $gullet->readBalanced, T_END); }
       elsif (my $defn = LookupDefinition($token)) {
         push(@tokens, Invocation($token, $defn->readArguments($gullet))); }
       else {
@@ -264,7 +264,7 @@ DefParameterType('Match', sub { shift->readMatch(@_); });
 DefParameterType('Keyword', sub { shift->readKeyword(@_); });
 
 # Read balanced material (?)
-DefParameterType('Balanced', sub { scalar($_[0]->readBalanced); });
+DefParameterType('Balanced', sub { $_[0]->readBalanced; });
 
 # Read a Semiverbatim argument; ie w/ most catcodes neutralized.
 DefParameterType('Semiverbatim', sub { $_[0]->readArg; }, semiverbatim => 1,
@@ -506,7 +506,7 @@ DefParameterType('CommaList', sub {
         elsif ($token->equals($comma)) {
           push(@items, Tokens(@tokens)); @tokens = (); }
         elsif ($token->equals(T_BEGIN)) {
-          push(@tokens, $token, $gullet->readBalanced); }
+          push(@tokens, $token, $gullet->readBalanced, T_END); }
         else {
           push(@tokens, $token); } }
       if ($typedef) {
@@ -3838,7 +3838,7 @@ DefMacroI('\eqno', undef, sub {
     # This is risky!!!
     while (my $t = $gullet->readXToken(0)) {
       if (Equals($t, T_BEGIN)) {
-        push(@stuff, $t, $gullet->readBalanced); }
+        push(@stuff, $t, $gullet->readBalanced, T_END); }
       # What do I need to explicitly list here!?!?!? UGGH!
       elsif (Equals($t, T_MATH) || Equals($t, T_CS('\]')) || Equals($t, T_CS('\@@ENDDISPLAYMATH'))
         || Equals($t, T_CS('\begingroup'))           # Totally wrong, but to catch expanded environments

--- a/lib/LaTeXML/Package/amsgen.sty.ltxml
+++ b/lib/LaTeXML/Package/amsgen.sty.ltxml
@@ -21,8 +21,6 @@ DefMacro('\@saveprimitive{}{}', '\let#2#1');
 Let('\@xp', '\expandafter');
 Let('\@nx', '\noexpand');
 DefRegister('\@emptytoks' => Tokens());
-DefMacro('\@oparg #1[#2]', '\@ifnextchar[{#1}{#1[#2]}');
-
 DefMacro('\@ifempty {}', '\@xifempty#1@@..\@nil');
 RawTeX(<<'EoTeX');
 \def\@oparg#1[#2]{\@ifnextchar[{#1}{#1[#2]}}

--- a/lib/LaTeXML/Package/pdfTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/pdfTeX.pool.ltxml
@@ -134,22 +134,6 @@ DefRegister('\pdfretval'               => Number(0));
 # \pdfximage [ image attr spec ] general text (h, v, m)
 # \pdfrefximage object number (h, v, m)
 # \pdfannot annot type spec (h, v, m)
-DefPrimitive('\pdfannot OpenAnnotSpecification', undef);
-
-# \pdfstartlink [ rule spec ] [ attr spec ] action spec (h, m)
-DefPrimitive('\pdfstartlink', undef);
-# \pdfendlink (h, m)
-DefPrimitive('\pdfendlink', undef);
-# \pdfoutline outline spec (h, v, m)
-# \pdfdest dest spec (h, v, m)
-# \pdfthread thread spec (h, v, m)
-# \pdfstartthread thread spec (v, m)
-# \pdfendthread (v, m)
-# \pdfsavepos (h, v, m)
-
-# See lxRDFa for ideas how this info might be used!
-DefMacro('\pdfinfo{}', '');
-
 # Ugh, what a mess of ugly syntax....
 DefParameterType('OpenActionSpecification', sub {
     my ($gullet) = @_;
@@ -175,6 +159,22 @@ DefParameterType('OpenAnnotSpecification', sub {
     my $discard_spec = &{ $$general_text_param{reader} }($gullet);
     return; }
   , optional => 1, undigested => 1);
+
+DefPrimitive('\pdfannot OpenAnnotSpecification', undef);
+
+# \pdfstartlink [ rule spec ] [ attr spec ] action spec (h, m)
+DefPrimitive('\pdfstartlink', undef);
+# \pdfendlink (h, m)
+DefPrimitive('\pdfendlink', undef);
+# \pdfoutline outline spec (h, v, m)
+# \pdfdest dest spec (h, v, m)
+# \pdfthread thread spec (h, v, m)
+# \pdfstartthread thread spec (v, m)
+# \pdfendthread (v, m)
+# \pdfsavepos (h, v, m)
+
+# See lxRDFa for ideas how this info might be used!
+DefMacro('\pdfinfo{}', '');
 
 DefMacro('\pdfcatalog{} OpenActionSpecification', '');
 DefMacro('\pdfnames{}',                           {});


### PR DESCRIPTION
Yep, misspelled. A series of smallish, but cumulative, optimizations. The main strategy is avoiding layers of subroutine calls, using operations that are faster in Perl, and open-coding accessors where not too offensive. Generally focussed on speeding up the expl3 test case, which appears to be 20% faster (tikz samples about 10%, make test around 7-8%)