### PR TITLE
Fix ligatures

### DIFF
--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -72,6 +72,7 @@ sub getNode { my ($self) = @_; return $$self{node}; }
 
 sub setNode {
   my ($self, $node) = @_;
+  $self->closeText_internal;                # Close any open text node, so ligatures run.
   my $type = $node->nodeType;
   if ($type == XML_DOCUMENT_FRAG_NODE) {    # Whoops
     my @n = $node->childNodes;
@@ -1201,7 +1202,7 @@ sub closeText_internal {
         next if ($fonttest = $$ligature{fontTest}) && !&$fonttest($font);
         $string = &{ $$ligature{code} }($string); } }
     $node->setData($string) unless $string eq $ostring;
-    $self->setNode($parent);    # Now, effectively Closed
+    $$self{node} = $parent;    # Effectively closed (->setNode, but don't recurse)
     return $parent; }
   else {
     return $node; } }


### PR DESCRIPTION
Make sure closeText runs ligatures when using setNode to move insertion point. This can happen when a floating insertion (like `\label` or `\index`) appears within text, which causes the insertion point to move,  but previously the ligatures didn't get applied to the preceding text.

Creating a PR just so @dginev can see it, but since I need it, I'm going to immediately merge.