### PR TITLE
Control scaling up/down during image conversion

### DIFF
--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -14,6 +14,7 @@ package LaTeXML::Package::Pool;
 use strict;
 use warnings;
 use LaTeXML::Package;
+use LaTeXML::Util::Image;
 no warnings 'redefine';    # ????
 
 #======================================================================
@@ -54,6 +55,13 @@ DeclareOption('nobibtex', sub { AssignValue('NO_BIBTEX' => 1, 'global'); });
 
 # Lexeme serialization for math formulas
 DeclareOption('mathlexemes', sub { AssignValue('LEXEMATIZE_MATH' => 1, 'global'); });
+
+# Image conversion fine-tuning
+# EXPERIMENTAL! Currently doing proof-of-concept experiments in working towards v0.8.7
+DeclareOption('scaledown',   sub { $LaTeXML::Util::Image::CAN_SCALE_DOWN = 1; return; });
+DeclareOption('noscaledown', sub { $LaTeXML::Util::Image::CAN_SCALE_DOWN = 0; return; });
+DeclareOption('scaleup',     sub { $LaTeXML::Util::Image::CAN_SCALE_UP   = 1; return; });
+DeclareOption('noscaleup',   sub { $LaTeXML::Util::Image::CAN_SCALE_UP   = 0; return; });
 
 # Finer control over which (if any) raw .sty/.cls files to include
 DeclareOption('rawstyles',      sub { AssignValue('INCLUDE_STYLES'  => 1,             'global'); });
@@ -251,8 +259,8 @@ DefPrimitive('\lxDefMath{}[Number][]{} OptionalKeyVals:XMath', sub {
     my $needsid = $params && ($params->getValue('tag') || $params->getValue('description'));
     my $id      = ($needsid ? next_declaration_id() : undef);
     DefMathI($cs, convertLaTeXArgs($nargs, $opt), $presentation,
-      name => $name, meaning => $meaning, omcd => $cd, role => $role, alias => $alias,
-      scope => $scope, decl_id => $id, revert_as => 'context');
+      name  => $name,  meaning => $meaning, omcd      => $cd, role => $role, alias => $alias,
+      scope => $scope, decl_id => $id,      revert_as => 'context');
     if ($needsid) {    # Also provide for decl_id hook for definition links.
       return Digest(Invocation('\@lxDefMathDeclare', $id, $params)); }
     else {


### PR DESCRIPTION
Can be used with the usual:
 * `--preload=[noscaledown]latexml.sty`, `--preload=[noscaleup]latexml.sty`

Continuing the tricky, but very useful, discussion in #1684 . I am getting good outcomes for the previously discussed article in #1665 with the `noscaledown` setting. Will experiment more tomorrow with other documents.

In truth, this is a kind of "minimal useful size" heuristic. If an author provided a source image at a certain width and height, we now allow users of latexml to say "do not scale above/below this size", depending on whether they are looking for bandwidth (same size or smaller) or quality (same size or higher).

I again used this in the `prescale` section of the conversion code, as it appears to be the chief component in the PDF image conversions I was looking into. It's also a single location that handles `prescale`, and that code path is the only one that uses the `density` flag, which I believe is the central imagemagick option on this quality-preserving topic.