### PR TITLE
patch \graphicspath for ZIP inputs

### DIFF
--- a/lib/LaTeXML/Package/graphics.sty.ltxml
+++ b/lib/LaTeXML/Package/graphics.sty.ltxml
@@ -223,9 +223,7 @@ DefConstructor('\graphicspath DirectoryList', sub {
     my @paths = ();
     my $root  = $STATE->lookupValue('SOURCEDIRECTORY') || '';
     foreach my $dir ($paths->getValues) {
-      $dir = pathname_canonical(ToString($dir));
-      $dir = pathname_concat($root, $dir) if $root && !pathname_is_absolute($dir);
-      my $path = pathname_absolute($dir);
+      my $path = pathname_absolute(pathname_canonical(ToString($dir)), $root);
       push(@paths, $path);
       PushValue(GRAPHICSPATHS => $path); }
     return (paths => [@paths]); });

--- a/lib/LaTeXML/Package/graphics.sty.ltxml
+++ b/lib/LaTeXML/Package/graphics.sty.ltxml
@@ -221,8 +221,11 @@ DefConstructor('\graphicspath DirectoryList', sub {
   properties => sub {
     my ($stomach, $paths) = @_;
     my @paths = ();
+    my $root  = $STATE->lookupValue('SOURCEDIRECTORY') || '';
     foreach my $dir ($paths->getValues) {
-      my $path = pathname_absolute(pathname_canonical(ToString($dir)));
+      $dir = pathname_canonical(ToString($dir));
+      $dir = pathname_concat($root, $dir) if $root;
+      my $path = pathname_absolute($dir);
       push(@paths, $path);
       PushValue(GRAPHICSPATHS => $path); }
     return (paths => [@paths]); });
@@ -281,4 +284,3 @@ DefPrimitive('\Gscale@div DefToken Dimension Dimension', sub {
 
 #======================================================================
 1;
-

--- a/lib/LaTeXML/Package/graphics.sty.ltxml
+++ b/lib/LaTeXML/Package/graphics.sty.ltxml
@@ -224,7 +224,7 @@ DefConstructor('\graphicspath DirectoryList', sub {
     my $root  = $STATE->lookupValue('SOURCEDIRECTORY') || '';
     foreach my $dir ($paths->getValues) {
       $dir = pathname_canonical(ToString($dir));
-      $dir = pathname_concat($root, $dir) if $root;
+      $dir = pathname_concat($root, $dir) if $root && !pathname_is_absolute($dir);
       my $path = pathname_absolute($dir);
       push(@paths, $path);
       PushValue(GRAPHICSPATHS => $path); }


### PR DESCRIPTION
Minor, but annoying in the arXiv previews - articles that used the `\graphicspath` macro were [not picking up](https://ar5iv.org/html/1804.11028) their images, as the source directory wasn't getting used (and the ZIP inputs change it).

If one wants to reproduce the issue:
```
latexmlc 1804.11028.zip --dest=test.html
```

Once the source directory is properly used, it gets propagated to post-processing via the usual path and the HTML has images again, even in a zip-to-zip conversion.