### PR TITLE
allow VERTBAR as anyOp in math parsing

### DIFF
--- a/lib/LaTeXML/MathGrammar
+++ b/lib/LaTeXML/MathGrammar
@@ -675,6 +675,7 @@ nestOperators :
 AnyOp   : relop | METARELOP | ARROW | AddOp | MulOp | MODIFIEROP
         | preScripted['bigop']
         | OPERATOR addScripts[$item[1]]
+        | VERTBAR addScripts[$item[1]]
 
 # Sub or superscripts on operators;
 # we recognize the structure, not necessarily the meaning

--- a/lib/LaTeXML/MathGrammar
+++ b/lib/LaTeXML/MathGrammar
@@ -79,6 +79,7 @@ AnythingAny :
         | FLOATSUPERSCRIPT                { NewScript(Absent(),$item[1]); }
         | FLOATSUBSCRIPT                  { NewScript(Absent(),$item[1]); }
         | AnyOp Expression                { Apply($item[1],Absent(),$item[2]);}
+        | VERTBAR addScripts[$item[1]]    # vertbar can confuse parsing if part of AnyOp, so hardcode at the end here.
 
 # a top level rule for sub and superscripts that can accept all sorts of junk.
 Subscript : <rulevar: local $MaxAbsDepth = $LaTeXML::MathParser::MAX_ABS_DEPTH>
@@ -96,6 +97,7 @@ aSubscript :
         | AnyOp Expression               { Apply($item[1],Absent(),$item[2]);}
         | AnyOp
         | OPEN aSubscript CLOSE          { Fence($item[1],$item[2],$item[3]); }
+        | VERTBAR addScripts[$item[1]]    # vertbar can confuse parsing if part of AnyOp, so hardcode at the end here.
 
 aSuperscript :
           supops
@@ -103,6 +105,7 @@ aSuperscript :
         | AnyOp Expression               { Apply($item[1],Absent(),$item[2]);}
         | AnyOp
         | OPEN aSuperscript CLOSE        { Fence($item[1],$item[2],$item[3]); }
+        | VERTBAR addScripts[$item[1]]    # vertbar can confuse parsing if part of AnyOp, so hardcode at the end here.
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Formulae  (relations or grouping of expressions or relations)
@@ -675,7 +678,6 @@ nestOperators :
 AnyOp   : relop | METARELOP | ARROW | AddOp | MulOp | MODIFIEROP
         | preScripted['bigop']
         | OPERATOR addScripts[$item[1]]
-        | VERTBAR addScripts[$item[1]]
 
 # Sub or superscripts on operators;
 # we recognize the structure, not necessarily the meaning


### PR DESCRIPTION
Another small PR while I'm warming up, from the [arXiv parse warnings with VERTBAR](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/warning/not%5Fparsed/%3EVERTBAR?all=false), which appear in 8.79% of arXiv docs.

Apparently we currently don't recognize the VERTBAR role in the "anyOp" category, thus failing to parse fragment expressions with vertical bars. Two simple motivating examples from the report that now pass with this PR:

* `$ |_{\cal L} $ `
* `$ J_{\parallel 2} $`

I *hope* this doesn't have side-effects in parsing actual fenced expressions with vertbars, due to the way `anyOp` is used in the AnythingAny and script rules -- it's only employed when the standard rules fail to match.