### PR TITLE
Avoid adding date to split-off pages

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -390,10 +390,12 @@
       <xsl:call-template name="authors">
         <xsl:with-param name="context" select="$context"/>
       </xsl:call-template>
-      <xsl:call-template name="dates">
-        <xsl:with-param name="context" select="$context"/>
-        <xsl:with-param name="dates" select="../ltx:date"/>
-      </xsl:call-template>
+      <xsl:if test="not(//ltx:navigation/ltx:ref[@rel='up'])">
+        <xsl:call-template name="dates">
+          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="dates" select="../ltx:date"/>
+        </xsl:call-template>
+      </xsl:if>
     </xsl:if>
     <xsl:apply-templates select="." mode="end">
       <xsl:with-param name="context" select="$context"/>


### PR DESCRIPTION
Indeed, the redundant dates wasn't intentional.  Your approach is basically correct, but I think (hope) this test is a more general way of excluding the dates.

fixes #1478