### PR TITLE
Consume output of latexmlc invocation and close pipe in EPUB test

### DIFF
--- a/t/931_epub.t
+++ b/t/931_epub.t
@@ -26,6 +26,8 @@ push(@invocation, $latexmlc, '--css=LaTeXML-epub.css', "--dest=$epub_filename", 
 
 my ($writer_discard, $reader_discard, $error_discard);
 my $pid = open3($writer_discard, $reader_discard, $error_discard, @invocation);
+{ local $/; <$reader_discard>; } # consume all output
+close($reader_discard);
 ok(waitpid( $pid, 0 ), "latexmlc invocation for test 931_epub.t : $!");
 
 ok(-f $epub_filename, 'epub file generated');


### PR DESCRIPTION
Apparently, Windows is more picky with `open3`: if you don't consume the output, the command hangs and `waitpid` waits forever. So consuming the output and calling `close` is the way to go, rather than `waitpid`.

This is the last Windows fix!