### PR TITLE
minor macro patches for todonotes.sty

### DIFF
--- a/lib/LaTeXML/Package/todonotes.sty.ltxml
+++ b/lib/LaTeXML/Package/todonotes.sty.ltxml
@@ -31,11 +31,12 @@ RequirePackage('calc');
 
 DefMacroI('\ext@todo', undef, 'todo');
 NewCounter('todo');
-DefMacro('\todotyperefname', 'ToDo');
-DefMacro('\todo',            '\lx@note{todo}');
-DefMacro('\missingfigure{}', '[Missing Figure: #1]');
-DefMacro('todototoc',        '');
+DefMacro('\todotyperefname',   'ToDo');
+DefMacro('\todo',              '\lx@note{todo}');
+DefMacro('\missingfigure[]{}', '[Missing Figure: #2]');
+DefMacro('\todototoc',         '');
+DefMacro('\listoftodos',       '');
+DefMacro('\@todo[]{}',         '');
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;
-


### PR DESCRIPTION
Spotted a weird Fatal error on arxiv related to `todototoc`:
```
	Fatal:misdefined:odototoc Unrecognized parameter type in "odototoc"
		at todonotes.sty.ltxml; line 37
```

And indeed there was a minor typo to fix. While there I opened [the docs](http://tug.ctan.org/macros/latex/contrib/todonotes/todonotes.pdf) and smoothed in a couple of other bits. All in all, an elbow grease PR.