### PR TITLE
Unwrap quoted filenames in \input

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2071,6 +2071,7 @@ my $input_options = {};    # [CONSTANT]
 sub Input {
   my ($request, %options) = @_;
   $request = ToString($request);
+  $request =~ s/^"(.+)"$/$1/;    # unwrap if in quotes \input{"file name"}
   CheckOptions("Input ($request)", $input_options, %options);
   # HEURISTIC! First check if equivalent style file, but only under very specific circumstances
   if (pathname_is_literaldata($request)) {

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2071,7 +2071,7 @@ my $input_options = {};    # [CONSTANT]
 sub Input {
   my ($request, %options) = @_;
   $request = ToString($request);
-  $request =~ s/^"(.+)"$/$1/;    # unwrap if in quotes \input{"file name"}
+  $request =~ s/^(".+)(.+)\g1$/$2/;    # unwrap if in quotes \input{"file name"}
   CheckOptions("Input ($request)", $input_options, %options);
   # HEURISTIC! First check if equivalent style file, but only under very specific circumstances
   if (pathname_is_literaldata($request)) {

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2071,7 +2071,7 @@ my $input_options = {};    # [CONSTANT]
 sub Input {
   my ($request, %options) = @_;
   $request = ToString($request);
-  $request =~ s/^(".+)(.+)\g1$/$2/;    # unwrap if in quotes \input{"file name"}
+  $request =~ s/^("+)(.+)\g1$/$2/;    # unwrap if in quotes \input{"file name"}
   CheckOptions("Input ($request)", $input_options, %options);
   # HEURISTIC! First check if equivalent style file, but only under very specific circumstances
   if (pathname_is_literaldata($request)) {

--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -52,7 +52,7 @@ DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbat
   properties => sub {
     my ($stomach, $starred, $kv, $path) = @_;
     $path = ToString($path); $path =~ s/^\s+//; $path =~ s/\s+$//;
-    $path =~ s/^(".+)(.+)\g1$/$2/;                          # unwrap if in quotes
+    $path =~ s/^("+)(.+)\g1$/$2/;                           # unwrap if in quotes
     my $searchpaths = LookupValue('GRAPHICSPATHS');
     if (my $svgpath = $kv && $kv->getValue('svgpath')) {    # Doesn't belong here!!!
       push(@$searchpaths, ToString($svgpath)); }

--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -52,6 +52,7 @@ DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbat
   properties => sub {
     my ($stomach, $starred, $kv, $path) = @_;
     $path = ToString($path); $path =~ s/^\s+//; $path =~ s/\s+$//;
+    $path =~ s/^(".+)(.+)\g1$/$2/;                          # unwrap if in quotes
     my $searchpaths = LookupValue('GRAPHICSPATHS');
     if (my $svgpath = $kv && $kv->getValue('svgpath')) {    # Doesn't belong here!!!
       push(@$searchpaths, ToString($svgpath)); }
@@ -73,4 +74,3 @@ DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbat
 
 #**********************************************************************
 1;
-


### PR DESCRIPTION
Seemingly harmless(?) addition of unwrapping quoted filenames in input directives, such as `\input{"epsf.sty"}`.

Seen in long-tail cases e.g. in the [arxmliv warning report](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/warning/missing%5Ffile?all=false). There's also [a couple of SE comments](https://tex.stackexchange.com/questions/191930/spaces-in-files-names-in-input-or-includegraphics#comment442865_191930) mentioning that as the preferred method when the filename has spaces.