### PR TITLE
Add bbding.sty binding

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -386,6 +386,7 @@ lib/LaTeXML/Package/avant.sty.ltxml
 lib/LaTeXML/Package/babel.def.ltxml
 lib/LaTeXML/Package/babel.sty.ltxml
 lib/LaTeXML/Package/balance.sty.ltxml
+lib/LaTeXML/Package/bbding.sty.ltxml
 lib/LaTeXML/Package/bbm.sty.ltxml
 lib/LaTeXML/Package/bbold.sty.ltxml
 lib/LaTeXML/Package/beton.sty.ltxml
@@ -426,6 +427,7 @@ lib/LaTeXML/Package/csquotes.sty.ltxml
 lib/LaTeXML/Package/dcolumn.sty.ltxml
 lib/LaTeXML/Package/deluxetable.sty.ltxml
 lib/LaTeXML/Package/diagbox.sty.ltxml
+lib/LaTeXML/Package/ding.fontmap.ltxml
 lib/LaTeXML/Package/doublespace.sty.ltxml
 lib/LaTeXML/Package/dsfont.sty.ltxml
 lib/LaTeXML/Package/empheq.sty.ltxml

--- a/lib/LaTeXML/Package/bbding.sty.ltxml
+++ b/lib/LaTeXML/Package/bbding.sty.ltxml
@@ -1,0 +1,21 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# | bbding.sty                                                          | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+InputDefinitions('bbding', type => 'sty', noltxml => 1);
+
+# See the font map ding.fontmap.ltxml for the Unicode equivalences.
+1;

--- a/lib/LaTeXML/Package/ding.fontmap.ltxml
+++ b/lib/LaTeXML/Package/ding.fontmap.ltxml
@@ -1,0 +1,56 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# | ding font encoding                                                 | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+# Note that we're defining encodings for the font families!
+DeclareFontMap('ding', [
+    # not in unicode: left-directed scissors
+    "\x{2701}", "\x{2702}", "\x{2703}", "\x{2701}", "\x{2702}", "\x{2703}",
+    "\x{2704}", "\x{2704}", "\x{260E}", "\x{2706}", "\x{2707}", "\x{2708}",
+    # not in unicode: handcuff right/left-up
+    # not in unicode: hand right/left-up
+    "\x{2709}",  "\x{261B}",  "\x{261A}",  "\x{261B}", "\x{261A}",
+    "\x{1F599}", "\x{1F598}", "\x{1F599}", "\x{1F598}",
+    "\x{270C}",  "\x{270D}",  "\x{270F}",  "\x{1F589}", "\x{2710}", "\x{1F589}",
+    # only lower-left pencil in unicode
+    "\x{270E}", "\x{1F589}", "\x{2711}", "\x{2711}", "\x{2712}", "\x{2712}",
+    # only right nib in unicode
+    "\x{2713}", "\x{2714}", "\x{2715}", "\x{2716}", "\x{2717}", "\x{2719}",
+    # no "bold outline" cross in unicode
+    "\x{271A}", "\x{271C}", "\x{271B}", "\x{271D}", "\x{271E}", "\x{271F}",
+    "\x{271F}", "\x{2720}", "\x{2736}", "\x{2721}", "\x{2722}", "\x{2723}",
+    "\x{2724}", "\x{2725}", "\x{2726}", "\x{2727}", "\x{26E4}", "\x{2605}",
+    "\x{2606}", "\x{272A}", "\x{272B}", "\x{272C}", "\x{272D}", "\x{272E}",
+    # no asterisk thin-center-open
+    "\x{272F}", "\x{2730}", "\x{2731}", "\x{2732}", "\x{2733}", "\x{2733}",
+    "\x{2734}", "\x{2735}", "\x{2736}", "\x{2737}", "\x{2738}", "\x{2739}",
+    "\x{273A}", "\x{273B}", "\x{273C}", "\x{273D}", "\x{273E}", "\x{273F}",
+    "\x{273E}",                  # \SixFlowerPetalDotted not in unicode
+    "\x{2740}",  "\x{2741}", "\x{2742}", "\x{2743}",
+    "\x{1F340}", "\x{1F340}",    # \FourClowerOpen,\FourClowerSolid not in unicode
+    "\x{2749}",  "\x{274A}", "\x{274B}",
+    "\x{273E}",                  # \SixFlowerRemovedOpenPetal not in unicode
+    "\x{2748}", "\x{2747}", "\x{2744}", "\x{2746}", "\x{2745}", "\x{25CF}",
+    "\x{2B2D}", "\x{2B2C}", "\x{274D}",
+    "\x{2B2D}",                  #  \EllipseShadow not in unicode
+    "\x{25A1}", "\x{25A0}", "\x{274F}", "\x{2750}",
+    "\x{2750}",                  # \SquareShadowTopLeft not in unicode
+    "\x{2751}", "\x{2752}",
+    "\x{2750}",                  # \SquareCastShadowTopLeft not in unicode
+    "\x{25B2}", "\x{25BC}", "\x{25C6}", "\x{2756}", "\x{25D7}", "\x{25D6}",
+    "\x{2758}", "\x{2759}", "\x{275A}", "\x{279F}", "\x{27A6}", "\x{27A5}",
+    "\x{27A7}", "\x{27B2}"
+]);
+1;


### PR DESCRIPTION
Adds the unicode map for the applicable characters in bbding.sty.

I may have made a mistake in trying to write a useful binding - I added comments for the cases which do not have a direct Unicode correspondence, and instead mapped them to the closest character that is available. For example there are three variations on a left-pointing pencil, but Unicode only has [U+1F589](https://www.fileformat.info/info/unicode/char/1f589/index.htm).

Maybe I should've left them as `undef`? Unsure what is the better user experience, getting no character at all, or a subtly wrong one.

To avoid adding a test that isn't testing much, here is the `.tex` and `.html` testing the macros of bbding: [example.zip](https://github.com/brucemiller/LaTeXML/files/7340050/example.zip)
