### PR TITLE
pgf/tikz improvements

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -586,6 +586,7 @@ lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
 lib/LaTeXML/Package/pgfmath.code.tex.ltxml
 lib/LaTeXML/Package/pgfmathcalc.code.tex.ltxml
 lib/LaTeXML/Package/pgfplots.sty.ltxml
+lib/LaTeXML/Package/pgfplotstable.sty.ltxml
 lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
 lib/LaTeXML/Package/pgfutil-common.tex.ltxml
 lib/LaTeXML/Package/physics.sty.ltxml

--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -492,21 +492,12 @@ sub computeBoxesSize {
   no warnings 'recursion';
   # Flatten top-level Lists (orrr pass-thru $fillwidth ???)
   my @boxes = map { (ref $_ eq 'LaTeXML::Core::List' ? $_->unlist : $_); } @$boxes;
-  #  foreach my $box (@$boxes) {
   foreach my $box (@boxes) {
     next unless defined $box;
     next if ref $box && !$box->can('getSize');    # Care!! Since we're asking ALL args/compoments
     ## Should any %options be inherited by the contained boxes?
-    my ($w, $h, $d);
-    if (ref $box) {
-      my ($rw, $rh, $rd);
-      ($rw, $rh, $rd, $w, $h, $d) = $box->getSize(); }
-    else {
-      ($w, $h, $d) = $font->computeStringSize($box); }
-    if ((ref $box) && $box->getProperty('isOverlay')) {
-      # An overlay doesn't take space inline, but requires total space (!?!?!)
-      $minwd = max($minwd, $w); $minht = max($minht, $h); $mindp = max($mindp, $d); }
-    elsif (ref $w) {
+    my ($w, $h, $d) = (ref $box ? $box->getSize() : $font->computeStringSize($box));
+    if (ref $w) {
       $wd += $w->valueOf; }
     else {
       Warn('expected', 'Dimension', undef,

--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -486,15 +486,27 @@ sub computeBoxesSize {
     $fillwidth = $fillwidth->valueOf; }    # get register
   my $maxwidth = $fillwidth && $fillwidth->valueOf;
   my @lines    = ();
-  my ($wd, $ht, $dp) = (0, 0, 0);
+  my ($wd, $ht, $dp)          = (0, 0, 0);
+  my ($minwd, $minht, $mindp) = (0, 0, 0);
   my $vattach = $options{vattach} || 'baseline';
   no warnings 'recursion';
-  foreach my $box (@$boxes) {
+  # Flatten top-level Lists (orrr pass-thru $fillwidth ???)
+  my @boxes = map { (ref $_ eq 'LaTeXML::Core::List' ? $_->unlist : $_); } @$boxes;
+  #  foreach my $box (@$boxes) {
+  foreach my $box (@boxes) {
     next unless defined $box;
     next if ref $box && !$box->can('getSize');    # Care!! Since we're asking ALL args/compoments
     ## Should any %options be inherited by the contained boxes?
-    my ($w, $h, $d) = (ref $box ? $box->getSize() : $font->computeStringSize($box));
-    if (ref $w) {
+    my ($w, $h, $d);
+    if (ref $box) {
+      my ($rw, $rh, $rd);
+      ($rw, $rh, $rd, $w, $h, $d) = $box->getSize(); }
+    else {
+      ($w, $h, $d) = $font->computeStringSize($box); }
+    if ((ref $box) && $box->getProperty('isOverlay')) {
+      # An overlay doesn't take space inline, but requires total space (!?!?!)
+      $minwd = max($minwd, $w); $minht = max($minht, $h); $mindp = max($mindp, $d); }
+    elsif (ref $w) {
       $wd += $w->valueOf; }
     else {
       Warn('expected', 'Dimension', undef,
@@ -540,6 +552,7 @@ sub computeBoxesSize {
     else {                            # default is baseline (of the 1st line)
       my $h = $lines[0][1];
       $dp = $ht + $dp - $h; $ht = $h; } }
+  $wd = max($minwd, $wd); $ht = max($minht, $ht); $dp = max($mindp, $dp);
   #print "BOXES SIZE ".($wd/65536)." x ".($ht/65536)." + ".($dp/65336)." for "
   #  .join(' ',grep {$_} map { Stringify($_) } @$boxes)."\n";
   Debug("Size boxes " . join(',', map { $_ . '=' . ToString($options{$_}); } sort keys %options) . "\n"
@@ -670,7 +683,7 @@ sub specialize {
     $shape  = $defshape;                                                    # defaults, always.
     if ($series && ($series ne $DEFSERIES)) { $series = $defseries; } }
   return (ref $self)->new_internal($family, $series, $shape, $size,
-    $color, $bg, $opacity,
+    $color,    $bg, $opacity,
     $encoding, $language, $mathstyle, $flags); }
 
 # A special form of merge when copying/moving nodes to a new context,

--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -381,7 +381,6 @@ sub normalizeAlignment {
   my ($self) = @_;
   return if $$self{normalized};
   #======================================================================
-  # Note: Cell Sizes & empty will have been set by extractAlignmentColumn
   $self->normalize_cell_sizes();
   $self->normalize_mark_spans();
   $self->normalize_prune_rows();
@@ -396,9 +395,6 @@ sub normalize_cell_sizes {
   my ($self) = @_;
   # Examines: boxes, align, vattach
   # Sets: cwidth, cheight, cdepth (per cell) & empty
-  # Whatabout: cellspan, rowspan?
-  # Can we deal with those now, or only after other normalization???
-  my $base = $STATE->lookupDefinition(T_CS('\baselineskip'))->valueOf->valueOf;
   foreach my $row (@{ $$self{rows} }) {
     # Do we need to account for any space in the $$row{before} or $$row{after}?
     foreach my $cell (@{ $$row{columns} }) {
@@ -414,9 +410,9 @@ sub normalize_cell_sizes {
           || (((!$ch) || $ch->valueOf < 1)
           && ((!$cd) || $cd->valueOf < 1))
           || !(grep { !$_->getProperty('isSpace'); } $boxes->unlist);
-        $$cell{cwidth}  = $cw;
-        $$cell{cheight} = $ch;
-        $$cell{cdepth}  = $cd;
+        $$cell{cwidth}  = $w || Dimension(0);
+        $$cell{cheight} = $h || Dimension(0);
+        $$cell{cdepth}  = $d || Dimension(0);
         $$cell{empty}   = $empty;
         $$cell{align}   = undef if $empty; }
       else {
@@ -425,13 +421,15 @@ sub normalize_cell_sizes {
   return; }
 
 sub showSize {
-  my ($self) = @_;
-  return '[' . ToString($self->getWidth) . ' x ' . ToString($self->getHeight) . ' + ' . ToString($self->getDepth) . ']'; }
+  my ($w, $h, $d) = @_;
+  return '[' . ToString($w) . ' x ' . ToString($h) . ' + ' . ToString($d) . ']'; }
 
 sub normalize_sum_sizes {
   my ($self)     = @_;
   my @rowheights = ();
   my @colwidths  = ();
+  my @colrights  = ();
+  my @collefts   = ();
   # Uses cell's cwidth,cheight,cdepth
   # Computes net row & column sizes & positions
   # add \baselineskip between rows? Or max the row heights with it ...
@@ -442,9 +440,13 @@ sub normalize_sum_sizes {
     my $row   = $rows[$i];
     my @cols  = @{ $$row{columns} };
     my $ncols = scalar(@cols);
-    if (my $short = $ncols - scalar(@colwidths)) {
-      push(@colwidths, map { 0 } 1 .. $short); }
-    my ($rowh, $rowd) = ($base * 0.7, $base * 0.3);
+    if (my $short = $ncols - scalar(@colwidths)) {    # Extend column arrays, if needed
+      push(@colwidths, map { 0 } 1 .. $short);
+      push(@collefts,  map { 0 } 1 .. $short);
+      push(@colrights, map { 0 } 1 .. $short); }
+    my ($rowh, $rowd) = (0, 0);
+    my ($rowt, $rowb) = (($$row{tpadding} ? $$row{tpadding}->valueOf : $base / 2),
+      ($$row{bpadding} ? $$row{bpadding}->valueOf : $base / 2));
     for (my $j = 0 ; $j < $ncols ; $j++) {
       my $cell = $cols[$j];
       next if $$cell{skipped};
@@ -452,35 +454,55 @@ sub normalize_sum_sizes {
       my $w = $$cell{cwidth};
       my $h = $$cell{cheight};
       my $d = $$cell{cdepth};
+      my $t = $$cell{tpadding};
+      my $b = $$cell{bpadding};
+      my $r = $$cell{rpadding};
+      my $l = $$cell{lpadding};
+
       if (($$cell{colspan} || 1) == 1) {
-        $colwidths[$j] = max($colwidths[$j], $w->valueOf) if $w; }
+        $colwidths[$j] = max($colwidths[$j], $w->valueOf) if $w;
+        $collefts[$j]  = max($collefts[$j],  $l->valueOf) if $l;
+        $colrights[$j] = max($colrights[$j], $r->valueOf) if $r; }
       if (($$cell{rowspan} || 1) == 1) {
         $rowh = max($rowh, $h->valueOf) if $h;
-        $rowd = max($rowd, $d->valueOf) if $d; }
+        $rowd = max($rowd, $d->valueOf) if $d;
+        $rowt = max($rowt, $t->valueOf) if $t;
+        $rowb = max($rowb, $b->valueOf) if $b; }
       else { }    # Ditto spanned rows
     }
-    $$row{height} = Dimension($rowh + 0.25 * $base);
-    $$row{depth}  = Dimension($rowd + 0.25 * $base);
+    $$row{cheight}  = Dimension($rowh);
+    $$row{cdepth}   = Dimension($rowd);
+    $$row{tpadding} = Dimension($rowt);
+    $$row{bpadding} = Dimension($rowb);
     # NOTE: Should be storing column widths to; individually, as well as per-column!
-    push(@rowheights, $rowh + $rowd + 0.5 * $base); }    # somehow our heights are way too short????
+    push(@rowheights, $rowh + $rowd); }    # somehow our heights are way too short????
   ## Now compute the positions
   my @rowpos = ();
   my @colpos = ();
   my $y      = 0;
+  # Row & column positions: left,top
   for (my $i = 0 ; $i < scalar(@rowheights) ; $i++) {
-    $rowpos[$i] = Dimension($y); $y += $rowheights[$i]; }
+    my $row = $rows[$i];
+    $y += $$row{tpadding}->valueOf if $$row{tpadding};
+    $rowpos[$i] = Dimension($y);
+    $y += $$row{cheight}->valueOf  if $$row{cheight};
+    $y += $$row{cdepth}->valueOf   if $$row{cdepth};
+    $y += $$row{bpadding}->valueOf if $$row{bpadding}; }
   my $x = 0;
   for (my $j = 0 ; $j < scalar(@colwidths) ; $j++) {
-    $colpos[$j] = Dimension($x); $x += $colwidths[$j]; }
+    $x += $collefts[$j];
+    $colpos[$j] = Dimension($x);
+    $x += $colwidths[$j];
+    $x += $colrights[$j]; }
   $$self{cwidth}  = Dimension($x);
-  $$self{cheight} = Dimension($y);
+  $$self{cheight} = Dimension($y);    # or account for vertical position of array as a whole?
   $$self{cdepth}  = Dimension(0);
   for (my $i = 0 ; $i < scalar(@rowheights) ; $i++) {
     my $row   = $rows[$i];
     my @cols  = @{ $$row{columns} };
     my $ncols = scalar(@cols);
-    $$row{x}       = $colpos[0]; $$row{y} = $rowpos[$i];
-    $$row{cheight} = Dimension($rowheights[$i]);
+    $$row{x}      = $colpos[0]; $$row{y} = $rowpos[$i];
+    $$row{cwidth} = Dimension($x);
     for (my $j = 0 ; $j < $ncols ; $j++) {
       my $cell = $cols[$j];
       $$cell{x} = $colpos[$j]; $$cell{y} = $rowpos[$i];
@@ -572,22 +594,30 @@ sub normalize_prune_rows {
       push(@filtered, $row); }
     elsif (my $next = $rows[$i + 1]) {    # Remove empty row, but copy top border to NEXT row
       if ($preserve) {
-        push(@filtered, $row); next; }    # don't remove inner rows from math
+        push(@filtered, $row); next; }    # don't remove inner rows from math EXCEPT last row!!
       my $nc = scalar(@{ $$row{columns} });
+      my ($pruneh, $pruned) = (0, 0);
       for (my $j = 0 ; $j < $nc ; $j++) {
         my $col = $$row{columns}[$j];
+        $pruneh = max($pruneh, $$col{cheight}->valueOf) if $$col{cheight};
+        $pruned = max($pruned, $$col{cdepth}->valueOf)  if $$col{cdepth};
         if (!$$row{pseudorow} && defined $$col{rowspanned}) {
           $rows[$$col{rowspanned}]{columns}[$j]{rowspan}--; }    # Decrement rowspan of spanning column
         my $border = $$col{border} || '';
         $border =~ s/[^tTbB]//g;                                 # mask all but top & bottom border
         $border =~ s/b/t/g;                                      # but convert to top
         $border =~ s/B/T/g;                                      # but convert to top
-        $$next{columns}[$j]{border} .= $border; } }              # add to next row
+        $$next{columns}[$j]{border} .= $border; }                # add to NEXT row
+          # This tpadding should be combined w/any extra rowspacing from \\[dim] !
+      $$next{tpadding} = Dimension($pruneh + $pruned) if $pruneh + $pruned; }    # And save padding.
     else {    # Remove empty last row, but copy top border to bottom of prev.
       my $prev = $filtered[-1];
       my $nc   = scalar(@{ $$row{columns} });
+      my ($pruneh, $pruned) = (0, 0);
       for (my $j = 0 ; $j < $nc ; $j++) {
         my $col = $$row{columns}[$j];
+        $pruneh = max($pruneh, $$col{cheight}->valueOf) if $$col{cheight};
+        $pruned = max($pruned, $$col{cdepth}->valueOf)  if $$col{cdepth};
         if (!$$row{pseudorow} && defined $$col{rowspanned}) {
           $rows[$$col{rowspanned}]{columns}[$j]{rowspan}--; }    # Decrement rowspan of spanning column
         my $border = $$col{border} || '';
@@ -597,7 +627,9 @@ sub normalize_prune_rows {
         my $ccol = $$prev{columns}[$j];
         if (defined $$ccol{rowspanned}) {                        # skip to spanning column if rowspanned!
           $ccol = $rows[$$ccol{rowspanned}]{columns}[$j]; }
-        $$ccol{border} .= $border; } }                           # add to previous row.
+        $$ccol{border} .= $border; }                             # add to PREVIOUS row.
+      Debug("PRUNING ROW (last) $pruneh + $pruned");
+      $$prev{bpadding} = Dimension($pruneh + $pruned) if $pruneh + $pruned; }    # And save padding.
   }
   @rows = @filtered;
   $$self{rows} = [@filtered];
@@ -613,12 +645,14 @@ sub normalize_prune_columns {
     foreach my $row (@rows) {
       my $n = scalar(@{ $$row{columns} });
       $nc = $n if $n > $nc; }
-    for (my $j = $nc - 1 ; $j >= 0 ; $j--) {
+    for (my $j = $nc - 1 ; $j >= 0 ; $j--) {    # Prune from RIGHT!
       if (!grep { (defined $$_{columns}[$j]) && !$$_{columns}[$j]{empty} } @rows) {    # Empty!
+        my $prunew = 0;
         foreach my $row (@rows) {
           if (my $col = $$row{columns}[$j]) {
             if (defined $$col{colspanned}) {
               $$row{columns}[$$col{colspanned}]{colspan}--; }    # Decrement colspan of spanning column
+            $prunew = max($prunew, $$col{cwidth}) if $$col{cwidth};
             my $border = $$col{border} || '';
             if ($j > 0) {
               my $prev = $$row{columns}[$j - 1];
@@ -642,8 +676,16 @@ sub normalize_prune_columns {
                   ? (@preserve, $$next{boxes}->unlist) : @preserve); }
             }    # Now, remove the column
             $$row{columns} = [grep { $_ ne $col } @{ $$row{columns} }];
-    } } } }
-  }
+        } }
+        if ($j) {    # If not 1st row, add right padding to previous column
+          foreach my $row (@rows) {
+            if (my $col = $$row{columns}[$j - 1]) {
+              $$col{rpadding} = Dimension($prunew); } } }
+        else {       # Else add left padding to (newly) first column
+          foreach my $row (@rows) {    # And add the padding to previous column
+            if (my $col = $$row{columns}[0]) {
+              $$col{lpadding} = Dimension($prunew); } } }
+  } } }
   return; }
 
 sub show_row {

--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -217,7 +217,7 @@ sub getSize {
       . "\n assigned : " . _showsize($$props{width},  $$props{height},  $$props{depth})
       . "\n calculated: " . _showsize($$props{cwidth}, $$props{cheight}, $$props{cdepth})
       . "\n =>: " . _showsize($$props{width} || $$props{cwidth}, $$props{height} || $$props{cheight}, $$props{depth} || $$props{cdepth})
-      . "\n   Of " . Stringify($self)) if $LaTeXML::DEBUG{size};
+      . "\n   Of " . ToString($self)) if $LaTeXML::DEBUG{size};
   return ($$props{width} || $$props{cwidth},
     $$props{height}  || $$props{cheight},
     $$props{depth}   || $$props{cdepth},

--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -213,9 +213,9 @@ sub getSize {
     && (defined $$props{cheight})
     && (defined $$props{cdepth});
   Debug("SIZE of $self"
-      . "\n options   :" . _showsize($options{width}, $options{height}, $options{depth})
-      . "\n assigned : " . _showsize($$props{width},  $$props{height},  $$props{depth})
-      . "\n calculated: " . _showsize($$props{cwidth}, $$props{cheight}, $$props{cdepth})
+      . "\n preassigned: " . _showsize($$props{width},  $$props{height},  $$props{depth})
+      . "\n calculated : " . _showsize($$props{cwidth}, $$props{cheight}, $$props{cdepth})
+      . "\n w/options " . join(',', map { $_ . "=" . ToString($options{$_}); } sort keys %options)
       . "\n =>: " . _showsize($$props{width} || $$props{cwidth}, $$props{height} || $$props{cheight}, $$props{depth} || $$props{cdepth})
       . "\n   Of " . ToString($self)) if $LaTeXML::DEBUG{size};
   return ($$props{width} || $$props{cwidth},

--- a/lib/LaTeXML/Core/Comment.pm
+++ b/lib/LaTeXML/Core/Comment.pm
@@ -28,7 +28,7 @@ sub getWidth       { return Dimension(0); }
 sub getHeight      { return Dimension(0); }
 sub getTotalHeight { return Dimension(0); }
 sub getDepth       { return Dimension(0); }
-sub getSize        { return (Dimension(0), Dimension(0), Dimension(0)); }
+sub getSize { return (Dimension(0), Dimension(0), Dimension(0), Dimension(0), Dimension(0), Dimension(0)); }
 
 #======================================================================
 1;

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -234,7 +234,7 @@ sub canHaveAttribute {
 sub canAutoOpen {
   my ($self, $tag) = @_;
   if (my $props = $STATE->lookupMapping('TAG_PROPERTIES', $tag)) {
-    return $$props{autoClose}; } }
+    return $$props{autoOpen}; } }
 
 # Dirty little secrets:
 #  You can generically allow an element to autoClose using Tag.

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -98,7 +98,7 @@ DefConstructor('\documentstyle OptionalSemiverbatim SkipSpaces Semiverbatim []',
     else {
       InputDefinitions('OmniBus', type => 'cls', noerror => 1,
         handleoptions => 1, options => $options,
-        after => Tokens(T_CS('\compat@loadpackages')));
+        after         => Tokens(T_CS('\compat@loadpackages')));
       RequirePackage($class, options => $options, as_class => 1); }
     return; });
 
@@ -282,11 +282,13 @@ EOTeX
 # In math, \\ is just a formatting hint, unless within an array, cases, .. environment.
 DefConstructor("\\\\ OptionalMatch:* [Glue]",
   "?#isMath(<ltx:XMHint name='newline'/>)(<ltx:break/>)",
-  reversion => Tokens(T_CS("\\\\"), T_CR));
+  reversion  => Tokens(T_CS("\\\\"), T_CR),
+  properties => { isBreak => 1 });
 
 DefConstructor('\newline',
   "?#isMath(<ltx:XMHint name='newline'/>)(<ltx:break/>)",
-  reversion => Tokens(T_CS('\newline'), T_CR));
+  reversion  => Tokens(T_CS('\newline'), T_CR),
+  properties => { isBreak => 1 });
 Let('\@normalcr',      "\\\\");
 Let('\@normalnewline', '\newline');
 ##PushValue(TEXT_MODE_BINDINGS => [
@@ -471,7 +473,7 @@ sub makeNoteTags {
       tags => Digest(T_BEGIN,
         T_CS('\def'), T_CS('\the' . $counter), T_BEGIN, Revert($tag), T_END,
         T_CS('\def'), T_CS('\typerefnum@' . $counter),
-        T_BEGIN, T_CS('\\' . $counter . 'typerefname'), T_SPACE, Revert($tag), T_END,
+        T_BEGIN,      T_CS('\\' . $counter . 'typerefname'), T_SPACE, Revert($tag), T_END,
         Invocation(T_CS('\lx@make@tags'), T_OTHER($counter)),
         T_END)); }
   else {
@@ -606,11 +608,11 @@ DefMacro('\@startsection{}{}{}{}{}{} OptionalMatch:*', sub {
       || LookupValue('no_number_sections')) {
       # No number, but in TOC
       (T_CS('\par'), T_CS('\@startsection@hook'), T_CS('\\@@unnumbered@section'),
-        T_BEGIN, $type->unlist, T_END,
+        T_BEGIN, $type->unlist,  T_END,
         T_BEGIN, T_OTHER('toc'), T_END); }
     else {          # Number and in TOC
       (T_CS('\par'), T_CS('\@startsection@hook'), T_CS('\\@@numbered@section'),
-        T_BEGIN, $type->unlist, T_END,
+        T_BEGIN, $type->unlist,  T_END,
         T_BEGIN, T_OTHER('toc'), T_END); } },
   locked => 1);
 
@@ -1043,7 +1045,7 @@ DefConstructor('\person@thanks{}', "^ <ltx:contact role='thanks'>#1</ltx:contact
   alias => '\thanks', mode => 'text');
 DefConstructor('\@personname{}', "<ltx:personname>#1</ltx:personname>",
   beforeDigest => sub { Let('\thanks', '\person@thanks'); },
-  bounded => 1, mode => 'text');
+  bounded      => 1, mode => 'text');
 
 DefConstructorI('\and', undef, " and ");
 
@@ -1187,7 +1189,7 @@ DefEnvironment('{titlepage}', '<ltx:titlepage>#body',
       "When using titlepage, Frontmatter will not be well-structured");
     return; },
   beforeDigestEnd => sub { Digest(T_CS('\maybe@end@titlepage')); },
-  locked => 1, mode => 'text');
+  locked          => 1, mode => 'text');
 
 Tag('ltx:titlepage', autoClose => 1);
 DefConstructorI('\maybe@end@titlepage', undef, sub {
@@ -1410,7 +1412,7 @@ sub RefStepItemCounter {
         T_CS('\let'), T_CS('\the' . $counter),   T_CS('\@empty'),
         T_CS('\def'), T_CS('\fnum@' . $counter), T_BEGIN, $formatter, T_BEGIN, Revert($tag), T_END, T_END,
         T_CS('\def'), T_CS('\typerefnum@' . $counter),
-        T_BEGIN, $typename, T_SPACE, Revert($tag), T_END,
+        T_BEGIN,      $typename, T_SPACE, Revert($tag), T_END,
         Invocation(T_CS('\lx@make@tags'), T_OTHER($counter)),
         T_END);
 
@@ -1737,7 +1739,7 @@ DefConstructorI('\lx@@verbatim', undef,
     my ($stomach) = @_;
     StartSemiverbatim('%', '\\', '{', '}');
     MergeFont(family => 'typewriter', series => 'medium', shape => 'upright');
-    $STATE->assignCatcode(' ', CC_ACTIVE);            # Do NOT (necessarily) skip spaces after \verb!!!
+    $STATE->assignCatcode(' ', CC_ACTIVE);    # Do NOT (necessarily) skip spaces after \verb!!!
     Let(T_ACTIVE(' '), T_SPACE); });
 DefConstructorI('\lx@end@verbatim', undef,
   "</ltx:verbatim>",
@@ -2641,7 +2643,7 @@ DefPrimitive('\DeclareFontFamily{}{}{}',      undef);
 DefPrimitive('\DeclareSizeFunction{}{}',      undef);
 
 my $symboltype_roles = {
-  '\mathord' => 'ID', '\mathop' => 'BIGOP', '\mathbin' => 'BINOP', '\mathrel' => 'RELOP',
+  '\mathord'  => 'ID',   '\mathop'    => 'BIGOP', '\mathbin'   => 'BINOP', '\mathrel' => 'RELOP',
   '\mathopen' => 'OPEN', '\mathclose' => 'CLOSE', '\mathpunct' => 'PUNCT' };
 DefPrimitive('\DeclareMathSymbol DefToken SkipSpaces DefToken {}{Number}', sub {
     my ($stomach, $cs, $type, $font, $code) = @_;
@@ -2661,7 +2663,7 @@ Let('\cdp@elt', '\relax');
 DefPrimitive('\DeclareFontEncoding{}{}{}', sub {
     my ($stomach, $encoding, $x, $y) = @_;
     AddToMacro(T_CS('\cdp@list'), T_CS('\cdp@elt'),
-      T_BEGIN, $_[1]->unlist, T_END,
+      T_BEGIN, $_[1]->unlist,           T_END,
       T_BEGIN, T_CS('\default@family'), T_END,
       T_BEGIN, T_CS('\default@series'), T_END,
       T_BEGIN, T_CS('\default@shape'),  T_END);
@@ -2890,7 +2892,7 @@ sub defineNewTheorem {
         $headformatter->unlist,
         T_BEGIN, ($type ? $type->unlist : ()), T_END,
         T_CS('\the' . $counter), T_BEGIN, Tokens(T_PARAM, T_OTHER('1')), T_END,
-        T_CS('\the'), T_CS('\thm@headpunct'))
+        T_CS('\the'),            T_CS('\thm@headpunct'))
       : '{\the\thm@headfont\lx@tag{\csname fnum@' . $thmset . '\endcsname}'
         . '{' . ($type ? '\ifx.#1.\else\space\the\thm@notefont(#1)\fi' : '#1') . '}'
         . '\the\thm@headpunct}'),
@@ -3868,7 +3870,7 @@ DefMacro('\lx@mung@bibliography{}', sub {
     if (($tag eq 'enumerate') || ($tag eq 'itemize') || ($tag eq 'description')) {
       # nDamn! We're in a list {$tag}; try to close it!
       push(@tokens, Invocation('\end', $env),
-        T_CS('\let'), T_CS('\end' . $tag), T_CS('\endthebibliography'),
+        T_CS('\let'), T_CS('\end' . $tag),        T_CS('\endthebibliography'),
         T_CS('\let'), T_CS('\end{' . $tag . '}'), T_CS('\end{thebibliography}')); }
     # else ? it probably isn't going to work??
     # Now, try to open {thebibliography}
@@ -4378,7 +4380,7 @@ DefConstructor('\@framebox[Dimension][]{}',
     . "(<ltx:text ?#width(width='#width') ?#align(align='#align')"
     . " framed='rectangle' framecolor='#framecolor'"
     . " _noautoclose='1'>#3</ltx:text>)",
-  alias => '\framebox', sizer => '#3',
+  alias        => '\framebox', sizer => '#3',
   beforeDigest => sub {
     my ($stomach) = @_;
     my $wasmath = LookupValue('IN_MATH');
@@ -4454,7 +4456,8 @@ EOL
 DefConstructor('\lx@parboxnewline[]', sub {
     my ($document, $ignore, %props) = @_;
     $document->maybeCloseElement('ltx:p');
-    return; });
+    return; },
+  properties => { isBreak => 1 });
 
 # NOTE: There are 2 extra arguments (See LaTeX Companion, p.866)
 # for height and inner-pos.  We're ignoring them, for now, though.
@@ -4470,7 +4473,7 @@ DefConstructor('\parbox[] OptionalUndigested OptionalUndigested {Dimension} VBox
     (width => $_[4],
       vattach => translateAttachment($_[1]),
       height  => $_[2]); },
-  mode => 'text', bounded => 1,
+  mode         => 'text', bounded => 1,
   beforeDigest => sub {
     AssignValue('\hsize' => $_[4]);
     Let('\\\\', '\lx@parboxnewline'); });
@@ -4919,32 +4922,32 @@ DefMacro('\usefont{}{}{}{}',
 
 # If these series or shapes appear in math, they revert it to roman, medium, upright (?)
 DefConstructor('\textmd@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { series => 'medium' }, alias => '\textmd',
+  bounded      => 1, font => { series => 'medium' }, alias => '\textmd',
   beforeDigest => sub { DefMacro('\f@series', 'm'); });
 DefConstructor('\textbf@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { series => 'bold' }, alias => '\textbf',
+  bounded      => 1, font => { series => 'bold' }, alias => '\textbf',
   beforeDigest => sub { DefMacro('\f@series', 'b'); });
 DefConstructor('\textrm@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { family => 'serif' }, alias => '\textrm',
+  bounded      => 1, font => { family => 'serif' }, alias => '\textrm',
   beforeDigest => sub { DefMacro('\f@family', 'cm'); });
 DefConstructor('\textsf@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { family => 'sansserif' }, alias => '\textsf',
+  bounded      => 1, font => { family => 'sansserif' }, alias => '\textsf',
   beforeDigest => sub { DefMacro('\f@family', 'cmss'); });
 DefConstructor('\texttt@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { family => 'typewriter' }, alias => '\texttt',
+  bounded      => 1, font => { family => 'typewriter' }, alias => '\texttt',
   beforeDigest => sub { DefMacro('\f@family', 'cmtt'); });
 
 DefConstructor('\textup@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'upright' }, alias => '\textup',
+  bounded      => 1, font => { shape => 'upright' }, alias => '\textup',
   beforeDigest => sub { DefMacro('\f@shape', ''); });
 DefConstructor('\textit@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'italic' }, alias => '\textit',
+  bounded      => 1, font => { shape => 'italic' }, alias => '\textit',
   beforeDigest => sub { DefMacro('\f@shape', 'i'); });
 DefConstructor('\textsl@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'slanted' }, alias => '\textsl',
+  bounded      => 1, font => { shape => 'slanted' }, alias => '\textsl',
   beforeDigest => sub { DefMacro('\f@shape', 'sl'); });
 DefConstructor('\textsc@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
-  bounded => 1, font => { shape => 'smallcaps' }, alias => '\textsc',
+  bounded      => 1, font => { shape => 'smallcaps' }, alias => '\textsc',
   beforeDigest => sub { DefMacro('\f@shape', 'sc'); });
 DefConstructor('\textnormal@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
   bounded => 1, font => { family => 'serif', series => 'medium', shape => 'upright' }, alias => '\textnormal',
@@ -4967,7 +4970,7 @@ DefPrimitive('\DeclareTextFontCommand{}{}', sub {
     my ($stomach, $cmd, $font) = @_;
     DefConstructorI($cmd, "{}",
       "?#isMath(<ltx:text _noautoclose='1'>#1</ltx:text>)(#1)",
-      mode => 'text', bounded => 1,
+      mode         => 'text', bounded => 1,
       beforeDigest => sub { Digest($font); (); });
     return; });
 

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2162,7 +2162,7 @@ DefConstructor('\hrule RuleSpecification',
     my $depth  = GetKeyVal($dims, 'depth');
     $whatsit->setProperties(width  => $width,  cwidth  => $width)  if $width;
     $whatsit->setProperties(height => $height, cheight => $height) if $height;
-    $whatsit->setProperties(depth  => $depth,  dcepth  => $depth)  if $depth;
+    $whatsit->setProperties(depth  => $depth,  cdepth  => $depth)  if $depth;
     my $w = ($width  ? $width->ptValue  : undef);
     my $h = ($height ? $height->ptValue : undef);
     my $d = ($depth  ? $depth->ptValue  : undef);
@@ -2795,9 +2795,15 @@ sub afterCellUnlist {
 #======================================================================
 DefConstructor('\halign BoxSpecification',
   "#alignment",
-  reversion   => '\halign #1{#2\cr#3}',
-  bounded     => 1,
-  sizer       => '#1',
+  reversion => sub {
+    my ($whatsit, $spec) = @_;
+    my $template  = $whatsit->getProperty('template');
+    my $alignment = $whatsit->getProperty('alignment');
+    Tokens(T_CS('\halign'), Revert($spec), T_BEGIN, Revert($template), T_CS('\cr'),
+      Revert($alignment), T_END); },
+  bounded => 1,
+  #  sizer       => '#1',
+  sizer       => sub { $_[0]->getProperty('alignment')->getSize; },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     $stomach->bgroup;    # This will be closed by the \halign's closing }  (or will it?)
@@ -2821,16 +2827,19 @@ sub parseHAlignTemplate {
   my $repeated = 0;
   my @nonreps  = ();
   my $tabskip;         # Need to use this somehow!
+  my @tokens = ();
   ## Only expand certain things; See TeX book p.238
   local $LaTeXML::ALIGN_STATE = 1000000;
   while ($t = $gullet->readToken) {
     if ($t->equals(T_CS('\tabskip'))) {    # Read the tabskip assignment
       $gullet->readKeyword('=');
-      $tabskip = $gullet->readGlue; }
+      $tabskip = $gullet->readGlue;
+      push(@tokens, $t, $tabskip); }
     elsif ($t->equals(T_CS('\span'))) {    # ex-span-ded next token.
       $gullet->unread($gullet->readXToken(0)); }
     elsif ($t->equals(T_PARAM)) {          # Found the template's column slot
-      $before = 0; }
+      $before = 0;
+      push(@tokens, $t); }
     elsif ($t->equals(T_ALIGN)
       || $t->equals(T_CS('\cr')) || $t->equals(T_CS('\crcr'))) {    # End the column
       if ($before) {                                                # Leading & ?
@@ -2842,16 +2851,22 @@ sub parseHAlignTemplate {
             before => Tokens(beforeCellUnlist(Tokens(@pre))),
             after  => Tokens(afterCellUnlist(Tokens(@post))) });
         @pre = @post = (); $before = 1; }
-      last unless $t->equals(T_ALIGN); }
+      last unless $t->equals(T_ALIGN);
+      push(@tokens, $t); }
     elsif ($before) {    # Other random tokens go into the column's pre-template
-      push(@pre, $t) if @pre || !$t->equals(T_SPACE); }
+      push(@pre,    $t) if @pre || !$t->equals(T_SPACE);
+      push(@tokens, $t); }
     else {               # Or the post-template
-      push(@post, $t) if @post || !$t->equals(T_SPACE); } }
+      push(@post,   $t) if @post || !$t->equals(T_SPACE);
+      push(@tokens, $t); } }
   # Now create & return the template object
-  return LaTeXML::Core::Alignment::Template->new(
+  my $template = LaTeXML::Core::Alignment::Template->new(
     ($repeated
       ? (columns => [@nonreps], repeated => [@cols])
-      : (columns => [@cols]))); }
+      : (columns => [@cols])),
+    tokens => [@tokens]);
+  $whatsit->setProperty(template => $template);
+  return $template; }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # And the general alignment processing.

--- a/lib/LaTeXML/Package/keyval.sty.ltxml
+++ b/lib/LaTeXML/Package/keyval.sty.ltxml
@@ -16,8 +16,7 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
-InputDefinitions('keyval', type => 'sty', noltxml => 1)
-  || Warn(":missing:keyval.sty Couldn't find keyval.sty");
+InputDefinitions('keyval', type => 'sty', noltxml => 1);
 
 # HOOK into define@key to make the latexml definitions as well
 DefPrimitive('\define@key{}{}[]{}', sub {

--- a/lib/LaTeXML/Package/pgf.sty.ltxml
+++ b/lib/LaTeXML/Package/pgf.sty.ltxml
@@ -26,8 +26,7 @@ DefMacro('\pgfsysdriver', 'pgfsys-latexml.def');    # and we'll load the .ltxml!
 # We're going to load the raw tex of pgf ...
 #   AND all the files it includes!
 #   (we should turn off @)#@# comments while we're at it!)
-InputDefinitions('pgf', type => 'sty', noltxml => 1)
-  || Warn('missing_file', 'pgf.sty', undef, "Couldn't find pgf.sty");
+InputDefinitions('pgf', type => 'sty', noltxml => 1);
 
 # This is very probably the wrong way to do this,
 # but it seems that pgfstrokecolor is the color used for default drawing, text, etc.

--- a/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
@@ -26,9 +26,7 @@ use LaTeXML::Package;
 # I _think_ this implementation fairly completely captures pgfkeys logic.
 #======================================================================
 # To disable the LaTeXML binding, uncomment the following bit of code
-InputDefinitions('pgfkeys.code', type => 'tex', noltxml => 1)
-  || Warn(":missing:pgfkeys.code.tex Couldn't find pgfkeys.code.tex");
-###Info('latexml', 'pgfkeys', undef, "Skipping LaTeXML binding for pgfkeys");
+InputDefinitions('pgfkeys.code', type => 'tex', noltxml => 1);
 1;
 
  __END__

--- a/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
@@ -26,13 +26,15 @@ use LaTeXML::Package;
 # I _think_ this implementation fairly completely captures pgfkeys logic.
 #======================================================================
 # To disable the LaTeXML binding, uncomment the following bit of code
-# InputDefinitions('pgfkeys.code', type => 'tex', noltxml => 1)
-#   || Warn(":missing:pgfkeys.code.tex Couldn't find pgfkeys.code.tex");
-# Info('latexml', 'pgfkeys', undef, "Skipping LaTeXML binding for pgfkeys");
-# 1;
-#
-# __END__
-#
+InputDefinitions('pgfkeys.code', type => 'tex', noltxml => 1)
+  || Warn(":missing:pgfkeys.code.tex Couldn't find pgfkeys.code.tex");
+###Info('latexml', 'pgfkeys', undef, "Skipping LaTeXML binding for pgfkeys");
+1;
+
+ __END__
+
+# To enable using the LaTeXML binding, comment out the preceding bit of code.
+# Note that the following code is faster and gets close, but NOT quite right or complete!
 #======================================================================
 DebuggableFeature('pgfkeys', 'pgfkeys processing');
 

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -30,8 +30,7 @@ use POSIX qw(floor ceil);
 
 #======================================================================
 # Load pgf's TeX code for math, first
-InputDefinitions('pgfmath.code', type => 'tex', noltxml => 1)
-  || Warn(":missing:pgfmath.code.tex Couldn't find pgfmath.code.tex");
+InputDefinitions('pgfmath.code', type => 'tex', noltxml => 1);
 
 #======================================================================
 # Then redefine math operations to be done directly in Perl.
@@ -116,7 +115,7 @@ DefParameterType('pgfNumbers', sub {
         if ($cc == CC_END) {
           $level--;
           last unless $level;
-          if ($level == 1) {                               # Next number
+          if ($level == 1) {    # Next number
             push(@results, $result); $result = ''; $char = ''; } }
         elsif ($cc == CC_BEGIN) {
           if ($level == 1) { $char = ''; }

--- a/lib/LaTeXML/Package/pgfmathcalc.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmathcalc.code.tex.ltxml
@@ -17,8 +17,7 @@ use LaTeXML::Package;
 
 #======================================================================
 # Load pgf's TeX code for math, first
-InputDefinitions('pgfmathcalc.code', type => 'tex', noltxml => 1)
-  || Warn(":missing:pgfmathcalc.code.tex Couldn't find pgfmath.code.tex");
+InputDefinitions('pgfmathcalc.code', type => 'tex', noltxml => 1);
 
 # \pgfmathsetmacro
 # \edef#1 as the result of evaluating #2.

--- a/lib/LaTeXML/Package/pgfplots.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfplots.sty.ltxml
@@ -23,5 +23,10 @@ use LaTeXML::Package;
 
 DefMacroI('\pgfplots@iffileexists', undef, '\IfFileExists', locked => 1);
 InputDefinitions('pgfplots', type => 'sty', noltxml => 1);
+# Avoid generic warnings:
+my $compat_cs  = T_CS('\pgfk@/pgfplots/compat/current');
+my $compat_val = IsDefined($compat_cs) && ToString(Expand($compat_cs));
+if (!$compat_val || $compat_val eq 'default') {
+  RawTeX('\pgfplotsset{compat=1.17}'); }
 
 1;

--- a/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
@@ -17,7 +17,9 @@ use LaTeXML::Package;
 
 #======================================================================
 InputDefinitions('pgfplotstable', type => 'sty', noltxml => 1);
-# Avoid warning...
-RawTeX('\pgfplotsset{compat=1.17}');
-
+# Avoid generic warnings:
+my $compat_cs  = T_CS('\pgfk@/pgfplots/compat/current');
+my $compat_val = IsDefined($compat_cs) && ToString(Expand($compat_cs));
+if (!$compat_val || $compat_val eq 'default') {
+  RawTeX('\pgfplotsset{compat=1.17}'); }
 1;

--- a/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
@@ -16,7 +16,8 @@ use warnings;
 use LaTeXML::Package;
 
 #======================================================================
-InputDefinitions('pgfplotstable', type => 'sty', noltxml => 1)
-  || Warn(":missing:pgfplotstable.sty Couldn't find pgfplotstable.sty");
+InputDefinitions('pgfplotstable', type => 'sty', noltxml => 1);
+# Avoid warning...
+RawTeX('\pgfplotsset{compat=1.17}');
 
 1;

--- a/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
@@ -1,0 +1,22 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  pgfplotstable.sty                                                  | #
+# | Implementation for LaTeXML                                          | #
+# |---------------------------------------------------------------------| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#======================================================================
+InputDefinitions('pgfplotstable', type => 'sty', noltxml => 1)
+  || Warn(":missing:pgfplotstable.sty Couldn't find pgfplotstable.sty");
+
+1;

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -22,6 +22,9 @@ use warnings;
 use LaTeXML::Package;
 use LaTeXML::Util::Image;
 use List::Util qw(min max);
+
+DebuggableFeature('pgf', "Debug pgf processing");
+
 #=====================================================================
 # TODO:
 # * ALL \pgfsys@<drivercmd> level commands should be Constructors
@@ -78,33 +81,53 @@ DefConstructor('\lxSVG@insertpicture{}',
   #   . '</ltx:picture>',
   sub {
     my ($document, $content, %props) = @_;
-    $document->openElement('ltx:picture');
-    $document->openElement('svg:svg',
-      version  => "1.1",
-      width    => $props{pxwidth}, height => $props{pxheight},
-      viewBox  => "$props{minx} $props{miny} $props{pxwidth} $props{pxheight}",
-      overflow => "visible");
-    $document->openElement('svg:g',
-      transform   => "matrix(1 0 0 -1 0 $props{flipnmove})",
-      _scopebegin => 1);
-    $document->absorb($content);
+    my $current = $document->getNode();
+    if (0 && $document->getNodeQName($current) =~ /^svg:/) {    # Already in svg:svg ?
+          # Possibly needs an svg:g with positioning ?
+          # Aparently these attributes not allowed on svg:g (in the schema we have?)
+          # Not yet ready for primetime...
+      my $gnode = $document->openElement('svg:g',
+        width    => $props{pxwidth}, height => $props{pxheight},
+        viewBox  => "$props{minx} $props{miny} $props{pxwidth} $props{pxheight}",
+        overflow => "visible");
+      $document->absorb($content);
+      $document->closeElement('svg:g'); }
+    else {
+      $document->openElement('ltx:picture');
+      $document->openElement('svg:svg',
+        version  => "1.1",
+        width    => $props{pxwidth}, height => $props{pxheight},
+        viewBox  => "$props{minx} $props{miny} $props{pxwidth} $props{pxheight}",
+        overflow => "visible");
+      $document->openElement('svg:g',
+        transform   => "matrix(1 0 0 -1 0 $props{flipnmove})",
+        _scopebegin => 1);
+      $document->insertElement('svg:rect', undef,
+        x    => $props{minx}, y      => $props{miny}, width => $props{width}, height => $props{height},
+        fill => 'none',       stroke => '#FF00FF') if $LaTeXML::DEBUG{pgf};
+      $document->absorb($content);
 ### Handled by \lxSVG@closegroups ???
-    while ($document->maybeCloseElement('svg:g')) { }
-    #                 $document->closeElement('svg:g');
-    $document->closeElement('svg:svg');
-    $document->closeElement('ltx:picture');
+      while ($document->maybeCloseElement('svg:g')) { }
+      #                 $document->closeElement('svg:g');
+      $document->closeElement('svg:svg');
+      $document->closeElement('ltx:picture'); }
     return; },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $margin  = Dimension('2pt');
     my $margin2 = Dimension('4pt');
     # \pgf@picmaxx,\pgf@pixmaxy are now the SIZE of the picture!!!!!!
-    my $minx   = LookupValue('\pgf@picminx')->subtract($margin);
-    my $miny   = LookupValue('\pgf@picminy')->subtract($margin);
-    my $width  = LookupValue('\pgf@picmaxx')->add($margin2);
-    my $height = LookupValue('\pgf@picmaxy')->add($margin2);
-    my $w      = max($width->pxValue,  1);
-    my $h      = max($height->pxValue, 1);
+    my $minx    = LookupValue('\pgf@picminx');
+    my $miny    = LookupValue('\pgf@picminy');
+    my $width   = LookupValue('\pgf@picmaxx');
+    my $height  = LookupValue('\pgf@picmaxy');
+    my $w       = max($width->pxValue,  1);
+    my $h       = max($height->pxValue, 1);
+    my $content = $whatsit->getArg(1);
+    my ($cwidth, $cheight, $cdepth) = $content->getSize;
+    Debug("TIKZ size: " . ToString($width) . " x " . ToString($height))   if $LaTeXML::DEBUG{pgf};
+    Debug("TIKZ BODY: " . ToString($cwidth) . " x " . ToString($cheight)) if $LaTeXML::DEBUG{pgf};
+    Debug("BODY is " . ToString($content))                                if $LaTeXML::DEBUG{pgf};
     # Note viewbox is minx, miny, width, height (NOT maxx,maxy!)
     $whatsit->setProperty(minx      => $minx->pxValue);
     $whatsit->setProperty(miny      => $miny->pxValue);
@@ -122,9 +145,9 @@ DefConstructor('\lxSVG@insertpicture{}',
     my $w         = $whatsit->getProperty('width')->ptValue;
     my $h         = $whatsit->getProperty('height')->ptValue;
     (T_CS('\hbox'), T_OTHER('to'), T_OTHER($w), T_OTHER('pt'), T_BEGIN,
-      T_CS('\vbox'), T_OTHER('to'), T_OTHER($h), T_OTHER('pt'), T_BEGIN,
+      T_CS('\vbox'),       T_OTHER('to'),         T_OTHER($h), T_OTHER('pt'), T_BEGIN,
       T_CS('\pgfpicture'), T_CS('\makeatletter'), $whatsit->getArg(1)->revert, T_CS('\endpgfpicture'),
-      T_END, T_END) });    # ?
+      T_END,               T_END) });    # ?
 
 DefParameterType('SVGMoveableBox', sub {
     my ($gullet) = @_;
@@ -175,12 +198,22 @@ Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
     # Make sure we get a size, in case autoOpen'd
     if ($whatsit) {
       my ($w, $h, $d) = $whatsit->getSize;
-      $node->setAttribute(width  => $w->toAttribute)          unless $node->hasAttribute('width');
-      $node->setAttribute(height => $h->add($d)->toAttribute) unless $node->hasAttribute('height');
+
+      my $font = $whatsit->getFont;
+      my ($fw, $fh, $fd) = $font && $font->getNominalSize;
+      # Fishing for the correct y position (maybe w/o the depth?)
+      my $y = $h->add(($font ? $fd : $d))->pxValue;    # Seemingly should NOT have ->add($d)
+          # But if the box's height has been set to 0, still need adjustment; Use font?
+      $y = $fh->add($fd)->pxValue if !$y && $font;    # Seemingly SHOULD have ->add($fd)
+
+      my $ht = $h->add($d);
+      $node->setAttribute(width  => $w->toAttribute)  unless $node->hasAttribute('width');
+      $node->setAttribute(height => $ht->toAttribute) unless $node->hasAttribute('height');
       # Odd, sometimes needed, sometimes too much (vtop type situations?)
-      if ($d->ptValue < 10) {    # Random heuristic
+      if ($d->ptValue < 10) {                         # Random heuristic
         $node->setAttribute(y => $d->negate->toAttribute) unless $node->hasAttribute('y'); }
-      $node->setAttribute(overflow => 'visible'); } });
+      $node->setAttribute(transform => "matrix(1 0 0 -1 0 $y)");
+      $node->setAttribute(overflow  => 'visible'); } });
 
 # Check whether a svg:foreignObject is open,
 # but don't check beyond an svg:svg node, in case we're nested.
@@ -218,7 +251,7 @@ DefConstructor('\lxSVG@hskip Glue', sub {
     my ($doc, $skip) = @_;
     if (foreignObjectCheck($doc)) {
       $doc->openElement('ltx:text', 'xoffset' => $skip->pxValue . 'px'); } },
-  alias      => '\hskip',
+  alias      => '\hskip', sizer => '#1',
   properties => sub { (width => $_[1], isSpace => 1); });
 
 DefMacroI('\pgf@shift@baseline',         undef, '0pt');
@@ -231,11 +264,15 @@ DefMacro('\pgfsys@typesetpicturebox{}', <<'EoTeX');
 % \pgf@picmaxx,\pgf@pixmaxy are now the SIZE of the picture!!!!!!
 \advance\pgf@picmaxy by-\pgf@picminy\relax%
    \advance\pgf@picmaxx by-\pgf@picminx\relax%
+   \setbox#1=\hbox{\hskip-\pgf@picminx\lower\pgf@picminy\box#1}
    \ht#1=\pgf@picmaxy%
    \wd#1=\pgf@picmaxx%
    \dp#1=0pt%
    \leavevmode%\message{width: \the\pgf@picmaxx, height:\the\pgf@picmaxy}%%
-   \lxSVG@insertpicture{\box#1\lxSVG@closescope}%
+%%%   \lxSVG@insertpicture{\box#1\lxSVG@closescope}%
+  \pgf@ya=\pgf@shift@baseline\relax%
+  \advance\pgf@ya by-\pgf@picminy\relax%
+   \lxSVG@insertpicture{\raise-\pgf@ya\box#1\lxSVG@closescope}%
 EoTeX
 
 DefMacro('\pgfsys@beginpicture', '');
@@ -245,20 +282,15 @@ DefConstructor('\pgfsys@hbox{Number}', sub {
     my ($doc, $boxnumber, %prop) = @_;
     my $box = $prop{thebox};
     return unless $box;
-    my $font = $box->getFont;
-    my ($w,  $h,  $d)  = $box->getSize;
-    my ($fw, $fh, $fd) = $font && $font->getNominalSize;
-    # Fishing for the correct y position (maybe w/o the depth?)
-    #    my $y = $h->pxValue;   # Seemingly should NOT have ->add($d)
-    my $y = $h->add(($font ? $fd : $d))->pxValue;    # Seemingly should NOT have ->add($d)
-        # But if the box's height has been set to 0, still need adjustment; Use font?
-    $y = $fh->add($fd)->pxValue if !$y && $font;    # Seemingly SHOULD have ->add($fd)
-    $doc->openElement('svg:g',
-      transform    => 'matrix(1 0 0 -1 0 ' . $y . ')',
-      _noautoclose => 1,
-      class        => 'ltx_svg_fog');
-    $doc->absorb($box);
-    $doc->maybeCloseElement('ltx:g'); },
+    # my $font = $box->getFont;
+    # my ($w,  $h,  $d)  = $box->getSize;
+    # my ($fw, $fh, $fd) = $font && $font->getNominalSize;
+    # # Fishing for the correct y position (maybe w/o the depth?)
+    # #    my $y = $h->pxValue;   # Seemingly should NOT have ->add($d)
+    # my $y = $h->add(($font ? $fd : $d))->pxValue;    # Seemingly should NOT have ->add($d)
+    #     # But if the box's height has been set to 0, still need adjustment; Use font?
+    # $y = $fh->add($fd)->pxValue if !$y && $font;    # Seemingly SHOULD have ->add($fd)
+    $doc->absorb($box); },
   sizer => sub {
     my $box = $_[0]->getProperty('thebox');
     return $box && $box->getSize; },
@@ -326,7 +358,6 @@ DefConstructor('\pgfsys@rect{Dimension}{Dimension}{Dimension}{Dimension}', '',
     addToSVGPath('v', $h);
     addToSVGPath('h', $w->negate);
     addToSVGPath('Z'); },
-  #  sizer => 0);
   sizer => sub {
     my ($x, $y, $w, $h) = $_[0]->getArgs;
     return ($w, $h, Dimension(0)); });
@@ -406,7 +437,7 @@ DefConstructor('\lxSVG@drawpath@clipped{}{}',
     . '</svg:clipPath>'
     . '<svg:use xlink:href="##pgfpath#obj" style="#2" />'
     . '<svg:g clip-path="url(##pgfcp#obj)">',
-  reversion => '', sizer => 0,
+  reversion  => '', sizer => 0,
   properties => { obj => sub { SVGNextObject(); } });
 
 # #======================================================================
@@ -429,7 +460,7 @@ DefConstructor('\lxSVG@discardpath@clipped{}',
     . '<svg:path d="#1" />'
     . '</svg:clipPath>'
     . '<svg:g clip-path="url(##pgfcp#obj)">',
-  reversion => '', sizer => 0,
+  reversion  => '', sizer => 0,
   properties => { obj => sub { SVGNextObject(); } });
 
 #=====================================================================#
@@ -532,8 +563,6 @@ sub collapseSVGGroup {
         $node->setAttribute($key => $av{$key}); }
       $nmerged++;
       $document->unwrapNodes($c); } }
-##  Debug("COLLAPSE empty=$nempty, redundant=$nredundant, merged=$nmerged, popped=$npopped, pushed=$npushed")
-##    if ($nempty || $nredundant || $nmerged || $npopped || $npushed);
   return; }
 
 #=====================================================================
@@ -780,7 +809,7 @@ DefMacro('\lxSVG@sh@create', sub {
       T_BEGIN, T_CS('\pgf@sys@shading@end@pos'), T_END,
       T_BEGIN, T_CS('\pgf@sys@shading@end@rgb'), T_END,
       T_BEGIN, T_CS('\pgf@sys@shading@end@rgb'), T_END,
-      T_END,   T_BEGIN, T_END); });
+      T_END,   T_BEGIN,                          T_END); });
 
 DefMacro('\lxSVG@sh@interval@{}{}',
   '\lxSVG@sh@stashstop{\lxSVG@sh@stop{#1}{\pgf@sys@shading@end@pos}#2}');
@@ -871,6 +900,7 @@ DefConstructor('\lxSVG@sh@insert{Dimension}{Dimension}{}',
   sizer => 0);
 
 # \lxSVG@process{Dimension}{Dimension}
+# NOTE: This just can't be right; see callers!?!?!?
 DefMacro('\lxSVG@process{}{}',
   '\ifdim\pgf@picmaxx<#1\global\pgf@picmaxx=#1\fi'
     . '\ifdim\pgf@picmaxy<#2\global\pgf@picmaxy=#2\fi'
@@ -1029,11 +1059,18 @@ RawTeX('\def\pgfsys@begininvisible#1\pgfsys@endinvisible{}');    # well...
 # tikz makes their width 0; unfortunately this makes them
 # disappear in the svg (overflow=visible doesn't seem to help)
 
+# row sep, column sep are not yet accounted for...
 DefConstructor('\lxSVG@halign BoxSpecification',
   "#alignment",
-  reversion   => '\halign #1{#2\cr#3}',
-  bounded     => 1,
-  sizer       => '#1',
+  reversion => sub {
+    my ($whatsit, $spec) = @_;
+    my $template  = $whatsit->getProperty('template');
+    my $alignment = $whatsit->getProperty('alignment');
+    Tokens(T_CS('\halign'), Revert($spec), T_BEGIN, Revert($template), T_CS('\cr'),
+      Revert($alignment), T_END); },
+  bounded => 1,
+  #  sizer       => '#1',
+  sizer       => sub { $_[0]->getProperty('alignment')->getSize; },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     $stomach->bgroup;    # This will be closed by the \halign's closing }  (or will it?)
@@ -1070,33 +1107,70 @@ sub tikzAlignmentBindings {
   Let(T_MATH,   ($ismath ? '\@dollar@in@mathmode' : '\@dollar@in@textmode'));
   return; }
 
+# Note that pgf *seems* to have set the coordinate system to the center(?) (w/ \pgfsys@transformcm)
+# Additionally, there's a svg:g outside the alignment (w/ ltx_svg_fog)
+# The following tweaks (heuristically) the transform to position the alignment object
+#
+# Coordinates are currently pgf: y moves UP
+# Coordinates of alignment are : y moves DOWN
 sub openTikzAlignment {
   my ($tag, $doc, %props) = @_;
-  my $h = ($props{cheight} && -$props{cheight}->pxValue) || 0;
-  return $doc->openElement($tag, class => 'ltx_tikzmatrix',
+  my $w          = ($props{cwidth}  && $props{cwidth}->pxValue)  || 0;
+  my $h          = ($props{cheight} && $props{cheight}->pxValue) || 0;
+  my $d          = ($props{cdepth}  && $props{cdepth}->pxValue)  || 0;
+  my @rowheights = ($props{rowheights}   ? @{ $props{rowheights} }   : (Dimension(0)));
+  my @colwidths  = ($props{columnwidths} ? @{ $props{columnwidths} } : (Dimension(0)));
+  my $x          = $colwidths[0]->pxValue / 2;
+  my $y          = ($h + $d) - $rowheights[0]->pxValue;
+  Debug("TIKZ Alignment size $w x $h + $d"
+      . "  rows: " . join(',', map { $_->pxValue; } @rowheights)
+      . "  cols: " . join(',', map { $_->pxValue; } @colwidths)
+      . " => alignment adjustment = $x, $y") if $LaTeXML::DEBUG{pgf};
+  my $array = $doc->openElement($tag, class => 'ltx_tikzmatrix',
     _scopebegin => 1,
-    transform   => "matrix(1 0 0 -1 0 $h)",
-    %props); }
+    transform   => "matrix(1 0 0 -1 $x $y)",
+    %props);
+  $doc->insertElement('svg:rect', undef,
+    x => -4, y => -4, width => $w + 8, height => $h + 8, stroke => '#FF0000', fill => 'none')
+    if $LaTeXML::DEBUG{pgf};
+  return $array; }
 
 sub openTikzAlignmentRow {
   my ($tag, $doc, %props) = @_;
   my $class = 'ltx_tikzmatrix_row' . ($props{class} ? ' ' . $props{class} : '');
-  my $y     = ($props{y}       && -$props{y}->pxValue)       || 0;
-  my $h     = ($props{cheight} && -$props{cheight}->pxValue) || 0;
+  my $y     = ($props{y}       && $props{y}->pxValue)       || 0;
+  my $w     = ($props{cwidth}  && $props{cwidth}->pxValue)  || 0;
+  my $h     = ($props{cheight} && $props{cheight}->pxValue) || 0;
+  my $d     = ($props{cdepth}  && $props{cdepth}->pxValue)  || 0;
   my $yy    = $y + $h;
-  return $doc->openElement($tag, class => $class,
+  Debug("TIKZ alignment Row ($w x $h + $d); y=$yy; ") if $LaTeXML::DEBUG{pgf};
+  my $row = $doc->openElement($tag, class => $class,
     _scopebegin => 1,
     transform   => "matrix(1 0 0 1 0 $yy)",
-  ); }
+  );
+  $doc->insertElement('svg:rect', undef,
+    x => -2, y => -$h - 2, width => $w + 4, height => $h + $d + 4, stroke => '#00FF00', fill => 'none')
+    if $LaTeXML::DEBUG{pgf};
+  return $row; }
 
 sub openTikzAlignmentCol {
   my ($tag, $doc, %props) = @_;
   my $class = 'ltx_tikzmatrix_col' . ($props{class} ? ' ' . $props{class} : '');
-  my $x     = ($props{x} && $props{x}->pxValue) || 0;
-  return $doc->openElement($tag, class => $class,
+  my $w     = ($props{cwidth}  && $props{cwidth}->pxValue)  || 0;
+  my $h     = ($props{cheight} && $props{cheight}->pxValue) || 0;
+  my $d     = ($props{cdepth}  && $props{cdepth}->pxValue)  || 0;
+  my $x     = ($props{x}       && $props{x}->pxValue)       || 0;
+  my $xpos  = $x + $w;
+  my $ypos  = 0;         #-$h;
+  Debug("TIKZ alignment Cell ($w x $h + $d); x=$x") if $LaTeXML::DEBUG{pgf};
+  my $col = $doc->openElement($tag, class => $class,
     _scopebegin => 1,
-    transform   => "matrix(1 0 0 1 $x 0)",
-  ); }
+    transform   => "matrix(1 0 0 -1 $xpos $ypos)",
+  );
+  $doc->insertElement('svg:rect', undef,
+    x => -$w, y => -$h, width => $w, height => $h + $d, stroke => '#0000FF', fill => 'none')
+    if $LaTeXML::DEBUG{pgf};
+  return $col; }
 
 #=====================================================================
 # Dealing with quick commands

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -82,14 +82,12 @@ DefConstructor('\lxSVG@insertpicture{}',
   sub {
     my ($document, $content, %props) = @_;
     my $current = $document->getNode();
-    if (0 && $document->getNodeQName($current) =~ /^svg:/) {    # Already in svg:svg ?
-          # Possibly needs an svg:g with positioning ?
-          # Aparently these attributes not allowed on svg:g (in the schema we have?)
-          # Not yet ready for primetime...
+    if ($document->getNodeQName($current) =~ /^svg:/) {    # Already in svg:svg ?
+          # Seemingly this positioning is correct; otherwise inherit from context
+      my ($x, $y) = (-$props{minx}, -$props{miny});
       my $gnode = $document->openElement('svg:g',
-        width    => $props{pxwidth}, height => $props{pxheight},
-        viewBox  => "$props{minx} $props{miny} $props{pxwidth} $props{pxheight}",
-        overflow => "visible");
+        transform   => "matrix(1 0 0 1 $x $y)",
+        _scopebegin => 1, class => 'ltx_nestedsvg');
       $document->absorb($content);
       $document->closeElement('svg:g'); }
     else {

--- a/lib/LaTeXML/Package/pgfutil-common.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfutil-common.tex.ltxml
@@ -19,8 +19,7 @@ use warnings;
 
 #======================================================================
 # Load pgf's TeX code for util-common, first
-InputDefinitions('pgfutil-common', type => 'tex', noltxml => 1)
-  || Warn(":missing:pgfutil-common.tex Couldn't find pgfutil-common.tex");
+InputDefinitions('pgfutil-common', type => 'tex', noltxml => 1);
 
 # Overwrite macros of interest
 

--- a/lib/LaTeXML/Package/xkvview.sty.ltxml
+++ b/lib/LaTeXML/Package/xkvview.sty.ltxml
@@ -19,12 +19,10 @@ use LaTeXML::Package;
 #======================================================================
 
 # load the original xkeyval
-InputDefinitions('xkeyval', type => 'sty', noltxml => 1)
-  || Warn(":missing:xkeyval.sty Couldn't find xkeyval.sty");
+InputDefinitions('xkeyval', type => 'sty', noltxml => 1);
 
 # load the xkvview style file
-InputDefinitions('xkvview', type => 'sty', noltxml => 1)
-  || Warn(":missing:xkvview.sty Couldn't find xkvview.sty");
+InputDefinitions('xkvview', type => 'sty', noltxml => 1);
 
 # and hook all the things
 
@@ -142,7 +140,7 @@ DefMacro('\define@boolkey OptionalMatch:+ []{}[]{}[]{}', sub {
     my @tokens = ();
     push(@tokens, T_CS('\\ltx@orig@define@boolkey'));
     push(@tokens, $plus) if defined($plus);
-    push(@tokens, T_OTHER('['), $prefix, T_OTHER(']')) if defined($prefix);
+    push(@tokens, T_OTHER('['), $prefix,      T_OTHER(']')) if defined($prefix);
     push(@tokens, T_BEGIN,      $keyset,      T_END);
     push(@tokens, T_OTHER('['), $macroprefix, T_OTHER(']')) if defined($macroprefix);
     push(@tokens, T_BEGIN,      $key,         T_END);

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
@@ -90,9 +90,10 @@
        If ltx:picture/svg:svg had any of those, they got lost! -->
   <xsl:template match="ltx:picture" mode="as-svg">
     <xsl:element name="svg" namespace="{$svg_ns}">
-      <!-- copy id, class, style from parent ltx:picture -->
+      <!-- copy id, class from parent ltx:picture, but do NOT derive css style from size -->
       <xsl:call-template name="add_id"/>
-      <xsl:call-template name="add_attributes"/>
+      <xsl:call-template name="add_classes"/>
+      <xsl:apply-templates select="." mode="add_RDFa"/>
       <!-- but copy other svg:svg attributes -->
       <xsl:for-each select="svg:svg/@*">
         <xsl:apply-templates select="." mode="copy-attribute"/>

--- a/t/alignment/cells.xml
+++ b/t/alignment/cells.xml
@@ -141,7 +141,7 @@
               </tabular> </td>
             <td align="center" border="r t" thead="column row"> <tabular rowsep="-1.5pt" vattach="middle">
                 <tr>
-                  <td align="center" thead="column row"><inline-block angle="90" depth="0.0pt" height="127.5pt" innerdepth="0.0pt" innerheight="36.0pt" innerwidth="127.5pt" width="36.0pt" xtranslate="-45.75pt" ytranslate="-45.75pt">
+                  <td align="center" thead="column row"><inline-block angle="90" depth="0.0pt" height="127.5pt" innerdepth="0.0pt" innerheight="42.0pt" innerwidth="127.5pt" width="42.0pt" xtranslate="-42.75pt" ytranslate="-42.75pt">
                       <p><text color="#FF0000" font="bold"><tabular rowsep="-1.5pt" vattach="middle">
                             <tr>
                               <td align="justify" width="127.5pt"><p vattach="top">Second multilined</p></td>

--- a/t/alignment/plainmath.xml
+++ b/t/alignment/plainmath.xml
@@ -53,9 +53,9 @@
                 <XMTok font="italic" role="UNKNOWN">C</XMTok>
               </XMCell>
               <XMCell rowspan="2">
-                <XMWrap depth="18.0pt">
-                  <XMTok depth="18.0pt" font="italic" height="0" role="OPEN" yoffset="-18.0pt">(</XMTok>
-                  <XMTok font="italic" height="18.0pt" yoffset="-18.0pt"> </XMTok>
+                <XMWrap depth="27.0pt">
+                  <XMTok depth="27.0pt" font="italic" height="0" role="OPEN" yoffset="-27.0pt">(</XMTok>
+                  <XMTok font="italic" height="27.0pt" yoffset="-27.0pt"> </XMTok>
                 </XMWrap>
               </XMCell>
               <XMCell align="center">
@@ -66,8 +66,8 @@
               </XMCell>
               <XMCell rowspan="2">
                 <XMWrap>
-                  <XMTok depth="18.0pt" font="italic" height="0" role="CLOSE" yoffset="-18.0pt">)</XMTok>
-                  <XMTok font="italic" height="18.0pt" yoffset="-18.0pt"> </XMTok>
+                  <XMTok depth="27.0pt" font="italic" height="0" role="CLOSE" yoffset="-27.0pt">)</XMTok>
+                  <XMTok font="italic" height="27.0pt" yoffset="-27.0pt"> </XMTok>
                 </XMWrap>
               </XMCell>
             </XMRow>

--- a/t/graphics/graphrot.xml
+++ b/t/graphics/graphrot.xml
@@ -75,7 +75,7 @@
         <tag role="refnum">2</tag>
         <tag role="typerefnum">Table 2</tag>
       </tags>
-      <inline-block depth="1.5pt" height="67.5pt" width="280.8pt" xscale="1.5" xtranslate="46.8pt" yscale="0.75" ytranslate="-11.5pt">
+      <inline-block depth="1.5pt" height="78.7pt" width="280.8pt" xscale="1.5" xtranslate="46.8pt" yscale="0.75" ytranslate="-13.4pt">
         <tabular class="ltx_centering ltx_guessed_headers" vattach="middle">
           <tbody>
             <tr>
@@ -122,7 +122,7 @@
         <tag role="refnum">3</tag>
         <tag role="typerefnum">Table 3</tag>
       </tags>
-      <inline-block depth="2.0pt" height="90.0pt" width="187.2pt" xscale="-1" yscale="1">
+      <inline-block depth="2.0pt" height="105.0pt" width="187.2pt" xscale="-1" yscale="1">
         <tabular class="ltx_centering ltx_guessed_headers" vattach="middle">
           <tbody>
             <tr>
@@ -169,7 +169,7 @@
         <tag role="refnum">4</tag>
         <tag role="typerefnum">Table 4</tag>
       </tags>
-      <inline-block angle="45" depth="0.0pt" height="197.4pt" innerdepth="2.0pt" innerheight="90.0pt" innerwidth="187.2pt" width="197.4pt" xtranslate="5.11pt" ytranslate="-50.3pt">
+      <inline-block angle="45" depth="0.0pt" height="208.0pt" innerdepth="2.0pt" innerheight="105.0pt" innerwidth="187.2pt" width="208.0pt" xtranslate="10.42pt" ytranslate="-48.1pt">
         <tabular class="ltx_centering ltx_guessed_headers" vattach="middle">
           <tbody>
             <tr>
@@ -448,7 +448,7 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
         </tabular>
       </quote>
     </para>
-    <table angle="90" depth="0.0pt" height="622.5pt" inlist="lot" innerdepth="45.0pt" innerheight="254.6pt" innerwidth="622.5pt" labels="LABEL:rotfloat2" width="299.6pt" xml:id="S2.T5" xtranslate="-161.45pt" ytranslate="-138.95pt">
+    <table angle="90" depth="0.0pt" height="622.5pt" inlist="lot" innerdepth="45.0pt" innerheight="294.0pt" innerwidth="622.5pt" labels="LABEL:rotfloat2" width="339.0pt" xml:id="S2.T5" xtranslate="-141.75pt" ytranslate="-119.25pt">
       <tags>
         <tag>Table 5</tag>
         <tag role="autoref">Table 5</tag>


### PR DESCRIPTION
A variety of pgf/tikz improvements. Lumped together since "everything is connected".

* sets pgfkeys to read raw style, so handles more keywords succesfully (but is slower)
* binding for pgfplotstable (hmm a dup?)
* better sizing & positioning
* improves `\halign` (matrices, etc)
* avoids nested `svg:svg` (within `svg:foreignObject`!) when tikz environments are nested.

fixes #771 
fixes #1304
fixes #1495
fixes #794 

Improves  #1196, perhaps not enough to close?
