### PR TITLE
Experiment: disable clip in image conversion

### DIFF
--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -154,7 +154,7 @@ sub image_graphicx_parse {
   # We ignore viewport & trim if clip isn't set, since in that case we shouldn't
   # actually remove anything from the image (and there's no way to have the image
   # overlap neighboring text, etc, in current HTML).
-  push(@transform, [($trim ? 'trim' : 'clip'), @vp]) if (@vp && $clip);
+  #push(@transform, [($trim ? 'trim' : 'clip'), @vp]) if (@vp && $clip);
   push(@transform, ['rotate', $angle]) if ($rotfirst && $angle);    # Rotate before scaling?
   if ($width && $height) { push(@transform, ['scale-to', $mag * $width, $mag * $height, $aspect]); }
   elsif ($width)         { push(@transform, ['scale-to', $mag * $width, 999999, 1]); }


### PR DESCRIPTION
This PR is another request for help/ideas, even if it technically completes the quest for high quality images in the article used in #1066 .

The summary of what the underlying issue is, if I traced it well enough, is in the following lines when 'trim' and 'clip' are handled:

```perl
      # Use the image's dpi for trim & clip!
      my $idppt = (defined $imagedpi ? ($imagedpi / 72.0) : $dppt);
```

To my understanding, as the optional higher DPI from #1692   gets applied during the first `prescale` phase, when this lower DPI (assuming the image had a lower original size) gets used in the trim/clip phase, the conversion never again returns the image to the high DPI. Disabling trim entirely indeed keeps the requested prescale DPI.

Curiously, when the `autocrop` option is enabled -- for only this very specific document -- it seems that trim has no further effect, as I think the authors also used it with a crop intent. But of course, in general there could be a significant difference between what the two options achieve.

The PR just comments out the line that applies the `trim` when `clip` is present, and by avoiding that operation runs away from the issue. I suspect the preferred solution would be to scale the image back to the desired DPI at the end, in something akin to a "postscale" phase? Unsure.

But yes, this is the last remaining problem for the article in #1066 , so that issue may be close to a resolution.