### PR TITLE
Guard existing macros from \DeclareMathAlphabet

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2632,8 +2632,15 @@ DefPrimitive('\DeclareSymbolFontAlphabet{}{}', sub {
 DefPrimitive('\DeclareMathSizes{}{}{}{}', undef);
 DefPrimitive('\DeclareMathAlphabet{}{}{}{}{}', sub {
     my ($stomach, $cs, $enc, $family, $series, $shape) = @_;
-    my %font = LaTeXML::Common::Font::lookupTeXFont($family, $series, $shape);
-    DefPrimitiveI(T_CS(ToString($cs)), undef, undef, font => {%font}); });
+    my $csname = ToString($cs);
+    # We won't override this, e.g. \mathrm by fouriernc.sty
+    if (IsDefined($csname)) {
+      Info('ignore', $csname, $stomach,
+        "Ignoring redefinition (\\DeclareMathAlphabet) of '" . $csname . "'"); }
+    else {
+      my %font = LaTeXML::Common::Font::lookupTeXFont($family, $series, $shape);
+      DefPrimitiveI(T_CS($csname), undef, undef, font => {%font}); }
+    return; });
 
 DefMacro('\newmathalphabet{}{}{}', Tokens());    # or expand int DeclareMathAlphabet?
 DefPrimitive('\DeclareFontShape{}{}{}{}{}{}', undef);


### PR DESCRIPTION
I was seeing some rather broken tokenization examples in `\mathrm` that lead to bad rendering in HTML. To reproduce an example, you can try:

```tex
\documentclass{article}
\usepackage{fouriernc}

\begin{document}

$\mathrm{Tribes}_{w,s} $

\end{document}
```

converted with `--includestyles`. The `fouriernc.sty` file was being loaded in an arXiv job as it was requested from within a different `.sty` file, and thus being allowed in raw. Turns out, that package has the definition:
```tex
\DeclareMathAlphabet{\mathrm}{T1}{fnc}{m}{n}
```

which derailed latexml's tokenization so that each letter in the example became its own `XMTok`. I am not sure what the ultimately best upgrade is in this regard, but for now we can guard existing macros with a simple `IsDefined` check, hence this PR.

Edit: to be precise, the bad spacing isn't from the single letter tokenization itself, but the follow-up insertion of invisible time `<mo>` elements after.