### PR TITLE
No parens for \date with spaces

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -649,7 +649,7 @@
   <xsl:template name="dates">
     <xsl:param name="context"/>
     <xsl:param name="dates" select="ltx:date"/>
-    <xsl:if test="$dates and string($dates)">
+    <xsl:if test="$dates and normalize-space(string($dates))">
       <xsl:text>&#x0A;</xsl:text>
       <!-- Originally, html5 seemed to suggest we might use h2 here, but that is retracted-->
       <xsl:element name="div" namespace="{$html_ns}">


### PR DESCRIPTION
More arXiv pain (e.g. [here](https://corpora.mathweb.org/preview/arxmliv/tex%5Fto%5Fhtml/math-ph0001001) ), this time continuing the battle with empty `()` parens for space-only dates.

E.g. `\date{ }` or `\date{  }` etc, still produced empty parentheses upon post-processing to HTML. `normalize-whitespace()` gets rid of such cases.