### PR TITLE
Don't concatenate digits into number if different fonts

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -4482,14 +4482,16 @@ DefMathLigature(matcher => sub { my ($document, $node) = @_;
     my $decrole = ($dec eq '.' ? 'PERIOD' : '');
     # my $skip  = Dimension('5mu')->valueOf;
     my @chars = ();
-    my ($n, $string, $number, $w) = (0, '', '', 0);
+    my ($n, $string, $number, $w, $font) = (0, '', '', 0, undef);
     # NOTE: We're scanning chars from END!
     while ($node) {
       my $qn = $document->getModel->getNodeQName($node);
       if ($qn =~ /^(ltx:XMTok|ltx:XMWrap)$/) {
         my $r    = ($node->getAttribute('role') || '');
+        my $f    = $document->getNodeFont($node);
         my $text = $node->textContent;
-        if ($r eq 'NUMBER') {
+        if (($r eq 'NUMBER') && (!$font || ($f->equals($font)))) {    # A number in same font?
+          $font   = $f;
           $string = $text . $string;
           $number = $node->getAttribute('meaning') . $number; }
         elsif (!$n) {    # any following cases are not allowed as LAST char


### PR DESCRIPTION
as it says.  So adjacent digits in different fonts end up separate number tokens, preserving their font.

Of course, in the current parser, the adjacency is taken as multiplication, which is most likely wrong, but what does it mean?  My favorite example comes from discussion of floating point numbers in numerical analysis, where you'd have `$b_0 b_1 b_2 ... b_n$`, which is a concatenation of bits into a computer word (or even number).

At any rate, this patch fixes the font problem, and defers parsing questions to a later time.

fixes #1463