### PR TITLE
\qed needs to be expandable for arXiv

### DIFF
--- a/lib/LaTeXML/Package/IEEEtran.cls.ltxml
+++ b/lib/LaTeXML/Package/IEEEtran.cls.ltxml
@@ -403,8 +403,10 @@ Let('\iedlabeljustifyr', '\IEEEiedlabeljustifyr');
 Let('\QED',       '\IEEEQED');
 Let('\QEDclosed', '\IEEEQEDclosed');
 Let('\QEDopen',   '\IEEEQEDopen');
-DefConstructor('\qed',
-  "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})");
+DefMacro('\qed', '\ltx@qed');
+DefConstructor('\ltx@qed',
+  "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})",
+  reversion => '\qed');
 Let('\proof',    '\IEEEproof');
 Let('\endproof', '\endIEEEproof');
 # V1.8 no longer support biography or biographynophoto

--- a/lib/LaTeXML/Package/aa_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aa_support.sty.ltxml
@@ -299,7 +299,7 @@ DefConstructor('\aas@@fstack{}',
     . "<ltx:XMWrap>#1</ltx:XMWrap>"
     . "</ltx:XMApp>",
   properties => { scriptpos => sub { "mid" . $_[0]->getScriptLevel; } },
-  mode => 'math', bounded => 1);
+  mode       => 'math', bounded => 1);
 DefMacro('\aas@fstack{}', '\ensuremath{\aas@@fstack{#1}}');
 DefMacro('\fd',           '\aas@fstack{d}');
 DefMacro('\fh',           '\aas@fstack{h}');
@@ -319,8 +319,8 @@ DefConstructor('\mathsc{}', '#1', bounded => 1, requireMath => 1,
 
 DefConstructor('\squareforqed',
   "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})");
-Let('\sq',  '\squareforqed');
-Let('\qed', '\squareforqed');
+DefMacro('\sq',  '\squareforqed');
+DefMacro('\qed', '\squareforqed');
 
 DefPrimitiveI('\bbbc',   undef, "\x{2102}");    #not sure if ok for the ones NOT of type I$
 DefPrimitiveI('\bbbf',   undef, "\x{1D53D}");

--- a/lib/LaTeXML/Package/amsppt.sty.ltxml
+++ b/lib/LaTeXML/Package/amsppt.sty.ltxml
@@ -311,7 +311,8 @@ DefMacro('\rom{}', '{rm #1}');
 
 DefMacro('\PSAMSFonts', '');
 RawTeX('\newif\ifPSAMSFonts\PSAMSFontstrue');
-DefConstructor('\qed', "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})");
+DefMacro('\qed', '\ltx@qed');
+DefConstructor('\ltx@qed', "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})", reversion => '\qed');
 
 DefPrimitiveI('\tildechar', undef, "~", font => { family => 'typewriter' });
 DefMacro('\breakcheck', '');

--- a/lib/LaTeXML/Package/amsthm.sty.ltxml
+++ b/lib/LaTeXML/Package/amsthm.sty.ltxml
@@ -112,8 +112,10 @@ DefMacro('\popQED',    sub { (PopValue('QED@stack') || ()); });
 
 # Should mark this as somehow ignorable for math,
 # but we DO want to keep it in the formula...
-DefConstructor('\qed',
-  "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})");
+DefMacro('\qed', '\ltx@qed');
+DefConstructor('\ltx@qed',
+  "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})",
+  reversion => '\qed');
 Let('\mathqed',    '\qed');
 Let('\textsquare', '\qed');
 Let('\qedsymbol',  '\qed');

--- a/lib/LaTeXML/Package/elsart_support.sty.ltxml
+++ b/lib/LaTeXML/Package/elsart_support.sty.ltxml
@@ -24,8 +24,10 @@ if (LookupValue('@amsthm')) {
   RequirePackage('amsthm'); }
 else {
   DefMacro('\theoremstyle{}', '');
-  DefConstructor('\qed',
-    "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})"); }
+  DefMacro('\qed',            '\ltx@qed');
+  DefConstructor('\ltx@qed',
+    "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})",
+    reversion => '\qed'); }
 
 RequirePackage('elsart_support_core');
 

--- a/lib/LaTeXML/Package/llncs.cls.ltxml
+++ b/lib/LaTeXML/Package/llncs.cls.ltxml
@@ -213,7 +213,7 @@ DefMath('\grole',  "\x{2277}", role => 'RELOP', meaning => 'greater-than-or-less
 
 DefConstructor('\squareforqed',
   "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})");
-Let('\qed', '\squareforqed');
+DefMacro('\qed', '\squareforqed');
 
 #======================================================================
 DefMacro('\backmatter', Tokens());

--- a/lib/LaTeXML/Package/sv_support.sty.ltxml
+++ b/lib/LaTeXML/Package/sv_support.sty.ltxml
@@ -227,8 +227,10 @@ DefEnvironment('{theopargself}',  '#body');    # ?
 DefEnvironment('{translation}{}', "<ltx:quote role='translation' lang='#1'>#body</ltx:quote>");
 
 #======================================================================
-DefConstructor('\qed',
-  "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})");
+DefMacro('\qed', '\ltx@qed');
+DefConstructor('\ltx@qed',
+  "?#isMath(<ltx:XMTok role='PUNCT'>\x{220E}</ltx:XMTok>)(\x{220E})",
+  reversion => '\qed');
 Let('\smartqed',     '\qed');
 Let('\squareforqed', '\qed');
 


### PR DESCRIPTION
As we've known for a while now, we have some arxiv articles that get emulated as "fork bombs" due to some latex macros being instead defined as latexml primitives/constructors. Spotted a really simple one today, which feels too simple to go unfixed:

```tex
\edef\qqed{\qed}
\def\qed{\qqed \medskip}
```

Allocates over 4 GB of RAM in 6 minutes when `\qed` is first invoked in the body of the document and dies through the [out-of-memory guard](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/fatal/cortex/oom?all=false). If `\qed` is always defined as a macro, that entire busy loop can be avoided.

Tested on [arXiv:math/0109221](https://ar5iv.org/html/math/0109221)