### PR TITLE
[arXiv] sandbox frontmatter expansions

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -4970,7 +4970,11 @@ DefPrimitive('\@add@frontmatter OptionalKeyVals {} OptionalKeyVals {}', sub {
       $$entry[1] = { $attr->beDigested($stomach)->getHash }; }
     $$entry[2] = Digest(Tokens(T_BEGIN, $tokens, T_END));
     AssignValue(inPreamble => $inpreamble);
-    return; });
+    return; },
+  beforeDigest => sub {
+    $_[0]->bgroup; },
+  afterDigest => sub {
+    $_[0]->egroup; });
 
 # Append a piece of data to an existing frontmatter item that is contained in <$tag>
 # If $label is given, look for an item which has label=>$label,
@@ -4998,7 +5002,11 @@ DefPrimitive('\@add@to@frontmatter {} [] {}', sub {
       push(@{ $$list[-1] }, $datum);
       return; }
     push(@{ $$frontmatter{$tag} }, [$tag, ($label ? { label => $label } : undef), $datum]);
-    return; });
+    return; },
+  beforeDigest => sub {
+    $_[0]->bgroup; },
+  afterDigest => sub {
+    $_[0]->egroup; });
 
 # This is called by afterOpen (by default on <ltx:document>) to
 # output any frontmatter that was accumulated.


### PR DESCRIPTION
I really want to move on from styling but way too frequently previewing a new arXiv article reveals a brand new edge case... 

```tex
\documentclass{aa}
\begin{document}
\title{title}
\keywords{planets and satellites: formation -- methods: N-body
simulations -- astrobiology}

\section{Introduction.}
The core accretion hypothesis of giant planet formation postulates
that giant planets originate in a cool location in a protoplanetary...
\end{document}
```

Upon converting that, one sees the text of the introduction is bold, and in the case of the full article - the entire document gets bold.

Turns out the definition in `aa_support.sty.ltxml` runs into trouble:
```perl
DefMacroI('\keywordname', undef, '\sffamily\bfseries Key Words.');
```

where the font switches escape out of the \keywords macro and into the main document - turning the entire thing bold. One would be tempted to switch `\bfseries` with a `\textbf` and scope it better, **but** the `\keywordname` macro is conceivably allowed to be redefined in various uses in arXiv. So rather than doing that, the right approach ought to be to sandbox its uses.

In particular, I thought it appropriate to add an auto-grouping for the primitives `\@add@frontmatter` and `\@add@to@frontmatter`, so that font switches never escape out from them into the rest of the document. 