### PR TITLE
Timeout-related arXiv patches

### DIFF
--- a/lib/LaTeXML/Package/amstext.sty.ltxml
+++ b/lib/LaTeXML/Package/amstext.sty.ltxml
@@ -20,7 +20,7 @@ use LaTeXML::Package;
 #**********************************************************************
 RequirePackage('amsgen');
 
-DefConstructor('\text{}', "<ltx:text _noautoclose='true'>#1</ltx:text>", mode => 'text');
+DefConstructor('\text{}', "<ltx:text _noautoclose='true'>#1</ltx:text>", mode => 'text', locked => 1);
 
 # There's also redefinitions of \stepcounter & \addtocounter
 # that I can't quite seethe point of including here...

--- a/lib/LaTeXML/Package/natbib.sty.ltxml
+++ b/lib/LaTeXML/Package/natbib.sty.ltxml
@@ -148,7 +148,7 @@ DefMacro('\cite OptionalMatch:* [][] Semiverbatim', sub {
             $keys,
             Invocation(T_CS('\@@citephrase'), $open),
             Invocation(T_CS('\@@citephrase'), $close))); } }
-});
+}, locked => 1);
 
 DefMacro('\citet OptionalMatch:* [][] Semiverbatim', sub {
     my ($gullet, $star, $pre, $post, $keys) = @_;
@@ -188,7 +188,7 @@ DefMacro('\citet OptionalMatch:* [][] Semiverbatim', sub {
             Tokens($open, ($pre ? ($pre, T_SPACE) : ()))),
           Invocation(T_CS('\@@citephrase'),
             Tokens(($post ? ($ns, T_SPACE, $post) : ()), $close)))); }
-});
+}, locked => 1);
 
 DefMacro('\citep OptionalMatch:* [][] Semiverbatim', sub {
     my ($gullet, $star, $pre, $post, $keys) = @_;
@@ -222,7 +222,7 @@ DefMacro('\citep OptionalMatch:* [][] Semiverbatim', sub {
             Invocation(T_CS('\@@citephrase'), Tokens($ay->unlist, T_SPACE)),
             undef),
           ($post ? ($ns, T_SPACE, $post) : ()), $close)); }
-});
+}, locked => 1);
 
 #======================================================================
 # 2.4 Extended Citation Commands
@@ -426,17 +426,17 @@ DefMacro('\bibstyle@agu',        '\bibpunct{[}{]}{;}{a}{,}{,~}');    #Amer. Geop
 DefMacro('\bibstyle@copernicus', '\bibpunct{(}{)}{;}{a}{,}{,}');     #Copernicus Publications
 Let('\bibstyle@egu', '\bibstyle@copernicus');
 Let('\bibstyle@egs', '\bibstyle@copernicus');
-DefMacro('\bibstyle@agsm',   '\bibpunct{(}{)}{,}{a}{}{,}\gdef\harvardand{\&}');
-DefMacro('\bibstyle@kluwer', '\bibpunct{(}{)}{,}{a}{}{,}\gdef\harvardand{\&}');
-DefMacro('\bibstyle@dcu',    '\bibpunct{(}{)}{;}{a}{;}{,}\gdef\harvardand{and}');
+DefMacro('\bibstyle@agsm',     '\bibpunct{(}{)}{,}{a}{}{,}\gdef\harvardand{\&}');
+DefMacro('\bibstyle@kluwer',   '\bibpunct{(}{)}{,}{a}{}{,}\gdef\harvardand{\&}');
+DefMacro('\bibstyle@dcu',      '\bibpunct{(}{)}{;}{a}{;}{,}\gdef\harvardand{and}');
 DefMacro('\bibstyle@aa',       '\bibpunct{(}{)}{;}{a}{}{,}');        # Astronomy & Astrophysics
 DefMacro('\bibstyle@pass',     '\bibpunct{(}{)}{;}{a}{,}{,}');       #Planet. & Space Sci
 DefMacro('\bibstyle@anngeo',   '\bibpunct{(}{)}{;}{a}{,}{,}');       #Annales Geophysicae
 DefMacro('\bibstyle@nlinproc', '\bibpunct{(}{)}{;}{a}{,}{,}');       #Nonlin.Proc.Geophys.
 DefMacro('\bibstyle@cospar',   '\bibpunct{/}{/}{,}{n}{}{}');
 DefMacro('\bibstyle@esa',      '\bibpunct{(Ref.~}{)}{,}{n}{}{}');
-DefMacro('\bibstyle@nature', '\bibpunct{}{}{,}{s}{}{\textsuperscript{,}}');
-DefMacro('\bibstyle@plain',  '\bibpunct{[}{]}{,}{n}{}{,}');
+DefMacro('\bibstyle@nature',   '\bibpunct{}{}{,}{s}{}{\textsuperscript{,}}');
+DefMacro('\bibstyle@plain',    '\bibpunct{[}{]}{,}{n}{}{,}');
 Let('\bibstyle@alpha', '\bibstyle@plain');
 Let('\bibstyle@abbrv', '\bibstyle@plain');
 Let('\bibstyle@unsrt', '\bibstyle@plain');
@@ -483,8 +483,7 @@ DefMacro('\shortcites Semiverbatim', '');
 #   \bibitem[\protect\citename{Jones et al., }1990]{key}...
 #   \harvarditem[Jones et al.]{Jones, Baker, and Williams}{1990}{key}...
 
-##DefMacro('\bibitem','\refstepcounter{enumiv}\@ifnextchar[{\@lbibitem}{\@lbibitem[\the@bibitem]}');
-DefMacro('\bibitem', '\reset@natbib@cites\refstepcounter{@bibitem}\@ifnextchar[{\@lbibitem}{\@lbibitem[\the@bibitem]}');
+DefMacro('\bibitem', '\reset@natbib@cites\refstepcounter{@bibitem}\@ifnextchar[{\@lbibitem}{\@lbibitem[\the@bibitem]}', locked => 1);
 
 RawTeX(<<'EOTeX');
 %%%
@@ -502,8 +501,6 @@ RawTeX(<<'EOTeX');
 \newcommand\harvarditem[4][]{%
   \if\relax#1\relax\bibitem[#2(#3)]{#4}\else\bibitem[#1(#3)#2]{#4}\fi }
 %%%%
-\def\@lbibitem[#1]#2{%
-  \@@lbibitem{#2}\NAT@ifcmd#1(@)(@)\@nil{#2}\newblock}
 \newcommand\NAT@ifcmd{\futurelet\NAT@temp\NAT@ifxcmd}
 \newcommand\NAT@ifxcmd{\ifx\NAT@temp\relax\else\expandafter\NAT@bare\fi}
 \def\NAT@bare#1(#2)#3(@)#4\@nil#5{%
@@ -549,6 +546,11 @@ DefConstructor('\NAT@@wrout{}{}{}{}{} Semiverbatim',
   bounded => 1, beforeDigest => sub { Let(T_ALIGN, '\&'); }
 );
 
+# see arXiv:cond-mat/0003435 for
+# an infinite loop we run into when this isn't locked
+# \@@lbibitem is a DefConstructor, so the connection should be kept
+DefMacro('\@lbibitem[]{}', '\@@lbibitem{#2}\NAT@ifcmd#1(@)(@)\@nil{#2}\newblock', locked => 1);
+
 # Similar to the one defined in LaTeX.pool, but the bibtag's have been setup above.
 DefConstructor('\@@lbibitem Semiverbatim',
   "<ltx:bibitem key='#key' xml:id='#id'>",
@@ -560,8 +562,8 @@ DefConstructor('\@@lbibitem Semiverbatim',
 #======================================================================
 # These macros allow you to get the pieces used in the current style
 # but don't seem to be used in natbib, so redefining them does nothing.
-DefMacro('\citestarts', sub { LookupValue('CITE_OPEN')->unlist; });
-DefMacro('\citeends',   sub { LookupValue('CITE_CLOSE')->unlist; });
+DefMacro('\citestarts',     sub { LookupValue('CITE_OPEN')->unlist; });
+DefMacro('\citeends',       sub { LookupValue('CITE_CLOSE')->unlist; });
 DefMacro('\betweenauthors', 'and');
 
 DefMacro('\harvardleft',      sub { LookupValue('CITE_OPEN')->unlist; });

--- a/lib/LaTeXML/Package/revtex4_support.sty.ltxml
+++ b/lib/LaTeXML/Package/revtex4_support.sty.ltxml
@@ -158,7 +158,7 @@ DefConstructor('\endnotetext[]{}',
 # Extra stuff
 Let('\case',      '\frac');
 Let('\slantfrac', '\frac');
-DefConstructor('\text{}', "<ltx:text>#1</ltx:text>", mode => 'text');
+DefConstructor('\text{}', "<ltx:text _noautoclose='true'>#1</ltx:text>", mode => 'text', locked => 1);
 
 # RevTeX3 (obsolete in RevTeX4)
 DefConstructor('\bm{}',   '#1', bounded => 1, requireMath => 1, font => { forcebold => 1 });
@@ -166,7 +166,7 @@ DefConstructor('\bbox{}', '#1', bounded => 1, requireMath => 1, font => { forceb
 DefConstructor('\pmb{}', '#1', bounded => 1, requireMath => 1,
   font => { forcebold => 1, family => 'blackboard',
     series => 'medium', shape => 'upright' });
-DefMacro('\eqnum {}', '\lx@equation@settag{\edef\theequation{#2}\lx@make@tags{equation}}');
+DefMacro('\eqnum {}', '\lx@equation@settag{\edef\theequation{#2}\lx@make@tags{equation}}', locked => 1);
 
 # Redefined in revtex3_support
 DefMacro('\mathletters',    '');
@@ -192,10 +192,10 @@ DefConstructor('\references',
     . "<ltx:biblist>",
   beforeDigest => sub {
     beforeDigestBibliography(); },
-  afterDigest => sub { beginBibliography($_[1]); });
+  afterDigest => sub { beginBibliography($_[1]); }, locked => 1);
 
 DefConstructor('\endreferences',
-  "</ltx:biblist></ltx:bibliography>");
+  "</ltx:biblist></ltx:bibliography>", locked => 1);
 # bibliography and biblist are already set as autoClose.
 
 #======================================================================
@@ -360,4 +360,63 @@ DefMacro('\sjqe',  'Sov.~J.~Quantum Elecron.~');
 DefMacro('\vr',    'Vision Res.~');
 
 #======================================================================
+
+# Some internal macros used in arXiv
+DefMacro('\@revmess{}{}', '\typeout{REVTeX #1: #2}');
+DefMacroI('\@ptsize',      undef, '0');
+DefMacroI('\ds@preprint',  undef, '\global\preprintstytrue \def\@ptsize{2}');
+DefMacroI('\ds@twoside',   undef, '\@twosidetrue \@mparswitchtrue');
+DefMacroI('\ds@draft',     undef, '\overfullrule 5\p@');
+DefMacroI('\ds@amsfonts',  undef, '\@amsfontstrue');
+DefMacroI('\ds@amssymb',   undef, '\@amssymbolstrue');
+DefMacroI('\ds@titlepage', undef, '\@titlepagefalse');
+DefMacroI('\ds@twocolumn', undef, '\@twocolumntrue');
+DefMacroI('\ds@tighten',   undef, '\@tightenlinestrue');
+DefMacroI('\ds@floats',    undef, '\@floatstrue');
+DefMacroI('\ds@eqsecnum',  undef, '\global\secnumberstrue');
+
+DefMacroI('\@journal', undef, 'pra');
+DefMacroI('\ds@pra',   undef, '\def\@journal{pra}');
+DefMacroI('\ds@prb',   undef, '\def\@journal{prb}');
+DefMacroI('\ds@prc',   undef, '\def\@journal{prc}');
+DefMacroI('\ds@prd',   undef, '\def\@journal{prd}');
+DefMacroI('\ds@pre',   undef, '\def\@journal{pre}');
+DefMacroI('\ds@prl',   undef, '\def\@journal{prl}');
+DefMacroI('\ds@josaa', undef, '\def\@journal{josaa}');
+DefMacroI('\ds@josab', undef, '\def\@journal{josab}');
+DefMacroI('\ds@aplop', undef, '\def\@journal{aplop}');
+
+Let('\ds@manuscript', '\ds@preprint');
+
+RawTeX(<<'EOL');
+\@namedef{ds@11pt}{\def\@ptsize{1}}
+\@namedef{ds@12pt}{\def\@ptsize{2}}
+\newif\ifpreprintsty \global\preprintstyfalse
+\@namedef{ds@aps}{\def\@society{aps}}
+\@namedef{ds@osa}{\def\@society{osa}}
+
+\newif\if@amsfonts  \@amsfontsfalse
+\newif\if@amssymbols  \@amssymbolsfalse
+\newif\if@titlepage  \@titlepagefalse
+\newif\if@tightenlines \@tightenlinesfalse
+\newif\if@floats \@floatsfalse
+\newif\ifsecnumbers \global\secnumbersfalse
+\newif\if@amsfonts  \@amsfontsfalse
+\newif\if@amssymbols  \@amssymbolsfalse
+\newif\if@titlepage  \@titlepagefalse
+\newif\if@tightenlines \@tightenlinesfalse
+\newif\if@floats \@floatsfalse
+\newif\ifsecnumbers \global\secnumbersfalse
+EOL
+
+DefMacroI('\ds@amsfonts',  undef, '\@amsfontstrue');
+DefMacroI('\ds@amssymb',   undef, '\@amssymbolstrue');
+DefMacroI('\ds@titlepage', undef, '\@titlepagefalse');
+DefMacroI('\ds@twocolumn', undef, '\@twocolumntrue');
+DefMacroI('\ds@tighten',   undef, '\@tightenlinestrue');
+DefMacroI('\ds@floats',    undef, '\@floatstrue');
+DefMacroI('\ds@eqsecnum',  undef, '\global\secnumberstrue');
+
+#======================================================================
+
 1;


### PR DESCRIPTION
Apparently seeing an arXiv PR gets one curious to also make another small arXiv PR...

This patch upgrades `arXiv:cond-mat/0003435` from a timeout Fatal to a Warning status (due to math parsing).

* lock more natbib macros to avoid redefinitions in arXiv that lead to badly broken misinterpretation with infinite loops in `\bibitem`.
  * Also make sure we have enough locked to keep the citation filling operational.
* add some minor internal revtex macros to silence some otherwise unimportant errors.

Hopefully no unintended consequences... 

There is a general pattern I've spotted, which is that quite often we don't want to allow redefining macros which have a constructor in their expansion, especially for core features of LaTeX, but maybe in general. OR, vice-versa, only allow a redefinition if the new definition *also* has a primitive or constructor in the expansion, to ensure we don't lose the level of supported XML markup. I haven't acted on this observation here, but felt worth recording.