### PR TITLE
Add binding for 'actuarialangle.sty'

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -336,6 +336,7 @@ lib/LaTeXML/Package/aastex.sty.ltxml
 lib/LaTeXML/Package/accents.sty.ltxml
 lib/LaTeXML/Package/acmart.cls.ltxml
 lib/LaTeXML/Package/acronym.sty.ltxml
+lib/LaTeXML/Package/actuarialangle.sty.ltxml
 lib/LaTeXML/Package/ae.sty.ltxml
 lib/LaTeXML/Package/aecompl.sty.ltxml
 lib/LaTeXML/Package/afterpage.sty.ltxml

--- a/lib/LaTeXML/Package/actuarialangle.sty.ltxml
+++ b/lib/LaTeXML/Package/actuarialangle.sty.ltxml
@@ -1,0 +1,40 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  actuarialangle                                                     | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+InputDefinitions('actuarialangle', type => 'sty', noltxml => 1);
+
+DefConstructor('\actuarialangle{}',
+  "<ltx:XMApp>"
+    . "<ltx:XMTok role='ENCLOSE' enclose='actuarial' meaning='actuarialangle' />"
+    . "<ltx:XMWrap>#1</ltx:XMWrap>"
+    . "</ltx:XMApp>");
+
+# define \overanglebracket, unless the nobracket option is passed
+if (IfCondition('\ifacta@bracket')) {
+  DefMath('\overanglebracket{}', "\x{23E0}", operator_role => 'OVERACCENT'); # TOP TORTOISE SHELL BRACKET
+  DefMath('\group{}', '\overanglebracket{#1}');
+}
+
+# preserve reversion
+Let('\lx@actuarialangle@angl', '\angl');
+DefMath('\angl{}', '\lx@actuarialangle@angl{#1}');
+
+DefMath('\angln', '\angl{n}');
+DefMath('\anglr', '\angl{r}');
+DefMath('\anglk', '\angl{k}');
+
+1;


### PR DESCRIPTION
As per subject, this is a small binding for [actuarialangle](https://mirrors.ctan.org/macros/latex/contrib/actuarialangle/actuarialangle.pdf). It translates `\actuarialangle` to the corresponding MathML `menclose` and `\overanglebracket` to its Unicode equivalent.

The output quality is hit and miss, unfortunately. Firefox renders the angled bracket properly, but messes up the actuarial angle; MathJax does the opposite.

Edit: here is a small example
```latex
\documentclass{article}
\usepackage[thinspace]{actuarialangle}
\begin{document}
\[ \actuarialangle{n} \quad a_{\actuarialangle{n}} \]

\[ \angl{ab} \quad \angln \quad \anglr \quad \anglk \]

\[ \overanglebracket{abcde} \quad \group{xy} \quad A_{\group{xy}:\angln} \]
\end{document}
```
which `pdflatex` renders as
![image](https://user-images.githubusercontent.com/1962985/125196458-f379b480-e251-11eb-847d-2e24b28baa92.png)