### PR TITLE
Add Exit Codes to 'latexmlpost' and 'latexmlmath' (Fixes #1417)

### DIFF
--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -240,12 +240,14 @@ if ($xmath) {
   outputXML($result->findnode('//ltx:XMath'), $xmath); }
 
 my $status = $latexml->getStatusMessage;
+my $code = $latexml->getStatusCode;
 # Should be combined with $post's status!
 # But better approach will be to manage all through LaTeXML.pm!!
 my $runtime = RunTime($starttime);
 NoteLog("Conversion complete: " . $status);
 NoteSTDERR("Conversion complete: " . $status . " (reqd. $runtime)");
 UseLog(undef);
+exit $code;
 
 #======================================================================
 # Helpers

--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -247,7 +247,7 @@ my $runtime = RunTime($starttime);
 NoteLog("Conversion complete: " . $status);
 NoteSTDERR("Conversion complete: " . $status . " (reqd. $runtime)");
 UseLog(undef);
-exit $code;
+exit $code == 3 ? 1 : 0;
 
 #======================================================================
 # Helpers

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -474,6 +474,7 @@ NoteSTDERR("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . " " . $sta
 UseLog(undef);
 CheckDebuggable();
 UseSTDERR(undef);
+exit $code;
 
 #======================================================================
 # helpers

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -474,7 +474,7 @@ NoteSTDERR("Postprocessing " . ($code == 3 ? 'failed' : 'complete') . " " . $sta
 UseLog(undef);
 CheckDebuggable();
 UseSTDERR(undef);
-exit $code;
+exit $code == 3 ? 1 : 0;
 
 #======================================================================
 # helpers


### PR DESCRIPTION
Fixes #1417 

This PR adds exit codes to the 'latexmlpost' and 'latexmlmath' executables, as suggested in https://github.com/brucemiller/LaTeXML/issues/1417#issuecomment-751760914.

The first commit uses a patch suggested by @epifanovsky.