### PR TITLE
Guard for Tokens in UnTeX

### DIFF
--- a/lib/LaTeXML/Core/Token.pm
+++ b/lib/LaTeXML/Core/Token.pm
@@ -136,7 +136,9 @@ my $UNTEX_LINELENGTH = 78;    # [CONSTANT]
 sub UnTeX {
   my ($thing, $suppress_linebreak) = @_;
   return unless defined $thing;
-  my @tokens = (ref $thing ? $thing->revert : Explode($thing));
+  my @tokens = ref $thing ?
+    map { ref $_ eq 'LaTeXML::Core::Tokens' ? $_->unlist : $_ } $thing->revert :
+    Explode($thing);
   my $string = '';
   my $length = 0;
   my $level  = 0;

--- a/lib/LaTeXML/Package/diagbox.sty.ltxml
+++ b/lib/LaTeXML/Package/diagbox.sty.ltxml
@@ -40,7 +40,7 @@ DefMacro('\diagbox OptionalKeyVals:diagbox {}{}', sub {
     my $dir = $kv && ToString($kv->getValue('dir')) || 'NW';
     if ($dir) {
     }
-    my $font = $kv->getValue('font');
+    my $font = $kv && $kv->getValue('font');
     return Invocation(T_CS('\lx@diagbox'),
       $kv,
       Invocation(T_CS('\lx@diagbox@head'), T_LETTER('l'), $font, $A),
@@ -73,8 +73,8 @@ DefConstructor('\lx@diagbox RequiredKeyVals:diagbox {}[]{}',
     my ($Mw, $Mh, $Md) = $M && $M->getSize; $Mh = $Mh->add($Md) if $Mh;
     my $maxw = $Aw->larger($Bw);
     my $maxh = $Ah->larger($Bh);
-    my $w    = $kv->getValue('width')  || $kv->getValue('innerwidth') || $Aw->add($Bw)->add($maxw);
-    my $h    = $kv->getValue('height') || $Ah->add($Bh)->add($maxh);
+    my $w = ($kv && ($kv->getValue('width') || $kv->getValue('innerwidth'))) || $Aw->add($Bw)->add($maxw);
+    my $h = ($kv && $kv->getValue('height')) || $Ah->add($Bh)->add($maxh);
     my ($ww,    $hh)  = ($w->ptValue, $h->ptValue);
     my ($wwm,   $hhm) = ($w->divide(2)->ptValue, $h->divide(2)->ptValue);
     my ($line1, $line2);
@@ -127,8 +127,8 @@ DefConstructor('\lx@diagbox RequiredKeyVals:diagbox {}[]{}',
       B         => $B,     Bx    => $Bx, By => $By, Bw => $Bw, Bh => $Bh,
       M         => $M,     Mx    => $Mx, My => $My, Mw => $Bw, Mh => $Mh,
       line1     => $line1, line2 => $line2,
-      linewidth => $kv->getValue('linewidth') || '0.4',
-      linecolor => $kv->getValue('linecolor') || 'black'); }
+      linewidth => ($kv && $kv->getValue('linewidth')) || '0.4',
+      linecolor => ($kv && $kv->getValue('linecolor')) || 'black'); }
 );
 
 # slashbox compatibility


### PR DESCRIPTION
Stumbled on a curious fatal error in the [sandbox reports](https://corpora.mathweb.org/corpus/sandbox%5Farxiv%5F1905/tex%5Fto%5Fhtml/fatal/perl/die?all=false), namely:

> Can't locate object method "getCatcode" via package "LaTeXML::Core::Tokens" at /usr/local/share/perl/5.30.0/LaTeXML/Core/Token.pm line 146

A quick check reveals a number of `reversion` attributes of `DefParameterType` declarations in TeX.pool which return a `Tokens` object rather than a perl list of `Token` objects. For now I made `UnTeX` more robust, where it will actively expect `Tokens` objects and unlist them.

In a hypothetical rewrite, I see I have made the choice of standardizing DefParameterType reversions to always return a single `Tokens` object. Which is almost identical to a list of individual Token objects, but a hypothetical compiler would indeed force the choice to be made and followed. Since we don't live in that hypothetical world, here's a runtime patch for UnTeX :)