### PR TITLE
3x the default dpi in image conversion

### DIFF
--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -310,8 +310,9 @@ sub image_graphicx_complex {
           if ($a1 / $w < $a2 / $h) { $a2 = $h * $a1 / $w; }
           else                     { $a1 = $w * $a2 / $h; } }
         ($w, $h) = (ceil($a1 * $dppt), ceil($a2 * $dppt)); } }
-    my $X = 4;                 # Expansion factor
-    my ($dx, $dy) = (int($X * 3 * 72 * $w / $w0), int($X * 3 * 72 * $h / $h0));
+    my $X = 4;    # Expansion factor
+    my $F = 3;    # Density upscale factor
+    my ($dx, $dy) = (int($X * $F * 72 * $w / $w0), int($X * $F * 72 * $h / $h0));
     Debug("reloading $source to desired size $w x $h (density = $dx x $dy)")
       if $LaTeXML::DEBUG{images};
     $image = image_read($source, antialias => 1, density => $dx . 'x' . $dy) or return;


### PR DESCRIPTION
Magic number PR, so I made it separate. I half-expect it to get rejected, but *maybe*, just *maybe* it gives an idea of how to get it transformed into a PR that gets accepted before we start the next arXiv run.

When combined with the autocrop PR ( #1683 ), latexml can deliver a high quality image for each of the problematic figures demoed in #1665 .

![image](https://user-images.githubusercontent.com/348975/136470776-83bb8ef4-07a0-4021-9dc3-2d8d7f049794.png)

This is already workable as it is sufficiently high qualtiy+size, and further adaptations could be enforced via CSS, if needed.
I admit this is a very fast-and-loose solution, but given how much better the images look, it really begs the question whether we have some slightly more refined variant of this PR that get us high quality images by default.