### PR TITLE
add PassOptionsToPackage as a latex trigger for TeX.pool

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -6747,7 +6747,8 @@ Tag('ltx:document', afterOpen => sub {
 # stuff the token back to be reexecuted.
 foreach my $ltxtrigger (qw(documentclass
   newcommand renewcommand newenvironment renewenvironment
-  NeedsTeXFormat ProvidesPackage RequirePackage ProvidesFile
+  NeedsTeXFormat ProvidesFile
+  ProvidesPackage RequirePackage PassOptionsToPackage
   makeatletter makeatother
   typeout begin listfiles nofiles)) {
   DefAutoload($ltxtrigger, 'LaTeX.pool.ltxml'); }


### PR DESCRIPTION
Another minor bit, found that `\PassOptionsToPackage` can be a trigger for LaTeX.pool in our case, as it is built-in and understood before the `\documentclass` command is encountered, as explained here:

https://texfaq.org/FAQ-optionclash

This is just a first step on the way to recovering [2002.11480](https://ar5iv.org/html/2002.11480), which is a timeout Fatal at the moment.