### PR TITLE
arxiv fixes from css sprint

### DIFF
--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -218,10 +218,10 @@ sub _spinnerstep {    # Increment stepper
   if ($USE_STDERR && $IS_TERMINAL && ($VERBOSITY >= 0) && @spinnerstack) {
     my ($stage, $short, $start) = @{ $spinnerstack[-1] };
     $spinnerpos = ($spinnerpos + 1) % 4;
-    if ($note) {      # If note, redraw whole line.
+    if ($note) {    # If note, redraw whole line.
       print STDERR join(' ', $spinnerpre, $spinnerchar[$spinnerpos],
         (map { $$_[1]; } @spinnerstack), $note, "\x1b[0K"), $spinnerpost; }
-    else {            # overwrite previous spinner
+    else {          # overwrite previous spinner
       print STDERR $spinnerpre . ' ', $spinnerchar[$spinnerpos], $spinnerpost; } }
   return; }
 
@@ -529,7 +529,7 @@ sub perl_warn_handler {
     my ($warning, $where) = ($1, $2);
     Warn('perl', 'warn', undef, $warning, $where, @line[1 .. $#line]); }
   else {
-    Warn('perl', 'warn', undef, "Perl warning", @line); }
+    Warn('perl', 'warn', undef, @line); }
   return; }
 
 # The following handlers SHOULD report the problem,

--- a/lib/LaTeXML/Package/AmSTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/AmSTeX.pool.ltxml
@@ -41,7 +41,7 @@ DefPrimitive('\define SkipSpaces Token UntilBrace {}', sub {
     $params = parseDefParameters($cs, $params);    # in TeX.pool
     if (LookupDefinition($cs)) {
       Info('ignore', $cs, $stomach,
-        "Ignoring redefinition (\\define) of '" . Stringify($cs) . "'");
+        "Ignoring redefinition (\\define) of '" . ToString($cs) . "'");
       return; }
     DefMacroI($cs, $params, $body);
     return; });
@@ -322,7 +322,7 @@ DefConstructor('\lx@ams@boldsymbol@{}', '#1',
 
 DefMacro('\boldsymbol DefToken', sub {
     my ($gullet, $token) = @_;
-    my $name = ToString($token); $name =~ s/^\\//;
+    my $name   = ToString($token); $name =~ s/^\\//;
     my $btoken = T_CS('\lx@ams@boldsymbol@' . $name);
     return (IsDefined($btoken) ? ($btoken) : (T_CS('\lx@ams@boldsymbol@'), $token)); });
 

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4642,8 +4642,6 @@ sub before_picture {
 sub after_picture {
   return; }
 
-# Since these ultimately generate external resources, it can be useful to have a handle on them.
-Tag('ltx:graphics', afterOpen => sub { GenerateID(@_, 'g'); });
 # Ugh... Is this safe?  Apparently, picture stuff is allowed w/o a {picture} environment???
 Tag('ltx:picture', autoOpen => 0.5, autoClose => 1,
   afterOpen  => sub { GenerateID(@_, 'pic'); },

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2469,7 +2469,7 @@ DefPrimitive('\newcommand OptionalMatch:* SkipSpaces DefToken [Number][]{}', sub
     my ($stomach, $star, $cs, $nargs, $opt, $body) = @_;
     if (!isDefinable($cs)) {
       Info('ignore', $cs, $stomach,
-        "Ignoring redefinition (\\newcommand) of '" . Stringify($cs) . "'")
+        "Ignoring redefinition (\\newcommand) of '" . ToString($cs) . "'")
         unless LookupValue(ToString($cs) . ':locked');
       return; }
     DefMacroI($cs, convertLaTeXArgs($nargs, $opt), $body); });

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -98,7 +98,7 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
     else {
       InputDefinitions('OmniBus', type => 'cls', noerror => 1,
         handleoptions => 1, options => $options,
-        after => Tokens(T_CS('\compat@loadpackages')));
+        after         => Tokens(T_CS('\compat@loadpackages')));
       RequirePackage($class, options => $options, as_class => 1); }
     return; });
 
@@ -330,12 +330,12 @@ DefConstructorI(T_CS('\begin{document}'), undef, sub {
     $_[1]->setProperty(id => Expand(T_CS('\thedocument@ID')));
     my @boxes = ();
     if (my $ops = LookupValue('@document@preamble@atend')) {
-      push(@boxes, Digest(Tokens(@$ops))); }
+      push(@boxes, $stomach->digest(Tokens(@$ops))); }
     if (my $ops = LookupValue('@at@begin@document')) {
-      push(@boxes, Digest(Tokens(@$ops))); }
+      push(@boxes, $stomach->digest(Tokens(@$ops))); }
     AssignValue(inPreamble => 0);    # atbegin is still (sorta) preamble
     if (my $ops = LookupValue('@document@preamble@afterend')) {
-      push(@boxes, Digest(Tokens(@$ops))); }
+      push(@boxes, $stomach->digest(Tokens(@$ops))); }
     $_[1]->setFont(LookupValue('font'));    # Start w/ whatever font was last selected.
     return @boxes; });
 
@@ -349,9 +349,9 @@ DefConstructorI(T_CS('\end{document}'), undef, sub {
     my ($stomach) = @_;
     my @boxes = ();
     if (my $ops = LookupValue('@at@end@document')) {
-      push(@boxes, Digest(Tokens(@$ops))); }
+      push(@boxes, $stomach->digest(Tokens(@$ops))); }
     # Should we try to indent the last paragraph? If so, it goes like this:
-    push(@boxes, Digest(T_CS('\normal@par')));
+    push(@boxes, $stomach->digest(T_CS('\normal@par')));
     # Now we check whether we're down to the last stack frame.
     # It is common for unclosed { or even environments
     # and we want to at least compress & avoid unnecessary errors & warnings.
@@ -471,7 +471,7 @@ sub makeNoteTags {
       tags => Digest(T_BEGIN,
         T_CS('\def'), T_CS('\the' . $counter), T_BEGIN, Revert($tag), T_END,
         T_CS('\def'), T_CS('\typerefnum@' . $counter),
-        T_BEGIN, T_CS('\\' . $counter . 'typerefname'), T_SPACE, Revert($tag), T_END,
+        T_BEGIN,      T_CS('\\' . $counter . 'typerefname'), T_SPACE, Revert($tag), T_END,
         Invocation(T_CS('\lx@make@tags'), T_OTHER($counter)),
         T_END)); }
   else {
@@ -606,11 +606,11 @@ DefMacro('\@startsection{}{}{}{}{}{} OptionalMatch:*', sub {
       || LookupValue('no_number_sections')) {
       # No number, but in TOC
       (T_CS('\par'), T_CS('\@startsection@hook'), T_CS('\\@@unnumbered@section'),
-        T_BEGIN, $type->unlist, T_END,
+        T_BEGIN, $type->unlist,  T_END,
         T_BEGIN, T_OTHER('toc'), T_END); }
     else {          # Number and in TOC
       (T_CS('\par'), T_CS('\@startsection@hook'), T_CS('\\@@numbered@section'),
-        T_BEGIN, $type->unlist, T_END,
+        T_BEGIN, $type->unlist,  T_END,
         T_BEGIN, T_OTHER('toc'), T_END); } },
   locked => 1);
 
@@ -1043,7 +1043,7 @@ DefConstructor('\person@thanks{}', "^ <ltx:contact role='thanks'>#1</ltx:contact
   alias => '\thanks', mode => 'text');
 DefConstructor('\@personname{}', "<ltx:personname>#1</ltx:personname>",
   beforeDigest => sub { Let('\thanks', '\person@thanks'); },
-  bounded => 1, mode => 'text');
+  bounded      => 1, mode => 'text');
 
 DefConstructorI('\and', undef, " and ");
 
@@ -1187,7 +1187,7 @@ DefEnvironment('{titlepage}', '<ltx:titlepage>#body',
       "When using titlepage, Frontmatter will not be well-structured");
     return; },
   beforeDigestEnd => sub { Digest(T_CS('\maybe@end@titlepage')); },
-  locked => 1, mode => 'text');
+  locked          => 1, mode => 'text');
 
 Tag('ltx:titlepage', autoClose => 1);
 DefConstructorI('\maybe@end@titlepage', undef, sub {
@@ -1410,7 +1410,7 @@ sub RefStepItemCounter {
         T_CS('\let'), T_CS('\the' . $counter),   T_CS('\@empty'),
         T_CS('\def'), T_CS('\fnum@' . $counter), T_BEGIN, $formatter, T_BEGIN, Revert($tag), T_END, T_END,
         T_CS('\def'), T_CS('\typerefnum@' . $counter),
-        T_BEGIN, $typename, T_SPACE, Revert($tag), T_END,
+        T_BEGIN,      $typename, T_SPACE, Revert($tag), T_END,
         Invocation(T_CS('\lx@make@tags'), T_OTHER($counter)),
         T_END);
 
@@ -1737,7 +1737,7 @@ DefConstructorI('\lx@@verbatim', undef,
     my ($stomach) = @_;
     StartSemiverbatim('%', '\\', '{', '}');
     MergeFont(family => 'typewriter', series => 'medium', shape => 'upright');
-    $STATE->assignCatcode(' ', CC_ACTIVE);            # Do NOT (necessarily) skip spaces after \verb!!!
+    $STATE->assignCatcode(' ', CC_ACTIVE);    # Do NOT (necessarily) skip spaces after \verb!!!
     Let(T_ACTIVE(' '), T_SPACE); });
 DefConstructorI('\lx@end@verbatim', undef,
   "</ltx:verbatim>",
@@ -2641,7 +2641,7 @@ DefPrimitive('\DeclareFontFamily{}{}{}',      undef);
 DefPrimitive('\DeclareSizeFunction{}{}',      undef);
 
 my $symboltype_roles = {
-  '\mathord' => 'ID', '\mathop' => 'BIGOP', '\mathbin' => 'BINOP', '\mathrel' => 'RELOP',
+  '\mathord'  => 'ID',   '\mathop'    => 'BIGOP', '\mathbin'   => 'BINOP', '\mathrel' => 'RELOP',
   '\mathopen' => 'OPEN', '\mathclose' => 'CLOSE', '\mathpunct' => 'PUNCT' };
 DefPrimitive('\DeclareMathSymbol DefToken SkipSpaces DefToken {}{Number}', sub {
     my ($stomach, $cs, $type, $font, $code) = @_;
@@ -2661,7 +2661,7 @@ Let('\cdp@elt', '\relax');
 DefPrimitive('\DeclareFontEncoding{}{}{}', sub {
     my ($stomach, $encoding, $x, $y) = @_;
     AddToMacro(T_CS('\cdp@list'), T_CS('\cdp@elt'),
-      T_BEGIN, $_[1]->unlist, T_END,
+      T_BEGIN, $_[1]->unlist,           T_END,
       T_BEGIN, T_CS('\default@family'), T_END,
       T_BEGIN, T_CS('\default@series'), T_END,
       T_BEGIN, T_CS('\default@shape'),  T_END);
@@ -2890,7 +2890,7 @@ sub defineNewTheorem {
         $headformatter->unlist,
         T_BEGIN, ($type ? $type->unlist : ()), T_END,
         T_CS('\the' . $counter), T_BEGIN, Tokens(T_PARAM, T_OTHER('1')), T_END,
-        T_CS('\the'), T_CS('\thm@headpunct'))
+        T_CS('\the'),            T_CS('\thm@headpunct'))
       : '{\the\thm@headfont\lx@tag{\csname fnum@' . $thmset . '\endcsname}'
         . '{' . ($type ? '\ifx.#1.\else\space\the\thm@notefont(#1)\fi' : '#1') . '}'
         . '\the\thm@headpunct}'),
@@ -3868,7 +3868,7 @@ DefMacro('\lx@mung@bibliography{}', sub {
     if (($tag eq 'enumerate') || ($tag eq 'itemize') || ($tag eq 'description')) {
       # nDamn! We're in a list {$tag}; try to close it!
       push(@tokens, Invocation('\end', $env),
-        T_CS('\let'), T_CS('\end' . $tag), T_CS('\endthebibliography'),
+        T_CS('\let'), T_CS('\end' . $tag),        T_CS('\endthebibliography'),
         T_CS('\let'), T_CS('\end{' . $tag . '}'), T_CS('\end{thebibliography}')); }
     # else ? it probably isn't going to work??
     # Now, try to open {thebibliography}
@@ -4378,7 +4378,7 @@ DefConstructor('\@framebox[Dimension][]{}',
     . "(<ltx:text ?#width(width='#width') ?#align(align='#align')"
     . " framed='rectangle' framecolor='#framecolor'"
     . " _noautoclose='1'>#3</ltx:text>)",
-  alias => '\framebox', sizer => '#3',
+  alias        => '\framebox', sizer => '#3',
   beforeDigest => sub {
     my ($stomach) = @_;
     my $wasmath = LookupValue('IN_MATH');
@@ -4470,7 +4470,7 @@ DefConstructor('\parbox[] OptionalUndigested OptionalUndigested {Dimension} VBox
     (width => $_[4],
       vattach => translateAttachment($_[1]),
       height  => $_[2]); },
-  mode => 'text', bounded => 1,
+  mode         => 'text', bounded => 1,
   beforeDigest => sub {
     AssignValue('\hsize' => $_[4]);
     Let('\\\\', '\lx@parboxnewline'); });
@@ -4919,32 +4919,32 @@ DefMacro('\usefont{}{}{}{}',
 
 # If these series or shapes appear in math, they revert it to roman, medium, upright (?)
 DefConstructor('\textmd@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { series => 'medium' }, alias => '\textmd',
+  bounded      => 1, font => { series => 'medium' }, alias => '\textmd',
   beforeDigest => sub { DefMacro('\f@series', 'm'); });
 DefConstructor('\textbf@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { series => 'bold' }, alias => '\textbf',
+  bounded      => 1, font => { series => 'bold' }, alias => '\textbf',
   beforeDigest => sub { DefMacro('\f@series', 'b'); });
 DefConstructor('\textrm@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { family => 'serif' }, alias => '\textrm',
+  bounded      => 1, font => { family => 'serif' }, alias => '\textrm',
   beforeDigest => sub { DefMacro('\f@family', 'cm'); });
 DefConstructor('\textsf@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { family => 'sansserif' }, alias => '\textsf',
+  bounded      => 1, font => { family => 'sansserif' }, alias => '\textsf',
   beforeDigest => sub { DefMacro('\f@family', 'cmss'); });
 DefConstructor('\texttt@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { family => 'typewriter' }, alias => '\texttt',
+  bounded      => 1, font => { family => 'typewriter' }, alias => '\texttt',
   beforeDigest => sub { DefMacro('\f@family', 'cmtt'); });
 
 DefConstructor('\textup@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'upright' }, alias => '\textup',
+  bounded      => 1, font => { shape => 'upright' }, alias => '\textup',
   beforeDigest => sub { DefMacro('\f@shape', ''); });
 DefConstructor('\textit@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'italic' }, alias => '\textit',
+  bounded      => 1, font => { shape => 'italic' }, alias => '\textit',
   beforeDigest => sub { DefMacro('\f@shape', 'i'); });
 DefConstructor('\textsl@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'slanted' }, alias => '\textsl',
+  bounded      => 1, font => { shape => 'slanted' }, alias => '\textsl',
   beforeDigest => sub { DefMacro('\f@shape', 'sl'); });
 DefConstructor('\textsc@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'smallcaps' }, alias => '\textsc',
+  bounded      => 1, font => { shape => 'smallcaps' }, alias => '\textsc',
   beforeDigest => sub { DefMacro('\f@shape', 'sc'); });
 DefConstructor('\textnormal@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
   bounded => 1, font => { family => 'serif', series => 'medium', shape => 'upright' }, alias => '\textnormal',
@@ -4967,7 +4967,7 @@ DefPrimitive('\DeclareTextFontCommand{}{}', sub {
     my ($stomach, $cmd, $font) = @_;
     DefConstructorI($cmd, "{}",
       "?#isMath(<ltx:text _noautoclose='1'>#1</ltx:text>)(#1)",
-      mode => 'text', bounded => 1,
+      mode         => 'text', bounded => 1,
       beforeDigest => sub { Digest($font); (); });
     return; });
 
@@ -5327,6 +5327,7 @@ RawTeX(<<'EoTeX');
 EoTeX
 
 DefPrimitive('\@setsize{}{}{}{}', undef);
+DefMacro('\on@line', ' on input line \the\inputlineno');
 Let('\@warning',  '\@latex@warning');
 Let('\@@warning', '\@latex@warning@no@line');
 

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2381,7 +2381,33 @@ DefPrimitive('\immediate', undef);
 #======================================================================
 # Remaining semi- Vertical Mode primitives in Ch.24, pp.280--281
 
-DefPrimitive('\special {}',     undef);
+DefPrimitive('\special {}', sub {
+    my ($stomach, $arg) = @_;
+    my $special_str = ToString($arg);
+    # recognize one special graphics inclusion case
+    if ($special_str =~ /\bpsfile=(.+?)(?:\s|\})/) {
+      my $graphic = $1;
+      RequirePackage('graphicx', searchpaths_only => 1);
+      $stomach->getGullet->unread(
+        Invocation(T_CS('\ltx@special@graphics'), T_OTHER($graphic))->unlist); }
+    return; });
+# adapted from graphicx.sty.ltxml
+DefConstructor('\ltx@special@graphics Semiverbatim',
+  "<ltx:graphics graphic='#path' candidates='#candidates'/>",
+  sizer      => \&image_graphicx_sizer,
+  properties => sub {
+    my ($stomach, $path) = @_;
+    $path = ToString($path); $path =~ s/^\s+//; $path =~ s/\s+$//;
+    my $searchpaths = LookupValue('GRAPHICSPATHS');
+    my @candidates  = pathname_findall($path, types => ['*'], paths => $searchpaths);
+    if (my $base = LookupValue('SOURCEDIRECTORY')) {
+      @candidates = map { pathname_relative($_, $base) } @candidates; }
+    (path => $path,
+      candidates => join(',', @candidates)); },
+  mode => 'text');
+# Since these ultimately generate external resources, it can be useful to have a handle on them.
+Tag('ltx:graphics', afterOpen => sub { GenerateID(@_, 'g'); });
+
 DefPrimitive('\penalty Number', undef);
 DefPrimitive('\kern Dimension', undef);
 DefPrimitiveI('\unpenalty', undef, undef);

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1089,7 +1089,7 @@ sub today {
 
 # Read-only Integer registers
 {
-  my %ro_iparms = (lastpenalty => 0, inputlineno => 0, badness => 0);
+  my %ro_iparms = (lastpenalty => 0, badness => 0);
   foreach my $p (keys %ro_iparms) {
     DefRegister("\\$p", Number($ro_iparms{$p}), readonly => 1); }
 }
@@ -1424,9 +1424,11 @@ DefPrimitive('\parshape SkipMatch:= Number', sub {
     # we _could_ conceivably store this somewhere for some attempt at stylistic purpose...
     return; });
 
-#DefRegister('\inputlineno',Number(0),
-#            readonly=>1,
-#            getter=>{ Number($stomach->getGullet->????? ->lineno); });
+DefRegister('\inputlineno', Number(0),
+  getter => sub {
+    my $locator = $STATE->getStomach->getGullet->getLocator();
+    Number($locator ? $$locator{fromLine} : 0); },
+  readonly => 1);
 
 DefRegister('\badness', Number(0), readonly => 1);
 

--- a/lib/LaTeXML/Package/amsbook.cls.ltxml
+++ b/lib/LaTeXML/Package/amsbook.cls.ltxml
@@ -57,5 +57,18 @@ DefPrimitive('\backmatter', undef);
 # commands for bibliography, indices
 # \end{document}
 
+# Couple of internals that get used in arXiv:
+DefMacro('\@listI', '\leftmargin\leftmargini \parsep\z@skip
+  \topsep\listisep \itemsep\z@skip
+  \listparindent\normalparindent');
+Let('\@listi',         '\@listI');
+Let('\enddescription', '\endlist');
+Let('\upn',            '\textup');
+
+RawTeX(<<'EOL');
+\newskip\listisep
+\listisep\smallskipamount
+EOL
+
 # #======================================================================
 1;

--- a/lib/LaTeXML/Package/amsthm.sty.ltxml
+++ b/lib/LaTeXML/Package/amsthm.sty.ltxml
@@ -40,6 +40,11 @@ setSavableTheoremParameters(qw(
     \thm@headfont \thm@bodyfont \thm@headpunct
     \thm@styling \thm@headstyling \thm@headformatter thm@swap));
 
+# extra stubs (for now?) for internals that show up in arXiv:
+DefRegisterI('\thm@preskip',  undef, Glue(0));
+DefRegisterI('\thm@postskip', undef, Glue(0));
+DefMacro('\thm@space@setup', '\thm@preskip=\topsep \thm@postskip=\thm@preskip');
+
 # activate a certain theorem style
 DefPrimitive('\theoremstyle{}', sub {
     my $style = ToString($_[1]);

--- a/lib/LaTeXML/Package/etoolbox.sty.ltxml
+++ b/lib/LaTeXML/Package/etoolbox.sty.ltxml
@@ -40,7 +40,7 @@ DefMacro('\newrobustcmd OptionalMatch:* DefToken [Number][]{}', sub {
     my ($stomach, $star, $cs, $nargs, $opt, $body) = @_;
     if (!isDefinable($cs)) {
       Info('ignore', $cs, $stomach,
-        "Ignoring redefinition (\\newcommand) of '" . Stringify($cs) . "'")
+        "Ignoring redefinition (\\newcommand) of '" . ToString($cs) . "'")
         unless LookupValue(ToString($cs) . ':locked'); }
     else {
       DefMacroI($cs, convertLaTeXArgs($nargs, $opt), $body, protected => 1, long => 1); }

--- a/lib/LaTeXML/Package/longtable.sty.ltxml
+++ b/lib/LaTeXML/Package/longtable.sty.ltxml
@@ -131,6 +131,6 @@ DefRegister('\LTPre'       => Glue(0));
 DefRegister('\LTPost'      => Glue(0));
 DefRegister('\LTcapwidth'  => Glue(0));
 DefRegister('\LTchunksize' => Number(20));
-
+Let('\setlongtables', '\relax');
 #======================================================================
 1;

--- a/lib/LaTeXML/Package/twoopt.sty.ltxml
+++ b/lib/LaTeXML/Package/twoopt.sty.ltxml
@@ -37,7 +37,7 @@ DefPrimitive('\newcommandtwoopt OptionalMatch:* DefToken [Number][][]{}', sub {
     my ($stomach, $star, $cs, $nargs, $opt1, $opt2, $body) = @_;
     if (!isDefinable($cs)) {
       Info('ignore', $cs, $stomach,
-        "Ignoring redefinition (\\newcommand) of '" . Stringify($cs) . "'")
+        "Ignoring redefinition (\\newcommand) of '" . ToString($cs) . "'")
         unless LookupValue(ToString($cs) . ':locked');
       return; }
     DefMacroI($cs, convert2optArgs($nargs, $opt1, $opt2), $body); });

--- a/lib/LaTeXML/Package/xargs.sty.ltxml
+++ b/lib/LaTeXML/Package/xargs.sty.ltxml
@@ -96,7 +96,7 @@ DefPrimitive('\newcommandx OptionalMatch:* DefToken [] OptionalKeyVals:xargs {}'
     my ($stomach, $star, $cs, $nargs, $defaults, $body) = @_;
     if (!isDefinable($cs)) {
       Info('ignore', $cs, $stomach,
-        "Ignoring redefinition (\\newcommandx) of '" . Stringify($cs) . "'");
+        "Ignoring redefinition (\\newcommandx) of '" . ToString($cs) . "'");
       return; }
     DefMacroI($cs, convertXArgsArgs($nargs, $defaults), $body, (getXArgsIsGlobal($star, $defaults) ? (scope => 'global') : ())); });
 
@@ -111,10 +111,10 @@ DefPrimitive('\providecommandx OptionalMatch:* DefToken [] OptionalKeyVals:xargs
 
 DefPrimitive('\DeclareRobustCommandx OptionalMatch:* DefToken [] OptionalKeyVals:xargs {}', sub {
     my ($stomach, $star, $cs, $nargs, $defaults, $body) = @_;
-    my @scope = (getXArgsIsGlobal($star, $defaults) ? (scope => 'global') : ());
+    my @scope    = (getXArgsIsGlobal($star, $defaults) ? (scope => 'global') : ());
     my $mungedcs = T_CS($cs->getString . ' ');
     DefMacroI($mungedcs, convertLaTeXArgs($nargs, $defaults), $body, @scope);
-    DefMacroI($cs, undef, Tokens(T_CS('\protect'), $mungedcs), @scope); });
+    DefMacroI($cs,       undef, Tokens(T_CS('\protect'), $mungedcs), @scope); });
 
 DefPrimitive('\newenvironmentx OptionalMatch:* {} [] OptionalKeyVals:xargs {}{}', sub {
     my ($stomach, $star, $cs, $nargs, $defaults, $preamble, $postamble) = @_;


### PR DESCRIPTION
A handful of smaller fixes during my CSS prototyping sessions with two books and ~10 articles from the arXiv corpus:

 - an experiment supporting the "psfile" key in `\special` to get graphics into some of the older docs
   - [astro-ph0001188](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/no_problem) is one example
 - slightly cleaner warning text for generic "perl warning" and "redefinition" messages
 - using `$stomach->digest` instead of `Digest` in a couple of obvious places
 - `\inputlineno` register and using it via the `\on@line` internal, 
 - some `\listi` internals for amsbook
 - a stub for `\setlongtables` in etoolbox
 - some internal skips for amsthm
 
There are still a couple of errors in the big books I was testing with, but already some improvement. The heavier lifting in #1549 can be done in the next release.