### PR TITLE
Fix tocs, navbar

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -749,6 +749,7 @@ DefConstructor('\addcontentsline{}{}{}', sub {
     if (my $savenode = $document->floatToLabel) {
       my $node  = $document->getNode;
       my $lists = $node->getAttribute('inlist');
+      $inlist = ToString($inlist);
       $document->setAttribute($node, inlist => ($lists ? $lists . ' ' . $inlist : $inlist));
       $document->setNode($savenode); } });
 

--- a/lib/LaTeXML/Post/Split.pm
+++ b/lib/LaTeXML/Post/Split.pm
@@ -43,7 +43,7 @@ sub process {
     my @nav = $doc->findnodes("descendant::ltx:navigation");
     $doc->removeNodes(@nav) if @nav;
     my $tree = { node => $root, document => $doc,
-      id => $root->getAttribute('xml:id'), name => $doc->getDestination,
+      id       => $root->getAttribute('xml:id'), name => $doc->getDestination,
       children => [] };
     # Group the pages into a tree, in case they are nested.
     my $haschildren = {};
@@ -97,8 +97,10 @@ sub processPages {
   my ($self, $doc, @entries) = @_;
   my $rootid = $doc->getDocumentElement->getAttribute('xml:id');
   # Before any document surgery, copy inheritable attributes.
+  my $intoc = 0;    # Whether ANY children appear in toc
   foreach my $entry (@entries) {
     my $node = $$entry{node};
+    $intoc ||= ($node->getAttribute('inlist') || '') =~ /\btoc\b/;
     foreach my $attr (qw(xml:lang backgroundcolor)) {
       if (my $anc = $doc->findnode('ancestor-or-self::*[@' . $attr . '][1]', $node)) {
         $node->setAttribute($attr => $anc->getAttribute($attr)); } } }
@@ -117,6 +119,8 @@ sub processPages {
     while (@entries && @removed && $entries[0]->{node}->isSameNode($removed[0])) {
       my $entry = shift(@entries);
       my $page  = $$entry{node};
+      # If any pages go in toc, Assume siblings on their own page should go also
+      $page->setAttribute(inlist => 'toc') if $intoc && !$page->hasAttribute('inlist');
       $doc->removeNodes(shift(@removed));
       my $id       = $page->getAttribute('xml:id');
       my $tocentry = ['ltx:tocentry', {},


### PR DESCRIPTION
When spliting a document and creating tables of contents, and some chapters/sections/... are included in the toc, include other split-off siblings in the toc, even if they aren't explicitly marked to go into the toc.  This is particularly helpful for things like bibliographies, indices, etc, and is probably what is most often expected.

fixes #1401