### PR TITLE
Recognize all-caps ".TEX" extensions in ZIP bundles

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -40,7 +40,7 @@ sub unpack_source {
   foreach my $member ($zip_handle->memberNames()) {
     $zip_handle->extractMember($member, catfile($sandbox_directory, $member)); }
   # Set $source to point to the main TeX file in that directory
-  my @TeX_file_members = map { $_->fileName() } $zip_handle->membersMatching('\.tex$');
+  my @TeX_file_members = map { $_->fileName() } $zip_handle->membersMatching('\.[tT][eE][xX]$');
   if (!@TeX_file_members) {    # No .tex file? Try files with no, or unusually long, extensions
     @TeX_file_members = grep { !/\./ || /\.[^.]{4,}$/ } map { $_->fileName() } $zip_handle->members();
   }


### PR DESCRIPTION
Apparently I had made an oversight when I wrote the ZIP unpacking that only looked at lowercased `.tex` files. 

I ended up examining one of the "invalid" arXiv sources today (since a yet-to-be-named preview service made it very easy) by chance, and I hope this tiny change will yield a lot of extra articles in our arXiv conversion runs (currently 25,000 articles are marked as invalid)