### PR TITLE
Latexml keys and dpi

### DIFF
--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -63,7 +63,11 @@ DeclareOption('rawclasses',     sub { AssignValue('INCLUDE_CLASSES' => 1,       
 DeclareOption('localrawclasses', sub { AssignValue('INCLUDE_CLASSES' => 'searchpaths', 'global'); });
 DeclareOption('norawclasses',    sub { AssignValue('INCLUDE_CLASSES' => 0, 'global'); });
 
-ProcessOptions();
+DefConstructor('\lx@save@DPI{Number}', sub { $_[0]->insertPI('latexml', DPI => $_[1]); });
+DefKeyVal('LTXML', 'dpi', 'Number', '', code => sub {
+    AtBeginDocument(Tokens(T_CS('\lx@save@DPI'), T_BEGIN, $_[1], T_END)); });
+
+ProcessOptions(inorder => 1, keysets => ['LTXML']);
 #======================================================================
 # From latexml.sty
 # [does this really belong here? or should this be disableable?]
@@ -251,8 +255,8 @@ DefPrimitive('\lxDefMath{}[Number][]{} OptionalKeyVals:XMath', sub {
     my $needsid = $params && ($params->getValue('tag') || $params->getValue('description'));
     my $id      = ($needsid ? next_declaration_id() : undef);
     DefMathI($cs, convertLaTeXArgs($nargs, $opt), $presentation,
-      name => $name, meaning => $meaning, omcd => $cd, role => $role, alias => $alias,
-      scope => $scope, decl_id => $id, revert_as => 'context');
+      name  => $name,  meaning => $meaning, omcd      => $cd, role => $role, alias => $alias,
+      scope => $scope, decl_id => $id,      revert_as => 'context');
     if ($needsid) {    # Also provide for decl_id hook for definition links.
       return Digest(Invocation('\@lxDefMathDeclare', $id, $params)); }
     else {

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -39,7 +39,7 @@ our $LATEXCMD = 'latex';    #(or elatex) [ CONFIGURABLE? Encoded in PI?]
 #   source         : (dir)
 #   magnification  : typically something like 1.33333, but you may want bigger
 #   maxwidth       : maximum page width, in pixels (whenever line breaking is possible)
-#   dpi            : assumed DPI for the target medium (default 96)
+#   DPI            : assumed DPI for the target medium (default 100)
 #   background     : color of background (for anti-aliasing, since it is made transparent)
 #   imagetype      : typically 'png' or 'gif'.
 sub new {
@@ -47,7 +47,7 @@ sub new {
   my $self = $class->SUPER::new(%options);
   $$self{magnification} = $options{magnification} || 1.33333;
   $$self{maxwidth}      = $options{maxwidth}      || 800;
-  $$self{dpi}           = $options{dpi}           || 96;
+  $$self{DPI}           = $options{DPI}           || 100;
   $$self{background}    = $options{background}    || "#FFFFFF";
   $$self{imagetype}     = $options{imagetype}     || 'png';
 
@@ -73,7 +73,7 @@ sub new {
 
   # Parameterize according to the selected dvi-to-whatever processor.
   my $mag = int($$self{magnification} * 1000);
-  my $dpi = int($$self{dpi} * $$self{magnification});
+  my $dpi = int($$self{DPI} * $$self{magnification});
   # Unfortunately, each command has incompatible -o option to name the output file.
   # Note that the formatting char used, '%', has to be doubled on Windows!!
   # Maybe that's only true when it looks like an environment variable?
@@ -316,7 +316,7 @@ sub generateImages {
         "Response was: $!");
       return $doc; }
     # === Convert each image to appropriate type and put in place.
-    my $pixels_per_pt = $$self{magnification} * $$self{dpi} / 72.27;
+    my $pixels_per_pt = $$self{magnification} * $$self{DPI} / 72.27;
     my ($index, $ndigits) = (0, 1 + int(log($doc->cacheLookup((ref $self) . ':_max_image_') || 1) / log(10)));
     foreach my $entry (@pending) {
       my $src = "$workdir/" . sprintf($$self{dvicmd_output_name}, ++$index);
@@ -368,7 +368,7 @@ sub pre_preamble {
   my $packages        = '';
   my $dest            = $doc->getDestination;
   my $description     = ($dest ? "% Destination $dest" : "");
-  my $pts_per_pixel   = 72.27 / $$self{dpi} / $$self{magnification};
+  my $pts_per_pixel   = 72.27 / $$self{DPI} / $$self{magnification};
 
   foreach my $pkgdata (@classdata) {
     my ($package, $package_options) = @$pkgdata;
@@ -446,7 +446,7 @@ sub convert_image {
   my ($self, $doc, $src, $dest) = @_;
   my ($bg, $fg) = ($$self{background}, 'black');
 
-  my $image = image_object(antialias => 'True', background => $bg, density => $$self{dpi});
+  my $image = image_object(antialias => 'True', background => $bg, density => $$self{DPI});
   my $err   = $image->Read($$self{dvicmd_output_type} . ':' . $src);
   if ($err) {
     Warn('imageprocessing', 'read', undef,

--- a/lib/LaTeXML/Post/SVG.pm
+++ b/lib/LaTeXML/Post/SVG.pm
@@ -70,7 +70,7 @@ sub copy_position {
 
 sub to_px {
   my ($pt) = @_;
-  return ($pt =~ s/pt$// ? $pt * $LaTeXML::Util::Image::DOTS_PER_POINT : $pt); }
+  return ($pt =~ s/pt$// ? $pt * $LaTeXML::Util::Image::DPI / 72.27 : $pt); }
 
 ####################################
 ## fixes an svg node

--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -34,9 +34,8 @@ our @EXPORT = (
 # difficult to port, or has mismatched versions or whatever.
 # We do, at least, need to be able to get image size.....
 
-our $DPI            = 90;               # [CONSTANT]
-our $DOTS_PER_POINT = ($DPI / 72.0);    # [CONSTANT] Dots per point.
-our $BACKGROUND     = "#FFFFFF";        # [CONSTANT]
+our $DPI        = 100;          # [CONSTANT]
+our $BACKGROUND = "#FFFFFF";    # [CONSTANT]
 
 # These environment variables can be used to limit the amount
 # of time & space used by ImageMagick.  They are particularly useful
@@ -187,7 +186,7 @@ sub to_bp {
 # [this is a simplification of image_graphicx_complex]
 sub image_graphicx_size {
   my ($source, $transform, %properties) = @_;
-  my $dppt = $properties{dppt} || $DOTS_PER_POINT;
+  my $dppt = ($properties{DPI} || $DPI) / 72.27;
   my ($w, $h) = image_size($source);
   return unless $w && $h;
   foreach my $trans (@$transform) {
@@ -224,6 +223,7 @@ sub image_graphicx_size {
 sub image_graphicx_sizer {
   my ($whatsit) = @_;
   if (my $candidates = $whatsit->getProperty('candidates')) {
+    my $dppt = (($STATE && $STATE->lookupValue('DPI')) || $DPI) / 72.27;
     foreach my $source (split(/,/, $candidates)) {
       if (!pathname_is_absolute($source)) {
         if (my $base = $STATE->lookupValue('SOURCEDIRECTORY')) {
@@ -232,7 +232,7 @@ sub image_graphicx_sizer {
       my $options = $whatsit->getProperty('options');
       local $LaTeXML::IGNORE_ERRORS = 1;
       my ($w, $h) = image_graphicx_size($source, image_graphicx_parse($options));
-      return (Dimension($w / $DOTS_PER_POINT . 'pt'), Dimension($h / $DOTS_PER_POINT . 'pt'), Dimension(0)) if $w; } }
+      return (Dimension($w / $dppt . 'pt'), Dimension($h / $dppt . 'pt'), Dimension(0)) if $w; } }
   return (Dimension(0), Dimension(0), Dimension(0)); }
 
 #======================================================================
@@ -257,7 +257,7 @@ sub image_graphicx_trivial {
   my ($source, $transform, %properties) = @_;
   my ($w, $h) = image_size($source);
   return unless $w && $h;
-  my $dppt = $properties{dppt} || $DOTS_PER_POINT;
+  my $dppt = ($properties{DPI} || $DPI) / 72.27;
   foreach my $trans (@$transform) {
     my ($op, $a1, $a2, $a3, $a4) = @$trans;
     if ($op eq 'scale') {    # $a1 => scale
@@ -274,7 +274,7 @@ sub image_graphicx_trivial {
 # sub complex_transform {
 sub image_graphicx_complex {
   my ($source, $transform, %properties) = @_;
-  my $dppt       = $properties{dppt}       || $DOTS_PER_POINT;
+  my $dppt       = ($properties{DPI} || $DPI) / 72.27;
   my $background = $properties{background} || $BACKGROUND;
   my $image      = image_read($source, antialias => 1) or return;
   # Get some defaults from the read-in image.

--- a/lib/LaTeXML/texmf/latexml.sty
+++ b/lib/LaTeXML/texmf/latexml.sty
@@ -24,6 +24,8 @@
 \DeclareOption{nomathparserspeculate}{}
 \DeclareOption{guesstabularheaders}{}
 \DeclareOption{noguesstabularheaders}{}
+% Just ignore unknown options, so that binding can evolve more easily.
+\DeclareOption*{\PackageWarning{latexml}{option  \CurrentOption\space ignored}}
 \ProcessOptions
 %======================================================================
 % NOTE: Figure out where this should go.

--- a/t/alignment/vmode.xml
+++ b/t/alignment/vmode.xml
@@ -193,7 +193,7 @@ This is random text. This is random text. This is random text.</p>
       <graphics candidates="foo.png" graphic="foo" xml:id="S4.p1.g1"/>
     </para>
     <para xml:id="S4.p2">
-      <inline-block depth="0.0pt" height="32.0pt" width="93.6pt" xscale="3.0" xtranslate="31.2pt" yscale="2.0" ytranslate="-8.0pt">
+      <inline-block depth="0.0pt" height="28.9pt" width="84.6pt" xscale="3.0" xtranslate="28.2pt" yscale="2.0" ytranslate="-7.2pt">
         <graphics candidates="foo.png" graphic="foo" xml:id="S4.p2.g1"/>
       </inline-block>
     </para>


### PR DESCRIPTION
This PR adds a simple capability to process keyvals in class and package options, which is then used by `latexml.sty` to add a new `dpi=xxx` package option.  That dpi is detected by postprocessing to adjust the resolution and size of images being processed.

Perhaps this should be a WiP, as there are a couple of messy details. It is unclear whether this option should set STATE's `DPI`, since that is used to convert points to "pixels", which is currently less about image processing, as for dealing with svg sizing and positioning, especially the attempt to match svg fonts with document fonts. Or maybe they're the same thing after all?

It is also clunky in that the `dpi` option adds a PI to the to-be-created document, but this gets lost when you use `--preload`, since it doesn't respect `@at@document@begin`.  The dpi is, however, present in the options of the package PI, which is manually added by `--preload`. Ugh!

So, maybe it's good enough as it is until we sort out some other issues?