### PR TITLE
Accept and ignore spacing args in \inner@par

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -3262,7 +3262,8 @@ DefConstructorI('\normal@par', undef, sub {
 Let('\par', '\normal@par');
 # OTOH, sometimes \par is just a minimalistic "start a new line"
 # This should be closer for those cases.
-DefConstructorI('\inner@par', undef, sub {
+# BUT! In the cases where an elaborate \\[0.4cm] or such sneaks in, gracefully ignore its args.
+DefConstructor('\inner@par OptionalMatch:* [Glue]', sub {
     if    ($_[0]->maybeCloseElement('ltx:p')) { }
     elsif ($_[0]->canContain($_[0]->getNode, 'ltx:break')) {
       $_[0]->insertElement('ltx:break'); } },


### PR DESCRIPTION
Motivating example: the two `[0.4cm]` leftovers in the rendering of [hep-ph0001194](https://corpora.mathweb.org/preview/arxmliv/tex%5Fto%5Fhtml/hep-ph0001194).

Some title pages on arXiv are held in a `{center}` environment, and the spacing information for `\\[0.4cm]` was remaining dropped as content, due to `\inner@par` not being prepared for such complications.

I simply added the arguments in without using them, which looks much better, and could be improved further if one gets very picky one day.
