### PR TITLE
Add binding for 'prettyref.sty'

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -585,6 +585,7 @@ lib/LaTeXML/Package/pgfutil-common.tex.ltxml
 lib/LaTeXML/Package/physics.sty.ltxml
 lib/LaTeXML/Package/pifont.sty.ltxml
 lib/LaTeXML/Package/placeins.sty.ltxml
+lib/LaTeXML/Package/prettyref.sty.ltxml
 lib/LaTeXML/Package/preview.sty.ltxml
 lib/LaTeXML/Package/proofwiki.sty.ltxml
 lib/LaTeXML/Package/psfig.sty.ltxml

--- a/lib/LaTeXML/Package/prettyref.sty.ltxml
+++ b/lib/LaTeXML/Package/prettyref.sty.ltxml
@@ -1,0 +1,20 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  prettyref                                                          | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+InputDefinitions('prettyref', type => 'sty', noltxml => 1);
+
+1;


### PR DESCRIPTION
I saw prettyref on [this list](https://github.com/brucemiller/LaTeXML/wiki/Porting-LaTeX-packages-for-LaTeXML) and I know it works with `--includestyles` because I use it regularly, so this is an easy one.

A small example:
```latex
\documentclass{article}

\usepackage{amsthm}
\usepackage{prettyref}

\newtheorem{thm}{Theorem}
\newtheorem{prop}[thm]{Proposition}
\newrefformat{prop}{Proposition~\ref{#1}}
% the thm format is builtin

\begin{document}
\begin{thm}
  \label{thm:theorem}
  A theorem.
\end{thm}

\begin{prop}
  \label{prop:proposition}
  A proposition.
\end{prop}

References: \prettyref{thm:theorem}, \prettyref{prop:proposition}.
\end{document}
```