### PR TITLE
Emulate more psfile options via includegraphics

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2392,22 +2392,71 @@ DefPrimitive('\special {}', sub {
     if ($special_str =~ /\bpsfile=(.+?)(?:\s|\})/) {
       my $graphic = $1;
       RequirePackage('graphicx', searchpaths_only => 1);
+      my @kv;
+      for my $prop (qw(voffset hoffset hscale vscale hsize vsize angle)) {
+        if ($special_str =~ /\b$prop=(.+?)(?:\s|\})/) {
+          push(@kv, T_OTHER(',')) if @kv;
+          push(@kv, T_OTHER($prop), T_OTHER("="), T_OTHER($1)); } }
+      @kv = (T_OTHER("["), @kv, T_OTHER("]")) if @kv;
       $stomach->getGullet->unread(
-        Invocation(T_CS('\ltx@special@graphics'), T_OTHER($graphic))->unlist); }
+        T_CS('\ltx@special@graphics'), @kv, T_BEGIN, T_OTHER($graphic), T_END); }
     return; });
 # adapted from graphicx.sty.ltxml
-DefConstructor('\ltx@special@graphics Semiverbatim',
-  "<ltx:graphics graphic='#path' candidates='#candidates'/>",
+DefKeyVal('SpecialPS', 'angle',   '');
+DefKeyVal('SpecialPS', 'voffset', '');
+DefKeyVal('SpecialPS', 'hoffset', '');
+DefKeyVal('SpecialPS', 'hsize',   '');
+DefKeyVal('SpecialPS', 'vsize',   '');
+DefKeyVal('SpecialPS', 'hscale',  '');
+DefKeyVal('SpecialPS', 'vscale',  '');
+DefConstructor('\ltx@special@graphics OptionalKeyVals:SpecialPS Semiverbatim',
+  "<ltx:graphics graphic='#path' candidates='#candidates' options='#options'/>",
   sizer      => \&image_graphicx_sizer,
   properties => sub {
-    my ($stomach, $path) = @_;
+    my ($stomach, $kv, $path) = @_;
     $path = ToString($path); $path =~ s/^\s+//; $path =~ s/\s+$//;
+    $path =~ s/("+)(.+)\g1/$2/;
     my $searchpaths = LookupValue('GRAPHICSPATHS');
     my @candidates  = pathname_findall($path, types => ['*'], paths => $searchpaths);
     if (my $base = LookupValue('SOURCEDIRECTORY')) {
       @candidates = map { pathname_relative($_, $base) } @candidates; }
-    (path => $path,
-      candidates => join(',', @candidates)); },
+    my $options = '';
+    if ($kv) {    # remap psfile options to includegraphics options:
+      if (my $hscale = $kv->getValue('hscale')) {
+        $hscale = $hscale && int(ToString($hscale)) / 100;
+        $options .= ',' if $options;
+        $options .= "xscale=$hscale"; }
+      if (my $vscale = $kv->getValue('vscale')) {
+        $vscale = $vscale && int(ToString($vscale)) / 100;
+        $options .= ',' if $options;
+        $options .= "yscale=$vscale"; }
+      if (my $hsize = $kv->getValue('hsize')) {
+        $hsize = ToString($hsize);
+        $options .= ',' if $options;
+        $options .= "width=$hsize"; }
+      if (my $vsize = $kv->getValue('vsize')) {
+        $vsize = ToString($vsize);
+        $options .= ',' if $options;
+        $options .= "height=$vsize"; }
+      if (my $angle = $kv->getValue('angle')) {
+        $angle = ToString($angle);
+        $options .= ',' if $options;
+        $options .= "angle=$angle"; }
+      my $voffset = $kv->getValue('voffset');
+      $voffset = $voffset && int(ToString($voffset));
+      my $hoffset = $kv->getValue('hoffset');
+      $hoffset = $hoffset && int(ToString($hoffset));
+      if ($voffset || $hoffset) {
+        my ($left, $bottom, $right, $top) = (0, 0, 0, 0);
+        # STRANGE: I get best results by applying the offsets as >0 TRIMs to both axes,
+        #          rather than as single-axis offset (via negative value trim).
+        $voffset = -$voffset if $voffset < 0;
+        $bottom  = $top = $voffset;
+        $hoffset = -$hoffset if $hoffset < 0;
+        $left    = $right = $hoffset;
+        $options .= "," if $options;
+        $options .= "trim=$left $bottom $right $top,clip=true"; } }
+    (options => $options, path => $path, candidates => join(',', @candidates)); },
   mode => 'text');
 # Since these ultimately generate external resources, it can be useful to have a handle on them.
 Tag('ltx:graphics', afterOpen => sub { GenerateID(@_, 'g'); });

--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -62,7 +62,7 @@ sub new {
     pdf => { destination_type => 'png',
       transparent => 1,
       prescale    => 1, ncolors => '400%', quality => 90, unit => 'point' },
-    ps => { destination_type => 'png', transparent => 1, autocrop => 1,
+    ps => { destination_type => 'png', transparent => 1,
       prescale => 1, ncolors => '400%', quality => 90, unit => 'point' },
     eps => { destination_type => 'png', transparent => 1,
       prescale => 1, ncolors => '400%', quality => 90, unit => 'point' },

--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -62,7 +62,7 @@ sub new {
     pdf => { destination_type => 'png',
       transparent => 1,
       prescale    => 1, ncolors => '400%', quality => 90, unit => 'point' },
-    ps => { destination_type => 'png', transparent => 1,
+    ps => { destination_type => 'png', transparent => 1, autocrop => 1,
       prescale => 1, ncolors => '400%', quality => 90, unit => 'point' },
     eps => { destination_type => 'png', transparent => 1,
       prescale => 1, ncolors => '400%', quality => 90, unit => 'point' },


### PR DESCRIPTION
This PR is meant to be a small stir of a recent hot pot :>

I was debugging [arXiv:hep-ph/0105138](https://ar5iv.org/html/hep-ph/0105138) which is no longer a timeout in the latest master. But, that allowed to notice the images reached HTML rather skewed, with an artificial A4/Letter-sized white frame. In other words, the same problem we started discussing at #1683 

Unsurprisingly, adding the `autocrop => 1` flag to the `.ps` case of Graphics.pm specifically reaches an optimal looking figure, as you can enjoy in this screenshot:
![image](https://user-images.githubusercontent.com/348975/145874289-12f70037-b0ea-49a3-8456-09f62589fc23.png)

The images in question all come from the `\special` directive which I recently enabled in #1616. In this case the source was:
```tex
\special{psfile=g0.ps   voffset=-200
hoffset=-20  angle=0   vscale=80  hscale=80 }
```

I'm not sure if these options would be useful to emulate to preserve the original aspect ratio, the autocrop is certainly the simplest one-line patch. Maybe they can be translated into a mixture of `trim`, `clip` and `scale` from `\includegraphics` and achieve the same result? Wondering about your preference @brucemiller 