### PR TITLE
JATS, TEI stylesheet cleanup

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-jats.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-jats.xsl
@@ -17,14 +17,15 @@
 \=========================================================ooo==U==ooo=/
 -->
 <xsl:stylesheet
-   version     ="1.0"
-   xmlns:xsl   ="http://www.w3.org/1999/XSL/Transform"
-   xmlns:ltx   ="http://dlmf.nist.gov/LaTeXML"
-   xmlns:str   ="http://exslt.org/strings"
-   xmlns:m     ="http://www.w3.org/1998/Math/MathML"
-   xmlns:xlink ="http://www.w3.org/1999/xlink"
-   extension-element-prefixes="str"
-   exclude-result-prefixes="ltx str m xlink">
+    version     ="1.0"
+    xmlns:xsl   ="http://www.w3.org/1999/XSL/Transform"
+    xmlns:ltx   ="http://dlmf.nist.gov/LaTeXML"
+    xmlns:str   ="http://exslt.org/strings"
+    xmlns:m     ="http://www.w3.org/1998/Math/MathML"
+    xmlns:svg   ="http://www.w3.org/2000/svg"
+    xmlns:xlink ="http://www.w3.org/1999/xlink"
+    extension-element-prefixes="str"
+    exclude-result-prefixes="ltx str m svg xlink">
 
   <xsl:import href="LaTeXML-tabular-xhtml.xsl"/>
   <xsl:import href="LaTeXML-common.xsl"/>
@@ -60,66 +61,79 @@
 
   <xsl:template match="*">
     <xsl:message> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-        <xsl:for-each select="./@*">
-          <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-        </xsl:for-each>
-      </xsl:if>
-      is currently not supported for the main body.
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the main body.
     </xsl:message>
     <xsl:comment> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-        <xsl:for-each select="./@*">
-          <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-        </xsl:for-each>
-      </xsl:if>
-      is currently not supported for the main body.
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the main body.
     </xsl:comment>
   </xsl:template>
 
-  <xsl:template match="*" mode="math">
-    <xsl:copy>
-      <xsl:apply-templates select="@*|node()" mode="math"/>
-    </xsl:copy>
+  <!-- Copy MathML as is, but use mml as namespace prefix,
+       since that's assumed by many non-XML aware JATS applications. -->
+  <xsl:template match="m:*">
+    <xsl:element name="mml:{local-name()}" namespace="http://www.w3.org/1998/Math/MathML">
+      <xsl:copy-of select="@*"/>
+      <xsl:apply-templates/>
+    </xsl:element>
   </xsl:template>
 
-  <xsl:template match="@*" mode="math">
-    <xsl:attribute name="{local-name()}"><xsl:value-of select="."/></xsl:attribute>
+  <xsl:template match="ltx:Math[@mode='inline']">
+    <inline-formula>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="m:math"/>
+    </inline-formula>
   </xsl:template>
 
-  <xsl:template match="@xml:id" mode="math">
-    <xsl:attribute name="id"><xsl:value-of select="."/></xsl:attribute>
+  <!-- caller (ltx:equation) will wrap disp-formula, as needed -->
+  <xsl:template match="ltx:MathFork">
+    <xsl:apply-templates select="ltx:Math[1]/m:math"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:Math">
+    <xsl:apply-templates select="m:math"/>
   </xsl:template>
 
   <xsl:template match="*" mode="front">
     <xsl:message> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-        <xsl:for-each select="./@*">
-          <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-        </xsl:for-each>
-      </xsl:if>
-      is currently not supported for the front matter.
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the front matter.
     </xsl:message>
     <xsl:comment> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-        <xsl:for-each select="./@*">
-          <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-        </xsl:for-each>
-      </xsl:if>
-      is currently not supported for the front matter.
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the front matter.
     </xsl:comment>
   </xsl:template>
 
   <xsl:template match="*" mode="back">
     <xsl:message> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-        <xsl:for-each select="./@*">
-          <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-        </xsl:for-each>
-      </xsl:if>
-      is currently not supported for the back matter.
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the back matter.
     </xsl:message>
     <xsl:comment> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-        <xsl:for-each select="./@*">
-          <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-        </xsl:for-each>
-      </xsl:if>
-      is currently not supported for the back matter
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the back matter
     </xsl:comment>
   </xsl:template>
 
@@ -257,14 +271,19 @@
 
   <xsl:template match="ltx:equationgroup" mode="front">
     <disp-formula-group>
-      <xsl:apply-templates select="@*|node()" mode="front"/>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates mode="front"/>
     </disp-formula-group>
   </xsl:template>
 
   <xsl:template match="ltx:equationgroup/ltx:equation" mode="front">
     <disp-formula>
-      <xsl:apply-templates select="@*" mode="front"/>
-      <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates mode="front"/>
     </disp-formula>
   </xsl:template>
 
@@ -275,16 +294,12 @@
   <xsl:template match="ltx:equation" mode="front">
     <p>
       <disp-formula>
-        <xsl:apply-templates select="@*|node()"/>
+        <xsl:if test="@xml:id">
+          <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates mode="front"/>
       </disp-formula>
     </p>
-  </xsl:template>
-
-  <xsl:template match="ltx:Math[@mode='inline']" mode="front">
-    <inline-formula>
-      <xsl:apply-templates select="@*"/>
-      <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
-    </inline-formula>
   </xsl:template>
 
   <xsl:template match="ltx:caption" mode="front">
@@ -369,28 +384,31 @@
 
   <xsl:template match="ltx:equationgroup" mode="back">
     <disp-formula-group>
-      <xsl:apply-templates select="@*|node()" mode="back"/>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates mode="back"/>
     </disp-formula-group>
   </xsl:template>
 
   <xsl:template match="ltx:equationgroup/ltx:equation" mode="back">
     <disp-formula>
-      <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates mode="back"/>
     </disp-formula>
   </xsl:template>
 
   <xsl:template match="ltx:equation" mode="back">
     <p>
       <disp-formula>
-        <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
+        <xsl:if test="@xml:id">
+          <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates mode="back"/>
       </disp-formula>
     </p>
-  </xsl:template>
-
-  <xsl:template match="ltx:Math[@mode='inline']" mode="back">
-    <inline-formula>
-      <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
-    </inline-formula>
   </xsl:template>
 
   <xsl:template match="ltx:bibliography" mode="back">
@@ -419,12 +437,12 @@
         <xsl:if test="./ltx:tags/ltx:tag[@class='ltx_bib_type']">
           <xsl:attribute name="publication-type"> <xsl:value-of select="./ltx:tag[@class='ltx_bib_type']/text()"/></xsl:attribute>
         </xsl:if>
-<!-- Isn't this better?
-        <xsl:if test="@type">
-          <xsl:attribute name="publication-type"> <xsl:value-of select="@type"/></xsl:attribute>
-        </xsl:if>
--->
-<!--        <xsl:apply-templates select="node()" mode="back"/>-->
+        <!-- Isn't this better?
+             <xsl:if test="@type">
+             <xsl:attribute name="publication-type"> <xsl:value-of select="@type"/></xsl:attribute>
+             </xsl:if>
+        -->
+        <!--        <xsl:apply-templates select="node()" mode="back"/>-->
         <xsl:apply-templates mode="back"/>
       </mixed-citation>
     </ref>
@@ -539,6 +557,8 @@
     <hr/>
   </xsl:template>
 
+  <!-- This is really sad; we should have preserved structured data from bibentry,
+       rather than formatted data from bibitem -->
   <xsl:template match="ltx:bibitem/ltx:tags/ltx:tag[@role='authors']" mode="back">
     <person-group person-group-type="author">
       <name>
@@ -555,7 +575,7 @@
           <given-names>
             <xsl:for-each select="str:tokenize(./text(),' ')">
               <xsl:if test="position()!=last()">
-                <xsl:value-of select="."/>&#160;
+                <xsl:value-of select="."/><xsl:text> </xsl:text>
               </xsl:if>
             </xsl:for-each>
           </given-names>
@@ -566,10 +586,9 @@
 
   <xsl:template match="ltx:tag[@role='fullauthors']" mode="back"/>
   <xsl:template match="ltx:bibitem/ltx:tags/ltx:text[@font='bold']" mode="back">
-    <bold>
-      <xsl:apply-templates mode="back" select="@*|node()"/>
-    </bold>
+    <bold><xsl:apply-templates mode="back" select="@*|node()"/></bold>
   </xsl:template>
+
   <xsl:template match="ltx:tag[@role='refnum']" mode="back"/>
   <xsl:template match="ltx:tag[@role='number']" mode="back"/>
 
@@ -605,7 +624,10 @@
   <xsl:template match="ltx:equationgroup">
     <p>
       <disp-formula-group>
-        <xsl:apply-templates select="@*|node()"/>
+        <xsl:if test="@xml:id">
+          <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates/>
       </disp-formula-group>
     </p>
   </xsl:template>
@@ -613,24 +635,21 @@
   <xsl:template match="ltx:equation">
     <p>
       <disp-formula>
-        <xsl:apply-templates select="@*"/>
-        <xsl:for-each select=".//m:math"><xsl:apply-templates select="." mode="math"/></xsl:for-each>
+        <xsl:if test="@xml:id">
+          <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates/>
       </disp-formula>
     </p>
   </xsl:template>
 
   <xsl:template match="ltx:equationgroup/ltx:equation">
     <disp-formula>
-      <xsl:apply-templates select="@*"/>
-      <xsl:for-each select=".//m:math"><xsl:apply-templates select="." mode="math"/></xsl:for-each>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
     </disp-formula>
-  </xsl:template>
-
-  <xsl:template match="ltx:Math[@mode='inline']">
-    <inline-formula>
-      <xsl:apply-templates select="@*"/>
-      <xsl:for-each select=".//m:math"><xsl:apply-templates select="." mode="math"/></xsl:for-each>
-    </inline-formula>
   </xsl:template>
 
   <xsl:template match="ltx:inline-block">

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-tei.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-tei.xsl
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet
-        version     ="1.0"
-        xmlns:xsl   ="http://www.w3.org/1999/XSL/Transform"
-        xmlns       ="http://www.tei-c.org/ns/1.0"
-        xmlns:ltx   ="http://dlmf.nist.gov/LaTeXML"
-        xmlns:str   ="http://exslt.org/strings"
-        xmlns:m     ="http://www.w3.org/1998/Math/MathML"
-        xmlns:xlink ="http://www.w3.org/1999/xlink"
-        extension-element-prefixes="str"
-        exclude-result-prefixes="ltx str m xlink">
+    version     ="1.0"
+    xmlns:xsl   ="http://www.w3.org/1999/XSL/Transform"
+    xmlns       ="http://www.tei-c.org/ns/1.0"
+    xmlns:ltx   ="http://dlmf.nist.gov/LaTeXML"
+    xmlns:str   ="http://exslt.org/strings"
+    xmlns:m     ="http://www.w3.org/1998/Math/MathML"
+    xmlns:svg   ="http://www.w3.org/2000/svg"
+    xmlns:xlink ="http://www.w3.org/1999/xlink"
+    extension-element-prefixes="str"
+    exclude-result-prefixes="ltx str m svg xlink">
 
-    <xsl:import href="LaTeXML-common.xsl"/>
+  <xsl:import href="LaTeXML-common.xsl"/>
 
   <xsl:strip-space elements="ltx:document ltx:part ltx:chapter ltx:section ltx:subsection
                              ltx:subsubsection ltx:paragraph ltx:subparagraph
@@ -35,1187 +36,1226 @@
   <xsl:strip-space elements="ltx:picture svg:*"/>
   <xsl:strip-space elements="ltx:Math"/>
 
-    <xsl:output
-        method = "xml"
-        indent = "yes"
-        encoding = 'utf-8'/>
+  <xsl:output
+      method = "xml"
+      indent = "yes"
+      encoding = 'utf-8'/>
 
-    <xsl:variable name="footnotes" select="//ltx:note[@role='footnote']"/>
-    <xsl:template name="add_classes"/>
-    <xsl:param name="html_ns"></xsl:param>
+  <xsl:variable name="footnotes" select="//ltx:note[@role='footnote']"/>
+  <xsl:template name="add_classes"/>
+  <xsl:param name="html_ns"></xsl:param>
 
-    <xsl:template match="*">
-        <xsl:message> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-            <xsl:for-each select="./@*">
-                <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-            </xsl:for-each>
+  <xsl:template match="*">
+    <xsl:message> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the main body.
+    </xsl:message>
+    <xsl:comment> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the main body.
+    </xsl:comment>
+  </xsl:template>
+
+  <xsl:template match="m:*">
+    <xsl:element name="m:{local-name()}" namespace="http://www.w3.org/1998/Math/MathML">
+      <xsl:copy-of select="@*"/>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- caller (ltx:equation) will wrap formula, as needed -->
+  <xsl:template match="ltx:MathFork">
+    <xsl:apply-templates select="ltx:Math[1]/m:math"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:Math">
+    <xsl:apply-templates select="m:math"/>
+  </xsl:template>
+
+  <xsl:template match="*" mode="front">
+    <xsl:message> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the front matter.
+    </xsl:message>
+    <xsl:comment> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the front matter.
+    </xsl:comment>
+  </xsl:template>
+
+  <xsl:template match="*" mode="back">
+    <xsl:message> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the back matter.
+    </xsl:message>
+    <xsl:comment> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
+    <xsl:for-each select="./@*">
+      <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
+    </xsl:for-each>
+  </xsl:if>
+  is currently not supported for the back matter
+    </xsl:comment>
+  </xsl:template>
+
+  <xsl:template match="ltx:ERROR">
+    An error in the conversion from LaTeX to XML has occurred here.
+  </xsl:template>
+
+  <xsl:template match="ltx:ERROR" mode="front">
+    An error in the conversion from LaTeX to XML has occurred here.
+  </xsl:template>
+
+  <xsl:template match="ltx:ERROR" mode="back">
+    An error in the conversion from LaTeX to XML has occurred here.
+  </xsl:template>
+
+  <xsl:template match="ltx:document">
+    <TEI xmlns="http://www.tei-c.org/ns/1.0">
+      <teiHeader>
+        <fileDesc>
+          <titleStmt>
+            <xsl:apply-templates select="ltx:title" mode="front"/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher></publisher>
+          </publicationStmt>
+          <sourceDesc>
+            <biblStruct>
+              <analytic>
+                <!-- All authors are included here -->
+                <xsl:apply-templates select="ltx:creator[@role='author']" mode="front"/>
+                <!-- Title information related to the paper goes here -->
+                <xsl:apply-templates select="ltx:title" mode="front"/>
+              </analytic>
+              <monogr>
+                <imprint>
+                  <xsl:apply-templates select="ltx:date"/>
+                </imprint>
+              </monogr>
+            </biblStruct>
+          </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+          <xsl:apply-templates select="ltx:abstract" mode="front"/>
+          <xsl:apply-templates select="ltx:keywords" mode="front"/>
+        </profileDesc>
+      </teiHeader>
+      <text>
+        <body>
+          <xsl:apply-templates select="@*|node()"/>
+        </body>
+        <back>
+          <xsl:apply-templates select="@*|node()" mode="back"/>
+        </back>
+      </text>
+    </TEI>
+  </xsl:template>
+
+  <xsl:template match="ltx:para[not(ancestor::ltx:section or ancestor::ltx:appendix or ancestor::ltx:acknowledgements) and preceding::ltx:section]">  <!-- Is not allowed -->
+    <xsl:comment><xsl:for-each select=".//text()"><xsl:value-of select="."/></xsl:for-each></xsl:comment> <!-- trying to provide the maximal information here -->
+  </xsl:template>
+
+  <xsl:template match="text()">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
+  <!-- Front matter section -->
+  <xsl:template match="ltx:emph" mode="front">
+    <hi rend="italic">
+      <xsl:apply-templates mode="front" select="@*|node()"/>
+    </hi>
+  </xsl:template>
+
+  <xsl:template match="ltx:creator[@role='author']" mode="front">
+    <author>
+      <xsl:apply-templates mode="front"/>
+    </author>
+  </xsl:template>
+
+  <xsl:template match="ltx:appendix" mode="app">
+    <app>
+      <xsl:apply-templates select="@*|node()"/>
+    </app>
+  </xsl:template>
+
+  <xsl:template match="ltx:appendix/ltx:title">
+    <head>
+      <xsl:apply-templates select="@*|node()"/>
+    </head>
+  </xsl:template>
+
+  <xsl:template match="ltx:date[@role='creation']" mode="front">
+    <date>
+      <xsl:for-each select="str:tokenize(./text(),' ')">
+        <xsl:if test="position()=last()">
+          <xsl:value-of select="."/>
         </xsl:if>
-            is currently not supported for the main body.
-        </xsl:message>
-        <xsl:comment> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-            <xsl:for-each select="./@*">
-                <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-            </xsl:for-each>
+      </xsl:for-each>
+    </date>
+  </xsl:template>
+
+  <xsl:template match="ltx:date[@role='creation']">
+    <date type="published">
+      <xsl:attribute name="when">
+        <xsl:for-each select="str:tokenize(./text(),' ')">
+          <xsl:if test="position()=last()">
+            <xsl:value-of select="."/>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:attribute>
+    </date>
+  </xsl:template>
+
+  <xsl:template match="ltx:creator" mode="front">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:contact[@role='affiliation']" mode="front">
+    <affiliation><xsl:apply-templates select="@*|node()" /></affiliation>
+  </xsl:template>
+
+  <xsl:template match="ltx:contact[@role='email']" mode="front">
+    <email><xsl:apply-templates select="@*|node()" /></email>
+  </xsl:template>
+
+  <xsl:template match="ltx:personname" mode="front">
+    <persName>
+      <surname>
+        <xsl:for-each select="str:tokenize(./text(),' ')">
+          <xsl:if test="position()=last()">
+            <xsl:value-of select="."/>
+          </xsl:if>
+        </xsl:for-each>
+      </surname>
+      <forename>
+        <xsl:for-each select="str:tokenize(./text(),' ')">
+          <xsl:if test="position()!=last()">
+            <xsl:value-of select="."/>
+          </xsl:if>
+        </xsl:for-each>
+      </forename>
+    </persName>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='bold']" mode="front">
+    <hi rend="bold">
+      <xsl:apply-templates mode="front" select="@*|node()"/>
+    </hi>
+  </xsl:template>
+  <xsl:template match="ltx:abstract" mode="front">
+    <abstract>
+      <xsl:apply-templates select="@*|node()" />
+    </abstract>
+  </xsl:template>
+
+  <xsl:template match="ltx:keywords" mode="front">
+    <kwd-group>
+      <xsl:for-each select="str:tokenize(./text(),',')">
+        <kwd><xsl:value-of select="."/></kwd>
+      </xsl:for-each>
+    </kwd-group>
+  </xsl:template>
+
+  <xsl:template match="ltx:document/ltx:title" mode="front">
+    <title level="a" type="main">
+      <xsl:apply-templates select="@*|node()" />
+    </title>
+  </xsl:template>
+
+  <xsl:template match="ltx:equationgroup" mode="front">
+    <p>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates mode="front"/>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="ltx:equationgroup/ltx:equation" mode="front">
+    <formula>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates mode="front"/>
+    </formula>
+  </xsl:template>
+
+  <xsl:template match="ltx:contact[@role='url']" mode="front">
+    <xsl:apply-templates select="@*|node()" mode="front"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:equation" mode="front">
+    <p>
+      <formula>
+        <xsl:if test="@xml:id">
+          <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
         </xsl:if>
-            is currently not supported for the main body.
-        </xsl:comment>
-    </xsl:template>
+        <xsl:apply-templates mode="front"/>
+      </formula>
+    </p>
+  </xsl:template>
 
-    <xsl:template match="*" mode="math">
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()" mode="math"/>
-        </xsl:copy>
-    </xsl:template>
+  <xsl:template match="ltx:Math[@mode='inline']" mode="front">
+    <formula>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="m:math"/>
+    </formula>
+  </xsl:template>
 
-    <xsl:template match="@*" mode="math">
-        <xsl:attribute name="{local-name()}"><xsl:value-of select="."/></xsl:attribute>
-    </xsl:template>
-
-    <xsl:template match="*" mode="front">
-        <xsl:message> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-            <xsl:for-each select="./@*">
-                <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-            </xsl:for-each>
-        </xsl:if>
-            is currently not supported for the front matter.
-        </xsl:message>
-        <xsl:comment> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-            <xsl:for-each select="./@*">
-                <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-            </xsl:for-each>
-        </xsl:if>
-            is currently not supported for the front matter.
-        </xsl:comment>
-    </xsl:template>
-
-    <xsl:template match="*" mode="back">
-        <xsl:message> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-            <xsl:for-each select="./@*">
-                <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-            </xsl:for-each>
-        </xsl:if>
-            is currently not supported for the back matter.
-        </xsl:message>
-        <xsl:comment> The element <xsl:value-of select="name(.)"/> <xsl:if test="@*"> with attributes
-            <xsl:for-each select="./@*">
-                <xsl:value-of select="name(.)"/>=<xsl:value-of select="."/>
-            </xsl:for-each>
-        </xsl:if>
-            is currently not supported for the back matter
-        </xsl:comment>
-    </xsl:template>
-
-    <xsl:template match="ltx:ERROR">
-        An error in the conversion from LaTeX to XML has occurred here.
-    </xsl:template>
-
-    <xsl:template match="ltx:ERROR" mode="front">
-        An error in the conversion from LaTeX to XML has occurred here.
-    </xsl:template>
-
-    <xsl:template match="ltx:ERROR" mode="back">
-        An error in the conversion from LaTeX to XML has occurred here.
-    </xsl:template>
-
-    <xsl:template match="ltx:document">
-
-        <TEI xmlns="http://www.tei-c.org/ns/1.0">
-            <teiHeader>
-                <fileDesc>
-                    <titleStmt>
-                        <xsl:apply-templates select="ltx:title" mode="front"/>
-                    </titleStmt>
-                    <publicationStmt>
-                        <publisher></publisher>
-                    </publicationStmt>
-                    <sourceDesc>
-                        <biblStruct>
-                            <analytic>
-                                <!-- All authors are included here -->
-                                <xsl:apply-templates select="ltx:creator[@role='author']" mode="front"/>
-                                <!-- Title information related to the paper goes here -->
-                                <xsl:apply-templates select="ltx:title" mode="front"/>
-                            </analytic>
-                            <monogr>
-                                <imprint>
-                                <xsl:apply-templates select="ltx:date"/>
-                                </imprint>
-                            </monogr>
-                        </biblStruct>
-                    </sourceDesc>
-                </fileDesc>
-                    <profileDesc>
-                                <xsl:apply-templates select="ltx:abstract" mode="front"/>
-                                <xsl:apply-templates select="ltx:keywords" mode="front"/>
-                    </profileDesc>
-            </teiHeader>
-            <text>
-                <body>
-                    <xsl:apply-templates select="@*|node()"/>
-                </body>
-                <back>
-                    <xsl:apply-templates select="@*|node()" mode="back"/>
-                </back>
-            </text>
-        </TEI>
-    </xsl:template>
-
-    <xsl:template match="ltx:para[not(ancestor::ltx:section or ancestor::ltx:appendix or ancestor::ltx:acknowledgements) and preceding::ltx:section]">  <!-- Is not allowed -->
-        <xsl:comment><xsl:for-each select=".//text()"><xsl:value-of select="."/></xsl:for-each></xsl:comment> <!-- trying to provide the maximal information here -->
-    </xsl:template>
-
-    <xsl:template match="text()">
-        <xsl:copy-of select="."/>
-    </xsl:template>
-    <!-- Front matter section -->
-    <xsl:template match="ltx:emph" mode="front">
-        <hi rend="italic">
-            <xsl:apply-templates mode="front" select="@*|node()"/>
-        </hi>
-    </xsl:template>
-
-    <xsl:template match="ltx:creator[@role='author']" mode="front">
-        <author>
-            <xsl:apply-templates mode="front"/>
-        </author>
-    </xsl:template>
-
-    <xsl:template match="ltx:appendix" mode="app">
-        <app>
-            <xsl:apply-templates select="@*|node()"/>
-        </app>
-    </xsl:template>
-
-    <xsl:template match="ltx:appendix/ltx:title">
-            <head>
-                <xsl:apply-templates select="@*|node()"/>
-            </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:date[@role='creation']" mode="front">
-        <date>
-                <xsl:for-each select="str:tokenize(./text(),' ')">
-                    <xsl:if test="position()=last()">
-                        <xsl:value-of select="."/>
-                    </xsl:if>
-                </xsl:for-each>
-        </date>
-    </xsl:template>
-
-    <xsl:template match="ltx:date[@role='creation']">
-        <date type="published">
-            <xsl:attribute name="when">
-                <xsl:for-each select="str:tokenize(./text(),' ')">
-                    <xsl:if test="position()=last()">
-                        <xsl:value-of select="."/>
-                    </xsl:if>
-                </xsl:for-each>
-            </xsl:attribute>
-        </date>
-    </xsl:template>
-
-    <xsl:template match="ltx:creator" mode="front">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:contact[@role='affiliation']" mode="front">
-        <affiliation><xsl:apply-templates select="@*|node()" /></affiliation>
-    </xsl:template>
-
-    <xsl:template match="ltx:contact[@role='email']" mode="front">
-        <email><xsl:apply-templates select="@*|node()" /></email>
-    </xsl:template>
-
-    <xsl:template match="ltx:personname" mode="front">
-        <persName>
-            <surname>
-                <xsl:for-each select="str:tokenize(./text(),' ')">
-                    <xsl:if test="position()=last()">
-                        <xsl:value-of select="."/>
-                    </xsl:if>
-                </xsl:for-each>
-            </surname>
-            <forename>
-                <xsl:for-each select="str:tokenize(./text(),' ')">
-                    <xsl:if test="position()!=last()">
-                        <xsl:value-of select="."/>
-                    </xsl:if>
-                </xsl:for-each>
-            </forename>
-        </persName>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='bold']" mode="front">
-        <hi rend="bold">
-            <xsl:apply-templates mode="front" select="@*|node()"/>
-        </hi>
-    </xsl:template>
-    <xsl:template match="ltx:abstract" mode="front">
-        <abstract>
-            <xsl:apply-templates select="@*|node()" />
-        </abstract>
-    </xsl:template>
-
-    <xsl:template match="ltx:keywords" mode="front">
-        <kwd-group>
-            <xsl:for-each select="str:tokenize(./text(),',')">
-                <kwd><xsl:value-of select="."/></kwd>
-            </xsl:for-each>
-        </kwd-group>
-    </xsl:template>
-
-    <xsl:template match="ltx:document/ltx:title" mode="front">
-            <title level="a" type="main">
-                <xsl:apply-templates select="@*|node()" />
-            </title>
-    </xsl:template>
-
-    <xsl:template match="ltx:equationgroup" mode="front">
-        <p>
-            <xsl:apply-templates select="@*|node()" mode="front"/>
-        </p>
-    </xsl:template>
-
-    <xsl:template match="ltx:equationgroup/ltx:equation" mode="front">
-        <formula>
-            <xsl:apply-templates select="@*" mode="front"/>
-            <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
-        </formula>
-    </xsl:template>
-
-    <xsl:template match="ltx:contact[@role='url']" mode="front">
+  <xsl:template match="ltx:caption" mode="front">
+    <head>
+      <xsl:if test="./ltx:p">
         <xsl:apply-templates select="@*|node()" mode="front"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:equation" mode="front">
+      </xsl:if>
+      <xsl:if test="not(./ltx:p)">
         <p>
-            <formula>
-                <xsl:apply-templates select="@*|node()"/>
-            </formula>
+          <xsl:apply-templates select="@*|node()" mode="front"/>
         </p>
-    </xsl:template>
+      </xsl:if>
+    </head>
+  </xsl:template>
 
-    <xsl:template match="ltx:Math[@mode='inline']" mode="front">
-        <formula>
-            <xsl:apply-templates select="@*"/>
-            <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
-        </formula>
-    </xsl:template>
-
-    <xsl:template match="ltx:caption" mode="front">
-        <head>
-            <xsl:if test="./ltx:p">
-                <xsl:apply-templates select="@*|node()" mode="front"/>
-            </xsl:if>
-            <xsl:if test="not(./ltx:p)">
-                <p>
-                    <xsl:apply-templates select="@*|node()" mode="front"/>
-                </p>
-            </xsl:if>
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:caption" mode="back">
-        <head>
-            <xsl:if test="./ltx:p">
-                <xsl:apply-templates select="@*|node()" mode="back"/>
-            </xsl:if>
-            <xsl:if test="not(./ltx:p)">
-                <p>
-                    <xsl:apply-templates select="@*|node()" mode="back"/>
-                </p>
-            </xsl:if>
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:caption">
-        <head>
-            <xsl:if test="./ltx:p">
-                <xsl:apply-templates select="@*|node()"/>
-            </xsl:if>
-            <xsl:if test="not(./ltx:p)">
-                <p>
-                    <xsl:apply-templates select="@*|node()"/>
-                </p>
-            </xsl:if>
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:float" mode="front">
-        <boxed-text>
-            <xsl:apply-templates select="@*|node()" mode="front"/>
-        </boxed-text>
-    </xsl:template>
-
-    <xsl:template match="ltx:paragraph">
-        <boxed-text>
-            <xsl:apply-templates select="@*|node()"/>
-        </boxed-text>
-    </xsl:template>
-
-    <xsl:template match="ltx:paragraph/ltx:title">
-        <head>
-            <xsl:if test="./ltx:p">
-                <xsl:apply-templates select="@*|node()"/>
-            </xsl:if>
-            <xsl:if test="not(./ltx:p)">
-                <p>
-                    <xsl:apply-templates select="@*|node()"/>
-                </p>
-            </xsl:if>
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='italic']">
-        <hi rend="italic">
-            <xsl:apply-templates select="@*|node()"/>
-        </hi>
-    </xsl:template>
-
-    <xsl:template match="ltx:table" mode="front"/>
-    <xsl:template match="ltx:abstract//ltx:table" mode="front">
-        <xsl:message> There was a table in an abstract, deal with it </xsl:message> <!-- TODO if this actually happens, then deal with it -->
-    </xsl:template>
-
-    <!-- End front matter section -->
-    <!-- Start back section -->
-    <!-- This is essentially for bibliography and acknowledgements-->
-    <!-- However I still need stuff to handle various other subcases that could come up in for example appendices or acknowledgements -->
-
-    <xsl:template match="ltx:equationgroup" mode="back">
+  <xsl:template match="ltx:caption" mode="back">
+    <head>
+      <xsl:if test="./ltx:p">
+        <xsl:apply-templates select="@*|node()" mode="back"/>
+      </xsl:if>
+      <xsl:if test="not(./ltx:p)">
         <p>
-            <xsl:apply-templates select="@*|node()" mode="back"/>
+          <xsl:apply-templates select="@*|node()" mode="back"/>
         </p>
-    </xsl:template>
+      </xsl:if>
+    </head>
+  </xsl:template>
 
-    <xsl:template match="ltx:equationgroup/ltx:equation" mode="back">
-        <formula>
-            <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
-        </formula>
-    </xsl:template>
-
-    <xsl:template match="ltx:equation" mode="back">
+  <xsl:template match="ltx:caption">
+    <head>
+      <xsl:if test="./ltx:p">
+        <xsl:apply-templates select="@*|node()"/>
+      </xsl:if>
+      <xsl:if test="not(./ltx:p)">
         <p>
-            <formula>
-                <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
-            </formula>
+          <xsl:apply-templates select="@*|node()"/>
         </p>
-    </xsl:template>
+      </xsl:if>
+    </head>
+  </xsl:template>
 
-    <xsl:template match="ltx:Math[@mode='inline']" mode="back">
-        <formula>
-            <xsl:for-each select=".//m:math"><xsl:copy-of select="."/></xsl:for-each>
-        </formula>
-    </xsl:template>
+  <xsl:template match="ltx:float" mode="front">
+    <boxed-text>
+      <xsl:apply-templates select="@*|node()" mode="front"/>
+    </boxed-text>
+  </xsl:template>
 
-    <xsl:template match="ltx:bibliography" mode="back">
-        <div type="references">
-            <listBibl>
-                <xsl:apply-templates mode="back"/>
-            </listBibl>
-        </div>
-    </xsl:template>
+  <xsl:template match="ltx:paragraph">
+    <boxed-text>
+      <xsl:apply-templates select="@*|node()"/>
+    </boxed-text>
+  </xsl:template>
 
-    <xsl:template match="ltx:bibliography/ltx:title" mode="back">
-        <head>
-            <xsl:apply-templates select="@*|node()" />
-        </head>
-    </xsl:template>
+  <xsl:template match="ltx:paragraph/ltx:title">
+    <head>
+      <xsl:if test="./ltx:p">
+        <xsl:apply-templates select="@*|node()"/>
+      </xsl:if>
+      <xsl:if test="not(./ltx:p)">
+        <p>
+          <xsl:apply-templates select="@*|node()"/>
+        </p>
+      </xsl:if>
+    </head>
+  </xsl:template>
 
-    <xsl:template match="ltx:biblist" mode="back">
+  <xsl:template match="ltx:text[@font='italic']">
+    <hi rend="italic">
+      <xsl:apply-templates select="@*|node()"/>
+    </hi>
+  </xsl:template>
+
+  <xsl:template match="ltx:table" mode="front"/>
+  <xsl:template match="ltx:abstract//ltx:table" mode="front">
+    <xsl:message> There was a table in an abstract, deal with it </xsl:message> <!-- TODO if this actually happens, then deal with it -->
+  </xsl:template>
+
+  <!-- End front matter section -->
+  <!-- Start back section -->
+  <!-- This is essentially for bibliography and acknowledgements-->
+  <!-- However I still need stuff to handle various other subcases that could come up in for example appendices or acknowledgements -->
+
+  <xsl:template match="ltx:equationgroup" mode="back">
+    <p>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates mode="back"/>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="ltx:equationgroup/ltx:equation" mode="back">
+    <formula>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates mode="back"/>
+    </formula>
+  </xsl:template>
+
+  <xsl:template match="ltx:equation" mode="back">
+    <p>
+      <formula>
+        <xsl:if test="@xml:id">
+          <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+        </xsl:if>
         <xsl:apply-templates mode="back"/>
-    </xsl:template>
+      </formula>
+    </p>
+  </xsl:template>
 
-    <xsl:template match="ltx:bibitem" mode="back">
-        <bibl>
-            <xsl:if test="./@xml:id">
-                <xsl:attribute name="xml:id"><xsl:value-of select="./@xml:id"/></xsl:attribute>
-            </xsl:if>
-                <!-- Getting the reference type into the reference, if possible -->
-                <xsl:if test="./ltx:tags/ltx:tag[@class='ltx_bib_type']">
-                    <xsl:attribute name="type"> <xsl:value-of select="./ltx:tags/ltx:tag[@class='ltx_bib_type']/text()"/></xsl:attribute>
-                </xsl:if>
-                <xsl:apply-templates select="node()" mode="back"/>
-        </bibl>
-    </xsl:template>
+  <xsl:template match="ltx:Math[@mode='inline']" mode="back">
+    <formula>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="m:math"/>
+    </formula>
+  </xsl:template>
+
+  <xsl:template match="ltx:bibliography" mode="back">
+    <div type="references">
+      <listBibl>
+        <xsl:apply-templates mode="back"/>
+      </listBibl>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="ltx:bibliography/ltx:title" mode="back">
+    <head>
+      <xsl:apply-templates select="@*|node()" />
+    </head>
+  </xsl:template>
+
+  <xsl:template match="ltx:biblist" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:bibitem" mode="back">
+    <bibl>
+      <xsl:if test="./@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="./@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <!-- Getting the reference type into the reference, if possible -->
+      <xsl:if test="./ltx:tags/ltx:tag[@class='ltx_bib_type']">
+        <xsl:attribute name="type"> <xsl:value-of select="./ltx:tags/ltx:tag[@class='ltx_bib_type']/text()"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="node()" mode="back"/>
+    </bibl>
+  </xsl:template>
 
   <xsl:template match="ltx:tags" mode="back">
     <xsl:apply-templates mode="back"/>
   </xsl:template>
 
-    <xsl:template match="ltx:tags/ltx:tag[@class='ltx_bib_type']" mode="back"/>
-    <xsl:template match="ltx:tags/ltx:tag[@role='key']" mode="back"/>
+  <xsl:template match="ltx:tags/ltx:tag[@class='ltx_bib_type']" mode="back"/>
+  <xsl:template match="ltx:tags/ltx:tag[@role='key']" mode="back"/>
 
-    <xsl:template match="ltx:bibblock//ltx:bib-part[@role='publisher']" mode="back">
+  <xsl:template match="ltx:bibblock//ltx:bib-part[@role='publisher']" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:bibblock//ltx:bib-note[@role='publication']" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
+  <xsl:template match="ltx:bibblock//ltx:bib-part[@role='series']" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:bibblock//ltx:bib-publisher" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:bibblock//ltx:bib-edition" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:tags/ltx:tag[@role='year']" mode="back">
+    <year>
+      <xsl:apply-templates mode="back"/>
+    </year>
+  </xsl:template>
+
+  <xsl:template match="ltx:bib-part[@role='volume']" mode="back">
+    <volume>
+      <xsl:apply-templates mode="back"/>
+    </volume>
+  </xsl:template>
+
+  <xsl:template match="ltx:bib-part[@role='pages']" mode="back">
+    <page-range>
+      <xsl:apply-templates/>
+    </page-range>
+  </xsl:template>
+
+  <xsl:template match="ltx:bibblock" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:tags/ltx:tag[@role='title']" mode="back">
+    <article-title>
+      <xsl:apply-templates mode="back"/>
+    </article-title>
+  </xsl:template>
+
+  <xsl:template match="ltx:bib-date[@role='publication']" mode="back"> <!-- We are making the assumption that this contains only the year of publication -->
+    <date>
+      <year>
         <xsl:apply-templates mode="back"/>
-    </xsl:template>
+      </year>
+    </date>
+  </xsl:template>
 
-    <xsl:template match="ltx:bibblock//ltx:bib-note[@role='publication']" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
-    <xsl:template match="ltx:bibblock//ltx:bib-part[@role='series']" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
+  <xsl:template match="ltx:bib-note[@role='annotation']" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
 
-    <xsl:template match="ltx:bibblock//ltx:bib-publisher" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
+  <xsl:template match="ltx:bibblock//ltx:bib-organization" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
 
-    <xsl:template match="ltx:bibblock//ltx:bib-edition" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
+  <xsl:template match="ltx:bibblock//ltx:bib-title" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
 
-    <xsl:template match="ltx:tags/ltx:tag[@role='year']" mode="back">
-        <year>
-            <xsl:apply-templates mode="back"/>
-        </year>
-    </xsl:template>
+  <xsl:template match="ltx:bibblock//ltx:bib-type" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
 
-    <xsl:template match="ltx:bib-part[@role='volume']" mode="back">
-        <volume>
-            <xsl:apply-templates mode="back"/>
-        </volume>
-    </xsl:template>
+  <xsl:template match="ltx:bibblock//ltx:bib-place" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
 
-    <xsl:template match="ltx:bib-part[@role='pages']" mode="back">
-        <page-range>
-            <xsl:apply-templates/>
-        </page-range>
-    </xsl:template>
+  <xsl:template match="ltx:bib-part[@role='number']" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
 
-    <xsl:template match="ltx:bibblock" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
+  <xsl:template match="ltx:emph" mode="back">
+    <hi rend="italic">
+      <xsl:apply-templates mode="back" select="@*|node()"/>
+    </hi>
+  </xsl:template>
 
-    <xsl:template match="ltx:tags/ltx:tag[@role='title']" mode="back">
-        <article-title>
-            <xsl:apply-templates mode="back"/>
-        </article-title>
-    </xsl:template>
+  <xsl:template match="ltx:acknowledgements" mode="back">
+    <div type="acknowledgements">
+      <xsl:if test="not(./ltx:p)">
+        <p>
+          <xsl:apply-templates mode="back" select="@*|node()"/>
+        </p>
+      </xsl:if>
+      <xsl:if test="./ltx:p">
+        <xsl:apply-templates mode="back" select="@*|node()"/>
+      </xsl:if>
+    </div>
+  </xsl:template>
 
-    <xsl:template match="ltx:bib-date[@role='publication']" mode="back"> <!-- We are making the assumption that this contains only the year of publication -->
-        <date>
-            <year>
-                <xsl:apply-templates mode="back"/>
-            </year>
-        </date>
-    </xsl:template>
+  <xsl:template match="ltx:text[@font='italic']" mode="back">
+    <hi rend="italic">
+      <xsl:apply-templates select="@*|node()"/>
+    </hi>
+  </xsl:template>
 
-    <xsl:template match="ltx:bib-note[@role='annotation']" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
+  <xsl:template match="ltx:rule" mode="back">
+    <hr/>
+  </xsl:template>
 
-    <xsl:template match="ltx:bibblock//ltx:bib-organization" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:bibblock//ltx:bib-title" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:bibblock//ltx:bib-type" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:bibblock//ltx:bib-place" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:bib-part[@role='number']" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:emph" mode="back">
-        <hi rend="italic">
-            <xsl:apply-templates mode="back" select="@*|node()"/>
-        </hi>
-    </xsl:template>
-
-    <xsl:template match="ltx:acknowledgements" mode="back">
-        <div type="acknowledgements">
-            <xsl:if test="not(./ltx:p)">
-                <p>
-                    <xsl:apply-templates mode="back" select="@*|node()"/>
-                </p>
+  <!-- This is really sad; we should have preserved structured data from bibentry,
+       rather than formatted data from bibitem -->
+  <xsl:template match="ltx:tags/ltx:tag[@role='authors']" mode="back">
+    <person-group person-group-type="author">
+      <name>
+        <!-- I will not do sophisticated handling trying to split this into several authors etc. -->
+        <surname>
+          <xsl:for-each select="str:tokenize(./text(),' ')">
+            <xsl:if test="position()=last()">
+              <xsl:value-of select="."/>
             </xsl:if>
-            <xsl:if test="./ltx:p">
-                <xsl:apply-templates mode="back" select="@*|node()"/>
-            </xsl:if>
-        </div>
-    </xsl:template>
+          </xsl:for-each>
+        </surname>
+        <xsl:if test="contains(./text(),' ')">
 
-    <xsl:template match="ltx:text[@font='italic']" mode="back">
-        <hi rend="italic">
-            <xsl:apply-templates select="@*|node()"/>
-        </hi>
-    </xsl:template>
-
-    <xsl:template match="ltx:rule" mode="back">
-        <hr/>
-    </xsl:template>
-
-    <xsl:template match="ltx:tags/ltx:tag[@role='authors']" mode="back">
-        <person-group person-group-type="author">
-            <name>
-                <!-- I will not do sophisticated handling trying to split this into several authors etc. -->
-                <surname>
-                    <xsl:for-each select="str:tokenize(./text(),' ')">
-                        <xsl:if test="position()=last()">
-                            <xsl:value-of select="."/>
-                        </xsl:if>
-                    </xsl:for-each>
-                </surname>
-                <xsl:if test="contains(./text(),' ')">
-
-                    <given-names>
-                        <xsl:for-each select="str:tokenize(./text(),' ')">
-                            <xsl:if test="position()!=last()">
-                                <xsl:value-of select="."/>&#160;
-                            </xsl:if>
-                        </xsl:for-each>
-                    </given-names>
-                </xsl:if>
-            </name>
-        </person-group>
-    </xsl:template>
-
-    <xsl:template match="ltx:tags/ltx:tag[@role='fullauthors']" mode="back"/>
-    <xsl:template match="ltx:text[@font='bold']" mode="back">
-        <hi rend="bold">
-            <xsl:apply-templates mode="back" select="@*|node()"/>
-        </hi>
-    </xsl:template>
-    <xsl:template match="ltx:tags/ltx:tag[@role='refnum']" mode="back"/>
-    <xsl:template match="ltx:tags/ltx:tag[@role='number']" mode="back"/>
-
-    <xsl:template match="ltx:table" mode="back"/>
-    <xsl:template match="ltx:acknowledgements//ltx:table">
-        <xsl:message> There's a table in the acknowledgements. Deal with it </xsl:message> <!-- TODO, actually do this if you ever see this -->
-    </xsl:template>
-
-    <!-- End back section -->
-    <!-- Start main section -->
-
-    <xsl:template match="ltx:text[@font='bold']">
-        <hi rend="bold">
-            <xsl:apply-templates select="@*|node()"/>
-        </hi>
-    </xsl:template>
-
-    <xsl:template match="ltx:note[@role='institutetext']" mode="back"/>
-    <xsl:template match="ltx:note[@role='institutetext']"/>
-    <xsl:template match="ltx:note[@role='institutetext']" mode="front"/>
-
-    <xsl:template match="ltx:text[@font='italic']">
-        <hi rend="italic">
-            <xsl:apply-templates select="@*|node()"/>
-        </hi>
-    </xsl:template>
-
-    <xsl:template match="ltx:emph">
-        <hi rend="italic">
-            <xsl:apply-templates select="@*|node()"/>
-        </hi>
-    </xsl:template>
-
-    <xsl:template match="ltx:note[@role='footnote']">
-        <note place="bottom">
-            <xsl:if test="not(./ltx:p)">
-                <p>
-                    <xsl:apply-templates select="@*|node()"/>
-                </p>
-            </xsl:if>
-            <xsl:if test="./ltx:p">
-                <xsl:apply-templates select="@*|node()"/>
-            </xsl:if>
-        </note>
-    </xsl:template>
-
-    <xsl:template match="ltx:para">
-        <xsl:apply-templates select="@*|node()" />
-    </xsl:template>
-
-    <xsl:template match="ltx:equationgroup">
-        <p>
-                <xsl:apply-templates select="@*|node()"/>
-        </p>
-    </xsl:template>
-
-    <xsl:template match="ltx:equation">
-        <p>
-            <formula>
-                <xsl:apply-templates select="@*"/>
-                <xsl:for-each select=".//m:math"><xsl:apply-templates select="." mode="math"/></xsl:for-each>
-            </formula>
-        </p>
-    </xsl:template>
-
-    <xsl:template match="ltx:equationgroup/ltx:equation">
-        <formula>
-            <xsl:apply-templates select="@*"/>
-            <xsl:for-each select=".//m:math"><xsl:apply-templates select="." mode="math"/></xsl:for-each>
-        </formula>
-    </xsl:template>
-
-    <xsl:template match="ltx:Math[@mode='inline']">
-        <formula>
-            <xsl:apply-templates select="@*"/>
-            <xsl:for-each select=".//m:math"><xsl:apply-templates select="." mode="math"/></xsl:for-each>
-        </formula>
-    </xsl:template>
-
-    <xsl:template match="ltx:inline-block">
-        <figure>
-            <xsl:apply-templates select="@*|node()"/>
-        </figure>
-    </xsl:template>
-
-    <xsl:template match="ltx:p">
-        <p>
-            <xsl:apply-templates select="@*|node()" />
-        </p>
-    </xsl:template>
-
-    <xsl:template match="ltx:itemize">
-        <p>
-            <list rend="bulleted">
-                <xsl:apply-templates select="@*|node()"/>
-            </list>
-        </p>
-    </xsl:template>
-
-    <xsl:template match="ltx:enumerate">
-        <p>
-            <list rend="numbered">
-                <xsl:apply-templates select="@*|node()"/>
-            </list>
-        </p>
-    </xsl:template>
-
-    <xsl:template match="ltx:item">
-        <item>
-            <xsl:apply-templates select="@*|node()"/>
-        </item>
-    </xsl:template>
-
-    <xsl:template match="ltx:section">
-        <div>
-            <xsl:apply-templates select="@*|node()" />
-        </div>
-    </xsl:template>
-
-    <xsl:template match="ltx:theorem">
-        <note>
-            <xsl:apply-templates select="@*|node()"/>
-        </note>
-    </xsl:template>
-
-    <xsl:template match="ltx:theorem/ltx:title">
-            <title>
-                <xsl:apply-templates select="@*|node()"/>
-            </title>
-    </xsl:template>
-
-    <xsl:template match="ltx:proof">
-        <note>
-            <xsl:apply-templates select="@*|node()"/>
-        </note>
-    </xsl:template>
-
-    <xsl:template match="ltx:proof/ltx:title">
-            <title>
-                <xsl:apply-templates select="@*|node()"/>
-            </title>
-    </xsl:template>
-
-    <xsl:template match="ltx:contact[@role='address']" mode="front">
-        <address>
-            <addrLine>
-                <xsl:apply-templates select="@*|node()" mode="front"/>
-            </addrLine>
-        </address>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@class='ltx_phantom']" mode="front">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:subsubsection">
-        <div>
-            <xsl:apply-templates select="@*|node()"/>
-        </div>
-    </xsl:template>
-
-    <xsl:template match="ltx:quote">
-        <disp-quote>
-            <xsl:apply-templates select="@*|node()"/>
-        </disp-quote>
-    </xsl:template>
-
-    <xsl:template match="ltx:section/ltx:title">
-        <head>
-            <xsl:apply-templates select="@*|node()"/>
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:float">
-        <boxed-text>
-            <xsl:apply-templates select="@*|node()"/>
-        </boxed-text>
-    </xsl:template>
-
-    <xsl:template match="ltx:subsection/ltx:title">
-        <head>
-            <xsl:apply-templates select="@*|node()"/>
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:subsubsection/ltx:title">
-        <head>
-            <xsl:apply-templates select="@*|node()"/>
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:subsection">
-        <div>
-            <xsl:apply-templates select="@*|node()"/>
-        </div>
-    </xsl:template>
-
-    <xsl:template match="ltx:figure/ltx:caption">
-        <head>
-                <xsl:apply-templates select="@*|node()"/>
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:figure">
-        <figure>
-            <xsl:apply-templates select="@*"/>
-            <xsl:apply-templates select="ltx:caption"/>
-            <xsl:apply-templates select="*[not(self::ltx:caption)]"/>
-        </figure>
-    </xsl:template>
-
-    <xsl:template match="ltx:table">
-        <table>
-            <xsl:apply-templates select="@*"/>
-            <xsl:apply-templates select="@*|node()"/>
-        </table>
-    </xsl:template>
-
-    <xsl:template match="ltx:tabular">
-            <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:thead | ltx:tbody | ltx:tfoot">
-            <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:tr">
-        <row>
-            <xsl:apply-templates select="@*|node()"/>
-        </row>
-    </xsl:template>
-
-    <xsl:template match="ltx:td">
-        <cell>
-            <xsl:apply-templates select="@*|node()"/>
-        </cell>
-    </xsl:template>
-
-    <xsl:template match="ltx:tabular">
-                <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:table/ltx:caption">
-        <head>
-            <xsl:apply-templates select="@*|node()"/>
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:graphics">
-        <graphic url="{./@graphic}"> <!-- Probably could have made this an empty element, but I just wanted to go sure -->
-            <xsl:apply-templates select="@*|node()"/>
-        </graphic>
-    </xsl:template>
-    <xsl:template match="ltx:text[@class='ltx_ref_tag']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:note[@role='thanks']">
-        <p>
-            <xsl:apply-templates select="@*|node()" />
-        </p>
-    </xsl:template>
-
-    <xsl:template match="ltx:p/ltx:note[@role='thanks']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='italic']">
-        <hi rend="italic">
-            <xsl:apply-templates select="@*|node()" />
-        </hi>
-    </xsl:template>
-
-    <xsl:template match="ltx:section/ltx:title">
-        <head>
-            <xsl:apply-templates select="@*|node()" />
-        </head>
-    </xsl:template>
-
-    <xsl:template match="ltx:cite">
-        <xsl:if test="./ltx:ref/@idref">
-            <ref type="bibr" target="{./ltx:ref/@idref}"><xsl:apply-templates select="@*|node()" /></ref>
-        </xsl:if>
-        <xsl:if test="./ltx:bibref/@bibrefs">
-            <xsl:for-each select="str:tokenize(./ltx:bibref/@bibrefs,./ltx:bibref/@yyseparator)">
-                <ref type="bibr" target="{.}"><xsl:apply-templates select="@*|node()"/></ref>
+          <given-names>
+            <xsl:for-each select="str:tokenize(./text(),' ')">
+              <xsl:if test="position()!=last()">
+                <xsl:value-of select="."/><xsl:text> </xsl:text>
+              </xsl:if>
             </xsl:for-each>
+          </given-names>
         </xsl:if>
-    </xsl:template>
+      </name>
+    </person-group>
+  </xsl:template>
 
-    <xsl:template match="ltx:bibref">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+  <xsl:template match="ltx:tags/ltx:tag[@role='fullauthors']" mode="back"/>
+  <xsl:template match="ltx:text[@font='bold']" mode="back">
+    <hi rend="bold">
+      <xsl:apply-templates mode="back" select="@*|node()"/>
+    </hi>
+  </xsl:template>
+  <xsl:template match="ltx:tags/ltx:tag[@role='refnum']" mode="back"/>
+  <xsl:template match="ltx:tags/ltx:tag[@role='number']" mode="back"/>
 
-    <xsl:template match="ltx:ref[@idref]">
-        <ref target="{./@idref}">
-            <xsl:apply-templates select="@*|node()"/>
-        </ref>
-    </xsl:template>
+  <xsl:template match="ltx:table" mode="back"/>
+  <xsl:template match="ltx:acknowledgements//ltx:table">
+    <xsl:message> There's a table in the acknowledgements. Deal with it </xsl:message> <!-- TODO, actually do this if you ever see this -->
+  </xsl:template>
 
-    <xsl:template match="ltx:ref[@idref and ancestor::ltx:cite]">
-        <xsl:apply-templates select="@*|node()" />
-    </xsl:template>
+  <!-- End back section -->
+  <!-- Start main section -->
 
-    <xsl:template match="ltx:ref[@labelref and not(@idref)]">
-        <ref target="{./@labelref}">
-            <xsl:apply-templates select="@*|node()"/>
-        </ref>
-    </xsl:template>
+  <xsl:template match="ltx:text[@font='bold']">
+    <hi rend="bold">
+      <xsl:apply-templates select="@*|node()"/>
+    </hi>
+  </xsl:template>
 
-    <xsl:template match="ltx:ref[@class='ltx_url']">
-        <ext-link xlink:href="{./href}">
-            <xsl:apply-templates select="@*|node()"/>
-        </ext-link>
-    </xsl:template>
+  <xsl:template match="ltx:note[@role='institutetext']" mode="back"/>
+  <xsl:template match="ltx:note[@role='institutetext']"/>
+  <xsl:template match="ltx:note[@role='institutetext']" mode="front"/>
 
-    <xsl:template match="ltx:ref[@class='ltx_url']" mode="front">
-        <ext-link xlink:href="{./href}">
-            <xsl:apply-templates select="@*|node()" mode="front"/>
-        </ext-link>
-    </xsl:template>
+  <xsl:template match="ltx:text[@font='italic']">
+    <hi rend="italic">
+      <xsl:apply-templates select="@*|node()"/>
+    </hi>
+  </xsl:template>
 
-    <xsl:template match="ltx:ref[@class='ltx_url']" mode="back">
-        <ext-link xlink:href="{./href}">
-            <xsl:apply-templates select="@*|node()" mode="back"/>
-        </ext-link>
-    </xsl:template>
+  <xsl:template match="ltx:emph">
+    <hi rend="italic">
+      <xsl:apply-templates select="@*|node()"/>
+    </hi>
+  </xsl:template>
 
-    <xsl:template match="ltx:ref[not(./@idref or ./@labelref) and ./@href]">
-        <ext-link xlink:href="{./href}">
-            <xsl:apply-templates select="@*|node()"/>
-        </ext-link>
-    </xsl:template>
-
-    <xsl:template match="ltx:ref[not(./@idref or ./@labelref) and ./@href]" mode="front">
-        <ext-link xlink:href="{./href}">
-            <xsl:apply-templates select="@*|node()"/>
-        </ext-link>
-    </xsl:template>
-
-    <xsl:template match="ltx:ref[not(./@idref or ./@labelref) and ./@href]" mode="back">
-        <ext-link xlink:href="{./href}">
-            <xsl:apply-templates select="@*|node()"/>
-        </ext-link>
-    </xsl:template>
-
-    <xsl:template match="ltx:ref[@idref]" mode="back">
-        <ref target="{./@idref}">
-            <xsl:apply-templates mode="back"/>
-        </ref>
-    </xsl:template>
-
-    <xsl:template match="ltx:ref[ancestor::ltx:bibblock]" mode="back">
-        <xsl:apply-templates mode="back"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:ref[@idref]" mode="front">
-        <ref target="{./@idref}">
-            <xsl:apply-templates mode="front"/>
-        </ref>
-    </xsl:template>
-
-    <xsl:template match="ltx:float" mode="back">
-        <boxed-text>
-            <xsl:apply-templates select="@*|node()" mode="back"/>
-        </boxed-text>
-    </xsl:template>
-
-    <xsl:template match="ltx:titlepage">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:description">
-        <list>
-            <xsl:apply-templates select="@*|node()"/>
-        </list>
-    </xsl:template>
-
-    <xsl:template match="ltx:verbatim">
-        <preformat>
-            <xsl:apply-templates select="@*|node()"/>
-        </preformat>
-    </xsl:template>
-
-    <!-- End body section -->
-    <xsl:template match="ltx:document/ltx:title"/>
-    <!-- This section is for elements that we aren't doing anything with and just removing from the document -->
-    <xsl:template match="ltx:resource[@type='text/css']"/>
-    <xsl:template match="ltx:creator[@role='author']"/>
-    <xsl:template match="ltx:resource[@type='text/css']" mode="front"/>
-    <xsl:template match="ltx:abstract"/>
-    <xsl:template match="ltx:keywords"/>
-    <xsl:template match="ltx:note[@role='thanks']" mode="front"/>
-    <xsl:template match="ltx:contact[@role='thanks']" mode="front"/>
-    <xsl:template match="ltx:section" mode="front"/>
-    <xsl:template match="ltx:acknowledgements"/>
-    <xsl:template match="ltx:acknowledgements" mode="front"/>
-    <xsl:template match="ltx:bibliography"/>
-    <xsl:template match="ltx:bibliography" mode="front"/>
-    <xsl:template match="ltx:date[@role='creation']"/>
-    <xsl:template match="ltx:tag"/>
-    <xsl:template match="ltx:break"/> <!-- Break isn't really supposed to be used -->
-    <xsl:template match="ltx:resource[@type='text/css']" mode="back"/>
-    <xsl:template match="ltx:creator[@role='author']" mode="back"/>
-    <xsl:template match="ltx:abstract" mode="back"/>
-    <xsl:template match="ltx:keywords" mode="back"/>
-    <xsl:template match="ltx:note[@role='thanks']" mode="back"/>
-    <xsl:template match="ltx:section" mode="back"/>
-    <xsl:template match="ltx:date[@role='creation']" mode="back"/>
-    <xsl:template match="ltx:document/ltx:title" mode="back"/>
-    <xsl:template match="ltx:para" mode="front"/>
-    <xsl:template match="ltx:para" mode="back"/>
-    <xsl:template match="ltx:toccaption"/>
-    <xsl:template match="ltx:classification"/>
-    <xsl:template match="ltx:classification" mode="back"/>
-    <xsl:template match="ltx:classification" mode="front"/>
-    <xsl:template match="ltx:note[@role='slugcomment']"/>
-    <xsl:template match="ltx:note[@role='slugcomment']" mode="front"/>
-    <xsl:template match="ltx:note[@role='slugcomment']" mode="back"/>
-    <xsl:template match="ltx:pagination"/>
-    <xsl:template match="ltx:pagination" mode="front"/>
-    <xsl:template match="ltx:pagination" mode="back"/>
-    <xsl:template match="ltx:toctitle"/>
-    <xsl:template match="ltx:toctitle" mode="front"/>
-    <xsl:template match="ltx:toctitle" mode="back"/>
-    <xsl:template match="ltx:appendix" mode="front"/>
-    <xsl:template match="ltx:appendix" mode="back"/>
-    <xsl:template match="ltx:appendix"/>
-    <xsl:template match="ltx:contact[@role='emailmark']" mode="front"/>
-    <xsl:template match="ltx:contact[@role='emailmark']" mode="back"/>
-    <xsl:template match="ltx:contact[@role='emailmark']"/>
-    <xsl:template match="ltx:contact[@role='institutemark']" mode="front"/>
-    <xsl:template match="ltx:contact[@role='institutemark']" mode="back"/>
-    <xsl:template match="ltx:contact[@role='institutemark']"/>
-    <xsl:template match="ltx:creator" mode="back"/>
-    <xsl:template match="ltx:creator"/>
-    <xsl:template match="ltx:contact[@role='affiliation']"/>
-    <xsl:template match="ltx:titlepage" mode="front"/>
-    <xsl:template match="ltx:titlepage" mode="back"/>
-    <xsl:template match="ltx:break" mode="front"/>
-    <xsl:template match="ltx:figure" mode="front"/>
-    <xsl:template match="ltx:figure" mode="back"/>
-    <xsl:template match="ltx:break" mode="back"/>
-    <xsl:template match="ltx:contact[@role='dedicatory']" mode="front"/>
-    <xsl:template match="ltx:contact[@role='dedicatory']" mode="back"/>
-    <xsl:template match="ltx:contact[@role='dedicatory']"/>
-    <xsl:template match="ltx:TOC"/>
-    <xsl:template match="ltx:TOC" mode="front"/>
-    <xsl:template match="ltx:TOC" mode="back"/>
-
-    <xsl:template match="ltx:abstract/ltx:figure" mode="front">
-        <xsl:message>figure in an abstract, fix this </xsl:message> <!-- TODO actualy fix it if it happens -->
-    </xsl:template>
-    <!-- hackish stuff for references -->
-
-    <xsl:template match="ltx:para/@xml:id"/>
-    <xsl:template match="ltx:para[@xml:id]/ltx:p">
-        <xsl:choose>
-            <xsl:when test="not(preceding-sibling::ltx:p)">
-                <p>
-                    <xsl:attribute name="xml:id"><xsl:value-of select="../@xml:id"/></xsl:attribute>
-                    <xsl:apply-templates select="@*|node()"/>
-                </p>
-            </xsl:when>
-            <xsl:otherwise>
-                <p>
-                    <xsl:apply-templates select="@*|node()"/>
-                </p>
-            </xsl:otherwise>
-        </xsl:choose>
-
-    </xsl:template>
-    <xsl:template match="ltx:document/@xml:id"/>
-    <xsl:template match="ltx:document/@xml:id" mode="front"/>
-    <xsl:template match="ltx:document/@xml:id" mode="back"/>
-    <xsl:template match="ltx:document/@labels"/>
-
-
-    <xsl:template match="ltx:para/@xml:id" mode="front"/>
-    <xsl:template match="ltx:para[@xml:id]/ltx:p" mode="front">
+  <xsl:template match="ltx:note[@role='footnote']">
+    <note place="bottom">
+      <xsl:if test="not(./ltx:p)">
         <p>
-            <xsl:apply-templates select="@*|node()" mode="back"/>
+          <xsl:apply-templates select="@*|node()"/>
         </p>
-    </xsl:template>
-    <xsl:template match="@xml:id" mode="front">
-        <xsl:attribute name="id"><xsl:value-of select="."/></xsl:attribute>
-    </xsl:template>
-
-    <xsl:template match="ltx:para/@xml:id" mode="back"/>
-    <xsl:template match="ltx:para[@xml:id]/ltx:p" mode="back">
-        <p>
-            <xsl:apply-templates select="@*|node()" mode="back"/>
-        </p>
-    </xsl:template>
-    <xsl:template match="@xml:id" mode="back">
-        <xsl:attribute name="id"><xsl:value-of select="."/></xsl:attribute>
-    </xsl:template>
-
-    <xsl:template match="@*"/>
-    <xsl:template match="@*" mode="back"/>
-    <xsl:template match="@*" mode="front"/>
-    <!-- end of hackish references stuff -->
-    <!-- font section -->
-    <xsl:template match="ltx:text[@font='medium']">
+      </xsl:if>
+      <xsl:if test="./ltx:p">
         <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+      </xsl:if>
+    </note>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@font='medium']" mode="back">
+  <xsl:template match="ltx:para">
+    <xsl:apply-templates select="@*|node()" />
+  </xsl:template>
+
+  <xsl:template match="ltx:equationgroup">
+    <p>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="ltx:equation">
+    <p>
+      <formula>
+        <xsl:if test="@xml:id">
+          <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates/>
+      </formula>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="ltx:equationgroup/ltx:equation">
+    <formula>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </formula>
+  </xsl:template>
+
+  <xsl:template match="ltx:Math[@mode='inline']">
+    <formula>
+      <xsl:if test="@xml:id">
+        <xsl:attribute name="xml:id"><xsl:value-of select="@xml:id"/></xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="m:math"/>
+    </formula>
+  </xsl:template>
+
+  <xsl:template match="ltx:inline-block">
+    <figure>
+      <xsl:apply-templates select="@*|node()"/>
+    </figure>
+  </xsl:template>
+
+  <xsl:template match="ltx:p">
+    <p>
+      <xsl:apply-templates select="@*|node()" />
+    </p>
+  </xsl:template>
+
+  <xsl:template match="ltx:itemize">
+    <p>
+      <list rend="bulleted">
         <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+      </list>
+    </p>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@font='medium']" mode="front">
+  <xsl:template match="ltx:enumerate">
+    <p>
+      <list rend="numbered">
         <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+      </list>
+    </p>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@fontsize='90%']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+  <xsl:template match="ltx:item">
+    <item>
+      <xsl:apply-templates select="@*|node()"/>
+    </item>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@fontsize='80%']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+  <xsl:template match="ltx:section">
+    <div>
+      <xsl:apply-templates select="@*|node()" />
+    </div>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@font='upright']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+  <xsl:template match="ltx:theorem">
+    <note>
+      <xsl:apply-templates select="@*|node()"/>
+    </note>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@font='smallcaps']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+  <xsl:template match="ltx:theorem/ltx:title">
+    <title>
+      <xsl:apply-templates select="@*|node()"/>
+    </title>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@font='smallcaps']" mode="front">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+  <xsl:template match="ltx:proof">
+    <note>
+      <xsl:apply-templates select="@*|node()"/>
+    </note>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@font='smallcaps']" mode="back">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+  <xsl:template match="ltx:proof/ltx:title">
+    <title>
+      <xsl:apply-templates select="@*|node()"/>
+    </title>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@class='ltx_markedasmath']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='sansserif']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='sansserif']" mode="front">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='sansserif']" mode="back">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='serif']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='serif']" mode="front">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='serif']" mode="back">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='typewriter']">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='typewriter']" mode="front">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@font='typewriter']" mode="back">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@xml:lang]">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@xml:lang]" mode="front">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@xml:lang]" mode="back">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@framed='underline']">
-        <underline>
-            <xsl:apply-templates select="@*|node()"/>
-        </underline>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@framed='underline']" mode="front">
-        <underline>
-            <xsl:apply-templates select="@*|node()" mode="front"/>
-        </underline>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@framed='underline']" mode="back">
-        <underline>
-            <xsl:apply-templates select="@*|node()" mode="back"/>
-        </underline>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@class]">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
-
-    <xsl:template match="ltx:text[@class]" mode="front">
+  <xsl:template match="ltx:contact[@role='address']" mode="front">
+    <address>
+      <addrLine>
         <xsl:apply-templates select="@*|node()" mode="front"/>
-    </xsl:template>
+      </addrLine>
+    </address>
+  </xsl:template>
 
-    <xsl:template match="ltx:text[@class]" mode="back">
-        <xsl:apply-templates select="@*|node()" mode="back"/>
-    </xsl:template>
+  <xsl:template match="ltx:text[@class='ltx_phantom']" mode="front">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
 
-    <xsl:template match="ltx:text">
-        <xsl:apply-templates select="@*|node()"/>
-    </xsl:template>
+  <xsl:template match="ltx:subsubsection">
+    <div>
+      <xsl:apply-templates select="@*|node()"/>
+    </div>
+  </xsl:template>
 
-    <xsl:template match="ltx:text" mode="back">
-        <xsl:apply-templates mode="back" select="@*|node()"/>
-    </xsl:template>
+  <xsl:template match="ltx:quote">
+    <disp-quote>
+      <xsl:apply-templates select="@*|node()"/>
+    </disp-quote>
+  </xsl:template>
 
-    <xsl:template match="ltx:text" mode="front">
-        <xsl:apply-templates mode="back" select="@*|node()"/>
-    </xsl:template>
-    <!-- Templates to make things more convenient -->
+  <xsl:template match="ltx:section/ltx:title">
+    <head>
+      <xsl:apply-templates select="@*|node()"/>
+    </head>
+  </xsl:template>
+
+  <xsl:template match="ltx:float">
+    <boxed-text>
+      <xsl:apply-templates select="@*|node()"/>
+    </boxed-text>
+  </xsl:template>
+
+  <xsl:template match="ltx:subsection/ltx:title">
+    <head>
+      <xsl:apply-templates select="@*|node()"/>
+    </head>
+  </xsl:template>
+
+  <xsl:template match="ltx:subsubsection/ltx:title">
+    <head>
+      <xsl:apply-templates select="@*|node()"/>
+    </head>
+  </xsl:template>
+
+  <xsl:template match="ltx:subsection">
+    <div>
+      <xsl:apply-templates select="@*|node()"/>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="ltx:figure/ltx:caption">
+    <head>
+      <xsl:apply-templates select="@*|node()"/>
+    </head>
+  </xsl:template>
+
+  <xsl:template match="ltx:figure">
+    <figure>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates select="ltx:caption"/>
+      <xsl:apply-templates select="*[not(self::ltx:caption)]"/>
+    </figure>
+  </xsl:template>
+
+  <xsl:template match="ltx:table">
+    <table>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates select="@*|node()"/>
+    </table>
+  </xsl:template>
+
+  <xsl:template match="ltx:tabular">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:thead | ltx:tbody | ltx:tfoot">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:tr">
+    <row>
+      <xsl:apply-templates select="@*|node()"/>
+    </row>
+  </xsl:template>
+
+  <xsl:template match="ltx:td">
+    <cell>
+      <xsl:apply-templates select="@*|node()"/>
+    </cell>
+  </xsl:template>
+
+  <xsl:template match="ltx:tabular">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:table/ltx:caption">
+    <head>
+      <xsl:apply-templates select="@*|node()"/>
+    </head>
+  </xsl:template>
+
+  <xsl:template match="ltx:graphics">
+    <graphic url="{./@graphic}"> <!-- Probably could have made this an empty element, but I just wanted to go sure -->
+      <xsl:apply-templates select="@*|node()"/>
+    </graphic>
+  </xsl:template>
+  <xsl:template match="ltx:text[@class='ltx_ref_tag']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:note[@role='thanks']">
+    <p>
+      <xsl:apply-templates select="@*|node()" />
+    </p>
+  </xsl:template>
+
+  <xsl:template match="ltx:p/ltx:note[@role='thanks']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='italic']">
+    <hi rend="italic">
+      <xsl:apply-templates select="@*|node()" />
+    </hi>
+  </xsl:template>
+
+  <xsl:template match="ltx:section/ltx:title">
+    <head>
+      <xsl:apply-templates select="@*|node()" />
+    </head>
+  </xsl:template>
+
+  <xsl:template match="ltx:cite">
+    <xsl:if test="./ltx:ref/@idref">
+      <ref type="bibr" target="{./ltx:ref/@idref}"><xsl:apply-templates select="@*|node()" /></ref>
+    </xsl:if>
+    <xsl:if test="./ltx:bibref/@bibrefs">
+      <xsl:for-each select="str:tokenize(./ltx:bibref/@bibrefs,./ltx:bibref/@yyseparator)">
+        <ref type="bibr" target="{.}"><xsl:apply-templates select="@*|node()"/></ref>
+      </xsl:for-each>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="ltx:bibref">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[@idref]">
+    <ref target="{./@idref}">
+      <xsl:apply-templates select="@*|node()"/>
+    </ref>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[@idref and ancestor::ltx:cite]">
+    <xsl:apply-templates select="@*|node()" />
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[@labelref and not(@idref)]">
+    <ref target="{./@labelref}">
+      <xsl:apply-templates select="@*|node()"/>
+    </ref>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[@class='ltx_url']">
+    <ext-link xlink:href="{./href}">
+      <xsl:apply-templates select="@*|node()"/>
+    </ext-link>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[@class='ltx_url']" mode="front">
+    <ext-link xlink:href="{./href}">
+      <xsl:apply-templates select="@*|node()" mode="front"/>
+    </ext-link>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[@class='ltx_url']" mode="back">
+    <ext-link xlink:href="{./href}">
+      <xsl:apply-templates select="@*|node()" mode="back"/>
+    </ext-link>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[not(./@idref or ./@labelref) and ./@href]">
+    <ext-link xlink:href="{./href}">
+      <xsl:apply-templates select="@*|node()"/>
+    </ext-link>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[not(./@idref or ./@labelref) and ./@href]" mode="front">
+    <ext-link xlink:href="{./href}">
+      <xsl:apply-templates select="@*|node()"/>
+    </ext-link>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[not(./@idref or ./@labelref) and ./@href]" mode="back">
+    <ext-link xlink:href="{./href}">
+      <xsl:apply-templates select="@*|node()"/>
+    </ext-link>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[@idref]" mode="back">
+    <ref target="{./@idref}">
+      <xsl:apply-templates mode="back"/>
+    </ref>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[ancestor::ltx:bibblock]" mode="back">
+    <xsl:apply-templates mode="back"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:ref[@idref]" mode="front">
+    <ref target="{./@idref}">
+      <xsl:apply-templates mode="front"/>
+    </ref>
+  </xsl:template>
+
+  <xsl:template match="ltx:float" mode="back">
+    <boxed-text>
+      <xsl:apply-templates select="@*|node()" mode="back"/>
+    </boxed-text>
+  </xsl:template>
+
+  <xsl:template match="ltx:titlepage">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:description">
+    <list>
+      <xsl:apply-templates select="@*|node()"/>
+    </list>
+  </xsl:template>
+
+  <xsl:template match="ltx:verbatim">
+    <preformat>
+      <xsl:apply-templates select="@*|node()"/>
+    </preformat>
+  </xsl:template>
+
+  <!-- End body section -->
+  <xsl:template match="ltx:document/ltx:title"/>
+  <!-- This section is for elements that we aren't doing anything with and just removing from the document -->
+  <xsl:template match="ltx:resource[@type='text/css']"/>
+  <xsl:template match="ltx:creator[@role='author']"/>
+  <xsl:template match="ltx:resource[@type='text/css']" mode="front"/>
+  <xsl:template match="ltx:abstract"/>
+  <xsl:template match="ltx:keywords"/>
+  <xsl:template match="ltx:note[@role='thanks']" mode="front"/>
+  <xsl:template match="ltx:contact[@role='thanks']" mode="front"/>
+  <xsl:template match="ltx:section" mode="front"/>
+  <xsl:template match="ltx:acknowledgements"/>
+  <xsl:template match="ltx:acknowledgements" mode="front"/>
+  <xsl:template match="ltx:bibliography"/>
+  <xsl:template match="ltx:bibliography" mode="front"/>
+  <xsl:template match="ltx:date[@role='creation']"/>
+  <xsl:template match="ltx:tag"/>
+  <xsl:template match="ltx:break"/> <!-- Break isn't really supposed to be used -->
+  <xsl:template match="ltx:resource[@type='text/css']" mode="back"/>
+  <xsl:template match="ltx:creator[@role='author']" mode="back"/>
+  <xsl:template match="ltx:abstract" mode="back"/>
+  <xsl:template match="ltx:keywords" mode="back"/>
+  <xsl:template match="ltx:note[@role='thanks']" mode="back"/>
+  <xsl:template match="ltx:section" mode="back"/>
+  <xsl:template match="ltx:date[@role='creation']" mode="back"/>
+  <xsl:template match="ltx:document/ltx:title" mode="back"/>
+  <xsl:template match="ltx:para" mode="front"/>
+  <xsl:template match="ltx:para" mode="back"/>
+  <xsl:template match="ltx:toccaption"/>
+  <xsl:template match="ltx:classification"/>
+  <xsl:template match="ltx:classification" mode="back"/>
+  <xsl:template match="ltx:classification" mode="front"/>
+  <xsl:template match="ltx:note[@role='slugcomment']"/>
+  <xsl:template match="ltx:note[@role='slugcomment']" mode="front"/>
+  <xsl:template match="ltx:note[@role='slugcomment']" mode="back"/>
+  <xsl:template match="ltx:pagination"/>
+  <xsl:template match="ltx:pagination" mode="front"/>
+  <xsl:template match="ltx:pagination" mode="back"/>
+  <xsl:template match="ltx:toctitle"/>
+  <xsl:template match="ltx:toctitle" mode="front"/>
+  <xsl:template match="ltx:toctitle" mode="back"/>
+  <xsl:template match="ltx:appendix" mode="front"/>
+  <xsl:template match="ltx:appendix" mode="back"/>
+  <xsl:template match="ltx:appendix"/>
+  <xsl:template match="ltx:contact[@role='emailmark']" mode="front"/>
+  <xsl:template match="ltx:contact[@role='emailmark']" mode="back"/>
+  <xsl:template match="ltx:contact[@role='emailmark']"/>
+  <xsl:template match="ltx:contact[@role='institutemark']" mode="front"/>
+  <xsl:template match="ltx:contact[@role='institutemark']" mode="back"/>
+  <xsl:template match="ltx:contact[@role='institutemark']"/>
+  <xsl:template match="ltx:creator" mode="back"/>
+  <xsl:template match="ltx:creator"/>
+  <xsl:template match="ltx:contact[@role='affiliation']"/>
+  <xsl:template match="ltx:titlepage" mode="front"/>
+  <xsl:template match="ltx:titlepage" mode="back"/>
+  <xsl:template match="ltx:break" mode="front"/>
+  <xsl:template match="ltx:figure" mode="front"/>
+  <xsl:template match="ltx:figure" mode="back"/>
+  <xsl:template match="ltx:break" mode="back"/>
+  <xsl:template match="ltx:contact[@role='dedicatory']" mode="front"/>
+  <xsl:template match="ltx:contact[@role='dedicatory']" mode="back"/>
+  <xsl:template match="ltx:contact[@role='dedicatory']"/>
+  <xsl:template match="ltx:TOC"/>
+  <xsl:template match="ltx:TOC" mode="front"/>
+  <xsl:template match="ltx:TOC" mode="back"/>
+
+  <xsl:template match="ltx:abstract/ltx:figure" mode="front">
+    <xsl:message>figure in an abstract, fix this </xsl:message> <!-- TODO actualy fix it if it happens -->
+  </xsl:template>
+  <!-- hackish stuff for references -->
+
+  <xsl:template match="ltx:para/@xml:id"/>
+  <xsl:template match="ltx:para[@xml:id]/ltx:p">
+    <xsl:choose>
+      <xsl:when test="not(preceding-sibling::ltx:p)">
+        <p>
+          <xsl:attribute name="xml:id"><xsl:value-of select="../@xml:id"/></xsl:attribute>
+          <xsl:apply-templates select="@*|node()"/>
+        </p>
+      </xsl:when>
+      <xsl:otherwise>
+        <p>
+          <xsl:apply-templates select="@*|node()"/>
+        </p>
+      </xsl:otherwise>
+    </xsl:choose>
+
+  </xsl:template>
+  <xsl:template match="ltx:document/@xml:id"/>
+  <xsl:template match="ltx:document/@xml:id" mode="front"/>
+  <xsl:template match="ltx:document/@xml:id" mode="back"/>
+  <xsl:template match="ltx:document/@labels"/>
+
+
+  <xsl:template match="ltx:para/@xml:id" mode="front"/>
+  <xsl:template match="ltx:para[@xml:id]/ltx:p" mode="front">
+    <p>
+      <xsl:apply-templates select="@*|node()" mode="back"/>
+    </p>
+  </xsl:template>
+  <xsl:template match="@xml:id" mode="front">
+    <xsl:attribute name="xml:id"><xsl:value-of select="."/></xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="ltx:para/@xml:id" mode="back"/>
+  <xsl:template match="ltx:para[@xml:id]/ltx:p" mode="back">
+    <p>
+      <xsl:apply-templates select="@*|node()" mode="back"/>
+    </p>
+  </xsl:template>
+  <xsl:template match="@xml:id" mode="back">
+    <xsl:attribute name="xml:id"><xsl:value-of select="."/></xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="@*"/>
+  <xsl:template match="@*" mode="back"/>
+  <xsl:template match="@*" mode="front"/>
+  <!-- end of hackish references stuff -->
+  <!-- font section -->
+  <xsl:template match="ltx:text[@font='medium']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='medium']" mode="back">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='medium']" mode="front">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@fontsize='90%']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@fontsize='80%']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='upright']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='smallcaps']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='smallcaps']" mode="front">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='smallcaps']" mode="back">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@class='ltx_markedasmath']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='sansserif']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='sansserif']" mode="front">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='sansserif']" mode="back">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='serif']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='serif']" mode="front">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='serif']" mode="back">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='typewriter']">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='typewriter']" mode="front">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@font='typewriter']" mode="back">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@xml:lang]">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@xml:lang]" mode="front">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@xml:lang]" mode="back">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@framed='underline']">
+    <underline>
+      <xsl:apply-templates select="@*|node()"/>
+    </underline>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@framed='underline']" mode="front">
+    <underline>
+      <xsl:apply-templates select="@*|node()" mode="front"/>
+    </underline>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@framed='underline']" mode="back">
+    <underline>
+      <xsl:apply-templates select="@*|node()" mode="back"/>
+    </underline>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@class]">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@class]" mode="front">
+    <xsl:apply-templates select="@*|node()" mode="front"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text[@class]" mode="back">
+    <xsl:apply-templates select="@*|node()" mode="back"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text" mode="back">
+    <xsl:apply-templates mode="back" select="@*|node()"/>
+  </xsl:template>
+
+  <xsl:template match="ltx:text" mode="front">
+    <xsl:apply-templates mode="back" select="@*|node()"/>
+  </xsl:template>
+  <!-- Templates to make things more convenient -->
 </xsl:stylesheet>

--- a/t/daemon/formats/jats.xml
+++ b/t/daemon/formats/jats.xml
@@ -15,8 +15,8 @@
             <addr-line>Somewhere, USA</addr-line>
           </address>
           <!-- The element contact with attributes
-        role=current_address
-      is currently not supported for the front matter.
+    role=current_address
+  is currently not supported for the front matter.
     -->
           <email>joe@blow</email>
         </contrib>
@@ -59,30 +59,30 @@
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p>
         <disp-formula id="S1.E1">
-          <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a+b," display="block">
-            <m:mrow>
-              <m:mrow>
-                <m:mi>a</m:mi>
-                <m:mo>+</m:mo>
-                <m:mi>b</m:mi>
-              </m:mrow>
-              <m:mo>,</m:mo>
-            </m:mrow>
-          </m:math>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="a+b," display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mi>a</mml:mi>
+                <mml:mo>+</mml:mo>
+                <mml:mi>b</mml:mi>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
         </disp-formula>
       </p>
       <p>
         <disp-formula id="S1.E2">
-          <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="c+d," display="block">
-            <m:mrow>
-              <m:mrow>
-                <m:mi>c</m:mi>
-                <m:mo>+</m:mo>
-                <m:mi>d</m:mi>
-              </m:mrow>
-              <m:mo>,</m:mo>
-            </m:mrow>
-          </m:math>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="c+d," display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mi>c</mml:mi>
+                <mml:mo>+</mml:mo>
+                <mml:mi>d</mml:mi>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
         </disp-formula>
       </p>
       <fig id="S1.F1">
@@ -102,12 +102,12 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 <tbody>
 <tr>
 <th>a</th>
-<td><inline-formula id="S1.T1.m1"><m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="x" display="inline"><m:mi>x</m:mi></m:math></inline-formula></td>
-<td><inline-formula id="S1.T1.m2"><m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="x^{2}" display="inline"><m:msup><m:mi>x</m:mi><m:mn>2</m:mn></m:msup></m:math></inline-formula></td></tr>
+<td><inline-formula id="S1.T1.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="x" display="inline"><mml:mi>x</mml:mi></mml:math></inline-formula></td>
+<td><inline-formula id="S1.T1.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="x^{2}" display="inline"><mml:msup><mml:mi>x</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:math></inline-formula></td></tr>
 <tr>
 <th>b</th>
-<td><inline-formula id="S1.T1.m3"><m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="y^{2}" display="inline"><m:msup><m:mi>y</m:mi><m:mn>2</m:mn></m:msup></m:math></inline-formula></td>
-<td><inline-formula id="S1.T1.m4"><m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="y" display="inline"><m:mi>y</m:mi></m:math></inline-formula></td></tr>
+<td><inline-formula id="S1.T1.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="y^{2}" display="inline"><mml:msup><mml:mi>y</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:math></inline-formula></td>
+<td><inline-formula id="S1.T1.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="y" display="inline"><mml:mi>y</mml:mi></mml:math></inline-formula></td></tr>
 </tbody>
 </table></table-wrap>
       <p>
@@ -169,468 +169,337 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
       <p id="S2.p2">Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p>
         <disp-formula id="S2.Ex1">
-          <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a=b" display="block">
-            <m:mrow>
-              <m:mi>a</m:mi>
-              <m:mo>=</m:mo>
-              <m:mi>b</m:mi>
-            </m:mrow>
-          </m:math>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="a=b" display="block">
+            <mml:mrow>
+              <mml:mi>a</mml:mi>
+              <mml:mo>=</mml:mo>
+              <mml:mi>b</mml:mi>
+            </mml:mrow>
+          </mml:math>
         </disp-formula>
       </p>
       <p>
         <disp-formula id="S2.E1">
-          <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a=b" display="block">
-            <m:mrow>
-              <m:mi>a</m:mi>
-              <m:mo>=</m:mo>
-              <m:mi>b</m:mi>
-            </m:mrow>
-          </m:math>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="a=b" display="block">
+            <mml:mrow>
+              <mml:mi>a</mml:mi>
+              <mml:mo>=</mml:mo>
+              <mml:mi>b</mml:mi>
+            </mml:mrow>
+          </mml:math>
         </disp-formula>
       </p>
       <p>
         <disp-formula id="S2.E2">
-          <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\begin{split}a&amp;=b+c-d\\&#10;&amp;\quad+e-f\\&#10;&amp;=g+h\\&#10;&amp;=i\end{split}" display="block">
-            <m:mtable columnspacing="0pt" displaystyle="true" rowspacing="0pt">
-              <m:mtr>
-                <m:mtd columnalign="right">
-                  <m:mi>a</m:mi>
-                </m:mtd>
-                <m:mtd columnalign="left">
-                  <m:mrow>
-                    <m:mi/>
-                    <m:mo>=</m:mo>
-                    <m:mrow>
-                      <m:mrow>
-                        <m:mi>b</m:mi>
-                        <m:mo>+</m:mo>
-                        <m:mi>c</m:mi>
-                      </m:mrow>
-                      <m:mo>-</m:mo>
-                      <m:mi>d</m:mi>
-                    </m:mrow>
-                  </m:mrow>
-                </m:mtd>
-              </m:mtr>
-              <m:mtr>
-                <m:mtd/>
-                <m:mtd columnalign="left">
-                  <m:mrow>
-                    <m:mrow>
-                      <m:mo lspace="12.5pt">+</m:mo>
-                      <m:mi>e</m:mi>
-                    </m:mrow>
-                    <m:mo>-</m:mo>
-                    <m:mi>f</m:mi>
-                  </m:mrow>
-                </m:mtd>
-              </m:mtr>
-              <m:mtr>
-                <m:mtd/>
-                <m:mtd columnalign="left">
-                  <m:mrow>
-                    <m:mi/>
-                    <m:mo>=</m:mo>
-                    <m:mrow>
-                      <m:mi>g</m:mi>
-                      <m:mo>+</m:mo>
-                      <m:mi>h</m:mi>
-                    </m:mrow>
-                  </m:mrow>
-                </m:mtd>
-              </m:mtr>
-              <m:mtr>
-                <m:mtd/>
-                <m:mtd columnalign="left">
-                  <m:mrow>
-                    <m:mi/>
-                    <m:mo>=</m:mo>
-                    <m:mi>i</m:mi>
-                  </m:mrow>
-                </m:mtd>
-              </m:mtr>
-            </m:mtable>
-          </m:math>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\begin{split}a&amp;=b+c-d\\&#10;&amp;\quad+e-f\\&#10;&amp;=g+h\\&#10;&amp;=i\end{split}" display="block">
+            <mml:mtable columnspacing="0pt" displaystyle="true" rowspacing="0pt">
+              <mml:mtr>
+                <mml:mtd columnalign="right">
+                  <mml:mi>a</mml:mi>
+                </mml:mtd>
+                <mml:mtd columnalign="left">
+                  <mml:mrow>
+                    <mml:mi/>
+                    <mml:mo>=</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mi>b</mml:mi>
+                        <mml:mo>+</mml:mo>
+                        <mml:mi>c</mml:mi>
+                      </mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mi>d</mml:mi>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd/>
+                <mml:mtd columnalign="left">
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mo lspace="12.5pt">+</mml:mo>
+                      <mml:mi>e</mml:mi>
+                    </mml:mrow>
+                    <mml:mo>-</mml:mo>
+                    <mml:mi>f</mml:mi>
+                  </mml:mrow>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd/>
+                <mml:mtd columnalign="left">
+                  <mml:mrow>
+                    <mml:mi/>
+                    <mml:mo>=</mml:mo>
+                    <mml:mrow>
+                      <mml:mi>g</mml:mi>
+                      <mml:mo>+</mml:mo>
+                      <mml:mi>h</mml:mi>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd/>
+                <mml:mtd columnalign="left">
+                  <mml:mrow>
+                    <mml:mi/>
+                    <mml:mo>=</mml:mo>
+                    <mml:mi>i</mml:mi>
+                  </mml:mrow>
+                </mml:mtd>
+              </mml:mtr>
+            </mml:mtable>
+          </mml:math>
         </disp-formula>
       </p>
       <p>
         <disp-formula id="S2.E3">
-          <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a+b+c+d+e+f\\&#10;+i+j+k+l+m+n" display="block">
-            <m:mtable displaystyle="true" rowspacing="0pt">
-              <m:mtr>
-                <m:mtd columnalign="left">
-                  <m:mrow>
-                    <m:mi>a</m:mi>
-                    <m:mo>+</m:mo>
-                    <m:mi>b</m:mi>
-                    <m:mo>+</m:mo>
-                    <m:mi>c</m:mi>
-                    <m:mo>+</m:mo>
-                    <m:mi>d</m:mi>
-                    <m:mo>+</m:mo>
-                    <m:mi>e</m:mi>
-                    <m:mo>+</m:mo>
-                    <m:mi>f</m:mi>
-                  </m:mrow>
-                </m:mtd>
-              </m:mtr>
-              <m:mtr>
-                <m:mtd columnalign="right">
-                  <m:mrow>
-                    <m:mrow>
-                      <m:mo>+</m:mo>
-                      <m:mi>i</m:mi>
-                    </m:mrow>
-                    <m:mo>+</m:mo>
-                    <m:mi>j</m:mi>
-                    <m:mo>+</m:mo>
-                    <m:mi>k</m:mi>
-                    <m:mo>+</m:mo>
-                    <m:mi>l</m:mi>
-                    <m:mo>+</m:mo>
-                    <m:mi>m</m:mi>
-                    <m:mo>+</m:mo>
-                    <m:mi>n</m:mi>
-                  </m:mrow>
-                </m:mtd>
-              </m:mtr>
-            </m:mtable>
-          </m:math>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="a+b+c+d+e+f\\&#10;+i+j+k+l+m+n" display="block">
+            <mml:mtable displaystyle="true" rowspacing="0pt">
+              <mml:mtr>
+                <mml:mtd columnalign="left">
+                  <mml:mrow>
+                    <mml:mi>a</mml:mi>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>b</mml:mi>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>c</mml:mi>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>d</mml:mi>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>e</mml:mi>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>f</mml:mi>
+                  </mml:mrow>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd columnalign="right">
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mo>+</mml:mo>
+                      <mml:mi>i</mml:mi>
+                    </mml:mrow>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>j</mml:mi>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>k</mml:mi>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>l</mml:mi>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>+</mml:mo>
+                    <mml:mi>n</mml:mi>
+                  </mml:mrow>
+                </mml:mtd>
+              </mml:mtr>
+            </mml:mtable>
+          </mml:math>
         </disp-formula>
       </p>
       <p>
         <disp-formula-group id="S3.EGx1">
           <disp-formula id="S2.E4">
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{1}=b_{1}+c_{1}" display="block">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>1</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>1</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>1</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{1}=b_{1}+c_{1}" display="block">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>1</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>b</mml:mi>
+                    <mml:mn>1</mml:mn>
+                  </mml:msub>
+                  <mml:mo>+</mml:mo>
+                  <mml:msub>
+                    <mml:mi>c</mml:mi>
+                    <mml:mn>1</mml:mn>
+                  </mml:msub>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
           </disp-formula>
           <disp-formula id="S2.E5">
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{2}=b_{2}+c_{2}-d_{2}+e_{2}" display="block">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>2</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:mrow>
-                    <m:mrow>
-                      <m:msub>
-                        <m:mi>b</m:mi>
-                        <m:mn>2</m:mn>
-                      </m:msub>
-                      <m:mo>+</m:mo>
-                      <m:msub>
-                        <m:mi>c</m:mi>
-                        <m:mn>2</m:mn>
-                      </m:msub>
-                    </m:mrow>
-                    <m:mo>-</m:mo>
-                    <m:msub>
-                      <m:mi>d</m:mi>
-                      <m:mn>2</m:mn>
-                    </m:msub>
-                  </m:mrow>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>e</m:mi>
-                    <m:mn>2</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{2}=b_{2}+c_{2}-d_{2}+e_{2}" display="block">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>2</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:msub>
+                        <mml:mi>b</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msub>
+                      <mml:mo>+</mml:mo>
+                      <mml:msub>
+                        <mml:mi>c</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msub>
+                    </mml:mrow>
+                    <mml:mo>-</mml:mo>
+                    <mml:msub>
+                      <mml:mi>d</mml:mi>
+                      <mml:mn>2</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo>+</mml:mo>
+                  <mml:msub>
+                    <mml:mi>e</mml:mi>
+                    <mml:mn>2</mml:mn>
+                  </mml:msub>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
           </disp-formula>
         </disp-formula-group>
       </p>
       <p>
         <disp-formula-group id="S3.EGx2">
           <disp-formula id="S2.E6">
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{1}=b_{1}+c_{1}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>1</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>1</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>1</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{1}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>1</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{1}+c_{1}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>1</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>1</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{1}=b_{1}+c_{1}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>1</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>b</mml:mi>
+                    <mml:mn>1</mml:mn>
+                  </mml:msub>
+                  <mml:mo>+</mml:mo>
+                  <mml:msub>
+                    <mml:mi>c</mml:mi>
+                    <mml:mn>1</mml:mn>
+                  </mml:msub>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
           </disp-formula>
           <disp-formula id="S2.E7">
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{2}=b_{2}+c_{2}-d_{2}+e_{2}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>2</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:mrow>
-                    <m:mrow>
-                      <m:msub>
-                        <m:mi>b</m:mi>
-                        <m:mn>2</m:mn>
-                      </m:msub>
-                      <m:mo>+</m:mo>
-                      <m:msub>
-                        <m:mi>c</m:mi>
-                        <m:mn>2</m:mn>
-                      </m:msub>
-                    </m:mrow>
-                    <m:mo>-</m:mo>
-                    <m:msub>
-                      <m:mi>d</m:mi>
-                      <m:mn>2</m:mn>
-                    </m:msub>
-                  </m:mrow>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>e</m:mi>
-                    <m:mn>2</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{2}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>2</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{2}+c_{2}-d_{2}+e_{2}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:mrow>
-                    <m:mrow>
-                      <m:msub>
-                        <m:mi>b</m:mi>
-                        <m:mn>2</m:mn>
-                      </m:msub>
-                      <m:mo>+</m:mo>
-                      <m:msub>
-                        <m:mi>c</m:mi>
-                        <m:mn>2</m:mn>
-                      </m:msub>
-                    </m:mrow>
-                    <m:mo>-</m:mo>
-                    <m:msub>
-                      <m:mi>d</m:mi>
-                      <m:mn>2</m:mn>
-                    </m:msub>
-                  </m:mrow>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>e</m:mi>
-                    <m:mn>2</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{2}=b_{2}+c_{2}-d_{2}+e_{2}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>2</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:msub>
+                        <mml:mi>b</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msub>
+                      <mml:mo>+</mml:mo>
+                      <mml:msub>
+                        <mml:mi>c</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msub>
+                    </mml:mrow>
+                    <mml:mo>-</mml:mo>
+                    <mml:msub>
+                      <mml:mi>d</mml:mi>
+                      <mml:mn>2</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo>+</mml:mo>
+                  <mml:msub>
+                    <mml:mi>e</mml:mi>
+                    <mml:mn>2</mml:mn>
+                  </mml:msub>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
           </disp-formula>
         </disp-formula-group>
       </p>
       <p>
         <disp-formula-group id="S3.EGx3">
           <disp-formula id="S2.E8">
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}=b_{11}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>11</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>11</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>11</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{11}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>11</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{12}=b_{12}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>12</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>12</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{12}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>12</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{12}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>12</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}=b_{11}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>11</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:msub>
+                  <mml:mi>b</mml:mi>
+                  <mml:mn>11</mml:mn>
+                </mml:msub>
+              </mml:mrow>
+            </mml:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{12}=b_{12}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>12</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:msub>
+                  <mml:mi>b</mml:mi>
+                  <mml:mn>12</mml:mn>
+                </mml:msub>
+              </mml:mrow>
+            </mml:math>
           </disp-formula>
           <disp-formula id="S2.E9">
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}=b_{21}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>21</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>21</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>21</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{21}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>21</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{22}=b_{22}+c_{22}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>22</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{22}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>22</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{22}+c_{22}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}=b_{21}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>21</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:msub>
+                  <mml:mi>b</mml:mi>
+                  <mml:mn>21</mml:mn>
+                </mml:msub>
+              </mml:mrow>
+            </mml:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{22}=b_{22}+c_{22}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>22</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>b</mml:mi>
+                    <mml:mn>22</mml:mn>
+                  </mml:msub>
+                  <mml:mo>+</mml:mo>
+                  <mml:msub>
+                    <mml:mi>c</mml:mi>
+                    <mml:mn>22</mml:mn>
+                  </mml:msub>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
           </disp-formula>
         </disp-formula-group>
       </p>
       <p id="S2.p10">Some text</p>
       <p>
         <disp-formula id="S2.E10">
-          <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a=\text{something}" display="block">
-            <m:mrow>
-              <m:mi>a</m:mi>
-              <m:mo>=</m:mo>
-              <m:mtext>something</m:mtext>
-            </m:mrow>
-          </m:math>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="a=\text{something}" display="block">
+            <mml:mrow>
+              <mml:mi>a</mml:mi>
+              <mml:mo>=</mml:mo>
+              <mml:mtext>something</mml:mtext>
+            </mml:mrow>
+          </mml:math>
         </disp-formula>
       </p>
       <statement id="Thmcorollary1">
@@ -650,138 +519,67 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
       <p>
         <disp-formula-group id="S3.EGx4">
           <disp-formula id="S2.Ex2">
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}=b_{11}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>11</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>11</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>11</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{11}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>11</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{12}=b_{12}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>12</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>12</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{12}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>12</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{12}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>12</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}=b_{11}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>11</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:msub>
+                  <mml:mi>b</mml:mi>
+                  <mml:mn>11</mml:mn>
+                </mml:msub>
+              </mml:mrow>
+            </mml:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{12}=b_{12}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>12</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:msub>
+                  <mml:mi>b</mml:mi>
+                  <mml:mn>12</mml:mn>
+                </mml:msub>
+              </mml:mrow>
+            </mml:math>
           </disp-formula>
           <disp-formula id="S2.Ex3">
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}=b_{21}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>21</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>21</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>21</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{21}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>21</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{22}=b_{22}+c_{22}" display="inline">
-              <m:mrow>
-                <m:msub>
-                  <m:mi>a</m:mi>
-                  <m:mn>22</m:mn>
-                </m:msub>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{22}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>22</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{22}+c_{22}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}=b_{21}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>21</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:msub>
+                  <mml:mi>b</mml:mi>
+                  <mml:mn>21</mml:mn>
+                </mml:msub>
+              </mml:mrow>
+            </mml:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{22}=b_{22}+c_{22}" display="inline">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>a</mml:mi>
+                  <mml:mn>22</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>b</mml:mi>
+                    <mml:mn>22</mml:mn>
+                  </mml:msub>
+                  <mml:mo>+</mml:mo>
+                  <mml:msub>
+                    <mml:mi>c</mml:mi>
+                    <mml:mn>22</mml:mn>
+                  </mml:msub>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
           </disp-formula>
         </disp-formula-group>
       </p>
@@ -812,9 +610,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
     <ref-list>
       <title>References</title>
       <ref id="bib.bib1">
-        <mixed-citation><person-group person-group-type="author"><name><surname>Stegun</surname><given-names>Abramowitz&#xA0;
-              and&#xA0;
-              </given-names></name></person-group><year>1964</year><article-title>Handbook of mathematical functions with formulas, graphs, and mathematical tables</article-title>M. Abramowitz and I. A. Stegun (<date><year>1964</year></date>)Handbook of mathematical functions with formulas, graphs, and mathematical tables.ninth Dover printing, tenth GPO printing edition,  Dover, New York.Cited by: &#xA7;1.</mixed-citation>
+        <mixed-citation><person-group person-group-type="author"><name><surname>Stegun</surname><given-names>Abramowitz and </given-names></name></person-group><year>1964</year><article-title>Handbook of mathematical functions with formulas, graphs, and mathematical tables</article-title>M. Abramowitz and I. A. Stegun (<date><year>1964</year></date>)Handbook of mathematical functions with formulas, graphs, and mathematical tables.ninth Dover printing, tenth GPO printing edition,  Dover, New York.Cited by: &#xA7;1.</mixed-citation>
       </ref>
     </ref-list>
     <app-group/>

--- a/t/daemon/formats/tei.xml
+++ b/t/daemon/formats/tei.xml
@@ -20,9 +20,9 @@
                 <addrLine>Somewhere, USA</addrLine>
               </address>
               <!-- The element contact with attributes
-            role=current_address
-            is currently not supported for the front matter.
-        -->
+    role=current_address
+  is currently not supported for the front matter.
+    -->
               <email>joe@blow</email>
             </author>
             <author>
@@ -66,13 +66,16 @@
     <body>
       <div>
         <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
         <head>Introduction</head>
         <p xml:id="S1.p1">As discussed in <ref type="bibr" target="bib.bib1">[AS64]</ref>,
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         <p>
-          <formula>
+          <formula xml:id="S1.E1">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a+b," display="block">
               <m:mrow>
                 <m:mrow>
@@ -86,7 +89,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           </formula>
         </p>
         <p>
-          <formula>
+          <formula xml:id="S1.E2">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="c+d," display="block">
               <m:mrow>
                 <m:mrow>
@@ -102,14 +108,14 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
         <figure>
           <head>A Figure</head>
           <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
           <p>A Figure</p>
         </figure>
         <table>
           <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
           <head>A Table</head>
           <row>
             <cell>Heading</cell>
@@ -119,14 +125,14 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           <row>
             <cell>a</cell>
             <cell>
-              <formula>
+              <formula xml:id="S1.T1.m1">
                 <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="x" display="inline">
                   <m:mi>x</m:mi>
                 </m:math>
               </formula>
             </cell>
             <cell>
-              <formula>
+              <formula xml:id="S1.T1.m2">
                 <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="x^{2}" display="inline">
                   <m:msup>
                     <m:mi>x</m:mi>
@@ -139,7 +145,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           <row>
             <cell>b</cell>
             <cell>
-              <formula>
+              <formula xml:id="S1.T1.m3">
                 <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="y^{2}" display="inline">
                   <m:msup>
                     <m:mi>y</m:mi>
@@ -149,7 +155,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
               </formula>
             </cell>
             <cell>
-              <formula>
+              <formula xml:id="S1.T1.m4">
                 <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="y" display="inline">
                   <m:mi>y</m:mi>
                 </m:math>
@@ -161,27 +167,27 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           <list rend="bulleted">
             <item>
               <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
               <p xml:id="S1.I1.i1.p1">one</p>
             </item>
             <item>
               <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
               <p xml:id="S1.I1.i2.p1">two</p>
               <p>
                 <list rend="bulleted">
                   <item>
                     <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
                     <p xml:id="S1.I1.i2.I1.i1.p1">one</p>
                   </item>
                   <item>
                     <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
                     <p xml:id="S1.I1.i2.I1.i2.p1">two</p>
                   </item>
                 </list>
@@ -193,27 +199,27 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           <list rend="numbered">
             <item>
               <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
               <p xml:id="S1.I2.i1.p1">one</p>
             </item>
             <item>
               <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
               <p xml:id="S1.I2.i2.p1">two</p>
               <p>
                 <list rend="numbered">
                   <item>
                     <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
                     <p xml:id="S1.I2.i2.I2.i1.p1">one</p>
                   </item>
                   <item>
                     <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
                     <p xml:id="S1.I2.i2.I2.i2.p1">two</p>
                   </item>
                 </list>
@@ -224,20 +230,20 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
         <list>
           <item>
             <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
             <p xml:id="S1.I3.ix1.p1">with some descriptive text.</p>
           </item>
           <item>
             <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
             <p xml:id="S1.I3.ix2.p1">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
           </item>
           <item>
             <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
             <p xml:id="S1.I3.ix3.p1">blah, blah. Moreover
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
           </item>
@@ -245,13 +251,13 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
       </div>
       <div>
         <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
         <head>A Math Section</head>
         <p xml:id="S2.p1">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
         <p xml:id="S2.p2">Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         <p>
-          <formula>
+          <formula xml:id="S2.Ex1">
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a=b" display="block">
               <m:mrow>
                 <m:mi>a</m:mi>
@@ -262,7 +268,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           </formula>
         </p>
         <p>
-          <formula>
+          <formula xml:id="S2.E1">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a=b" display="block">
               <m:mrow>
                 <m:mi>a</m:mi>
@@ -273,7 +282,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           </formula>
         </p>
         <p>
-          <formula>
+          <formula xml:id="S2.E2">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\begin{split}a&amp;=b+c-d\\&#10;&amp;\quad+e-f\\&#10;&amp;=g+h\\&#10;&amp;=i\end{split}" display="block">
               <m:mtable columnspacing="0pt" displaystyle="true" rowspacing="0pt">
                 <m:mtr>
@@ -338,7 +350,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
           </formula>
         </p>
         <p>
-          <formula>
+          <formula xml:id="S2.E3">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a+b+c+d+e+f\\&#10;+i+j+k+l+m+n" display="block">
               <m:mtable displaystyle="true" rowspacing="0pt">
                 <m:mtr>
@@ -382,8 +397,11 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
             </m:math>
           </formula>
         </p>
-        <p>
-          <formula>
+        <p xml:id="S3.EGx1">
+          <formula xml:id="S2.E4">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{1}=b_{1}+c_{1}" display="block">
               <m:mrow>
                 <m:msub>
@@ -405,7 +423,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
               </m:mrow>
             </m:math>
           </formula>
-          <formula>
+          <formula xml:id="S2.E5">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{2}=b_{2}+c_{2}-d_{2}+e_{2}" display="block">
               <m:mrow>
                 <m:msub>
@@ -442,8 +463,11 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
             </m:math>
           </formula>
         </p>
-        <p>
-          <formula>
+        <p xml:id="S3.EGx2">
+          <formula xml:id="S2.E6">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{1}=b_{1}+c_{1}" display="inline">
               <m:mrow>
                 <m:msub>
@@ -464,31 +488,11 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
                 </m:mrow>
               </m:mrow>
             </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{1}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>1</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{1}+c_{1}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>1</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>1</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
           </formula>
-          <formula>
+          <formula xml:id="S2.E7">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{2}=b_{2}+c_{2}-d_{2}+e_{2}" display="inline">
               <m:mrow>
                 <m:msub>
@@ -523,69 +527,19 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
                 </m:mrow>
               </m:mrow>
             </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{2}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>2</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{2}+c_{2}-d_{2}+e_{2}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:mrow>
-                    <m:mrow>
-                      <m:msub>
-                        <m:mi>b</m:mi>
-                        <m:mn>2</m:mn>
-                      </m:msub>
-                      <m:mo>+</m:mo>
-                      <m:msub>
-                        <m:mi>c</m:mi>
-                        <m:mn>2</m:mn>
-                      </m:msub>
-                    </m:mrow>
-                    <m:mo>-</m:mo>
-                    <m:msub>
-                      <m:mi>d</m:mi>
-                      <m:mn>2</m:mn>
-                    </m:msub>
-                  </m:mrow>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>e</m:mi>
-                    <m:mn>2</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
           </formula>
         </p>
-        <p>
-          <formula>
+        <p xml:id="S3.EGx3">
+          <formula xml:id="S2.E8">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}=b_{11}" display="inline">
               <m:mrow>
                 <m:msub>
                   <m:mi>a</m:mi>
                   <m:mn>11</m:mn>
                 </m:msub>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>11</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>11</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{11}" display="inline">
-              <m:mrow>
-                <m:mi/>
                 <m:mo>=</m:mo>
                 <m:msub>
                   <m:mi>b</m:mi>
@@ -606,24 +560,11 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
                 </m:msub>
               </m:mrow>
             </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{12}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>12</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{12}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>12</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
           </formula>
-          <formula>
+          <formula xml:id="S2.E9">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}=b_{21}" display="inline">
               <m:mrow>
                 <m:msub>
@@ -637,51 +578,12 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
                 </m:msub>
               </m:mrow>
             </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>21</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{21}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>21</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{22}=b_{22}+c_{22}" display="inline">
               <m:mrow>
                 <m:msub>
                   <m:mi>a</m:mi>
                   <m:mn>22</m:mn>
                 </m:msub>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{22}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>22</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{22}+c_{22}" display="inline">
-              <m:mrow>
-                <m:mi/>
                 <m:mo>=</m:mo>
                 <m:mrow>
                   <m:msub>
@@ -700,7 +602,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
         </p>
         <p xml:id="S2.p10">Some text</p>
         <p>
-          <formula>
+          <formula xml:id="S2.E10">
+            <!-- The element tags
+  is currently not supported for the main body.
+    -->
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="a=\text{something}" display="block">
               <m:mrow>
                 <m:mi>a</m:mi>
@@ -712,8 +617,8 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
         </p>
         <note>
           <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
           <title>
             <hi rend="italic">.</hi>
           </title>
@@ -721,37 +626,21 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
         </note>
         <note>
           <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
           <title>
             <hi rend="italic">.</hi>
           </title>
           <p xml:id="Thmcorollaryx1.p1">And whatever.</p>
         </note>
-        <p>
-          <formula>
+        <p xml:id="S3.EGx4">
+          <formula xml:id="S2.Ex2">
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}=b_{11}" display="inline">
               <m:mrow>
                 <m:msub>
                   <m:mi>a</m:mi>
                   <m:mn>11</m:mn>
                 </m:msub>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>11</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{11}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>11</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{11}" display="inline">
-              <m:mrow>
-                <m:mi/>
                 <m:mo>=</m:mo>
                 <m:msub>
                   <m:mi>b</m:mi>
@@ -772,46 +661,14 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
                 </m:msub>
               </m:mrow>
             </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{12}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>12</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{12}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>12</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
           </formula>
-          <formula>
+          <formula xml:id="S2.Ex3">
             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}=b_{21}" display="inline">
               <m:mrow>
                 <m:msub>
                   <m:mi>a</m:mi>
                   <m:mn>21</m:mn>
                 </m:msub>
-                <m:mo>=</m:mo>
-                <m:msub>
-                  <m:mi>b</m:mi>
-                  <m:mn>21</m:mn>
-                </m:msub>
-              </m:mrow>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{21}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>21</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{21}" display="inline">
-              <m:mrow>
-                <m:mi/>
                 <m:mo>=</m:mo>
                 <m:msub>
                   <m:mi>b</m:mi>
@@ -839,41 +696,18 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
                 </m:mrow>
               </m:mrow>
             </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle a_{22}" display="inline">
-              <m:msub>
-                <m:mi>a</m:mi>
-                <m:mn>22</m:mn>
-              </m:msub>
-            </m:math>
-            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" alttext="\displaystyle=b_{22}+c_{22}" display="inline">
-              <m:mrow>
-                <m:mi/>
-                <m:mo>=</m:mo>
-                <m:mrow>
-                  <m:msub>
-                    <m:mi>b</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                  <m:mo>+</m:mo>
-                  <m:msub>
-                    <m:mi>c</m:mi>
-                    <m:mn>22</m:mn>
-                  </m:msub>
-                </m:mrow>
-              </m:mrow>
-            </m:math>
           </formula>
         </p>
         <div>
           <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
           <head>A subsection</head>
           <p xml:id="S2.SS1.p1">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
           <div>
             <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
             <head>A subsubsection</head>
             <p xml:id="S2.SS1.SSS1.p1">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
             <boxed-text>
@@ -887,8 +721,8 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
       </div>
       <div>
         <!-- The element tags
-            is currently not supported for the main body.
-        -->
+  is currently not supported for the main body.
+    -->
         <head>
           <hi rend="italic">Section with explicit font</hi>
         </head>
@@ -902,9 +736,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
       <div type="references">
         <listBibl>
           <head>References</head>
-          <bibl xml:id="bib.bib1"><person-group person-group-type="author"><name><surname>Stegun</surname><given-names>Abramowitz 
-                            and 
-                            </given-names></name></person-group><year>1964</year><article-title>Handbook of mathematical functions with formulas, graphs, and mathematical tables</article-title>M. Abramowitz and I. A. Stegun (<date><year>1964</year></date>)Handbook of mathematical functions with formulas, graphs, and mathematical tables.ninth Dover printing, tenth GPO printing edition,  Dover, New York.Cited by: §1.</bibl>
+          <bibl xml:id="bib.bib1"><person-group person-group-type="author"><name><surname>Stegun</surname><given-names>Abramowitz and </given-names></name></person-group><year>1964</year><article-title>Handbook of mathematical functions with formulas, graphs, and mathematical tables</article-title>M. Abramowitz and I. A. Stegun (<date><year>1964</year></date>)Handbook of mathematical functions with formulas, graphs, and mathematical tables.ninth Dover printing, tenth GPO printing edition,  Dover, New York.Cited by: §1.</bibl>
         </listBibl>
       </div>
     </back>


### PR DESCRIPTION
Quite by accident, I discovered some oddities in these stylesheets and that they were not reusing the base LaTeXML stylesheet modules as much as I had expected. Among other things that made it quite easy to use the `mml` namespace prefix (even if it annoys :> ). And also discovered that instances `ltx:MathFork` (used for aligned sets of equations) was getting *all* math branches copied, resulting in redundant math.  Along with other general stylesheet formatting, namespace cleanup.

Fixes #1499.

Please @rgieseke, @xworld21 and any other JATS or TEI users, please take a look that I haven't inadvertently broken anything.