### PR TITLE
[arXiv] more frontmatter guards

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2294,7 +2294,7 @@ sub AddToMacro {
   else {
     DefMacroI($cs, undef, Tokens(map { $_->unlist }
           map { (blessed $_ ? $_ : TokenizeInternal($_)) } ($defn->getExpansion, @tokens)),
-      nopackParameters => 1, scope => 'global'); }
+      nopackParameters => 1, scope => 'global', locked => $$defn{locked}); }
   return; }
 
 #======================================================================

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1045,6 +1045,25 @@ DefConstructor('\@personname{}', "<ltx:personname>#1</ltx:personname>",
   beforeDigest => sub { Let('\thanks', '\person@thanks'); },
   bounded => 1, mode => 'text');
 
+# Sanitize person names for (obvious) punctuation abuse at start+end
+Tag('ltx:personname', afterClose => sub {
+  my ($document, $node) = @_;
+  if (my $first = $node->firstChild) {
+    if ($first->nodeType == XML_TEXT_NODE) {
+      my $first_text = $first->data;
+      my $new_text   = $first_text;
+      $new_text =~ s/^\W+//;
+      if ($first_text ne $new_text) {
+        $first->setData($new_text); } } }
+  if (my $last = $node->lastChild) {
+    if ($last->nodeType == XML_TEXT_NODE) {
+      my $last_text = $last->data;
+      my $new_text  = $last_text;
+      $new_text =~ s/\W+$//;
+      if ($last_text ne $new_text) {
+        $last->setData($new_text); } } }
+  return; });
+
 DefConstructorI('\and', undef, " and ");
 
 AssignValue(NUMBER_OF_AUTHORS => 0);
@@ -1073,7 +1092,7 @@ DefConstructor('\lx@author@prefix', sub {
 });
 
 DefMacro('\@author',                 '\@empty');
-DefMacro('\author{}',                '\def\@author{#1}\lx@make@authors@anded{#1}', locked => 1);
+DefMacro('\author[]{}',              '\def\@author{#2}\lx@make@authors@anded{#2}', locked => 1);
 DefMacro('\lx@make@authors@anded{}', sub { andSplit(T_CS('\lx@author'), $_[1]); });
 DefPrimitive('\ltx@authors@oneline', sub {
     AssignMapping('DOCUMENT_CLASSES', ltx_authors_1line => 1);
@@ -1098,7 +1117,7 @@ DefMacroI('\maketitle', undef,
     . '\global\let\title\relax'
     . '\global\let\author\relax'
     . '\global\let\date\relax'
-    . '\global\let\and\relax');
+    . '\global\let\and\relax', locked=>1);
 
 DefMacro('\@thanks',  '\@empty');
 DefMacro('\thanks{}', '\def\@thanks{#1}\lx@make@thanks{#1}');

--- a/t/structure/article.xml
+++ b/t/structure/article.xml
@@ -6,7 +6,7 @@
   <resource src="ltx-article.css" type="text/css"/>
   <title>A Test Article</title>
   <creator role="author">
-    <personname>John Q. Author </personname>
+    <personname>John Q. Author</personname>
   </creator>
   <creator before="  " role="author">
     <personname>Someone Else</personname>


### PR DESCRIPTION
Searching for more trade-offs, this PR introduces:
* lock \maketitle;
* sanitize ltx:personname for punctuation abuse
* allow optional arg for \author and lock
* keep locked definitions locked if they get extended (via bindings) by the `AddToMacro` utility 

---

1. Locking \maketitle avoids doubling the frontmatter when a custom `.sty` file redefines it, as in [cs0010030](https://corpora.mathweb.org/preview/arxmliv/tex%5Fto%5Fhtml/cs0010030)

2. Similarly, locking `\author` avoids issues where an otherwise correct author entry does not make it to the frontmatter infrastructure. But, at least one redefinition introduces an optional argument (example I saw: adds a note marker). So I made provisions to accept and drop that.

3. Lastly, some papers redefining `\author` abused it somewhat, where they started the intermediate ones with a leading comma, as in `\author{ , FirstName  LastName }`. And since such `\W` chars don't belong at the ends of person names, I added a sanitization clause to the `ltx:personname` tag. I did it on the tag since there are multiple venues from where person names are created, and also multiple XSLT sheets that map those elements into other formats.

4. `AddToMacro` could be invoked on a locked definition, which I think is OK, since if one does it from a binding there is usually (always?) a good reason. But what the way it did it dropped the `locked` declaration upon extension. So making sure locked definitions remain locked (for raw tex) after getting extended via a binding.