### PR TITLE
[arXiv patch] more internal \input macros, typo and lighter font Info logs

### DIFF
--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -35,7 +35,7 @@ use lib catdir($RealBin_safe, "..", "lib");
 use LaTeXML;
 use LaTeXML::Common::Config;
 use LaTeXML::Common::Error;
-use LaTeXML::Util::Pathname qw(pathname_is_literaldata);
+use LaTeXML::Util::Pathname;
 use URI::Escape;
 use HTTP::Response;
 use HTTP::Request;

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -993,7 +993,7 @@ DefPrimitive('\markboth{}{}',    undef);
 DefPrimitiveI('\leftmark',  undef, undef);
 DefPrimitiveI('\rightmark', undef, undef);
 DefPrimitive('\pagenumbering{}', undef);
-DefMacro('\@mkboth', '\@gobbletwo');    # default, just in case
+#DefMacro('\@mkboth', '\@gobbletwo');    # default, just in case
 DefMacro('\ps@empty',
   '\let\@mkboth\@gobbletwo\let\@oddhead\@empty\let\@oddfoot\@empty' .
     '\let\@evenhead\@empty\let\@evenfoot\@empty');
@@ -3949,8 +3949,12 @@ Let('\@@input', '\input');    # Save TeX's version.
                               # LaTeX's \input is a bit different...
 DefMacroI('\input', undef, '\@ifnextchar\bgroup\@iinput\@@input');
 DefPrimitive('\@iinput {}', sub { Input(Expand($_[1])); });
-DefMacro('\@input{}',  '\IfFileExists{#1}{\@@input\@filef@und}{\typeout{No file #1.}}}');
+DefMacro('\@input{}',  '\IfFileExists{#1}{\@@input\@filef@und}{\typeout{No file #1.}}');
 DefMacro('\@input@{}', '\InputIfFileExists{#1}{}{\typeout{No file #1.}}');
+
+DefMacro('\quote@name{}',          '"\quote@@name#1\@gobble""');
+DefMacro('\quote@@name{} Match:"', '#1\quote@@name');
+DefMacro('\unquote@name{}',        '\quote@@name#1\@gobble"');
 
 # Note that even excluded files SHOULD have the effects of their inclusion
 # simulated by having read the corresponding aux file;
@@ -5613,19 +5617,19 @@ DefMacro('\IfFileExists{}{}{}', sub {
     my ($gullet, $file, $if, $else) = @_;
     my $file_string = ToString(Expand($file));
     if (FindFile($file_string)) {
-      DefMacroI('\@filef@und', undef, $file);
-      return $if->unlist; }
+      DefMacro('\@filef@und', '"' . $file_string . '" ');
+      return ($if->unlist); }
     else {
-      return $else->unlist; } });
+      return ($else->unlist); } });
 
 DefMacro('\InputIfFileExists{}{}{}', sub {
     my ($gullet, $file, $if, $else) = @_;
     my $file_string = ToString(Expand($file));
-    if (my $path = FindFile($file_string)) {
-      DefMacroI('\@filef@und', undef, $file);
-      Input($path);
-      $if->unlist; }
-    else { $else->unlist; } });
+    if (FindFile($file_string)) {
+      DefMacro('\@filef@und', '"' . $file_string . '" ');
+      Input($file_string);
+      return ($if->unlist); }
+    else { return ($else->unlist); } });
 
 #======================================================================
 # Hair

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -98,7 +98,7 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
     else {
       InputDefinitions('OmniBus', type => 'cls', noerror => 1,
         handleoptions => 1, options => $options,
-        after => Tokens(T_CS('\compat@loadpackages')));
+        after         => Tokens(T_CS('\compat@loadpackages')));
       RequirePackage($class, options => $options, as_class => 1); }
     return; });
 
@@ -472,7 +472,7 @@ sub makeNoteTags {
       tags => Digest(T_BEGIN,
         T_CS('\def'), T_CS('\the' . $counter), T_BEGIN, Revert($tag), T_END,
         T_CS('\def'), T_CS('\typerefnum@' . $counter),
-        T_BEGIN, T_CS('\\' . $counter . 'typerefname'), T_SPACE, Revert($tag), T_END,
+        T_BEGIN,      T_CS('\\' . $counter . 'typerefname'), T_SPACE, Revert($tag), T_END,
         Invocation(T_CS('\lx@make@tags'), T_OTHER($counter)),
         T_END)); }
   else {
@@ -607,11 +607,11 @@ DefMacro('\@startsection{}{}{}{}{}{} OptionalMatch:*', sub {
       || LookupValue('no_number_sections')) {
       # No number, but in TOC
       (T_CS('\par'), T_CS('\@startsection@hook'), T_CS('\\@@unnumbered@section'),
-        T_BEGIN, $type->unlist, T_END,
+        T_BEGIN, $type->unlist,  T_END,
         T_BEGIN, T_OTHER('toc'), T_END); }
     else {          # Number and in TOC
       (T_CS('\par'), T_CS('\@startsection@hook'), T_CS('\\@@numbered@section'),
-        T_BEGIN, $type->unlist, T_END,
+        T_BEGIN, $type->unlist,  T_END,
         T_BEGIN, T_OTHER('toc'), T_END); } });
 
 # Not sure if this is best, but if no explicit \section'ing...
@@ -993,6 +993,7 @@ DefPrimitive('\markboth{}{}',    undef);
 DefPrimitiveI('\leftmark',  undef, undef);
 DefPrimitiveI('\rightmark', undef, undef);
 DefPrimitive('\pagenumbering{}', undef);
+DefMacro('\@mkboth', '\@gobbletwo');    # default, just in case
 DefMacro('\ps@empty',
   '\let\@mkboth\@gobbletwo\let\@oddhead\@empty\let\@oddfoot\@empty' .
     '\let\@evenhead\@empty\let\@evenfoot\@empty');
@@ -1042,7 +1043,7 @@ DefConstructor('\person@thanks{}', "^ <ltx:contact role='thanks'>#1</ltx:contact
   alias => '\thanks', mode => 'text');
 DefConstructor('\@personname{}', "<ltx:personname>#1</ltx:personname>",
   beforeDigest => sub { Let('\thanks', '\person@thanks'); },
-  bounded => 1, mode => 'text');
+  bounded      => 1, mode => 'text');
 
 DefConstructorI('\and', undef, " and ");
 
@@ -1185,7 +1186,7 @@ DefEnvironment('{titlepage}', '<ltx:titlepage>#body',
       "When using titlepage, Frontmatter will not be well-structured");
     return; },
   beforeDigestEnd => sub { Digest(T_CS('\maybe@end@title')); },
-  locked => 1, mode => 'text');
+  locked          => 1, mode => 'text');
 
 Tag('ltx:titlepage', autoClose => 1);
 DefConstructorI('\maybe@end@title', undef, sub {
@@ -1402,7 +1403,7 @@ sub RefStepItemCounter {
         T_CS('\let'), T_CS('\the' . $counter),   T_CS('\@empty'),
         T_CS('\def'), T_CS('\fnum@' . $counter), T_BEGIN, $formatter, T_BEGIN, Revert($tag), T_END, T_END,
         T_CS('\def'), T_CS('\typerefnum@' . $counter),
-        T_BEGIN, $typename, T_SPACE, Revert($tag), T_END,
+        T_BEGIN,      $typename, T_SPACE, Revert($tag), T_END,
         Invocation(T_CS('\lx@make@tags'), T_OTHER($counter)),
         T_END);
 
@@ -1729,7 +1730,7 @@ DefConstructorI('\lx@@verbatim', undef,
     my ($stomach) = @_;
     StartSemiverbatim('%', '\\', '{', '}');
     MergeFont(family => 'typewriter', series => 'medium', shape => 'upright');
-    $STATE->assignCatcode(' ', CC_ACTIVE);            # Do NOT (necessarily) skip spaces after \verb!!!
+    $STATE->assignCatcode(' ', CC_ACTIVE);    # Do NOT (necessarily) skip spaces after \verb!!!
     Let(T_ACTIVE(' '), T_SPACE); });
 DefConstructorI('\lx@end@verbatim', undef,
   "</ltx:verbatim>",
@@ -2633,7 +2634,7 @@ DefPrimitive('\DeclareFontFamily{}{}{}',      undef);
 DefPrimitive('\DeclareSizeFunction{}{}',      undef);
 
 my $symboltype_roles = {
-  '\mathord' => 'ID', '\mathop' => 'BIGOP', '\mathbin' => 'BINOP', '\mathrel' => 'RELOP',
+  '\mathord'  => 'ID',   '\mathop'    => 'BIGOP', '\mathbin'   => 'BINOP', '\mathrel' => 'RELOP',
   '\mathopen' => 'OPEN', '\mathclose' => 'CLOSE', '\mathpunct' => 'PUNCT' };
 DefPrimitive('\DeclareMathSymbol DefToken SkipSpaces DefToken {}{Number}', sub {
     my ($stomach, $cs, $type, $font, $code) = @_;
@@ -2653,7 +2654,7 @@ Let('\cdp@elt', '\relax');
 DefPrimitive('\DeclareFontEncoding{}{}{}', sub {
     my ($stomach, $encoding, $x, $y) = @_;
     AddToMacro(T_CS('\cdp@list'), T_CS('\cdp@elt'),
-      T_BEGIN, $_[1]->unlist, T_END,
+      T_BEGIN, $_[1]->unlist,           T_END,
       T_BEGIN, T_CS('\default@family'), T_END,
       T_BEGIN, T_CS('\default@series'), T_END,
       T_BEGIN, T_CS('\default@shape'),  T_END);
@@ -2882,7 +2883,7 @@ sub defineNewTheorem {
         $headformatter->unlist,
         T_BEGIN, ($type ? $type->unlist : ()), T_END,
         T_CS('\the' . $counter), T_BEGIN, Tokens(T_PARAM, T_OTHER('1')), T_END,
-        T_CS('\the'), T_CS('\thm@headpunct'))
+        T_CS('\the'),            T_CS('\thm@headpunct'))
       : '{\the\thm@headfont\lx@tag{\csname fnum@' . $thmset . '\endcsname}'
         . '{' . ($type ? '\ifx.#1.\else\space\the\thm@notefont(#1)\fi' : '#1') . '}'
         . '\the\thm@headpunct}'),
@@ -3851,7 +3852,7 @@ DefMacro('\lx@mung@bibliography{}', sub {
     if (($tag eq 'enumerate') || ($tag eq 'itemize') || ($tag eq 'description')) {
       # nDamn! We're in a list {$tag}; try to close it!
       push(@tokens, Invocation('\end', $env),
-        T_CS('\let'), T_CS('\end' . $tag), T_CS('\endthebibliography'),
+        T_CS('\let'), T_CS('\end' . $tag),        T_CS('\endthebibliography'),
         T_CS('\let'), T_CS('\end{' . $tag . '}'), T_CS('\end{thebibliography}')); }
     # else ? it probably isn't going to work??
     # Now, try to open {thebibliography}
@@ -3948,6 +3949,8 @@ Let('\@@input', '\input');    # Save TeX's version.
                               # LaTeX's \input is a bit different...
 DefMacroI('\input', undef, '\@ifnextchar\bgroup\@iinput\@@input');
 DefPrimitive('\@iinput {}', sub { Input(Expand($_[1])); });
+DefMacro('\@input{}',  '\IfFileExists{#1}{\@@input\@filef@und}{\typeout{No file #1.}}}');
+DefMacro('\@input@{}', '\InputIfFileExists{#1}{}{\typeout{No file #1.}}');
 
 # Note that even excluded files SHOULD have the effects of their inclusion
 # simulated by having read the corresponding aux file;
@@ -4355,7 +4358,7 @@ DefConstructor('\@framebox[Dimension][]{}',
     . "(<ltx:text ?#width(width='#width') ?#align(align='#align')"
     . " framed='rectangle' framecolor='#framecolor'"
     . " _noautoclose='1'>#3</ltx:text>)",
-  alias => '\framebox', sizer => '#3',
+  alias        => '\framebox', sizer => '#3',
   beforeDigest => sub {
     my ($stomach) = @_;
     my $wasmath = LookupValue('IN_MATH');
@@ -4447,7 +4450,7 @@ DefConstructor('\parbox[][Dimension][]{Dimension} VBoxContents', sub {
     (width => $_[4],
       vattach => translateAttachment($_[1]),
       height  => $_[2]); },
-  mode => 'text', bounded => 1,
+  mode         => 'text', bounded => 1,
   beforeDigest => sub {
     AssignValue('\hsize' => $_[4]);
     Let('\\\\', '\lx@parboxnewline'); });
@@ -4856,12 +4859,18 @@ DefPrimitive('\selectfont', sub {
     my $family = ToString(Expand(T_CS('\f@family')));
     my $series = ToString(Expand(T_CS('\f@series')));
     my $shape  = ToString(Expand(T_CS('\f@shape')));
-    if (my $sh = LaTeXML::Common::Font::lookupFontFamily($family)) { MergeFont(%$sh); }
-    else { Info('unexpected', $family, $_[0], "Unrecognized font family '$family'."); }
-    if (my $sh = LaTeXML::Common::Font::lookupFontSeries($series)) { MergeFont(%$sh); }
-    else { Info('unexpected', $series, $_[0], "Unrecognized font series '$series'."); }
-    if (my $sh = LaTeXML::Common::Font::lookupFontShape($shape)) { MergeFont(%$sh); }
-    else { Info('unexpected', $shape, $_[0], "Unrecognized font shape '$shape'."); }
+    if    (my $sh = LaTeXML::Common::Font::lookupFontFamily($family)) { MergeFont(%$sh); }
+    elsif (!LookupValue("reported_unrecognized_font_family_$family")) {
+      AssignValue("reported_unrecognized_font_family_$family", 1, 'global');
+      Info('unexpected', $family, $_[0], "Unrecognized font family '$family'."); }
+    if    (my $sh = LaTeXML::Common::Font::lookupFontSeries($series)) { MergeFont(%$sh); }
+    elsif (!LookupValue("reported_unrecognized_font_series_$series")) {
+      AssignValue("reported_unrecognized_font_series_$series", 1, 'global');
+      Info('unexpected', $series, $_[0], "Unrecognized font series '$series'."); }
+    if    (my $sh = LaTeXML::Common::Font::lookupFontShape($shape)) { MergeFont(%$sh); }
+    elsif (!LookupValue("reported_unrecognized_font_shape_$shape")) {
+      AssignValue("reported_unrecognized_font_shape_$shape", 1, 'global');
+      Info('unexpected', $shape, $_[0], "Unrecognized font shape '$shape'."); }
     return; });
 
 DefMacro('\usefont{}{}{}{}',
@@ -4869,32 +4878,32 @@ DefMacro('\usefont{}{}{}{}',
 
 # If these series or shapes appear in math, they revert it to roman, medium, upright (?)
 DefConstructor('\textmd@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { series => 'medium' }, alias => '\textmd',
+  bounded      => 1, font => { series => 'medium' }, alias => '\textmd',
   beforeDigest => sub { DefMacro('\f@series', 'm'); });
 DefConstructor('\textbf@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { series => 'bold' }, alias => '\textbf',
+  bounded      => 1, font => { series => 'bold' }, alias => '\textbf',
   beforeDigest => sub { DefMacro('\f@series', 'b'); });
 DefConstructor('\textrm@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { family => 'serif' }, alias => '\textrm',
+  bounded      => 1, font => { family => 'serif' }, alias => '\textrm',
   beforeDigest => sub { DefMacro('\f@family', 'cm'); });
 DefConstructor('\textsf@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { family => 'sansserif' }, alias => '\textsf',
+  bounded      => 1, font => { family => 'sansserif' }, alias => '\textsf',
   beforeDigest => sub { DefMacro('\f@family', 'cmss'); });
 DefConstructor('\texttt@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { family => 'typewriter' }, alias => '\texttt',
+  bounded      => 1, font => { family => 'typewriter' }, alias => '\texttt',
   beforeDigest => sub { DefMacro('\f@family', 'cmtt'); });
 
 DefConstructor('\textup@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'upright' }, alias => '\textup',
+  bounded      => 1, font => { shape => 'upright' }, alias => '\textup',
   beforeDigest => sub { DefMacro('\f@shape', ''); });
 DefConstructor('\textit@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'italic' }, alias => '\textit',
+  bounded      => 1, font => { shape => 'italic' }, alias => '\textit',
   beforeDigest => sub { DefMacro('\f@shape', 'i'); });
 DefConstructor('\textsl@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'slanted' }, alias => '\textsl',
+  bounded      => 1, font => { shape => 'slanted' }, alias => '\textsl',
   beforeDigest => sub { DefMacro('\f@shape', 'sl'); });
 DefConstructor('\textsc@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'smallcaps' }, alias => '\textsc',
+  bounded      => 1, font => { shape => 'smallcaps' }, alias => '\textsc',
   beforeDigest => sub { DefMacro('\f@shape', 'sc'); });
 DefConstructor('\textnormal@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
   bounded => 1, font => { family => 'serif', series => 'medium', shape => 'upright' }, alias => '\textnormal',
@@ -4917,7 +4926,7 @@ DefPrimitive('\DeclareTextFontCommand{}{}', sub {
     my ($stomach, $cmd, $font) = @_;
     DefConstructorI($cmd, "{}",
       "?#isMath(<ltx:text _noautoclose='1'>#1</ltx:text>)(#1)",
-      mode => 'text', bounded => 1,
+      mode         => 'text', bounded => 1,
       beforeDigest => sub { Digest($font); (); });
     return; });
 
@@ -5602,14 +5611,19 @@ EoTeX
 
 DefMacro('\IfFileExists{}{}{}', sub {
     my ($gullet, $file, $if, $else) = @_;
-    $file = ToString(Expand($file));
-    (FindFile($file) ? $if->unlist : $else->unlist); });
+    my $file_string = ToString(Expand($file));
+    if (FindFile($file_string)) {
+      DefMacroI('\@filef@und', undef, $file);
+      return $if->unlist; }
+    else {
+      return $else->unlist; } });
 
 DefMacro('\InputIfFileExists{}{}{}', sub {
     my ($gullet, $file, $if, $else) = @_;
-    $file = ToString(Expand($file));
-    if (FindFile($file)) {
-      Input($file);
+    my $file_string = ToString(Expand($file));
+    if (my $path = FindFile($file_string)) {
+      DefMacroI('\@filef@und', undef, $file);
+      Input($path);
       $if->unlist; }
     else { $else->unlist; } });
 

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -993,7 +993,7 @@ DefPrimitive('\markboth{}{}',    undef);
 DefPrimitiveI('\leftmark',  undef, undef);
 DefPrimitiveI('\rightmark', undef, undef);
 DefPrimitive('\pagenumbering{}', undef);
-#DefMacro('\@mkboth', '\@gobbletwo');    # default, just in case
+DefMacro('\@mkboth', '\@gobbletwo');    # default, just in case
 DefMacro('\ps@empty',
   '\let\@mkboth\@gobbletwo\let\@oddhead\@empty\let\@oddfoot\@empty' .
     '\let\@evenhead\@empty\let\@evenfoot\@empty');


### PR DESCRIPTION
### Book discussion

An impressive book-sized manuscript made the rounds recently, at [arXiv:2105.10386](https://arxiv.org/abs/2105.10386), totaling 419 PDF pages.

With this PR, the conversion with latexml parses over 16,000 math expressions, makes an index of 500 entries and finishes in a total of 12 minutes, without errors. It has 415 warnings, mostly due to math parsing.

The run seems to do quite well with the custom `.sty` file of the book, OmniBus recovers well the custom `.cls` and loads the dependencies. Impressively latexml does quite well with raw interpretation of three unsual styles: `nomencl.sty`, `combelow.sty` and `letltxmacro.sty`, all of which are loaded raw.

The book can be converted into a 8.5MB-sized ePub file, which I'll attach here for a preview until we merged. Also, here's a screenshot from calibre, which really lags under the size, but manages to render in 3 columns on my wide screen:
![image](https://user-images.githubusercontent.com/348975/120868562-4e88ff00-c562-11eb-91e5-9c070e9e3e6b.png)

[aobf.epub.gz](https://github.com/brucemiller/LaTeXML/files/6601495/aobf.epub.gz)
(of course I had to gzip it for github to accept the attachment...)

### Patches

The book was written in a way where it was almost fully supported by latexml, but for a handful of custom bits.
 * A binding typo had to be fixed (which I also fixed in #1525 , but that's ok, either PR can be rebased when the time comes).
 * Some internal input-related macros had to be added
 * And I suppressed one of the font-related info messages which was printing once on each line of the TeX source file (i.e. thousands of prints with the same message).

For some strange reason the babel greek test broke, adding an extra space char, so I have to troubleshoot that before we can merge...
