### PR TITLE
add \@footnotetext for arxiv:1807.00181

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -518,6 +518,7 @@ DefConstructor('\lx@notetext[]{}[]{}',
 DefMacro('\footnote',     '\lx@note{footnote}');
 DefMacro('\footnotemark', '\lx@notemark{footnote}');
 DefMacro('\footnotetext', '\lx@notetext{footnote}');
+DefMacro('\@footnotetext', '\lx@notetext{footnote}');
 
 Tag('ltx:note', afterClose => \&relocateFootnote);
 


### PR DESCRIPTION
Minor PR (I hope).

An arXiv paper relied directly on `\@footnotetext` in a custom footnote definition. Which we can support just as we do `\footnotetext`, I think.

At least that paper's footnote looked reasonable with this PR.

Edit: FWIW, 0.14% of arXiv articles had this as an undefined macro, so at least somewhat tangible benefit in merging.