### PR TITLE
epub: allow all core media types; safer ids; portable href's

### DIFF
--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -13,6 +13,7 @@ package LaTeXML::Post::Manifest::Epub;
 use strict;
 use warnings;
 use File::Find qw(find);
+use URI::file;
 
 our $uuid_tiny_installed;
 
@@ -180,7 +181,7 @@ sub process {
       my $manifest = $$self{opf_manifest};
       my $item     = $manifest->addNewChild(undef, 'item');
       $item->setAttribute('id',         $file);
-      $item->setAttribute('href',       $relative_destination);
+      $item->setAttribute('href',       URI::file->new($relative_destination));
       $item->setAttribute('media-type', "application/xhtml+xml");
       my @properties;
       push @properties, 'mathml' if $doc->findnode('//*[local-name() = "math"]');
@@ -197,7 +198,7 @@ sub process {
       my $nav_map = $$self{nav_map};
       my $nav_li  = $nav_map->addNewChild(undef, 'li');
       my $nav_a   = $nav_li->addNewChild(undef, 'a');
-      $nav_a->setAttribute('href', $file);
+      $nav_a->setAttribute('href', URI::file->new($file));
       $nav_a->appendText($file); } }
   $self->finalize;
   return; }
@@ -233,7 +234,7 @@ sub finalize {
 
     my $file_item = $manifest->addNewChild(undef, 'item');
     $file_item->setAttribute('id',         $file_id);
-    $file_item->setAttribute('href',       $file);
+    $file_item->setAttribute('href',       URI::file->new($file));
     $file_item->setAttribute('media-type', $file_type); }
 
   # Write the content.opf file to disk

--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -169,11 +169,13 @@ sub initialize {
 
 sub url_id {
   my ($name) = @_;
-  # convert file name to valid NCName for use as id
-  # any invalid character, and -, are converted to -xN- where N is the hex codepoint
-  $name =~ s/([^A-Z_a-z\x{C0}-\x{D6}\x{D8}-\x{F6}\x{F8}-\x{2FF}\x{370}-\x{37D}\x{37F}-\x{1FFF}\x{200C}-\x{200D}\x{2070}-\x{218F}\x{2C00}-\x{2FEF}\x{3001}-\x{D7FF}\x{F900}-\x{FDCF}\x{FDF0}-\x{FFFD}\x{10000}-\x{EFFFF}.0-9\x{B7}\x{0300}-\x{036F}\x{203F}-\x{2040}])/-x${\(sprintf("%X", ord($1)))}-/g;
-  # ensure the starting char is valid and prevent collisions with the other id's
-  $name = 'file-' . $name;
+  # convert a relative url to a valid NCName for use as id
+  # any invalid character is encoded as _xN_ where N is its uppercase hex codepoint
+  # underscores starting a sequence of the form _xN_ are encoded as _x5F_
+  $name =~ s/_(x[0-9A-F]+)(?=_)/_x5F_$1/g;
+  $name =~ s/([^A-Z_a-z\x{C0}-\x{D6}\x{D8}-\x{F6}\x{F8}-\x{2FF}\x{370}-\x{37D}\x{37F}-\x{1FFF}\x{200C}-\x{200D}\x{2070}-\x{218F}\x{2C00}-\x{2FEF}\x{3001}-\x{D7FF}\x{F900}-\x{FDCF}\x{FDF0}-\x{FFFD}\x{10000}-\x{EFFFF}\-.0-9\x{B7}\x{0300}-\x{036F}\x{203F}-\x{2040}])/_x${\(sprintf("%X", ord($1)))}_/g;
+  # ensure the starting char is valid and prevent collisions with the other id's below
+  $name = '_' . $name;
   return $name;
 }
 

--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -167,7 +167,7 @@ sub initialize {
   $$self{nav_map}       = $nav_map;
   return; }
 
-sub file_id {
+sub url_id {
   my ($name) = @_;
   # convert file name to valid NCName for use as id
   # any invalid character, and -, are converted to -xN- where N is the hex codepoint
@@ -190,9 +190,10 @@ sub process {
       # Add to manifest
       my $manifest = $$self{opf_manifest};
       my $item     = $manifest->addNewChild(undef, 'item');
-      my $item_id  = file_id($relative_destination);
+      my $item_url = URI::file->new($relative_destination);
+      my $item_id  = url_id($item_url);
       $item->setAttribute('id',         $item_id);
-      $item->setAttribute('href',       URI::file->new($relative_destination));
+      $item->setAttribute('href',       $item_url);
       $item->setAttribute('media-type', "application/xhtml+xml");
       my @properties;
       push @properties, 'mathml' if $doc->findnode('//*[local-name() = "math"]');
@@ -238,8 +239,9 @@ sub finalize {
       $file_type = 'application/octet-stream'; }
 
     my $file_item = $manifest->addNewChild(undef, 'item');
-    $file_item->setAttribute('id',         file_id($file));
-    $file_item->setAttribute('href',       URI::file->new($file));
+    my $file_url  = URI::file->new($file);
+    $file_item->setAttribute('id',         url_id($file_url));
+    $file_item->setAttribute('href',       $file_url);
     $file_item->setAttribute('media-type', $file_type); }
 
   # Write the content.opf file to disk

--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -198,7 +198,7 @@ sub process {
       my $nav_map = $$self{nav_map};
       my $nav_li  = $nav_map->addNewChild(undef, 'li');
       my $nav_a   = $nav_li->addNewChild(undef, 'a');
-      $nav_a->setAttribute('href', URI::file->new($file));
+      $nav_a->setAttribute('href', URI::file->new($relative_destination));
       $nav_a->appendText($file); } }
   $self->finalize;
   return; }

--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -226,7 +226,7 @@ sub finalize {
         my $OPS_abspath  = $_;
         my $OPS_pathname = pathname_relative($OPS_abspath, $OPS_directory);
         my (undef, $name, $ext) = pathname_split($OPS_pathname);
-        if (-f $OPS_abspath && $ext ne 'xhtml' && "$name.$ext" ne 'LaTeXML.cache') {
+        if (-f $OPS_abspath && $ext ne 'xhtml' && "$name.$ext" ne 'LaTeXML.cache' && $OPS_abspath ne 'content.opf') {
           push(@content, $OPS_pathname); }
       } }, $OPS_directory);
 


### PR DESCRIPTION
As promised, a quick improvement on #1635. In short:
- recognise all 'core media types' listed in the EPUB3.2 spec, not just the arbitrary css/png/svg (incidentally, the `.css` match was still case-sensitive);
- be excessively accurate with `@id`, down to encoding invalid characters as `-xNNN-` so that there can't be collisions or invalid id's, ever ~; files starting with a digit would have caused problems so we might as well do the right thing™; the regex is almost a copy and paste from the XML 1.0 spec (collision is still a risk, but a small one, and easy to fix on the user side)~
- use `URI::file` to make sure the `href`'s are actual URLs; things would have probably exploded on Windows
- fix a tiny bug that causes invalid output when using `--splitnaming=*relative`
- do not include the log in the output

Hopefully I'll get around to test this on Windows over the weekend, just to be sure.

I am still missing a couple of XSLT fixes, I'll get them to you soon.