### PR TITLE
no XSLT date delimiter

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -673,7 +673,7 @@
 
   <xsl:template match="ltx:date" mode="intitle">
     <xsl:param name="context"/>
-    <xsl:if test="@name"><xsl:value-of select="@name"/><xsl:text>: </xsl:text></xsl:if>
+    <xsl:if test="@name"><xsl:value-of select="@name"/><xsl:text> </xsl:text></xsl:if>
     <xsl:apply-templates select="node()">
       <xsl:with-param name="context" select="$context"/>
     </xsl:apply-templates>


### PR DESCRIPTION
Fixes #1607

One can play around with the issue by defining:
```tex
\def\datename{\textit{Date}:}
```

with and without a colon. I think carrying that as-is to the XML `ltx:date` element is correct, and then we can make a provision for it in the XSLT with a simple if. Since I don't think we support using colons inside the date itself, a simple conditional can do the job.