### PR TITLE
Table and ref fixes for arxiv:1804.11028

### DIFF
--- a/lib/LaTeXML/Package/longtable.sty.ltxml
+++ b/lib/LaTeXML/Package/longtable.sty.ltxml
@@ -125,8 +125,8 @@ DefPrimitive('\@longtable@@toccaption{}', sub {
 
 #======================================================================
 # Not used, but must be defined.
-DefRegister('\LTleft'      => Glue(0, '1fill'));
-DefRegister('\LTright'     => Glue(0, '1fill'));
+DefRegister('\LTleft'      => Glue('0pt plus 1fill'));
+DefRegister('\LTright'     => Glue('0pt plus 1fill'));
 DefRegister('\LTpre'       => Glue('12pt plus 4pt minus 4pt'));
 DefRegister('\LTpost'      => Glue('12pt plus 4pt minus 4pt'));
 DefRegister('\LTcapwidth'  => Dimension('4in'));

--- a/lib/LaTeXML/Package/longtable.sty.ltxml
+++ b/lib/LaTeXML/Package/longtable.sty.ltxml
@@ -125,12 +125,22 @@ DefPrimitive('\@longtable@@toccaption{}', sub {
 
 #======================================================================
 # Not used, but must be defined.
-DefRegister('\LTLeft'      => Glue(0));
-DefRegister('\LTRight'     => Glue(0));
-DefRegister('\LTPre'       => Glue(0));
-DefRegister('\LTPost'      => Glue(0));
-DefRegister('\LTcapwidth'  => Glue(0));
-DefRegister('\LTchunksize' => Number(20));
+DefRegister('\LTleft'      => Glue(0, '1fill'));
+DefRegister('\LTright'     => Glue(0, '1fill'));
+DefRegister('\LTpre'       => Glue('12pt plus 4pt minus 4pt'));
+DefRegister('\LTpost'      => Glue('12pt plus 4pt minus 4pt'));
+DefRegister('\LTcapwidth'  => Dimension('4in'));
+DefRegister('\LTchunksize' => Number(200));
+DefRegister('\LT@cols'     => Number(0));
+DefRegister('\LT@rows'     => Number(0));
+Let('\c@LTchunksize', '\LTchunksize');
+RawTeX(<<'EOL');
+\newbox\LT@head
+\newbox\LT@firsthead
+\newbox\LT@foot
+\newbox\LT@lastfoot
+\newbox\LT@gbox
+EOL
 Let('\setlongtables', '\relax');
 #======================================================================
 1;

--- a/lib/LaTeXML/Package/tabulary.sty.ltxml
+++ b/lib/LaTeXML/Package/tabulary.sty.ltxml
@@ -19,9 +19,9 @@ RequirePackage('array');
 
 # \tabularx{Dimension}[]{}
 DefMacro('\tabulary{}[]{}',
-  '\@tabular@bindings{#3}[vattach=#2,width=#1]\@@tabulary{#1}[#2]{#3}\@start@alignment');
+  '\@tabular@bindings{#3}[vattach=#2,width=#1]\@@tabulary{#1}[#2]{#3}\@start@alignment', locked => 1);
 DefMacro('\endtabulary',
-  '\@finish@alignment\@end@tabulary');
+  '\@finish@alignment\@end@tabulary', locked => 1);
 DefPrimitive('\@end@tabulary', sub { $_[0]->egroup; });
 DefConstructor('\@@tabulary{Dimension}[] Undigested DigestedBody',
   '#4',
@@ -46,5 +46,8 @@ DefColumnType('J', sub {
     $LaTeXML::BUILD_TEMPLATE->addColumn(before => Tokens(T_CS('\vtop'), T_BEGIN),
       after => Tokens(T_END),
       align => 'justify'); return; });
+
+# stub in for macros that try to redefine it.
+DefMacro('\TY@tabular', '\relax');
 
 1;

--- a/lib/LaTeXML/Package/varioref.sty.ltxml
+++ b/lib/LaTeXML/Package/varioref.sty.ltxml
@@ -21,12 +21,12 @@ use LaTeXML::Package;
 # | remove this comment, when done.                                      |
 # | Drafted by texscan --stub varioref.sty                               |
 #  \--------------------------------------------------------------------/
-DefMacro('\vref OptionalMatch:* Semiverbatim',                       '\ref{#2}');
-DefMacro('\vpageref OptionalMatch:* Semiverbatim',                   '\ref{#2}');
-DefMacro('\vrefrange OptionalMatch:* Semiverbatim Semiverbatim',     '\vref{#2}--\vref{#3}');
-DefMacro('\vpagerefrange OptionalMatch:* Semiverbatim Semiverbatim', '\vref{#2}--\vref{#3}');
+DefMacro('\vref OptionalMatch:* Semiverbatim',                   '\ref{#2}', locked => 1);
+DefMacro('\vpageref OptionalMatch:* Semiverbatim',               '\ref{#2}', locked => 1);
+DefMacro('\vrefrange OptionalMatch:* Semiverbatim Semiverbatim', '\vref{#2}--\vref{#3}', locked => 1);
+DefMacro('\vpagerefrange OptionalMatch:* Semiverbatim Semiverbatim', '\vref{#2}--\vref{#3}', locked => 1);
 
-DefMacro('\vrefpagenum DefToken Semiverbatim', '\def#1{\ref{#2}}');
+DefMacro('\vrefpagenum DefToken Semiverbatim', '\def#1{\ref{#2}}', locked => 1);
 
 # Should use this, but....
 DefMacro('\labelformat{}{}', '');


### PR DESCRIPTION
This is an independent PR from me randomly checking a Fatal-error conversion from arXiv, which had an easy patch. The PR upgrades to a Warning status, where one of the remaining issues is my minimal example in #1703 

So, the main problems encountered here were due to:
 * capitalization typo in some longtable registers, and adding some extras
 * locking the \tabulary definition, as redefinitions using the .sty internals lead to unpredictable errors+loops, which lead too 100+ error fatals.
 * locking the \vref and related macro definitions in varioref.sty.ltxml, since modifying them using the internal .sty code also leads to unpredictable breakages.

That's all! The resulting HTML is very high quality from what I could tell, again with the notable exception of the \label issue in #1703 .