### PR TITLE
detect presence of toc nav in EPUB

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -201,6 +201,8 @@ sub convert {
     $$opts{sitedirectory} = $sandbox_directory;
 
     if ($$opts{format} eq 'epub') {
+      # give main document a predictable name, avoid clash with nav.xhtml
+      $sandbox_destination = 'index.xhtml';
       $$opts{resource_directory} = File::Spec->catdir($sandbox_directory, 'OPS');
       $$opts{destination} = pathname_concat(File::Spec->catdir($sandbox_directory, 'OPS'), $sandbox_destination); }
     else {
@@ -609,7 +611,7 @@ sub convert_post {
     my $manifest_maker = LaTeXML::Post::Manifest->new(db => $DB, format => $format, log => $$opts{log}, %PostOPS);
     $manifest_maker->process(@postdocs); }
   # Archives: when a relative --log is requested, write to sandbox prior packing
-  #     TODO: This can be enhanced, as any path can be relativized. 
+  #     TODO: This can be enhanced, as any path can be relativized.
   #     TODO: ALSO, we now always have a log file, so maybe always add it as default?
   if ($$opts{log} && ($$opts{whatsout} =~ /^archive/) && (!pathname_is_absolute($$opts{log}))) {
     ### We can't rely on the ->getDestinationDirectory method, as Fatal post-processing jobs have UNDEF @postdocs !!!

--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -154,6 +154,7 @@ sub initialize {
     my $nav_html = $opf->createElementNS("http://www.w3.org/1999/xhtml", 'html');
     $nav->setDocumentElement($nav_html);
     $nav_html->setNamespace("http://www.idpf.org/2007/ops", "epub", 0);
+    $nav_html->setAttribute('xml:lang', $document_language);
     my $nav_head  = $nav_html->addNewChild(undef, 'head');
     my $nav_title = $nav_head->addNewChild(undef, 'title');
     $nav_title->appendText($document_title);

--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -15,6 +15,9 @@ use warnings;
 use File::Find qw(find);
 use URI::file;
 
+# ensure that we can use xhtml: in the xpath queries below
+$LaTeXML::Post::Document::XPATH->registerNS('xhtml' => 'http://www.w3.org/1999/xhtml');
+
 our $uuid_tiny_installed;
 
 BEGIN {
@@ -213,7 +216,8 @@ sub process {
       my $nav_li  = $nav_map->addNewChild(undef, 'li');
       my $nav_a   = $nav_li->addNewChild(undef, 'a');
       $nav_a->setAttribute('href', URI::file->new($relative_destination));
-      $nav_a->appendText($file); } }
+      map { $nav_a->appendChild($_->cloneNode(1)) }
+        $doc->findnodes('/xhtml:html/xhtml:head/xhtml:title/node()'); } }
   $self->finalize;
   return; }
 

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
@@ -31,6 +31,9 @@
   <xsl:param name="USE_NAMESPACES"  >true</xsl:param>
   <xsl:param name="USE_HTML5"       >true</xsl:param>
 
+  <!-- Remove context from head title -->
+  <xsl:param name="HEAD_TITLE_SHOW_CONTEXT"/>
+
   <!-- Do not copy the RDFa prefix, but proceed as usual -->
   <xsl:template match="/">
     <xsl:apply-templates select="." mode="doctype"/>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -151,7 +151,7 @@
           </xsl:choose>
           <xsl:if test="$HEAD_TITLE_SHOW_CONTEXT">
             <xsl:for-each select="//ltx:navigation/ltx:ref[@rel='up']">
-              <xsl:text>&#x2023; </xsl:text>
+              <xsl:text> &#x2023; </xsl:text>
               <xsl:value-of select="@title"/>
             </xsl:for-each>
           </xsl:if>

--- a/t/931_epub.t
+++ b/t/931_epub.t
@@ -37,7 +37,7 @@ my $zip_file = Archive::Zip->new();
 is($zip_file->read($epub_filename), AZ_OK, 'epub file successfully loads as Archive::Zip object');
 is($zip_file->numberOfMembers, 10, "correct number of files were present in final ePub");
 my $names = join(", ",sort($zip_file->memberNames));
-ok($names =~ /^META-INF\/, META-INF\/container\.xml, OPS\/, OPS\/931_test\.log, OPS\/931_test....\.xhtml, OPS\/LaTeXML-epub\.css, OPS\/LaTeXML\.css, OPS\/content\.opf, OPS\/nav\.xhtml, mimetype$/, "correct files were present in final ePub: $names");
+ok($names =~ /^META-INF\/, META-INF\/container\.xml, OPS\/, OPS\/931_test\.log, OPS\/LaTeXML-epub\.css, OPS\/LaTeXML\.css, OPS\/content\.opf, OPS\/index\.xhtml, OPS\/nav\.xhtml, mimetype$/, "correct files were present in final ePub: $names");
 
 my $log_member = $zip_file->memberNamed("OPS/$log_filename");
 ok($log_member, "log file was written to epub");


### PR DESCRIPTION
This adds three commits on top of #1643. Technically, it is probably 5-6 new lines, but there is some reshuffling of the `nav.xhtml` code to get the right logic, so I'll keep it separate.

The change lets the user customise the navigation document in three ways, in order of priority:
1. supply the file `nav.xhtml` in some way (`RequireResource`, `--splitnaming=label`, ???) – merged in #1639
2. add `<nav epub:type="toc" ...>` in at least one the documents; the first one (in reading order) will be marked as navigation document
3. (default) let latexmlc generate `nav.xhtml` – hopefully with titles instead of filenames #1643

This PR adds 2, which is suggested by the spec itself: any document can do double duty as navigation document, see [§5.1, paragraph 3](https://www.w3.org/publishing/epub3/epub-packages.html#sec-package-nav). `<nav epub:type="toc" ...>` is exactly the tag that must appear in the navigation document, so the code just checks whether it exists or not.

I think this is the best we can do for EPUB without refactoring, so I'll stop the PRs now. Long term, I plan to send some XSLT that generates a valid `<nav epub:type="toc">` in the front page, so that 2 becomes as easy as calling `--navigationtoc=...`. I don't think I can improvise it, though.

PS: setting the destination to `index.xhtml` is necessary, otherwise `--dest=nav.epub` will create `nav.xhtml` and end up with a non-working EPUB!