### PR TITLE
update MathJax url to load mml-chtml component only

### DIFF
--- a/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
+++ b/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
@@ -3,7 +3,7 @@
 
 (function() {
     var mathjax_url =
-        "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js?config=MML_HTMLorMML";
+        "https://cdn.jsdelivr.net/npm/mathjax@3/es5/mml-chtml.js";
 
     function refreshMath() {
         // Maybe unnecessary, or overkill, but...


### PR DESCRIPTION
Something I spotted in quick PR by @dginev: MathJax version 3 is being called with the options meant for version 2 (see [Loading MathJax](http://docs.mathjax.org/en/latest/web/configuration.html#loading-mathjax) versus the old [Combined Configurations](https://docs.mathjax.org/en/v2.7-latest/config-files.html#combined-configurations)).

I believe the url below is the intented one (MathML input, CommonHTML output; there is [no "or MathML" anymore](http://docs.mathjax.org/en/latest/web/components/output.html#output-chtml)).