### PR TITLE
Recognize \maketitle in titlepage

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1180,18 +1180,28 @@ DefMacro('\format@title@abstract{}', '#1');
 # For now, we just give an info message
 DefEnvironment('{titlepage}', '<ltx:titlepage>#body',
   beforeDigest => sub { Let('\centering', '\relax');
+    AddToMacro(T_CS('\maketitle'), T_CS('\unwind@titlepage'));
     DefEnvironment('{abstract}',
       '<ltx:abstract>#body</ltx:abstract>');
     Info('unexpected', 'titlepage', $_[0],
       "When using titlepage, Frontmatter will not be well-structured");
     return; },
-  beforeDigestEnd => sub { Digest(T_CS('\maybe@end@title')); },
+  beforeDigestEnd => sub { Digest(T_CS('\maybe@end@titlepage')); },
   locked          => 1, mode => 'text');
 
 Tag('ltx:titlepage', autoClose => 1);
-DefConstructorI('\maybe@end@title', undef, sub {
+DefConstructorI('\maybe@end@titlepage', undef, sub {
     my ($document) = @_;
     $document->maybeCloseElement('ltx:titlepage'); });
+DefConstructorI('\maybe@end@titlepage', undef, sub {
+    my ($document) = @_;
+    $document->maybeCloseElement('ltx:titlepage'); });
+DefConstructorI('\unwind@titlepage', undef, sub {
+    my ($document) = @_;
+    if (my $titlepage = $document->maybeCloseElement('ltx:titlepage')) {
+      $document->unwrapNodes($titlepage);
+    }
+});
 
 DefMacro('\sectionmark{}',       Tokens());
 DefMacro('\subsectionmark{}',    Tokens());

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1193,9 +1193,6 @@ Tag('ltx:titlepage', autoClose => 1);
 DefConstructorI('\maybe@end@titlepage', undef, sub {
     my ($document) = @_;
     $document->maybeCloseElement('ltx:titlepage'); });
-DefConstructorI('\maybe@end@titlepage', undef, sub {
-    my ($document) = @_;
-    $document->maybeCloseElement('ltx:titlepage'); });
 DefConstructorI('\unwind@titlepage', undef, sub {
     my ($document) = @_;
     if (my $titlepage = $document->maybeCloseElement('ltx:titlepage')) {


### PR DESCRIPTION
Debugging [arXiv:1606.02688](https://corpora.mathweb.org/preview/arxmliv/tex%5Fto%5Fhtml/1606.02688), I noticed that `{titlepage}` currently gives up on collecting any metadata, until better recognition algorithms come to mind.

However, in that arXiv article, it gave up a bit prematurely, as the metadata is provided properly and a `\maketitle` macro is explicitly used within the titlepage. So I added a check that upon encountering `\maketitle` will unwind/unwrap the `ltx:titlepage` element and revert back to the default handling with healthy metadata.

Fixes that article, and may be an easy upgrade? I am separately looking into improving the `\maketitle` machinery to be closer to the latex.ltx implementation for issue #1536 , but that is a lot more far-reaching and involved. This PR addresses only a single small use case that is easy to improve on.