### PR TITLE
[arXiv] minor upgrades for svmult, ifsym and bbding

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -387,6 +387,7 @@ lib/LaTeXML/Package/babel.def.ltxml
 lib/LaTeXML/Package/babel.sty.ltxml
 lib/LaTeXML/Package/balance.sty.ltxml
 lib/LaTeXML/Package/bbm.sty.ltxml
+lib/LaTeXML/Package/bbding.sty.ltxml
 lib/LaTeXML/Package/bbold.sty.ltxml
 lib/LaTeXML/Package/beton.sty.ltxml
 lib/LaTeXML/Package/bibunits.sty.ltxml
@@ -508,6 +509,7 @@ lib/LaTeXML/Package/IEEEtran.cls.ltxml
 lib/LaTeXML/Package/ifluatex.sty.ltxml
 lib/LaTeXML/Package/ifpdf.sty.ltxml
 lib/LaTeXML/Package/ifplatform.sty.ltxml
+lib/LaTeXML/Package/ifsym.sty.ltxml
 lib/LaTeXML/Package/ifthen.sty.ltxml
 lib/LaTeXML/Package/ifvtex.sty.ltxml
 lib/LaTeXML/Package/ifxetex.sty.ltxml

--- a/lib/LaTeXML/Package/bbding.sty.ltxml
+++ b/lib/LaTeXML/Package/bbding.sty.ltxml
@@ -1,0 +1,27 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  ifsym.sty                                                           | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@nist.gov>                          #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+
+DefMacro('\Envelope', "\x{2709}");
+
+Warn('missing_file', "bbding", $STATE->getStomach->getGullet,
+  "Only partial binding is available. Anticipate undefined macros or environments");
+
+#**********************************************************************
+
+1;

--- a/lib/LaTeXML/Package/ifsym.sty.ltxml
+++ b/lib/LaTeXML/Package/ifsym.sty.ltxml
@@ -1,0 +1,27 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  ifsym.sty                                                           | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@nist.gov>                          #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+
+DefMacro('\Letter', "\x{2709}");
+
+Warn('missing_file', "ifsym", $STATE->getStomach->getGullet,
+  "Only partial binding is available. Anticipate undefined macros or environments");
+
+#**********************************************************************
+
+1;

--- a/lib/LaTeXML/Package/svmult.cls.ltxml
+++ b/lib/LaTeXML/Package/svmult.cls.ltxml
@@ -85,6 +85,13 @@ DefMath('\gid',    "\x{2267}", role => 'RELOP', meaning => 'greater-than-or-equa
 DefMath('\grole',  "\x{2277}", role => 'RELOP', meaning => 'greater-than-or-less-than');
 Let('\qedsymbol', '\qed');
 
+#  special signs and characters
+DefMacro('\D', '\mathrm{d}');
+DefMacro('\E', '\mathrm{e}');
+Let('\eul', '\E');
+DefMacro('\I', '{\rm i}');
+Let('\imag', '\I');
+
 DefMacro('\partsize',    '\Large');
 DefMacro('\partstyle',   '\bfseries\boldmath');
 DefMacro('\chapsize',    '\Large');


### PR DESCRIPTION
A basic debugging session over arXiv:1606.00123, upgrading it to a warning status quickly:

- some missing convenience macros from svmult.cls.ltxml
- a very minor convenience macro (which I saw recommended in both bbding and ifsym) for producing a unicode envelope ✉

As usual, tried to be creative in time management. I added the two new binding files without implementing them in their entirety - just the macro I was debugging - which allows making this PR in the same morning as my first encountering the problem.

But, to keep the reporting honest and address the sentiment of "let's not claim we support capabilities we really do not", I left in the **same warning** which would have been produced if the binding wasn't present, just tweaking a little the Details message. I'm hoping this is an acceptable way for having my cake and eating it too - have latexml openly claim the binding is not supported, while incrementally adding individual macros, as we need them in arXiv and other places.