### PR TITLE
Fix typo in manual (Closes #1527)

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -118,7 +118,7 @@ where there is a tendency for the markup to focus on appearance rather than mean
 The choice of \LaTeX\ for authoring, and \XML\ for delivery were natural and uncontroversial
 choices for the \URL[Digital Library of Mathematical Functions]{http://dlmf.nist.gov}.
 Faced with the need to perform this conversion and the lack of suitable tools to perform it, 
-the DLMF project proceeded to develop thier own tool, \LaTeXML, for this purpose.
+the DLMF project proceeded to develop their own tool, \LaTeXML, for this purpose.
 %This document describes a \emph{preview} release of \LaTeXML.
 
 \paragraph{Design Goals}\label{intro.goals} The idealistic goals of \LaTeXML\ are:


### PR DESCRIPTION
As noted in #1527 there is a typo in the documentation. This PR fixes the typo. 
Thanks @samzhang111 for spotting it.