### PR TITLE
Add binding for 'xparse-2018-04-12.sty'

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -695,6 +695,7 @@ lib/LaTeXML/Package/xfrac.sty.ltxml
 lib/LaTeXML/Package/xkeyval.sty.ltxml
 lib/LaTeXML/Package/xkvview.sty.ltxml
 lib/LaTeXML/Package/xparse.sty.ltxml
+lib/LaTeXML/Package/xparse-2018-04-12.sty.ltxml
 lib/LaTeXML/Package/xspace.sty.ltxml
 lib/LaTeXML/Package/xunicode.sty.ltxml
 lib/LaTeXML/Package/yfonts.sty.ltxml

--- a/lib/LaTeXML/Package/xparse-2018-04-12.sty.ltxml
+++ b/lib/LaTeXML/Package/xparse-2018-04-12.sty.ltxml
@@ -1,0 +1,20 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  xparse-2018-04-12                                                  | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+# Should just work?
+InputDefinitions('xparse-2018-04-12', type => 'sty', noltxml => 1);
+1;


### PR DESCRIPTION
This is about fixing #1566. It looks like `xparse.sty` has been split off into a few frozen versions. From the comments:
```tex
%% This is file `xparse-2018-04-12.sty', generated from
%% xparse.dtx  (with options: `core,package', on 2021-01-20)
%% then adapted and frozen for compatibility.  Development of
%% xparse.dtx will continue in the LaTeX2e kernel as ltcmd.dtx.
```
If I understand correctly, some core commands, like `\NewDocumentCommand`, are being moved into LaTeX2e kernel, so `xparse.sty` has to detect the LaTeX version, then load the appropriate version of `xparse.sty` to fill the gaps.

At the moment, LaTeXML is detected as an old format, and `xparse.sty` tries to load the 2018-04-12 version. The binding is needed to prevent LaTeXML falling back to `xparse.sty.ltxml`.