### PR TITLE
Add binding for 'ifplatform.sty'

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -502,6 +502,7 @@ lib/LaTeXML/Package/ieeeconf.cls.ltxml
 lib/LaTeXML/Package/IEEEtran.cls.ltxml
 lib/LaTeXML/Package/ifluatex.sty.ltxml
 lib/LaTeXML/Package/ifpdf.sty.ltxml
+lib/LaTeXML/Package/ifplatform.sty.ltxml
 lib/LaTeXML/Package/ifthen.sty.ltxml
 lib/LaTeXML/Package/ifvtex.sty.ltxml
 lib/LaTeXML/Package/ifxetex.sty.ltxml

--- a/lib/LaTeXML/Package/ifplatform.sty.ltxml
+++ b/lib/LaTeXML/Package/ifplatform.sty.ltxml
@@ -1,0 +1,68 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  ifplatform                                                         | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |=====================================================================| #
+# | Thanks to Tom Wiesing <tom.wiesing@gmail.com>.                      | #
+# | Additional thanks to GitHub user "aivokalu" for part of the         | #
+# | original implementation.                                            | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+# Define the names for the common operating systems
+DefMacro('\windowsname',    'Windows');
+DefMacro('\notwindowsname', '*NIX');
+DefMacro('\linuxname',      'Linux');
+DefMacro('\macosxname',     'Mac\,OS\,X');
+DefMacro('\cygwinname',     'Cygwin');
+
+# internal 'if' being used to detect if shell escape is enabled.
+# The concept doesn't exist in LaTeXML the way it exists in pdflatex,
+# so we hardcode it as true.
+DefConditional('\ifshellescape', sub { 1; });
+
+# Do a check for the various operating systems
+# and store the result in appropriate variables
+my $isWindows = $^O eq "Win32";
+my $isLinux   = $^O eq "linux";
+my $isMacOSX  = $^O eq "darwin";
+my $isCygwin  = $^O eq "cygwin";
+
+# Check which platform we are on so that we can define the platformname macro.
+# Also define the '\unknownplatform' macro from the output of uname.
+my ($platformNameMacro, $unknownPlatformName) = ('', '[Unknown]');
+if ($isWindows) {
+  $platformNameMacro = '\windowsname'; }
+elsif ($isLinux) {
+  $platformNameMacro = '\linuxname'; }
+elsif ($isMacOSX) {
+  $platformNameMacro = '\macosxname'; }
+elsif ($isCygwin) {
+  $platformNameMacro = '\cygwinname'; }
+else {
+  $platformNameMacro = '\unknownplatform';
+  eval { require POSIX; } or last;
+  ($unknownPlatformName) = POSIX::uname(); }
+
+DefMacro('\unknownplatform', $unknownPlatformName);
+Let('\platformname', $platformNameMacro);
+
+# \newif s for the various operation systems.
+# In the original package these rely on 'shell escape' being enabled, and otherwise return false.
+# This is not emulated here, it is considered an implementation detail.
+DefConditional('\ifwindows', sub { $isWindows; });
+DefConditional('\iflinux',   sub { $isLinux; });
+DefConditional('\ifmacosx',  sub { $isMacOSX; });
+DefConditional('\ifcygwin',  sub { $isCygwin; });
+
+1;


### PR DESCRIPTION
This PR adds a binding for the 'ifplatform.sty' package, emulating the package as closely as possible.

This commit does not add any tests for the package, because the output is operating system dependent. As such it would likely fail for a large part of users of LaTeXML. 

Fixes #1531.