### PR TITLE
Read $dtdfile into a string before parsing

### DIFF
--- a/lib/LaTeXML/Common/Model/DTD.pm
+++ b/lib/LaTeXML/Common/Model/DTD.pm
@@ -16,6 +16,7 @@ use LaTeXML::Util::Pathname;
 use LaTeXML::Global;
 use LaTeXML::Common::Error;
 use LaTeXML::Common::XML;
+use URI::file;
 
 #**********************************************************************
 # NOTE: Arglist is DTD specific.
@@ -117,7 +118,7 @@ sub readDTD {
       paths               => $STATE->lookupValue('SEARCHPATHS'),
       installation_subdir => 'resources/DTD');
     if ($dtdfile) {
-      $dtd = XML::LibXML::Dtd->new($$self{public_id}, $dtdfile);
+      $dtd = XML::LibXML::Dtd->new($$self{public_id}, URI::file->new($dtdfile));
       $how = " from $dtdfile ";
       Error('misdefined', $$self{system_id}, undef,
         "Parsing of DTD \"$$self{public_id}\" \"$$self{system_id}\" failed")


### PR DESCRIPTION
Fix #1571.

After reading more than should have been necessary, I am convinced that this approach (reading the file into a string, then call `parse_string`) works correctly re DTD encoding. The DTD will not know its `public_id` but it hardly seems relevant.

The only other approach is to turn `$dtdfile` into a `file://` URI, but that would be more code (or a `URI::file` dependency).