### PR TITLE
Downgrade to medium security of File::Temp

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -16,7 +16,7 @@ use Carp;
 use Encode;
 use Data::Dumper;
 use File::Temp;
-File::Temp->safe_level(File::Temp::HIGH);
+File::Temp->safe_level(File::Temp::MEDIUM);
 use File::Path qw(rmtree);
 use File::Spec;
 use List::Util qw(max);

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -251,7 +251,7 @@ sub generateImages {
   Debug("LaTeXImages: $nuniq unique; " . scalar(@pending) . " new") if $LaTeXML::DEBUG{images};
   if (@pending) {    # if any images need processing
         # Create working directory; note TMPDIR attempts to put it in standard place (like /tmp/)
-    File::Temp->safe_level(File::Temp::HIGH);
+    File::Temp->safe_level(File::Temp::MEDIUM);
     my $workdir = File::Temp->newdir("LaTeXMLXXXXXX", TMPDIR => 1);
     # === Generate the LaTeX file.
     my $texfile = pathname_make(dir => $workdir, name => $jobname, type => 'tex');


### PR DESCRIPTION
Fixes #1669 

From what I understood while reading the File::Temp documentation, I didnt see how the downgrade to medium could cause any immediate security issues when using latexml.

So if we can avoid unnecessary test failures (and likely usability issues on some server-like deployments), might as well.