### PR TITLE
Add "token limit" guard; fix two regressions

### DIFF
--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -286,6 +286,11 @@ sub readToken {
         elsif ($cc == CC_MARKER) {
           $self->handleMarker($token); } } }
     ProgressStep() if ($$self{progress}++ % $TOKEN_PROGRESS_QUANTUM) == 0;
+    # some infinite loops are hard to predict and may be
+    # better guarded against via a global token limit.
+    if ($LaTeXML::TOKEN_LIMIT and $$self{progress} > $LaTeXML::TOKEN_LIMIT) {
+      Fatal('timeout', 'token_limit', $self,
+        "Token limit of $LaTeXML::TOKEN_LIMIT exceeded, infinite loop?"); }
     # Wow!!!!! See TeX the Program \S 309
     if ((defined $token)
       && !$LaTeXML::ALIGN_STATE    # SHOULD count nesting of { }!!! when SCANNED (not digested)

--- a/lib/LaTeXML/Core/MuDimension.pm
+++ b/lib/LaTeXML/Core/MuDimension.pm
@@ -35,7 +35,7 @@ sub new {
   $spec = "0" unless $spec;
   $spec = ToString($spec) if ref $spec;
   if ($spec =~ /^(-?\d*\.?\d*)mu$/) {    # mu given, convert to scaled mu
-    return bless [fixedpoint($1, $UNITY)], $class; }    # fake "mu" in sp
+    return bless [fixpoint($1, $UNITY)], $class; }    # fake "mu" in sp
   else {
     # See comment in Dimension for why kround rather than int
     return bless [kround($spec || 0)], $class; } }
@@ -98,4 +98,3 @@ Public domain software, produced as part of work done by the
 United States Government & not subject to copyright in the US.
 
 =cut
-

--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -225,7 +225,8 @@ sub localized_anchor {
   my $id = $whatsit->getProperty('id');
   if ($candidate) {
     my $anchor = $document->wrapNodes('ltx:anchor', $candidate);
-    $anchor->setAttribute('xml:id', $id); }
+    $anchor->setAttribute('xml:id', $id);
+    $document->closeNode($anchor) if $document->isOpen($anchor); }
   else {
     Error("No available insertion point for ltx:anchor, failing \\hypertarget to $id"); }
   return; }

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -74,6 +74,9 @@ DefKeyVal('LTXML', 'upsample', 'Number', '', code => sub {
     AtBeginDocument(Tokens(T_CS('\lx@save@parameter'), T_OTHER('upsample'), T_BEGIN, $_[1], T_END)); });
 DefKeyVal('LTXML', 'zoomout', 'Number', '', code => sub {
     AtBeginDocument(Tokens(T_CS('\lx@save@parameter'), T_OTHER('zoomout'), T_BEGIN, $_[1], T_END)); });
+DefKeyVal('LTXML', 'tokenlimit', 'Number', '', code => sub {
+    $LaTeXML::TOKEN_LIMIT = int(ToString($_[1]));
+    return; });
 
 ProcessOptions(inorder => 1, keysets => ['LTXML']);
 #======================================================================


### PR DESCRIPTION
I'm anticipating a large wait on timeout jobs in the next arXiv rerun, as we have a large number of first-time converting articles, a new texlive 2021, and a contingent of [previously infinitely-looping jobs](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/fatal/timeout?all=false). I've done a small boost to my available hardware to mitigate, but software guards are a much cheaper solution.

So, to borrow an old TeX idea - token limits.

latexml's Gullet already maintains a very adequate counter in a `{progress}` field. What the PR adds is a keyval option to latexml.sty called `tokenlimit`, and raises a Fatal once the limit is surpassed. By default the current behavior is used, i.e. the limit guard is off/disabled.

So, testing in arXiv, I found that a limit of 100,000,000 (one hundred million tokens) suffices to convert the two biggest book documents already on my radar (2105.10386 and 2105.04026). Equally importantly, when running on a randomly sampled timeout, we see some improvement:

(math/0306435, due to a wrongly infinite loop via missing xy.sty support)
```
time latexmlc import_2436854.zip --preload=[localrawstyles,tokenlimit=100000000]latexml.sty 
...
Fatal:timeout:token_limit Token limit of 100000000 exceeded, infinite loop?
	at CY.tex; line 1601 col 47 - line 1601 col 47
	In Core::Gullet[@0x56192de08628] /tmp/ZF41Wy_c4_/CY.tex; from line 1601 col 47 to line 1601 col 47
Conversion complete: 55 warnings; 4 errors; 1 fatal error; 3 undefined macros[\ar, \xymatrix, \lx@ams@matrix@]; 1 missing file[xy.sty] (See /tmp/import_2436854.latexml.log)
Status:conversion:3

real	6m13.407s
user	6m12.544s
sys	0m0.791s
```

ending the run in 6 minutes, instead of what would have been 30 in the usual arXiv settings.

For some fast-and-loose hopeful numbers: If half of the arXiv timeouts are due to infinite loops in the token reading phase, that would be 7,000 documents saving roughly 20 minutes each, for a total of 97 CPU **days**. So, maybe less excitingly, the overall conversion may finish a day earlier than it would have otherwise, since there are over 100 CPUs running in parallel. But there is a bit of quality-of-life added to future debugging, as it would be clear which jobs are due to token loops, specifically.

Debugging the big books also revealed two regressions from recent PRs:
 * a sub name typo in MuDimension,
 *  a node left open that couldn't auto-close, from my change to hyperref.