### PR TITLE
Set pgfplots version to the most recent version;

### DIFF
--- a/lib/LaTeXML/Package/pgfplots.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfplots.sty.ltxml
@@ -27,6 +27,8 @@ InputDefinitions('pgfplots', type => 'sty', noltxml => 1);
 my $compat_cs  = T_CS('\pgfk@/pgfplots/compat/current');
 my $compat_val = IsDefined($compat_cs) && ToString(Expand($compat_cs));
 if (!$compat_val || $compat_val eq 'default') {
-  RawTeX('\pgfplotsset{compat=1.17}'); }
-
+  my $recent_cs  = T_CS('\pgfk@/pgfplots/compat/mostrecent');
+  my $recent_val = IsDefined($recent_cs) && ToString(Expand($recent_cs));
+  if ($recent_val && $recent_val ne 'default') {
+    RawTeX('\pgfplotsset{compat=' . $recent_val . '}'); } }
 1;

--- a/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfplotstable.sty.ltxml
@@ -17,9 +17,4 @@ use LaTeXML::Package;
 
 #======================================================================
 InputDefinitions('pgfplotstable', type => 'sty', noltxml => 1);
-# Avoid generic warnings:
-my $compat_cs  = T_CS('\pgfk@/pgfplots/compat/current');
-my $compat_val = IsDefined($compat_cs) && ToString(Expand($compat_cs));
-if (!$compat_val || $compat_val eq 'default') {
-  RawTeX('\pgfplotsset{compat=1.17}'); }
 1;


### PR DESCRIPTION
 Avoid warnings by setting pgfplots to its most recent version, rather than a specific one. pgfplotstable doesn't need to set the version, since it loads pgfplots.