### PR TITLE
Invoke commands by passing the arguments in a list of strings

### DIFF
--- a/t/931_epub.t
+++ b/t/931_epub.t
@@ -21,11 +21,11 @@ my $log_filename = "931_test.log";
 my $latexmlc = catfile($FindBin::Bin, '..', 'blib', 'script', 'latexmlc');
 
 my $path_to_perl = $Config{perlpath};
-my $invocation = $path_to_perl . " " . join(" ", map { ("-I", $_) } @INC) . " ";
-$invocation .= $latexmlc . " --css=LaTeXML-epub.css --dest=$epub_filename --log=$log_filename literal:test ";
+my @invocation = $path_to_perl, map { ('-I', $_) } @INC;
+push(@invocation, $latexmlc, '--css=LaTeXML-epub.css', "--dest=$epub_filename", "--log=$log_filename", 'literal:test');
 
 my ($writer_discard, $reader_discard, $error_discard);
-my $pid = open3($writer_discard, $reader_discard, $error_discard, $invocation);
+my $pid = open3($writer_discard, $reader_discard, $error_discard, @invocation);
 ok(waitpid( $pid, 0 ), "latexmlc invocation for test 931_epub.t : $!");
 
 ok(-f $epub_filename, 'epub file generated');


### PR DESCRIPTION
Reason: most tests above 90 fail when a parent folder contains a space, or if a required Perl module has a space in its path (noticed on Windows, where it's much more likely to actually happen). ~~I have added double quotes around all paths.~~

Edit: I replaced the `$invocation` strings with arrays of strings, each representing the argument in its plain form (unquoted, unescaped). I think this is the most correct solution.

If you like this approach, I can grep for all the other `system()` and backticks and do the same, because e.g. the kpsewhich calls are also giving me problem related to spaces in the arguments.