### PR TITLE
avoid empty kpsewhich calls

### DIFF
--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -385,7 +385,7 @@ our $kpse_toolchain = "";
 
 sub pathname_kpsewhich {
   my (@candidates) = @_;
-  return             unless $kpsewhich;
+  return             unless $kpsewhich && @candidates;
   build_kpse_cache() unless $kpse_cache;
   foreach my $file (@candidates) {
     if (my $result = $$kpse_cache{$file}) {


### PR DESCRIPTION
These should clearly never happen, but I saw a broken tikz case where they did. The terminal logs:
```
Missing argument. Try `kpsewhich --help' for more information.
Missing argument. Try `kpsewhich --help' for more information.
Missing argument. Try `kpsewhich --help' for more information.
Missing argument. Try `kpsewhich --help' for more information.
Missing argument. Try `kpsewhich --help' for more information.
Missing argument. Try `kpsewhich --help' for more information.
Missing argument. Try `kpsewhich --help' for more information.
Missing argument. Try `kpsewhich --help' for more information.
```

And I think I've seen these blocks of STDERR prints fly by also in the arXiv conversion logs.

The immediate fix is a one-liner, just don't do anything in `pathname_kpsewhich` when called without arguments.
The tikz coverage fix isn't something I'm attempting on a short notice, but I can catalog I was testing [this example](https://texample.net/tikz/examples/rose-rhodonea-curve/)