### PR TITLE
create proper EPUB3 navigation document

### DIFF
--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -15,6 +15,9 @@ use warnings;
 use File::Find qw(find);
 use URI::file;
 
+# ensure that we can use xhtml: in the xpath queries below
+$LaTeXML::Post::Document::XPATH->registerNS('xhtml' => 'http://www.w3.org/1999/xhtml');
+
 our $uuid_tiny_installed;
 
 BEGIN {
@@ -213,7 +216,8 @@ sub process {
       my $nav_li  = $nav_map->addNewChild(undef, 'li');
       my $nav_a   = $nav_li->addNewChild(undef, 'a');
       $nav_a->setAttribute('href', URI::file->new($relative_destination));
-      $nav_a->appendText($file); } }
+      map { $nav_a->appendChild($_->cloneNode(1)) }
+        $doc->findnodes('/xhtml:html/xhtml:head/xhtml:title/node()'); } }
   $self->finalize;
   return; }
 

--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -248,7 +248,7 @@ sub finalize {
         my $OPS_abspath  = $_;
         my $OPS_pathname = pathname_relative($OPS_abspath, $OPS_directory);
         my (undef, $name, $ext) = pathname_split($OPS_pathname);
-        if (-f $OPS_abspath && $ext ne 'xhtml' && "$name.$ext" ne 'LaTeXML.cache' && $OPS_abspath ne 'content.opf') {
+        if (-f $OPS_abspath && $ext ne 'xhtml' && "$name.$ext" ne 'LaTeXML.cache' && $OPS_pathname ne 'content.opf') {
           push(@content, $OPS_pathname); }
       } }, $OPS_directory);
 

--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -142,11 +142,6 @@ sub initialize {
   $identifier->appendText($$self{'unique-identifier'});
   # Manifest
   my $manifest = $package->addNewChild(undef, 'manifest');
-  my $nav_item = $manifest->addNewChild(undef, 'item');
-  $nav_item->setAttribute('id',         'nav');
-  $nav_item->setAttribute('href',       'nav.xhtml');
-  $nav_item->setAttribute('properties', 'nav');
-  $nav_item->setAttribute('media-type', 'application/xhtml+xml');
   # Spine
   my $spine = $package->addNewChild(undef, 'spine');
   # 3.2 OPS/nav.xhtml
@@ -266,6 +261,25 @@ sub finalize {
     $file_item->setAttribute('href',       $file_url);
     $file_item->setAttribute('media-type', $file_type); }
 
+  # Write toc.ncx file to disk
+  my $nav_count = 0;
+  my $nav_name  = 'nav.xhtml';
+  my $nav_path  = pathname_concat($OPS_directory, $nav_name);
+  while (-f $nav_path) {    # do not overwrite existing files
+    $nav_count += 1;
+    $nav_name = "nav-$nav_count.xhtml";
+    $nav_path = pathname_concat($OPS_directory, $nav_name); }
+  my $NAV_FH;
+  open($NAV_FH, ">", $nav_path)
+    or Fatal('I/O', $nav_path, undef, "Couldn't open '$nav_path' for writing: $!");
+  print $NAV_FH $$self{nav}->toString(1);
+  close $NAV_FH;
+  my $nav_item = $manifest->addNewChild(undef, 'item');
+  $nav_item->setAttribute('id',         'nav');
+  $nav_item->setAttribute('href',       $nav_name);
+  $nav_item->setAttribute('properties', 'nav');
+  $nav_item->setAttribute('media-type', 'application/xhtml+xml');
+
   # Write the content.opf file to disk
   my $directory    = $$self{siteDirectory};
   my $content_path = pathname_concat($OPS_directory, 'content.opf');
@@ -277,17 +291,6 @@ sub finalize {
       or Fatal('I/O', 'content.opf', undef, "Couldn't open '$content_path' for writing: $_");
     print $OPF_FH $$self{opf}->toString(1);
     close $OPF_FH; }
-
-  # Write toc.ncx file to disk
-  my $nav_path = pathname_concat($OPS_directory, 'nav.xhtml');
-  if (-f $nav_path) {
-    Info('note', 'nav.xhtml', undef, 'using the navigation document supplied by the user'); }
-  else {
-    my $NAV_FH;
-    open($NAV_FH, ">", $nav_path)
-      or Fatal('I/O', 'nav.xhtml', undef, "Couldn't open '$nav_path' for writing: $!");
-    print $NAV_FH $$self{nav}->toString(1);
-    close $NAV_FH; }
 
   return (); }
 

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
@@ -34,6 +34,17 @@
   <!-- Remove context from head title -->
   <xsl:param name="HEAD_TITLE_SHOW_CONTEXT"/>
 
+  <!-- Navigation is already handled by the navigation document -->
+  <xsl:template match="/" mode="header"/>
+  <xsl:template match="/" mode="footer-navigation"/>
+
+  <!-- Generator footer on front page only -->
+  <xsl:template match="/" mode="footer">
+    <xsl:if test="not(//ltx:navigation/ltx:ref[@rel='up'])">
+      <xsl:apply-imports/>
+    </xsl:if>
+  </xsl:template>
+
   <!-- Do not copy the RDFa prefix, but proceed as usual -->
   <xsl:template match="/">
     <xsl:apply-templates select="." mode="doctype"/>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
@@ -31,6 +31,9 @@
   <xsl:param name="USE_NAMESPACES"  >true</xsl:param>
   <xsl:param name="USE_HTML5"       >true</xsl:param>
 
+  <!-- Remove context from head title -->
+  <xsl:param name="HEAD_TITLE_SHOW_CONTEXT"/>
+
   <!-- Do not copy the RDFa prefix, but proceed as usual -->
   <xsl:template match="/">
     <xsl:apply-templates select="." mode="doctype"/>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -151,7 +151,7 @@
           </xsl:choose>
           <xsl:if test="$HEAD_TITLE_SHOW_CONTEXT">
             <xsl:for-each select="//ltx:navigation/ltx:ref[@rel='up']">
-              <xsl:text>&#x2023; </xsl:text>
+              <xsl:text> &#x2023; </xsl:text>
               <xsl:value-of select="@title"/>
             </xsl:for-each>
           </xsl:if>


### PR DESCRIPTION
[Edited to match updates.]

This PR:
- removes the context from `<xhtml:title>`
- uses `<xhtml:title>` to populate the navigation document
- makes the navigation document nested
- remove navigation headers and footers from the pages (redundant, and quite an odd sight in EPUB)
- does not use `nav.xhtml` if already present: create `nav-1.xhtml` instead (or `nav-2.xhtml`, ...)

(I have also added a missing space in front of the separator, that was just a typo, right?)