### PR TITLE
[arXiv] Prune empty affil notes, improve IEEEtran keywords

### DIFF
--- a/lib/LaTeXML/Package/IEEEtran.cls.ltxml
+++ b/lib/LaTeXML/Package/IEEEtran.cls.ltxml
@@ -151,10 +151,10 @@ DefMacro('\IEEEauthorblockA{}', '\@add@to@frontmatter{ltx:creator}{\@@@affiliati
 
 DefMacro(T_CS('\begin{IEEEkeywords}'), '\@IEEEkeywords');
 DefMacro(T_CS('\end{IEEEkeywords}'),   '\@endIEEEkeywords');
-Let('\@endIEEEkeywords', '\relax');                             # stub
-DefMacro('\@IEEEkeywords XUntil:\@endIEEEkeywords', '\@add@frontmatter{ltx:keywords}{#1}');
-DefMacro('\IEEEraisesectionheading{}',              '#1');
-DefMacro('\IEEEPARstart{}{}',                       '#1#2');    # Eventually, dropcap?
+Let('\@endIEEEkeywords', '\relax');                # stub
+DefMacro('\@IEEEkeywords XUntil:\@endIEEEkeywords', '\@add@frontmatter{ltx:keywords}[name={\IEEEkeywordsname}]{#1}');
+DefMacro('\IEEEraisesectionheading{}', '#1');
+DefMacro('\IEEEPARstart{}{}',          '#1#2');    # Eventually, dropcap?
 
 DefMacro('\IEEEcompsocitemizethanks{}', '\thanks{#1}');
 DefMacro('\IEEEcompsocthanksitem[]',    '');
@@ -355,6 +355,21 @@ DefEnvironment('{IEEEdescription}',
   beforeDigestEnd => sub { Digest('\par'); },
   locked          => 1, mode => 'text');
 
+# V1.7 provide string macros as article.cls does
+DefMacro('\contentsname',     'Contents');
+DefMacro('\listfigurename',   'List of Figures');
+DefMacro('\listtablename',    'List of Tables');
+DefMacro('\refname',          'References');
+DefMacro('\indexname',        'Index');
+DefMacro('\figurename',       'Fig.');
+DefMacro('\tablename',        'TABLE');
+DefMacro('\figurename',       'Figure');
+DefMacro('\partname',         'Part');
+DefMacro('\appendixname',     'Appendix');
+DefMacro('\abstractname',     'Abstract');
+DefMacro('\IEEEkeywordsname', 'Index Terms');
+DefMacro('\IEEEproofname',    'Proof');
+
 # V1.8a no more support for these legacy commands
 Let('\authorblockA',       '\IEEEauthorblockA');
 Let('\authorblockN',       '\IEEEauthorblockN');
@@ -366,7 +381,6 @@ Let('\specialpapernotice', '\IEEEspecialpapernotice');
 # and environments
 DefMacro(T_CS('\begin{keywords}'), '\@IEEEkeywords');
 DefMacro(T_CS('\end{keywords}'),   '\@endIEEEkeywords');
-
 DefMacro('\keywords', sub {
     my ($gullet) = @_;
     ($gullet->ifNext(T_BEGIN)

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -86,9 +86,9 @@ DefMacro('\altaffilmark{}', sub {
     my ($gullet, $marks) = @_;
     map { (T_CS('\@altaffilmark'), T_BEGIN, @$_, T_END) } SplitTokens($marks, T_OTHER(',')); });
 DefConstructor('\@altaffilmark{}',
-  "<ltx:note role='affiliationmark' mark='#1'/> ");
+  "?#1(<ltx:note role='affiliationmark' mark='#1'/> )()");
 DefConstructor('\altaffiltext{}{}',
-  "<ltx:note role='affiliationtext' mark='#1'>#2</ltx:note>");
+  "?#2(<ltx:note role='affiliationtext' mark='#1'>#2</ltx:note>)()");
 
 DefConstructor('\@@@address{}', "^ <ltx:contact role='address'>#1</ltx:contact>");
 DefMacro('\address[]{}',   '\@add@to@frontmatter{ltx:creator}{\@@@address{#2}}');

--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -123,9 +123,9 @@ DefMacro('\altaffilmark{}', sub {
     my ($gullet, $marks) = @_;
     map { (T_CS('\@altaffilmark'), T_BEGIN, @$_, T_END) } SplitTokens($marks, T_OTHER(',')); });
 DefConstructor('\@altaffilmark{}',
-  "<ltx:note role='affiliationmark' mark='#1'/> ");
+  "?#1(<ltx:note role='affiliationmark' mark='#1'/> )()");
 DefConstructor('\altaffiltext{}{}',
-  "<ltx:note role='affiliationtext' mark='#1'>#2</ltx:note>");
+  "?#2(<ltx:note role='affiliationtext' mark='#1'>#2</ltx:note>)");
 
 DefMacro('\software{}',      '\@add@frontmatter{ltx:note}[role=software]{#1}');
 DefMacro('\submitjournal{}', '\@add@frontmatter{ltx:note}[role=journal]{#1}');
@@ -343,7 +343,7 @@ DefMacro('\aas@start@D@column XUntil:\aas@end@D@column', sub {
         T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_norightpad'), T_END,
         T_CS('\@alignment@align'),
         T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_noleftpad'), T_END,
-        T_OTHER('.'), @$f)
+        T_OTHER('.'),       @$f)
       : ($n,
         T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_norightpad'), T_END,
         T_CS('\@alignment@align')));
@@ -474,7 +474,7 @@ DefConstructor('\aas@@fstack Undigested {}',
     . "<ltx:XMWrap>#2</ltx:XMWrap>"
     . "</ltx:XMApp>",
   properties => { scriptpos => sub { "mid" . $_[0]->getScriptLevel; } },
-  mode => 'math', font => { shape => 'upright' }, bounded => 1, reversion => '#1');
+  mode       => 'math', font => { shape => 'upright' }, bounded => 1, reversion => '#1');
 DefMacro('\aas@fstack{}', '\ensuremath{\aas@@fstack{#1}}');
 
 DefMacro('\fd',    '\ensuremath{\@fd}');

--- a/lib/LaTeXML/Package/authblk.sty.ltxml
+++ b/lib/LaTeXML/Package/authblk.sty.ltxml
@@ -37,11 +37,11 @@ DefMacro('\lx@ab@author[]{}',
     . '{\@personname{#2}\lx@authormark{\if.#1.\the@affil\else#1\fi}}');
 
 DefConstructor('\lx@authormark{}',
-  "^<ltx:contact role='affiliationmark' _mark='#mark'></ltx:contact>",
+  "?#mark(^<ltx:contact role='affiliationmark' _mark='#mark'></ltx:contact>)()",
   properties => sub { (mark => ToString($_[1])); });
 
 DefConstructor('\affil[]{}',
-  "^ <ltx:note mark='#mark' role='affiliationtext'>#2</ltx:note>",
+  "?#2(^ <ltx:note mark='#mark' role='affiliationtext'>#2</ltx:note>)()",
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $mark = $whatsit->getArg(1);
@@ -51,7 +51,8 @@ DefConstructor('\affil[]{}',
     $whatsit->setProperty(mark => ToString($mark));
     return; });
 
-Tag('ltx:note', afterClose => \&authblkRelocateAffil);
+Tag('ltx:note',     afterClose => \&authblkRelocateAffil);
+Tag('ltx:document', afterClose => \&pruneEmptyAffil);
 
 sub authblkRelocateAffil {
   my ($document, $affilnode) = @_;
@@ -63,6 +64,13 @@ sub authblkRelocateAffil {
         $document->appendClone($author, $affilnode->childNodes);
         $author->setAttribute(role => 'affiliation'); }
       $affilnode->parentNode->removeChild($affilnode); } }
+  return; }
+
+sub pruneEmptyAffil {
+  my ($document) = @_;
+  # Some affiliations never get filled, prune them.
+  for my $empty_node ($document->findnodes(".//ltx:contact[\@role='affiliationmark' and not(node()) and not(text())]")) {
+    $document->removeNode($empty_node); }
   return; }
 
 #======================================================================


### PR DESCRIPTION
Fixes improving the display of [1804.11034](https://ar5iv.org/html/1804.11034). Another easy+minor PR

1. Vertical author list caused by a bunch of empty affiliation notes, which can be avoided. I added some general checks that avoid creating notes without any useful content, and a special pruning step at the end of documents using `authblk.sty`.

2. Keywords were not properly announced for IEEEtran.cls. I added and used the macro responsible, and threw in a handful of other simple naming macros I saw in the class file.