### PR TITLE
convert paths to urls

### DIFF
--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -240,6 +240,7 @@ sub find_preambles {
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 package LaTeXML::Post::MathProcessor;
 use strict;
+use LaTeXML::Util::Pathname;
 use LaTeXML::Post;
 use LaTeXML::Common::Error;
 use base qw(LaTeXML::Post::Processor);
@@ -382,7 +383,7 @@ sub maybeSetMathImage {
   if ((($$conversion{mimetype} || '') =~ /^image\//)    # Got an image?
     && !$math->getAttribute('imagesrc')) {              # and it's the first one
     if (my $src = $$conversion{src}) {
-      $math->setAttribute(imagesrc    => $src);
+      $math->setAttribute(imagesrc    => pathname_to_url($src));
       $math->setAttribute(imagewidth  => $$conversion{width});
       $math->setAttribute(imageheight => $$conversion{height});
       $math->setAttribute(imagedepth  => $$conversion{depth}); } }

--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -355,7 +355,7 @@ sub fill_in_refs {
           $ref->setAttribute(title => $titlestring); } }
       if (!$ref->textContent && !element_nodes($ref)
         && !(($tag eq 'ltx:graphics') || ($tag eq 'ltx:picture'))) {
-        my $is_nameref = ($ref->getAttribute('class')||'') =~ 'ltx_refmacro_nameref';
+        my $is_nameref = ($ref->getAttribute('class') || '') =~ 'ltx_refmacro_nameref';
         $doc->addNodes($ref, $self->generateRef($doc, $id, $show, $is_nameref)); }
       if (my $entry = $$self{db}->lookup("ID:$id")) {
         $ref->setAttribute(stub => 1) if $entry->getValue('stub'); }
@@ -631,7 +631,7 @@ sub generateURL {
         $url .= '#' . $fragid; }
       elsif ($location eq $doclocation) {
         $url = ''; }
-      return $url; }
+      return pathname_to_url($url); }
     else {
       $self->note_missing('warn', 'File location for ID', $id); } }
   else {

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -158,7 +158,7 @@ sub format_tex {
 # This is the default
 sub setTeXImage {
   my ($self, $doc, $node, $path, $width, $height, $depth) = @_;
-  $node->setAttribute('imagesrc',    $path);
+  $node->setAttribute('imagesrc',    pathname_to_url($path));
   $node->setAttribute('imagewidth',  $width);
   $node->setAttribute('imageheight', $height);
   $node->setAttribute('imagedepth',  $depth) if defined $depth;

--- a/lib/LaTeXML/Post/XSLT.pm
+++ b/lib/LaTeXML/Post/XSLT.pm
@@ -66,7 +66,7 @@ sub process {
       foreach my $node (@resnodes) {
         my $src  = $node->getAttribute('src');
         my $path = $self->copyResource($doc, $src, $node->getAttribute('type'));
-        $node->setAttribute(src => $path) unless $path eq $src; } } }
+        $node->setAttribute(src => pathname_to_url($path)) unless $path eq $src; } } }
   if (my $css = $params{CSS}) {
     $params{CSS} = '"' . join('|', map { $self->copyResource($doc, $_, 'text/css') } @$css) . '"'; }
   if (my $js = $params{JAVASCRIPT}) {
@@ -123,4 +123,3 @@ sub copyResource {
 
 # ================================================================================
 1;
-

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -119,7 +119,8 @@ sub pathname_canonical {
   $pathname =~ s|/\./|/|g;
   # Collapse any foo/.. patterns, but not ../..
   while ($pathname =~ s|/(?!\.\./)[^/]+/\.\.(/\|$)|$1|) { }
-  $pathname =~ s|^\./||;
+  # Reduce ./foo to foo, but preserve ./
+  $pathname =~ s|^\./(.)|$1|;
   return (defined $urlprefix ? $urlprefix . $pathname : $pathname); }
 
 # Convenient extractors;


### PR DESCRIPTION
Yet another Windows problem. Some paths need to be converted to URLs, or Windows will end up with lots of `%5C` instead of slashes. This PR seems to fix:
- images
- math images
- resources in subfolders
- `--splitnaming=*relative`

If you know of any other path that is being shoved into an attribute, can you please check and add `pathname_to_url`? I am not sure I fixed all of them.

~PS: I took the opportunity to replace some `URI::file->new` with `pathname_to_url` since it does the same job.~ Edit: with apologies for the forced pushes, I realised that `URI::file` and `pathname_to_url` are probably not equivalent, as the latter does not encode the string.