### PR TITLE
Texlive 2021

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1936,10 +1936,10 @@ sub FindFile_aux {
   my $urlbase       = LookupValue('URLBASE');
   my $nopaths       = LookupValue('REMOTE_REQUEST');
   my $ltxml_paths   = $nopaths ? [] : $paths;
-  my $interpreting  = LookupValue('INTERPRETING_DEFINITIONS');    # Globally allow interpretation
-  my $interpretable = LookupValue('INTERPRETABLE_DEFINITIONS_' . $file);    # Specifically allow
-      # If we're looking for ltxml, look within our paths & installation first (faster than kpse)
+  my $interpreting  = LookupValue('INTERPRETING_DEFINITIONS');         # Globally allow interpretation
+  my $interpretable = LookupMapping('INTERPRETABLE_SOURCES', $file);   # Specifically allow
 
+  # If we're looking for ltxml, look within our paths & installation first (faster than kpse)
   if (!$options{noltxml}
     && ($path = pathname_find("$file.ltxml", paths => $ltxml_paths, installation_subdir => 'Package'))) {
     return $path; }

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -347,7 +347,6 @@ DefConstructorI(T_CS('\end{document}'), undef, sub {
     $document->closeElement('ltx:document'); },
   beforeDigest => sub {
     my ($stomach) = @_;
-    $stomach->getGullet->flush;
     my @boxes = ();
     if (my $ops = LookupValue('@at@end@document')) {
       push(@boxes, Digest(Tokens(@$ops))); }
@@ -390,6 +389,7 @@ DefConstructorI(T_CS('\end{document}'), undef, sub {
     #      push(@boxes, Digest(Tokens(@$ops))); }
     # NOTE: Don't flush gullet (tempting);
     # Babel's expecting \bbl@pop@language
+    $stomach->getGullet->flush;
     return @boxes; });
 
 # \enddocument is used directly in e.g. standalone.cls
@@ -5339,6 +5339,7 @@ RawTeX(<<'EOTeX');
   \mathchardef\@Mii=10002
   \mathchardef\@Miii=10003
   \mathchardef\@Miv=10004
+  \def\@fontenc@load@list{\@elt{T1,OT1}}
 EOTeX
 DefMacroI('\@vpt',    undef, '5');
 DefMacroI('\@vipt',   undef, '6');
@@ -5846,6 +5847,15 @@ DefPrimitive('\DeclareUnicodeCharacter Expanded {}', sub {
 
 # LaTeX now includes textcomp by default.
 RequirePackage('textcomp');
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# Expl3 "Experimental LaTeX 3" is no longer Experimental!
+# It is beginning to be built into latex.ltx
+# We WILL need a new strategy to keep up; probably based in some form
+# of pre-read/pre-processed latex.ltx !
+#
+# For now, a few macros required by other packages will be included:
+DefMacroI(T_CS('\hook_gput_code:nnn'), '{}{}{}', '');
 
 #**********************************************************************
 1;

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -387,8 +387,6 @@ DefConstructorI(T_CS('\end{document}'), undef, sub {
     # ???? don't push? or what
     #    if (my $ops = LookupValue('@after@end@document')) {
     #      push(@boxes, Digest(Tokens(@$ops))); }
-    # NOTE: Don't flush gullet (tempting);
-    # Babel's expecting \bbl@pop@language
     $stomach->getGullet->flush;
     return @boxes; });
 

--- a/lib/LaTeXML/Package/xparse.sty.ltxml
+++ b/lib/LaTeXML/Package/xparse.sty.ltxml
@@ -17,8 +17,8 @@ use LaTeXML::Package;
 
 # Newer versions of xparse *may* want to defer to one of these versioned files
 # They are also acceptable for interpretation, but must avoid the de-versioning hack/fallback.
-AssignValue("INTERPRETABLE_DEFINITIONS_xparse-2018-04-12.sty" => 1);
-AssignValue("INTERPRETABLE_DEFINITIONS_xparse-2020-10-01.sty" => 1);
+AssignMapping('INTERPRETABLE_SOURCES', 'xparse-2018-04-12.sty' => 1);
+AssignMapping('INTERPRETABLE_SOURCES', 'xparse-2020-10-01.sty' => 1);
 
 # Should just work?
 InputDefinitions('xparse', type => 'sty', noltxml => 1);

--- a/lib/LaTeXML/Package/xparse.sty.ltxml
+++ b/lib/LaTeXML/Package/xparse.sty.ltxml
@@ -15,6 +15,14 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+# Newer versions of xparse *may* want to defer to one of these versioned files
+# They are also acceptable for interpretation, but must avoid the de-versioning hack/fallback.
+AssignValue("INTERPRETABLE_DEFINITIONS_xparse-2018-04-12.sty" => 1);
+AssignValue("INTERPRETABLE_DEFINITIONS_xparse-2020-10-01.sty" => 1);
+
 # Should just work?
 InputDefinitions('xparse', type => 'sty', noltxml => 1);
+
+# Presumably we'll want our own k3backend_latexml !?!?!?!
+
 1;


### PR DESCRIPTION
This PR fixes some regressions (or lags, rather) for TeXLive 2021 (at least, the included tests).

It is an alternative to #1569 that I couldn't flesh out, without trying it out. (Sorry for stealing the glory) After experimentation, I pretty much ended up following @dginev's idea of recording the files that we are willing to interpret (so they don't hit the binding fallback).  [Not yet a full API for this yet, but could evolve into something where we'd simply have a list of interpretable files, rather than trivial bindings]

Hopefully this will resolve #1566 and #1565 ? @xworld21, @flyn-org could you check?