### PR TITLE
add space before keywords

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -173,7 +173,7 @@
           <xsl:apply-templates select="@name">
             <xsl:with-param name="context" select="$innercontext"/>
           </xsl:apply-templates>
-          <xsl:text>:</xsl:text>
+          <xsl:text>: </xsl:text>
         </xsl:element>
       </xsl:if>
       <xsl:apply-templates>


### PR DESCRIPTION
One character patch adding one missing space in a stylesheet between the colon and the following keywords. I grepped the other `<xsl:text>:` and this seems to be the only offender re spaces.