### PR TITLE
Patch expl3.sty regression on texlive 2020

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -103,7 +103,7 @@ our @EXPORT = (qw(&DefAutoload &DefExpandable
     &LookupLCcode &AssignLCcode
     &LookupUCcode &AssignUCcode
     &LookupDelcode &AssignDelcode
-    ),
+  ),
 
   # Random low-level token or string operations.
   qw(&CleanID &CleanLabel &CleanIndexKey  &CleanClassName &CleanBibKey &NormalizeBibKey &CleanURL
@@ -443,7 +443,7 @@ sub roman_aux {
   while ($n %= $div) {
     $div /= 10;
     my $d = int($n / $div);
-    if ($d % 5 == 4) { $s .= $rmletters[$p];               $d++; }
+    if ($d % 5 == 4) { $s .= $rmletters[$p]; $d++; }
     if ($d > 4)      { $s .= $rmletters[$p + int($d / 5)]; $d %= 5; }
     if ($d)          { $s .= $rmletters[$p] x $d; }
     $p -= 2; }
@@ -544,8 +544,8 @@ sub ComposeURL {
   $fragid = ToString($fragid);
   return CleanURL(join('',
       ($base ?
-          ($url =~ /^\w+:/ ? ''                            # already has protocol, so is absolute url
-          : $base . ($url =~ /^\// ? '' : '/'))            # else start w/base, possibly /
+          ($url =~ /^\w+:/ ? ''    # already has protocol, so is absolute url
+          : $base . ($url =~ /^\// ? '' : '/'))    # else start w/base, possibly /
         : ''),
       $url,
       ($fragid ? '#' . CleanID($fragid) : ''))); }
@@ -2065,7 +2065,7 @@ sub Input {
       loadTeXDefinitions($request, $path); }
     else {
       loadTeXContent($path); } }
-  else {                                     # Couldn't find anything?
+  else {    # Couldn't find anything?
     $STATE->noteStatus(missing => $request);
     # We presumably are trying to input Content; an error if we can't find it (contrast to Definitions)
     Error('missing_file', $request, $STATE->getStomach->getGullet,
@@ -2133,7 +2133,7 @@ sub loadTeXDefinitions {
   $stomach->getGullet->readingFromMouth(
     LaTeXML::Core::Mouth->create($pathname,
       fordefinitions => 1, notes => 1,
-      content => LookupValue($pathname . '_contents')),
+      content        => LookupValue($pathname . '_contents')),
     sub {
       my ($gullet) = @_;
       my $token;
@@ -2290,7 +2290,7 @@ sub AddToMacro {
 #======================================================================
 my $inputdefinitions_options = {    # [CONSTANT]
   options          => 1, withoptions => 1, handleoptions => 1,
-  type             => 1, as_class    => 1, noltxml => 1, notex => 1, noerror => 1, after => 1,
+  type             => 1, as_class    => 1, noltxml       => 1, notex => 1, noerror => 1, after => 1,
   searchpaths_only => 1 };
 #   options=>[options...]
 #   withoptions=>boolean : pass options from calling class/package
@@ -2330,6 +2330,7 @@ sub InputDefinitions {
   if (my $file = FindFile($filename, type => $options{type},
       notex => $options{notex}, noltxml => $options{noltxml}, searchpaths_only => $options{searchpaths_only})) {
     if ($options{handleoptions}) {
+# Note: this is trying to emulate the LaTeX 2 (latex.ltx) use of \@pushfilename. For expl3, see expl3.sty.ltxml
       Digest(T_CS('\@pushfilename'));
       # For \RequirePackageWithOptions, pass the options from the outer class/style to the inner one.
       if (my $passoptions = $options{withoptions} && $prevname
@@ -2394,7 +2395,7 @@ sub InputDefinitions {
 
 my $require_options = {    # [CONSTANT]
   options => 1, withoptions => 1, type => 1, as_class => 1,
-  noltxml => 1, notex => 1, raw => 1, after => 1, searchpaths_only => 1 };
+  noltxml => 1, notex       => 1, raw  => 1, after    => 1, searchpaths_only => 1 };
 # This (& FindFile) needs to evolve a bit to support reading raw .sty (.def, etc) files from
 # the standard texmf directories.  Maybe even use kpsewhich itself (INSTEAD of pathname_find ???)
 # Another potentially useful option might be that if we are reading a raw file,

--- a/lib/LaTeXML/Package/expl3.sty.ltxml
+++ b/lib/LaTeXML/Package/expl3.sty.ltxml
@@ -21,6 +21,7 @@ InputDefinitions('expl3', type => 'sty', noltxml => 1);
 # Redefine aux macro to avoid reliance on argument ordering artefacts in latex.ltx
 # The purpose here was originally to set `\g_file_curr_name_str`,
 #  but I am unsure if it is used anywhere currently?
-DefMacroI('\@pushfilenameaux', undef, Tokens(), locked => 1);
+DefMacroI('\@pushfilenameaux',          undef, Tokens(), locked => 1);
+DefMacroI('\@expl@push@filename@aux@@', undef, Tokens(), locked => 1);
 
 1;


### PR DESCRIPTION
Fixes #1454 .

Now that I updated my texlive and can reproduce locally, I traced this issue to one of my older patches in `Package::InputDefinitions` which hardcoded a little too closely the LaTeX 2 behavior of a standalone `Digest(T_CS('\@pushfilename'))` while loading e.g. a new .sty package with definitions.

In LaTeX 3 that internal macro gets extended to do more token interplay with the rest of the input stream, so my standalone `Digest` call creates the errors reported in the issue - and I could reproduce those clearly.

However, the expl3 metadata fishing is a bit of a hack in all honesty: It relies on the exact placement of `\@pushfilename` in the original `latex.ltx`. You move that macro e.g. a line or two down, or worse - change the definition pattern on the line after - and it will completely break its behavior. So my instinct again was that we shouldn't be emulating that directly. Which lead me to the comment we have had in `expl3.sty.ltxml`:

```
# Redefine aux macro to avoid reliance on argument ordering artefacts in latex.ltx
# The purpose here was originally to set `\g_file_curr_name_str`,
#  but I am unsure if it is used anywhere currently?
```

Which deactivated the `\@pushfilenameaux` in previous texlives.  I think the original point still holds, so I also deactivated the equally hacky `\@expl@push@filename@aux@@`, making the surface error disappear.

Happily, our expl3 tests had not regressed, and the core interpretation is still solid on texlive 2020 (for the degree we've tested it).