### PR TITLE
Portable update_revision

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -129,7 +129,7 @@ sub record_revision {
     $$MORE_MACROS{REVISION} = '$(shell git log --max-count=1 --abbrev-commit --pretty="%h")'; }
   # Extract the previously recorded revision from the revision file (awkward)
   $$MORE_MACROS{OLD_REVISION}
-    = '`$(PERLRUN) -ne \'chomp;if(s/.*?REVISION\\s*=\\s*\\"// && s/\\".*//){print;}\' < $(REVISION_FILE)`';
+    = '$(shell $(PERLRUN) -ne "chomp;if(s/.*?REVISION\s*=\s*\'// && s/\s*\'.*//){print;}" < $(REVISION_FILE))';
   # Substitute the revision into the revision template
   $$MORE_MACROS{RECORD_REVISION} = '$(PERLRUN) -pe "s@__REVISION__@$(REVISION)@" ';
 
@@ -149,7 +149,7 @@ $(REVISION_FILE): lib/LaTeXML/Version.in
 # update version if stored revision if not current
 update_revision:
 	$(NOECHO) $(MKPATH) $(INST_LIBDIR)/LaTeXML
-	- $(NOECHO) test $(REVISION) = $(OLD_REVISION) \
+	- $(NOECHO) $(PERLRUN) -e "exit(1) unless '$(REVISION)' eq '$(OLD_REVISION)';" \
 	|| $(RECORD_REVISION) lib/LaTeXML/Version.in > $(REVISION_FILE)
 
 RecordRevision

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -124,7 +124,7 @@ sub record_revision {
   ## This command is appropriate for svn
   ##  $$MORE_MACROS{REVISION} = '$(shell svnversion $(REVISION_BASE))';
   ## This command is appropriate for git (I think)
-  if ((-d '.git') && (system("git --version") == 0)) {    # If a git checkout & can run git?
+  if ((-e '.git') && (system("git --version") == 0)) {    # If a git checkout & can run git?
     print STDERR "\n";                                    # space out messages
     $$MORE_MACROS{REVISION} = '$(shell git log --max-count=1 --abbrev-commit --pretty="%h")'; }
   # Extract the previously recorded revision from the revision file (awkward)

--- a/lib/LaTeXML/Version.in
+++ b/lib/LaTeXML/Version.in
@@ -39,7 +39,7 @@ use FindBin;
 #======================================================================
 
 # This is the git/svn/whatever revision; it should be filled in by make.
-our $REVISION = "__REVISION__";
+our $REVISION = '__REVISION__';
 
 1;
 


### PR DESCRIPTION
Another Windows motivated PR. The `update_revision` part of the Makefile essentially expects a POSIX system, but we can do without. This is a bit delicate, I think I have tested it properly, but please double check.

The changes:
1. Only check that `.git` exists (sometimes it is a file, e.g. when using submodules - not Windows related, but relevant);
2. Replace backticks with `$(shell ...)`, and fiddle with the quotes, again because Windows does not understand them;
3. Replace `test` with a tiny perl script, because `test` is not available from Windows.