### PR TITLE
pgfplotstable.sty: add binding allowing raw interpretation

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -586,6 +586,7 @@ lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
 lib/LaTeXML/Package/pgfmath.code.tex.ltxml
 lib/LaTeXML/Package/pgfmathcalc.code.tex.ltxml
 lib/LaTeXML/Package/pgfplots.sty.ltxml
+lib/LaTeXML/Package/pgfplotstable.sty.ltxml
 lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
 lib/LaTeXML/Package/pgfutil-common.tex.ltxml
 lib/LaTeXML/Package/physics.sty.ltxml

--- a/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
@@ -18,7 +18,10 @@ use LaTeXML::Package;
 #**********************************************************************
 InputDefinitions('pgfplotstable', type => 'sty', noltxml => 1);
 # Avoid generic warnings:
-RawTeX('\pgfplotsset{compat=1.17}');
+my $compat_cs  = T_CS('\pgfk@/pgfplots/compat/current');
+my $compat_val = IsDefined($compat_cs) && ToString(Expand($compat_cs));
+if (!$compat_val || $compat_val eq 'default') {
+  RawTeX('\pgfplotsset{compat=1.17}'); }
 
 #**********************************************************************
 

--- a/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
@@ -1,0 +1,25 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  pgfplotstable.sty                                                  | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+InputDefinitions('pgfplotstable', type => 'sty', noltxml => 1);
+# Avoid generic warnings:
+RawTeX('\pgfplotsset{compat=1.17}');
+
+#**********************************************************************
+
+1;


### PR DESCRIPTION
Fixes #1304

latexml can now interpret this style raw.

We just need to avoid a generic warning for backwards compatibility (on my texlive 2020) and we get good outcomes, as described in the issue.