### PR TITLE
Softer alignment errors

### DIFF
--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -175,6 +175,13 @@ INVOKE:
     elsif ($CATCODE_ABSORBABLE[$cc]) {
       @result = $self->invokeToken_simple($token, $meaning); }
     else {
+      # Special error guard for the align char "&":
+      # Locally deactivate to avoid a flurry of errors in the same table.
+      # Alert the end user once per table, allowing longer documents to not
+      # hit 100 errors too quickly.
+      $STATE->assignMeaning(T_ALIGN,
+        $STATE->lookupMeaning(T_CS('\relax')), 'local')
+        if Equals($token, T_ALIGN);
       Error('misdefined', $token, $self,
         "The token " . Stringify($token) . " should never reach Stomach!");
       @result = $self->invokeToken_simple($token, $meaning); } }
@@ -357,7 +364,7 @@ sub setMode {
     # but inherit color and size
     $STATE->assignValue(font => $STATE->lookupValue('savedfont')->merge(
         color => $curfont->getColor, background => $curfont->getBackground,
-        size => $curfont->getSize), 'local'); }
+        size  => $curfont->getSize), 'local'); }
   return; }
 
 sub beginMode {


### PR DESCRIPTION
Another angle of attack for reducing the Fatal errors in arXiv and other yet-to-be-remediated long documents.

Currently, latexml will raise an error for every unexpected alignment token it encounters outside of some tabular environment. So in a document with e.g. `xymatrix` today, after 100 cells, the processing will emit 100 errors, hence a Fatal error and halt.

A random document I drew from cortex is [math0002083](https://corpora.mathweb.org/preview/arxmliv/tex%5Fto%5Fhtml/math0002083), encounters 40 errors of this nature. With this PR, that document only encounters 9 errors, 7 of which for alignments - and indeed we can count exactly one such error per used xymatrix environment.

The trick I found was to let the alignment to `\relax` for just the **current local TeX scope**, which elegantly suppresses any following T_ALIGNS, until the environment is closed. This may save a very large number of errors in bigger tables. Thoughts?