### PR TITLE
Detect experimental MathML support from maybeMathjax.js

### DIFF
--- a/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
+++ b/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
@@ -1,7 +1,7 @@
 //======================================================================
 // Load MathJax, IFF the current browser can't handle MathML natively.
 
-(function() {
+(function () {
     var mathjax_url =
         "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js?config=MML_HTMLorMML";
 
@@ -14,13 +14,18 @@
 
     // Add script element loading MathJax unless we can handle MathML
     var agent = navigator.userAgent;
-    var is_gecko = (agent.indexOf("Gecko") > -1 &&
-                    agent.indexOf("KHTML") === -1 &&
-                    agent.indexOf("Trident") === -1);
+    var is_gecko = (
+        agent.indexOf("Gecko") > -1 &&
+        agent.indexOf("KHTML") === -1 &&
+        agent.indexOf("Trident") === -1);
     // Check for MathPlayer, but only IE's before IE 10 when it was disabled.
-    var has_mathplayer = (agent.indexOf("MathPlayer") > -1 &&
-                    agent.indexOf("rv:1") === -1); /* till ie 20! */
-    if (!is_gecko && !has_mathplayer) {
+    var has_mathplayer = (
+        agent.indexOf("MathPlayer") > -1 &&
+        agent.indexOf("rv:1") === -1); /* till ie 20! */
+    // Check if the public MathML interface is implemented, for any other variants
+    // e.g. Chrome in 2021 + "Experimental Web Platform features"
+    var has_mathml_interface = typeof (MathMLElement) == "function";
+    if (!is_gecko && !has_mathplayer && !has_mathml_interface) {
         var head = document.getElementsByTagName("head")[0];
         if (head != null) {
             var script = document.createElement("script");


### PR DESCRIPTION
It appears there is a nice and simple trick one can currently use to detect an "intention for" MathML support in browsers, namely having made available the interface:

```javascript
var has_mathml_interface = typeof (MathMLElement) == "function";
```

This neatly allows detecting unusual MathML browsers, such as a regular Chrome with experimental features enabled.

I tested with:
```
latexmlc --pmml --cmml --whatsin=math 'literal:Q_{m,n}^{[i+j<m+n]}(z_{i,j})' \
              --dest=test.html --javascript=LaTeXML-maybeMathjax.js
```

and the detection worked well in Firefox and the two Chrome variants. I would like to update the official script and deploy this to CorTeX, so that we feast our eyes on arXiv documents rendered with Chrome's MathML support.