### PR TITLE
Empty frontmatter

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -4965,11 +4965,12 @@ DefPrimitive('\@add@frontmatter OptionalKeyVals {} OptionalKeyVals {}', sub {
       $$frontmatter{$tag} = []; }                                      # Remove previous entries
     if ($keys && $keys->hasKey('ifnew') && $$frontmatter{$tag}) {      # if ifnew and previous entries
       return; }                                                        # Skip this one.
-    my $entry = [$tag, undef, 'to-be-filled-in'];
-    push(@{ $$frontmatter{$tag} }, $entry);
-    if ($attr) {
-      $$entry[1] = { $attr->beDigested($stomach)->getHash }; }
-    $$entry[2] = Digest(Tokens(T_BEGIN, $tokens, T_END));
+    if ($tokens->unlist) {                                             # Add an entry, if non-empty
+      my $entry = [$tag, undef, 'to-be-filled-in'];
+      push(@{ $$frontmatter{$tag} }, $entry);
+      if ($attr) {
+        $$entry[1] = { $attr->beDigested($stomach)->getHash }; }
+      $$entry[2] = Digest(Tokens(T_BEGIN, $tokens, T_END)); }
     AssignValue(inPreamble => $inpreamble);
     return; },
   beforeDigest => sub {

--- a/lib/LaTeXML/Package/jheppub.sty.ltxml
+++ b/lib/LaTeXML/Package/jheppub.sty.ltxml
@@ -46,7 +46,7 @@ DefMacro('\emailAdd Semiverbatim', '\@add@to@frontmatter{ltx:creator}{\@@@email{
 DefMacro('\keywordname', '\textbf{Keywords}');
 DefMacro('\keywords{}',  '\@add@frontmatter{ltx:keywords}[name={\keywordname}]{#1}');
 
-DefMacro('\artxivnumber{}', '\@add@frontmatter{ltx:note}[role=arxiv]{#1}');
+DefMacro('\arxivnumber{}', '\@add@frontmatter{ltx:note}[role=arxiv]{#1}');
 
 DefMacro('\toccontinuoustrue', '');
 

--- a/lib/LaTeXML/Package/moderncv.cls.ltxml
+++ b/lib/LaTeXML/Package/moderncv.cls.ltxml
@@ -23,7 +23,6 @@ RequirePackage('hyperref');
 
 RequireResource('ltx-cv.css');
 
-RawTeX('\@add@frontmatter{ltx:creator}[role=cv]{}');
 DefConstructor('\@@@address{}', "^ <ltx:contact role='address'>#1</ltx:contact>");
 DefMacro('\address{}{}', '\@add@to@frontmatter{ltx:creator}{\@@@address{#1\newline #2}}');
 
@@ -66,7 +65,7 @@ DefConstructor('\@@cv@section{} Undigested OptionalUndigested Undigested', sub {
   properties => sub {
     my ($stomach, $type, $inlist, $toctitle, $title) = @_;
     my %props = RefStepID(ToString($type));
-    $props{title} = Digest(T_CS('\@hidden@bgroup'), $title, T_CS('\@hidden@egroup'));
+    $props{title}    = Digest(T_CS('\@hidden@bgroup'), $title, T_CS('\@hidden@egroup'));
     $props{toctitle} = $toctitle
       && Digest(T_CS('\@hidden@bgroup'), $toctitle, T_CS('\@hidden@egroup'));
     return %props; },
@@ -76,11 +75,20 @@ Let(T_CS('\\@@unnumbered@section'), T_CS('\\@@cv@section'));
 
 DefMacro('\closesection{}', Tokens(), locked => 1);
 
-DefMacro('\title Semiverbatim',      '\@add@to@frontmatter{ltx:creator}{\@@@position{#1}}');
-DefMacro('\email Semiverbatim',      '\@add@to@frontmatter{ltx:creator}{\@@@email{#1}}');
-DefMacro('\firstname Semiverbatim',  '\@add@to@frontmatter{ltx:creator}{\@@@firstname{#1}}');
-DefMacro('\familyname Semiverbatim', '\@add@to@frontmatter{ltx:creator}{\@@@familyname{#1}}');
-DefMacro('\photo[]{}',               Tokens());                                               # TODO
+# Make the "creator" have role='cv'
+DefConstructor('\@creator@cv', sub {
+    my ($document) = @_;
+    my $creator = $document->findnode('descendant::ltx:creator');
+    $document->setAttribute($creator, role => 'cv') if $creator; });
+
+DefMacro('\title Semiverbatim', '\@add@to@frontmatter{ltx:creator}{\@@@position{#1}\@creator@cv}');
+DefMacro('\email Semiverbatim', '\@add@to@frontmatter{ltx:creator}{\@@@email{#1}\@creator@cv}');
+# These really should reconstruct a proper ltx:personname (and cleanup the xslt)
+# but I'm keeping the test case unchanged for now...
+DefMacro('\firstname Semiverbatim', '\@add@to@frontmatter{ltx:creator}{\@@@firstname{#1}\@creator@cv}');
+DefMacro('\familyname Semiverbatim', '\@add@to@frontmatter{ltx:creator}{\@@@familyname{#1}\@creator@cv}');
+
+DefMacro('\photo[]{}', Tokens());    # TODO
 
 DefConstructor('\@@@position{}',   "^ <ltx:contact role='position'>#1</ltx:contact>");
 DefConstructor('\@@@email{}',      "^ <ltx:contact role='email'>#1</ltx:contact>");
@@ -98,13 +106,13 @@ DefMacro('\moderncvstyle',     Tokens());
 #
 # TODO: should we use them in the final HTML style? Feedback from professionals welcome.
 #       for now just adding the macro support, but omitting them from the final output
-DefMacro('\marvosymbol {}',    '');
-DefMacro('\addresssymbol',     '');
-DefMacro('\mobilephonesymbol', '📱');
-DefMacro('\fixedphonesymbol',  '☎');
-DefMacro('\faxphonesymbol',    '📠');
-DefMacro('\emailsymbol',       '✉');
-DefMacro('\homepagesymbol',    '🖰');
+DefMacro('\marvosymbol {}',       '');
+DefMacro('\addresssymbol',        '');
+DefMacro('\mobilephonesymbol',    '📱');
+DefMacro('\fixedphonesymbol',     '☎');
+DefMacro('\faxphonesymbol',       '📠');
+DefMacro('\emailsymbol',          '✉');
+DefMacro('\homepagesymbol',       '🖰');
 DefMacro('\linkedinsocialsymbol', '');  # Tikz image, needs a smart workaround (font awesome maybe?)
 DefMacro('\twittersocialsymbol',  '');  # Tikz image, needs a smart workaround (font awesome maybe?)
 DefMacro('\githubsocialsymbol',   '');  # Tikz image, needs a smart workaround (font awesome maybe?)

--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -240,8 +240,6 @@ sub image_graphicx_sizer {
       my $options = $whatsit->getProperty('options');
       local $LaTeXML::IGNORE_ERRORS = 1;
       my ($w, $h) = image_graphicx_size($source, image_graphicx_parse($options), DPI => $dpi);
-      Debug("IMAGE SIZE $source => $w x $h; dpi=$dpi") if $w;
-
       return (Dimension($w * 72.27 / $dpi . 'pt'), Dimension($h * 72.27 / $dpi . 'pt'), Dimension(0)) if $w; } }
   return (Dimension(0), Dimension(0), Dimension(0)); }
 


### PR DESCRIPTION
This PR omits empty front matter, added by `\@add@frontmatter`.

It also fixes a misspelled command in jheppub.

However, it fails a test in `moderncv`, since that binding adds an empty creator with `role='cv'` and then adds separate firstname, lastname contacts, and cobbles together a title in xslt. That will need some adapting.