### PR TITLE
Less arxiv fatals

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -691,6 +691,7 @@ lib/LaTeXML/Package/wiki.sty.ltxml
 lib/LaTeXML/Package/wrapfig.sty.ltxml
 lib/LaTeXML/Package/xargs.sty.ltxml
 lib/LaTeXML/Package/xcolor.sty.ltxml
+lib/LaTeXML/Package/xfrac.sty.ltxml
 lib/LaTeXML/Package/xkeyval.sty.ltxml
 lib/LaTeXML/Package/xkvview.sty.ltxml
 lib/LaTeXML/Package/xparse.sty.ltxml

--- a/MANIFEST
+++ b/MANIFEST
@@ -589,6 +589,7 @@ lib/LaTeXML/Package/preview.sty.ltxml
 lib/LaTeXML/Package/proofwiki.sty.ltxml
 lib/LaTeXML/Package/psfig.sty.ltxml
 lib/LaTeXML/Package/psfig.tex.ltxml
+lib/LaTeXML/Package/psfrag.sty.ltxml
 lib/LaTeXML/Package/pslatex.sty.ltxml
 lib/LaTeXML/Package/pspicture.sty.ltxml
 lib/LaTeXML/Package/pst-grad.sty.ltxml

--- a/lib/LaTeXML/Common/Model.pm
+++ b/lib/LaTeXML/Common/Model.pm
@@ -253,7 +253,7 @@ sub encodeQName {
 # NOTE: Reconsider how _Capture_ & _WildCard_ should be integrated!?!
 sub getNodeQName {
   my ($self, $node) = @_;
-  my $type = $node->nodeType;
+  my $type = ($node ? $node->nodeType : -1);
   if ($type == XML_TEXT_NODE) {
     return '#PCDATA'; }
   elsif ($type == XML_DOCUMENT_NODE) {

--- a/lib/LaTeXML/Common/XML.pm
+++ b/lib/LaTeXML/Common/XML.pm
@@ -91,19 +91,19 @@ our $XML_NS   = 'http://www.w3.org/XML/1998/namespace';    # [CONSTANT]
 # XML Utilities
 sub element_nodes {
   my ($node) = @_;
-  return grep { $_->nodeType == XML_ELEMENT_NODE } $node->childNodes; }
+  return ($node ? grep { $_->nodeType == XML_ELEMENT_NODE } $node->childNodes : ()); }
 
 sub text_in_node {
   my ($node) = @_;
-  return join("\n", map { $_->data } grep { $_->nodeType == XML_TEXT_NODE } $node->childNodes); }
+  return ($node ? join("\n", map { $_->data } grep { $_->nodeType == XML_TEXT_NODE } $node->childNodes) : ''); }
 
 sub isTextNode {
   my ($node) = @_;
-  return $node->nodeType == XML_TEXT_NODE; }
+  return ($node ? $node->nodeType == XML_TEXT_NODE : 0); }
 
 sub isElementNode {
   my ($node) = @_;
-  return $node->nodeType == XML_ELEMENT_NODE; }
+  return ($node ? $node->nodeType == XML_ELEMENT_NODE : 0); }
 
 # Is $child a child of $parent?
 sub isChild {

--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -704,7 +704,7 @@ sub guess_alignment_headers {
   my ($document, $table, $alignment) = @_;
   # Assume that headers don't make sense for nested tables.
   # OR Maybe we should only do this within table environments???
-  return if $document->findnodes("ancestor::ltx:tabular", $table);
+  return if !$table || $document->findnodes("ancestor::ltx:tabular", $table);
 
   my $tag = $document->getModel->getNodeQName($table);
   my $x;

--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -121,14 +121,14 @@ sub rows {
 
 sub addLine {
   my ($self, $border, @cols) = @_;
-  my $row = $$self{current_row};
-  if (@cols) {
-    foreach my $c (@cols) {
-      my $colspec = $row->column($c);
-      $$colspec{border} .= $border; } }
-  else {
-    foreach my $colspec (@{ $$row{columns} }) {
-      $$colspec{border} .= $border; } }
+  if (my $row = $$self{current_row}) {
+    if (@cols) {
+      foreach my $c (@cols) {
+        my $colspec = $row->column($c);
+        $$colspec{border} .= $border; } }
+    else {
+      foreach my $colspec (@{ $$row{columns} }) {
+        $$colspec{border} .= $border; } } }
   return; }
 
 sub nextColumn {

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -556,11 +556,11 @@ sub readUntil {
         $nbraces++;
         push(@tokens, $self->readBalanced, T_END); } } }
   else {
+
     my @ring = ();
     while (1) {
       # prefill the required number of tokens
-      while (scalar(@ring) < $ntomatch) {
-        $token = $self->readToken;
+      while ((scalar(@ring) < $ntomatch) && ($token = $self->readToken)) {
         if ($$token[1] == CC_BEGIN) {    # read balanced, and refill ring.
           $nbraces++;
           push(@tokens, @ring, $token, $self->readBalanced, T_END);    # Copy directly to result
@@ -568,11 +568,12 @@ sub readUntil {
         else {
           push(@ring, $token); } }
       my $i;
-      for ($i = 0 ; ($i < $ntomatch) && ($ring[$i]->equals($want[$i])) ; $i++) { }    # Test match
-      last if $i >= $ntomatch;                                                        # Matched all!
+      for ($i = 0 ; ($i < $ntomatch) && $ring[$i] && ($ring[$i]->equals($want[$i])) ; $i++) { } # Test match
+      last if $i >= $ntomatch;    # Matched all!
+      last unless $token;
       push(@tokens, shift(@ring)); } }
-  if (!defined $token) {                                                              # Ran out!
-    $self->unread(@tokens);    # Not more correct, but maybe less confusing?
+  if (!defined $token) {          # Ran out!
+    $self->unread(@tokens);       # Not more correct, but maybe less confusing?
     return; }
   # Notice that IFF the arg looks like {balanced}, the outer braces are stripped
   # so that delimited arguments behave more similarly to simple, undelimited arguments.

--- a/lib/LaTeXML/Core/Parameters.pm
+++ b/lib/LaTeXML/Core/Parameters.pm
@@ -61,7 +61,7 @@ sub readArguments {
   my @args = ();
   $gullet->setup_scan();
   my ($p, $v);
-  return map { $p = $_; $v = $p->read($gullet, $fordefn); ($$p{novalue} ? () : $v); } @$self; }
+  return map { $p = $_; $v = $p && $p->read($gullet, $fordefn); ($$p{novalue} ? () : $v); } @$self; }
 
 sub readArgumentsAndDigest {
   my ($self, $stomach, $fordefn) = @_;

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -133,14 +133,15 @@ DefEnvironment('{keywords}', '',
     return; });
 # Extend to be callable as \keywords{} or \begin{keywords}...
 # Probably want to use this trick more often?
+Let('\lx@begin@keywords', '\keywords');
 DefMacro('\keywords', sub {
     my ($gullet) = @_;
     ($gullet->ifNext(T_BEGIN)
       ? (T_CS('\keywords@onearg'))
       : (T_CS('\g@addto@macro'), T_CS('\@startsection@hook'), T_CS('\maybe@end@keywords'),
-        T_CS('\begin{keywords}'))); });
+        T_CS('\lx@begin@keywords'))); });
 DefMacro('\keywords@onearg{}', '\begin{keywords}#1\end{keywords}\let\endkeywords\relax');
-DefMacroI('\maybe@end@keywords', undef, '\endkeywords');
+DefMacroI('\maybe@end@keywords', undef, '\endkeywords\let\maybe@end@keywords\relax');
 
 DefMacro('\classification{}', '\@add@frontmatter{ltx:classification}{#1}');
 DefMacro('\pacs{}',           '\@add@frontmatter{ltx:classification}[scheme=pacs]{#1}');

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -70,7 +70,9 @@ Let('\notag', '\nonumber');
 
 DefMacro('\tag OptionalMatch:* {}',
   # expand \theequation, but in text mode! undo formatting if *
-'\lx@equation@settag{\ifx#1*\let\fnum@equation\relax\fi\edef\theequation{#2}\lx@make@tags{equation}}');
+  '\lx@equation@settag{\ifx#1*\let\fnum@equation\relax\fi'
+    . '\expandafter\def\expandafter\theequation\expandafter{#2}'
+    . '\lx@make@tags{equation}}');
 
 # Note that \intertext may or may not be preceded by an explicit \\, with no apparent difference in TeX.
 # latexml, however, can end up with 2, which end up incrementing coutners twice!

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -64,17 +64,17 @@ DefMacro('\lstinline OptionalKeyVals:LST', sub {
       @{ LookupValue('LISTINGS_POSTAMBLE') },
       T_END); });                  # to balance ->bgroup
 
-DefPrimitive('\lstMakeShortInline [] Token', sub {
+DefPrimitive('\lstMakeShortInline [] DefToken', sub {
     my ($stomach, $kv, $token) = @_;
     my $ch = $token->getString;
     AssignMapping('LST_SHORT_INLINE',
       $ch => [LookupCatcode($ch) // CC_OTHER, $STATE->lookupMeaning($token)]);
     AssignCatcode($ch, CC_ACTIVE);
     DefMacro(T_ACTIVE($ch),
-      Tokens(T_CS('\lstinline'), T_OTHER('['), $kv, T_OTHER(']'), T_ACTIVE($ch)));
+      Tokens(T_CS('\lstinline'), ($kv ? (T_OTHER('['), $kv, T_OTHER(']')) : ()), T_ACTIVE($ch)));
     return; });
 
-DefPrimitive('\lstDeleteShortInline Token', sub {
+DefPrimitive('\lstDeleteShortInline DefToken', sub {
     my ($stomach, $token) = @_;
     my $ch = $token->getString;
     if (my $entry = LookupMapping('LST_SHORT_INLINE', $ch)) {

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -230,6 +230,15 @@ DefMacro('\pgfmathfactorial@', sub {
 DefMacro('\pgfmathreciprocal@ pgfNumber', sub {
     return pgfmathresult(1 / pgfmath_divisor($_[1])); });
 
+# Stuff for computability with the calc package .
+DefMacro('\pgfmath@calc@real {}',     '#1');
+DefMacro('\pgfmath@calc@minof {}{}',  'min(#1,#2)');
+DefMacro('\pgfmath@calc@maxof {}{}',  'max(#1,#2)');
+DefMacro('\pgfmath@calc@ratio {}{}',  '#1/#2');
+DefMacro('\pgfmath@calc@widthof {}',  'width("#1")');
+DefMacro('\pgfmath@calc@heightof {}', 'height("#1")');
+DefMacro('\pgfmath@calc@depthof {}',  'depth("#1")');
+
 sub pgfmath_divisor {
   my $divisor = 0.0 + $_[0];
   if (!$divisor) {
@@ -292,8 +301,16 @@ sub pgfmathparse {
   my ($gullet, $tokens) = @_;
   SetCondition(T_CS('\ifpgfmathunitsdeclared'),     0, 'global');
   SetCondition(T_CS('\ifpgfmathmathunitsdeclared'), 0, 'global');
+  # Stuff for calc compatibility.
+  Let('\real',     '\pgfmath@calc@real');
+  Let('\minof',    '\pgfmath@calc@minof');
+  Let('\maxof',    '\pgfmath@calc@maxof');
+  Let('\ratio',    '\pgfmath@calc@ratio');
+  Let('\widthof',  '\pgfmath@calc@widthof');
+  Let('\heightof', '\pgfmath@calc@heightof');
+  Let('\depthof',  '\pgfmath@calc@depthof');
   my $string = (ref $tokens ? ToString(Expand($tokens)->stripBraces) : $tokens);
-  $string =~ s/^\s+//; $string =~ s/\s+$//;
+  $string =~ s/^\s+//; $string =~ s/\s+$//; $string =~ s/\s+/ /gs;
   my $input = $string;
   my $result;
   $PGMATH_UNITS_REGEXP
@@ -319,6 +336,7 @@ sub pgfmathparse {
     $result         = $PGFMATHGrammar->expr(\$string); }
 
   $result = $result || 0.0;
+  $string =~ s/^[\)\]]+$//;    # Forgive excess trailing ) !?!?!?!?!
   if ($string) {
     Error('pgfparse', 'pgfparse', $gullet,
       "Parse of '$input' failed",
@@ -330,7 +348,7 @@ sub pgfmathparse {
   # NOT really correct, but would like to use an internal to distinguish 1.0 from int(1.0)!!!
   elsif ($result == int($result)) {
     $result = int($result) . '.'; }
-  else {    # We don't want scientific notation output!!!
+  else {                       # We don't want scientific notation output!!!
     $result = sprintf("%f", $result); }
   return $result; }
 
@@ -510,13 +528,14 @@ BEGIN {
     asin       => sub { rad2deg(asin($_[0])); },
     atan       => sub { rad2deg(atan($_[0])); },
     atan2      => sub { rad2deg(atan2($_[0], $_[1])); },
-    #    bin   => sub { },
-    ceil  => sub { ceil($_[0]); },
-    cos   => sub { cos(pgfmathargradians($_[0])); },
-    cosec => sub { cosec(pgfmathargradians($_[0])); },
-    cosh  => sub { cosh($_[0]); },
-    cot   => sub { cot(pgfmathargradians($_[0])); },
-    deg   => sub { rad2deg($_[0]); },
+    angle      => sub { rad2deg(atan2($_[0], $_[1])); },    # Assume same? Where's documentation?
+                                                            #    bin   => sub { },
+    ceil       => sub { ceil($_[0]); },
+    cos        => sub { cos(pgfmathargradians($_[0])); },
+    cosec      => sub { cosec(pgfmathargradians($_[0])); },
+    cosh       => sub { cosh($_[0]); },
+    cot        => sub { cot(pgfmathargradians($_[0])); },
+    deg        => sub { rad2deg($_[0]); },
     #    depth => sub { },
     exp       => sub { exp($_[0]); },
     factorial => sub { pgfmathfactorial($_[0]); },
@@ -629,7 +648,7 @@ expr :
     FUNCTION0 : /(?:e|pi|false|rand|rnd|true)/
         | /([a-zA-Z][a-zA-Z0-9]*)/ { LaTeXML::Package::Pool::pgfmath_checkuserconstant($item[1]); }
 
-    FUNCTION : /(?:abs|acos|asin|atan2|atan|bin|ceil|cos|cosec|cosh|cot|deg|exp|factorial|floor|frac|hex|Hex|int|iseven|isodd|isprime|ln|log10|log2|neg|not|oct|rad|real|round|sec|sign|sin|sinh|sqrt|tan|tanh|add|and|divide|div|equal|gcd|greater|less|max|min|mod|Mod|multiply|notequal|notgreater|notless|or|pow|random|subtract|ifthenelse|veclen)/
+    FUNCTION : /(?:abs|acos|asin|atan2|atan|angle|bin|ceil|cos|cosec|cosh|cot|deg|exp|factorial|floor|frac|hex|Hex|int|iseven|isodd|isprime|ln|log10|log2|neg|not|oct|rad|real|round|sec|sign|sin|sinh|sqrt|tan|tanh|add|and|divide|div|equal|gcd|greater|less|max|min|mod|Mod|multiply|notequal|notgreater|notless|or|pow|random|subtract|ifthenelse|veclen)/
         | /([a-zA-Z][a-zA-Z0-9]*)/ { LaTeXML::Package::Pool::pgfmath_checkuserfunction($item[1]); }
 # ? array|scalar
 # These take boxes!  depth|height|width

--- a/lib/LaTeXML/Package/psfrag.sty.ltxml
+++ b/lib/LaTeXML/Package/psfrag.sty.ltxml
@@ -1,0 +1,51 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  psfrag                                                             | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+use LaTeXML::Util::Image;
+
+#**********************************************************************
+# STUB BINDING!
+#   Basically a NO-OP binding to avoid errors in olrder arXiv docs.
+# psfrag is a cool hack that allows the author to enhance thier graphics
+# by REPLACING bits of postscript figures with TeX formatted stuff.
+# The big question for LaTeXML is:
+#   What is the Web or XML analog or simulation of that?
+# There are several, unappealing options to simulate:
+#  * Contrive an svg overlay of the graphic
+#    IFF we knew the desired positions of the fragments
+#  * Do surgery on the postscript (embedding what?) and
+#    then rasterizing the image to png, losing all XML/MathML/semantics...
+#  other?
+# Or, we could simply fudge them:
+#  * Ignore the fragments (with warning).
+#  * Add a footnote, or better, add to a figure caption, or ...
+
+#
+# For now, just warn and go.
+DefMacro('\psfrag@warning', sub {
+    my ($gullet) = @_;
+    Warn('psfrag', 'psfrag', $gullet, "PSFrag fragments are being converted to footnotes.");
+    return; });
+
+# This would be much nicer if we could at least tell which figures were affected
+# and add the notes to the captions!
+DefMacro('\psfrag OptionalMatch:* {}[][][][]{}',
+  '\psfrag@warning\global\let\psfrag@warning\relax'
+    . '\footnote{A PSFrag replacing \texttt{#2} by #7 was dropped.}');
+
+#**********************************************************************
+1;
+

--- a/lib/LaTeXML/Package/siunitx.sty.ltxml
+++ b/lib/LaTeXML/Package/siunitx.sty.ltxml
@@ -868,7 +868,7 @@ DefMacro('\ang OptionalKeyVals:SIX {}', sub {
 # Unit processing macros
 sub six_peel_group {
   my (@tokens) = @_;
-  if ($tokens[0]->getCatcode == CC_BEGIN) {
+  if (@tokens && $tokens[0]->getCatcode == CC_BEGIN) {
     shift(@tokens);
     my @result = ();
     my $level  = 1;

--- a/lib/LaTeXML/Package/svg.sty.ltxml
+++ b/lib/LaTeXML/Package/svg.sty.ltxml
@@ -46,8 +46,8 @@ DefKeyVal('Gin', 'svgpath', '', '');
 #       my $path = pathname_absolute(pathname_canonical(ToString($dir)));
 #       $document->insertPI('latexml', graphicspath => $path); } });
 
-DefMacro('lx@svg@options', '');
-DefMacro('\setsvg{}',      '\gdef\lx@svg@options{#1}');
+DefMacro('\lx@svg@options', '');
+DefMacro('\setsvg{}',       '\gdef\lx@svg@options{#1}');
 
 # Note that various sizing & rescaling are not yet supported by the Post::Graphics,
 # although it oughtn't to be so hard; just adjust the attributes on the outer svg:svg?

--- a/lib/LaTeXML/Package/xfrac.sty.ltxml
+++ b/lib/LaTeXML/Package/xfrac.sty.ltxml
@@ -1,0 +1,25 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  xfrac                                                              | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+RequirePackage('nicefrac');
+DefMacro('\sfrac[]{}[]{}', '\ensuremath{\@UnitsNiceFrac{#2}{#4}}');
+
+DefMacro('\DeclareInstance{}{}{}{}',             '');
+DefMacro('\DeclareCollectionInstance{}{}{}{}{}', '');
+DefMacro('\UseCollection{}{}',                   '');
+#======================================================================
+1;

--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -657,12 +657,12 @@ sub generateRef {
         $pending = $$self{ref_join}; } # inside/outside this brace determines if text can START with the join.
       $id = $entry->getValue('parent'); } }
   if (!@stuff) {                       # Try first child for a title-less document?
-    my $entry = $$self{db}->lookup("ID:$reqid");
-    if (($entry->getValue('type') || '') eq 'ltx:document') {
-      foreach my $c (@{ $entry->getValue('children') }) {
-        if (my $centry = $$self{db}->lookup("ID:$c")) {
-          if (my @s = $self->generateRef_aux($doc, $centry, $reqshow)) {
-            push(@stuff, @s); last; } } } } }
+    if (my $entry = $$self{db}->lookup("ID:$reqid")) {
+      if (($entry->getValue('type') || '') eq 'ltx:document') {
+        foreach my $c (@{ $entry->getValue('children') }) {
+          if (my $centry = $$self{db}->lookup("ID:$c")) {
+            if (my @s = $self->generateRef_aux($doc, $centry, $reqshow)) {
+              push(@stuff, @s); last; } } } } } }
   if (@stuff) {
     return @stuff; }
   else {

--- a/lib/LaTeXML/Util/WWW.pm
+++ b/lib/LaTeXML/Util/WWW.pm
@@ -48,7 +48,7 @@ sub auth_get {
         $req->authorization_basic($uname, $pass);
         $response = $browser->request($req); } } }
   return auth_get("$url.tex", $authlist) if ((!$response->is_success) && $url !~ /\.tex$/);
-  Fatal('www', 'get', $url, 'HTTP GET failed with: "' . $response->message . '"') unless ($response->is_success);
+  Error('www', 'get', $url, 'HTTP GET failed with: "' . $response->message . '"') unless ($response->is_success);
   return $response->content; }
 
 sub url_find {


### PR DESCRIPTION
This cleans up a handfull of random fatals that were easy to isolate & fix with the generally cleaned up state of things.

Most significant may be a stubby binding for `psfrag`. It doesn't actually add the fragments, but creates footnotes to inform of what would have been added to the figures. So an imperfect, but error free, result.  Could be non-trivial move of error to warning, since psfrag was used a lot in older arXiv papers.

Still WiP, since I may sneak in a few other minor cleanups.