### PR TITLE
[minor] variety robustness patches

### DIFF
--- a/lib/LaTeXML/Core.pm
+++ b/lib/LaTeXML/Core.pm
@@ -208,7 +208,11 @@ sub convertDocument {
       $model->loadSchema();                                  # If needed?
       if (my $paths = $state->lookupValue('SEARCHPATHS')) {
         if ($state->lookupValue('INCLUDE_PATH_PIS')) {
-          $document->insertPI('latexml', searchpaths => join(',', @$paths)); } }
+          my @copy  = @{ $state->lookupValue('SEARCHPATHS') };
+          my @dedup = ();
+          while (my $check = shift(@copy)) {
+            unshift(@dedup, $check) if !(grep { $_ eq $check } @dedup); }
+          $document->insertPI('latexml', searchpaths => join(',', @dedup)); } }
       foreach my $preload_by_reference (@{ $$self{preload} }) {
         my $preload = $preload_by_reference; # copy preload value, as we want to preserve the hash as-is, for (potential) future daemon calls
         next if $preload =~ /\.pool$/;

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -647,7 +647,7 @@ sub NewCounter {
 
 sub CounterValue {
   my ($ctr) = @_;
-  $ctr = ToString($ctr) if ref $ctr;
+  $ctr = ToString(Expand($ctr)) if ref $ctr;
   my $value = LookupValue('\c@' . $ctr);
   if (!$value) {
     Warn('undefined', $ctr, $STATE->getStomach,
@@ -663,7 +663,7 @@ sub AfterAssignment {
 
 sub SetCounter {
   my ($ctr, $value) = @_;
-  $ctr = ToString($ctr) if ref $ctr;
+  $ctr = ToString(Expand($ctr)) if ref $ctr;
   AssignValue('\c@' . $ctr => $value, 'global');
   AfterAssignment();
   DefMacroI(T_CS("\\\@$ctr\@ID"), undef, Tokens(Explode($value->valueOf)), scope => 'global');
@@ -671,7 +671,7 @@ sub SetCounter {
 
 sub AddToCounter {
   my ($ctr, $value) = @_;
-  $ctr = ToString($ctr) if ref $ctr;
+  $ctr = ToString(Expand($ctr)) if ref $ctr;
   my $v = CounterValue($ctr)->add($value);
   AssignValue('\c@' . $ctr => $v, 'global');
   AfterAssignment();
@@ -697,6 +697,7 @@ sub StepCounter {
 sub RefStepCounter {
   my ($type, $noreset) = @_;
   my $ctr = LookupMapping('counter_for_type', $type) || $type;
+  $ctr = ToString(Expand($ctr)) if ref $ctr;
   StepCounter($ctr, $noreset);
   maybePreemptRefnum($ctr);
   my $iddef = $STATE->lookupDefinition(T_CS("\\the$ctr\@ID"));

--- a/lib/LaTeXML/Package/IEEEtran.cls.ltxml
+++ b/lib/LaTeXML/Package/IEEEtran.cls.ltxml
@@ -229,13 +229,15 @@ RawTeX(<<'EoTeX');
 \setlength\belowcaptionskip{0pt}
 EoTeX
 
-DefEnvironment('{IEEEbiography}[]',
+DefEnvironment('{IEEEbiography}[]{}',
   "<ltx:float class='biography'><ltx:tabular>"
-    . "<ltx:tr><ltx:td>#1</ltx:td><ltx:td><ltx:p>#body</ltx:p></ltx:td></ltx:tr>"
+    . "<ltx:tr><ltx:td>#1</ltx:td><ltx:td><ltx:inline-block><ltx:text class='ltx_font_bold'>#2</ltx:text> "
+    . "#body</ltx:inline-block></ltx:td></ltx:tr>"
     . "</ltx:tabular></ltx:float>");
-DefEnvironment('{IEEEbiographynophoto}[]',
+DefEnvironment('{IEEEbiographynophoto}[]{}',
   "<ltx:float class='biography'><ltx:tabular>"
-    . "<ltx:tr><ltx:td><ltx:p>#body</ltx:p></ltx:td></ltx:tr>"
+    . "<ltx:tr><ltx:td><ltx:inline-block><ltx:text class='ltx_font_bold'>#2</ltx:text> "
+    . "#body</ltx:inline-block></ltx:td></ltx:tr>"
     . "</ltx:tabular></ltx:float>");
 
 # IEEEeqnarray is similar to eqnarray, but supports subequation numbering.

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -5387,7 +5387,11 @@ RawTeX(<<'EoTeX');
   \@latex@info{#1\@gobble}}
 EoTeX
 
-DefPrimitive('\@setsize{}{}{}{}', undef);
+DefMacro('\@setsize{}{}{}{}', '');
+DefMacro('\hexnumber@ {}', '\ifcase\number#1
+ 0\or 1\or 2\or 3\or 4\or 5\or 6\or 7\or 8\or
+ 9\or A\or B\or C\or D\or E\or F\fi');
+
 DefMacro('\on@line', ' on input line \the\inputlineno');
 Let('\@warning',  '\@latex@warning');
 Let('\@@warning', '\@latex@warning@no@line');

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -924,7 +924,9 @@ DefMacro('\AtEndOfPackage{}', sub {
     AddToMacro(T_CS('\\' . $name . '.' . $type . '-h@@k'), $code); });
 
 DefMacro('\@ifpackageloaded', '\@ifl@aded\@pkgextension');
-DefMacro('\@ifclassloaded',   '\@ifl@aded\@clsextension');
+Let('\ltx@ifpackageloaded', '\@ifpackageloaded');
+DefMacro('\@ifclassloaded', '\@ifl@aded\@clsextension');
+Let('\ltx@ifclassloaded', '\@ifclassloaded');
 DefMacro('\@ifl@aded{}{}', sub {
     my ($gullet, $ext, $name) = @_;
     my $path = ToString(Expand($name)) . '.' . ToString(Expand($ext));

--- a/lib/LaTeXML/Package/subfiles.sty.ltxml
+++ b/lib/LaTeXML/Package/subfiles.sty.ltxml
@@ -19,8 +19,9 @@ use LaTeXML::Package;
 # Redefine \documentclass to do nothring
 DefMacro('\documentclass OptionalSemiverbatim SkipSpaces Semiverbatim []', undef);
 # And {document} environment likewise
-DefEnvironment('{document}', "#body");
-
+DefEnvironment('{document}', "#body", beforeDigest => sub {
+    AssignValue(inPreamble => 0);
+    return; });
 # Define \subfiles to be \input
 Let('\subfile', '\input');
 

--- a/t/structure/IEEE.xml
+++ b/t/structure/IEEE.xml
@@ -1005,7 +1005,9 @@ Stuff, More Stuff
       <tabular>
         <tr>
           <td>Picture of Me</td>
-          <td><p><text font="bold">ME</text> is a really great guy.</p></td>
+          <td><inline-block>
+              <p><text class="ltx_font_bold"><text font="bold">ME</text> is a really great guy.</text></p>
+            </inline-block></td>
         </tr>
       </tabular>
     </float>


### PR DESCRIPTION
In the process of developing with [1804.11021](https://ar5iv.org/html/1804.11021) for flex subfigures, I debugged a few unrelated issues and factored the patches out in this separate PR.

Details of the tidbits:
 - [guard] deduplicate the searchpaths list before writing in the processing instructions in the core XML
 - Make sure counter arguments are expanded so that uses such as `\addtocounter{\@captype}{...}` work as expected
 - handle name arg of `{IEEEbiography}` and also allow for inline-block content - the article has multiple paragraphs
 - a handful of extra small auxiliary macros in LaTeX.pool
 - make sure the `{document}` redefinition in subfiles.sty leaves preamble mode.

This gets 1804.11021 to a "no problem" status and I can now focus on getting just the right subfigure flavor.