### PR TITLE
Allow spaces in rgb expressions from xcolor

### DIFF
--- a/lib/LaTeXML/Package/xcolor.sty.ltxml
+++ b/lib/LaTeXML/Package/xcolor.sty.ltxml
@@ -278,8 +278,8 @@ sub DecodeColor {
   my $dec_re         = qr/[+-]*(?:\d*\.?\d*)/;
   # <ext_expr>     : <core_model>,<div>:<expr1><dec1>;...;<exprk><deck>
   #                     | <core_model>:<expr1><dec1>;...;<exprk><deck>
-  my $ext_expr_re = qr/($core_model_re)(,($div_re))?:
-                       (($expr_re|$name_re),$dec_re(?:;(?:$expr_re|$name_re),$dec_re)*)/x;
+  my $ext_expr_re = qr/($core_model_re)(,($div_re))?:\s*
+                       (($expr_re|$name_re),$dec_re(?:;\s*(?:$expr_re|$name_re),$dec_re)*)/x;
   # <color_expr>   : <name> | <expr> | <ext_expt>
   my $color_expr_re = qr/$expr_re|$ext_expr_re/;
   my $function_re   = qr/wheel|twheel/;


### PR DESCRIPTION
Encountered a strange fatal in [2012.09061](https://ar5iv.org/html/2012.09061), due to the 100 errors in the xcolor rgb spec. They looked like:
```
Error:misdefined:rgb,255: red,68; green,136; blue,255 syntax error in <color> expression 'rgb,255: red,68; green,136; blue,255' at phase-gadget-GCZ.tikz; line 157 col 0
Error:misdefined:rgb,255: red,221; green,255; blue,221 syntax error in <color> expression 'rgb,255: red,221; green,255; blue,221' at phase-gadget.tikz; line 7 col 0
...
```

Turns out this was resolvable via a simple allowance of space(s) after the punctuation in the rgb expression. The  doc in question converts to warning status (very slowly), though the resulting SVG for the tikz graphics is a bit jumbled up compared to the PDF. But it beats a Fatal, and the colors are correct.