### PR TITLE
[arXiv] inline top-level notes; drop empty textual frontmatter

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -546,16 +546,16 @@ sub relocateFootnote {
     if (my $previous_sibling = $node->previousSibling) {
       if ($previous_sibling->nodeType == XML_ELEMENT_NODE) {
         my $sibling_qname = $document->getNodeQName($previous_sibling);
-        if ($sibling_qname eq 'ltx:abstract') {
-          # try to tuck into the last abstract paragraph
+        if ($sibling_qname =~ /^ltx:(?:abstract|creator|para)/) {
+          # if the parent is an expected logical-level element,
+          #   try to tuck into its last inline-allowing child
           my @abstract_children = element_nodes($previous_sibling);
           $previous_sibling = pop(@abstract_children);
           $sibling_qname    = $document->getNodeQName($previous_sibling); }
-        if ($sibling_qname eq 'ltx:p' or $sibling_qname eq 'ltx:text' or $sibling_qname =~ /^ltx:h\d/) {
-          $document->removeNode($node);
-          # usually there is a single runaway footnote of this type,
-          # so the clone is fine, worth the convenience
-          $document->appendClone($previous_sibling, $node);
+        # Is the previous sibling appropriate for containing a note?
+        if ($sibling_qname =~ /^ltx:(?:p|classification|keywords|personname|contact|date|subtitle)/) {
+          $node->unbindNode;
+          $previous_sibling->appendChild($node);
         }
       }
     }

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -5039,7 +5039,14 @@ sub insertFrontMatter {
           (scalar(@stuff) && $document->canHaveAttribute($tag, 'font')
             ? (font => $stuff[0]->getFont, _force_font => 'true') : ()));
         map { $document->absorb($_) } @stuff;
-        $document->closeElement($tag); } } }
+        my $completed_node = $document->closeElement($tag);
+        # At this time, the frontmatter element should really carry the actual literal values intended.
+        # Thus, if we see an empty element, something went wrong -- including our bindings are too verbose,
+        # as e.g. \preprint{} always generates a ltx:note element.
+        #
+        # To solve this in a single location: prune here!
+        if (($tag ne "ltx:rdf") && !scalar($completed_node->childNodes)) {
+          $document->removeNode($completed_node); } } } }
   return; }
 
 Tag('ltx:document', 'afterOpen:late' => \&insertFrontMatter);


### PR DESCRIPTION
Trying out a bigger hammer against the swarm of frontmatter bugs I am spectating in the arXiv showcase:

1. Sometimes we get metadata realized as footnotes (`ltx:note`) at the top level of the TeX `{document}`, which respectively get deposited in the top-level(-ish) of the generated XML document, most typically parented by `ltx:document` or `ltx:abstract`.

   - When such XML is mapped into HTML, these notes end up displayed as standalone blocks, which is rather unsightly. One example doc is [1802.06880](https://ar5iv.org/html/1802.06880).
   - This PR tries to auto-correct this. When we are in this known top-level situation, and can find a previous sibling that is inline (such as a `ltx:p`), I try to move the note into the inline previous sibling, thus rendering it as an end-of-text inline mark in the HTML.
   - I think I got most real-world cases covered, tested on ~5 articles.

2. Sometimes we write bindings that unconditionally create frontmatter elements, assuming authors only use macros with a purpose. 
   - arXiv experience casts that as a "cute assumption". 
   - But since we have so many uses of `\@add@frontmatter`, I think policing each and every call to them is going to be brittle and prone to oversight. 
   - Luckily, there is a single execution bottleneck at the end of `insertFrontMatter`, where I can vet all final frontmatter nodes, after they have been inserted in the document, and have had their content absorbed.
   - Whenever a textual frontmatter node ends up empty at that stage, I now prune it entirely from the document. I've implemented that as anything except `ltx:rdf`, since that's what I concluded after inspecting all uses of `\@add@frontmatter`.
   - Examples are bits such as `\preprint{}` or `\date{}`

If the code here works as intended, it will avoid one big source of noisy rendering in the arXiv sources - these frontmatter block notes are easy to stumble on when browsing.

P.S. This issue is one of those things I would have preferred to fix via CSS, but there is no way to express "stay inline in the previous sibling" directive.