### PR TITLE
inline-block styling for ltx_parbox

### DIFF
--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -220,7 +220,9 @@ dl.ltx_description dl.ltx_description dd { margin-left:3em; }
     position:absolute; left:0em;
     max-width:0em; text-align:right; }
 */
-.ltx_parbox {text-indent:0em; }
+.ltx_parbox {
+    text-indent:0em;
+    display: inline-block; }
 
 /* NOTE that it is CRITICAL to put position:relative outside & absolute inside!!
    I wish I understood why!


### PR DESCRIPTION
Fixes #1720 .

Unsure what other common uses there are of parbox, but since there is a desire to use it outside of a figure context then the flexbox solution (in #1700)  isn't the best fit. Styling its display as inline-block is a good pragmatic fix, to the degree I understand the applications.