### PR TITLE
[arXiv] 2nd try, recover abstract order in raw frontmatter uses

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1161,6 +1161,10 @@ DefEnvironment('{abstract}', '',
         @LaTeXML::LIST]);
     DefMacroI('\maybe@end@abstract', undef, Tokens(), scope => 'global');
     return; },
+  afterConstruct => sub {
+    if (LookupValue('standalone_abstract_in_frontmatter')) {
+      insertFrontMatter(@_); }
+    return; },
   locked => 1, mode => 'text');
 # If we get a plain \abstract, instead of an environment, look for \abstract{the abstract}
 AssignValue('\abstract:locked' => 0);    # REDEFINE the above locked definition!

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -5020,7 +5020,16 @@ my %frontmatter_elements = map { ($_ => 1) } @frontmatter_elements;
 sub insertFrontMatter {
   my ($document) = @_;
   my $frontmatter = LookupValue('frontmatter');
-  foreach my $key (@frontmatter_elements, grep { !$frontmatter_elements{$_} } keys %$frontmatter) {
+  my @set_keys = $frontmatter ? (keys %$frontmatter) : ();
+  # if doc only has a solo abstract as frontmatter,
+  #    don't deposit here but mark to be placed as-is.
+  if ((scalar(@set_keys) == 1) && ($set_keys[0] eq 'ltx:abstract') &&
+    # Avoid cargo cult: allow this sub to be called twice with solo abstract,
+    #                   where 2nd call is at the right location for insertion.
+    !LookupValue('standalone_abstract_in_frontmatter')) {
+    AssignValue('standalone_abstract_in_frontmatter', 1, 'global');
+    return; }
+  foreach my $key (@frontmatter_elements, grep { !$frontmatter_elements{$_} } @set_keys) {
     if (my $list = $$frontmatter{$key}) {
       # Dubious, but assures that frontmatter appears in text mode...
       local $LaTeXML::BOX = Box('', $STATE->lookupValue('font'), '', T_SPACE);


### PR DESCRIPTION
Better technical implementation for #1621 , as suggested by Bruce.

When the frontmatter of a document contains only a single `ltx:abstract` at the point of frontmatter insertion, do not perform it. Instead, defer inserting the abstract until the exact location where the abstract was originally digested.

I can also confirm this successfully corrects the test article in question (hep-ph0001194).

After merging here, I think we're ready for a rerun of the arXiv sandboxes, which I can start right away.