### PR TITLE
Safe(r) backticks

### DIFF
--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -354,8 +354,10 @@ sub texlive_version {
       $tex = $path; } }
   if (!$tex) {    # Else look for executable
     $tex = which("tex"); }
-  if ($tex) {     # If we found one, hope it has TeX Live version in it's --version
-    my $version_string = `$tex --version`;
+  if ($tex && open(my $texfh, '-|', $tex, '--version')) { # If we found one, hope it has TeX Live version in it's --version
+    my $version_string;
+    { local $/; $version_string = <$texfh>; }
+    close($texfh);
     if ($version_string =~ /TeX Live (\d+)/) {
       $texlive_version = int($1); }
     else {


### PR DESCRIPTION
Another fix about passing the arguments in a list so that they are escaped correctly. With this, Windows passes all tests except for `931_epub.t`, so it's very close to working out of the box!

On the other hand, this is only a stopgap measure because Perl may still mangle the arguments under certain conditions. My suggestion would be to add a small `LaTeXML::Util::Run` module with say `run` and `capture` in order to deal with this properly.

In the meanwhile, this PR should cover like 99.9% of the situations correctly.