### PR TITLE
New guards: iflimit, absorblimit; subeqn.sty; misc patches

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -668,6 +668,7 @@ lib/LaTeXML/Package/standalone.sty.ltxml
 lib/LaTeXML/Package/stfloats.sty.ltxml
 lib/LaTeXML/Package/stmaryrd.sty.ltxml
 lib/LaTeXML/Package/subcaption.sty.ltxml
+lib/LaTeXML/Package/subeqn.sty.ltxml
 lib/LaTeXML/Package/subfig.sty.ltxml
 lib/LaTeXML/Package/subfigure.sty.ltxml
 lib/LaTeXML/Package/subfloat.sty.ltxml

--- a/lib/LaTeXML/Common/Object.pm
+++ b/lib/LaTeXML/Common/Object.pm
@@ -158,6 +158,14 @@ sub beDigested {
 
 sub beAbsorbed {
   my ($self, $document) = @_;
+  # Guard via the absorb limit to avoid infinite loops
+  if ($LaTeXML::ABSORB_LIMIT) {
+    my $absorb_counter = $STATE->lookupValue('absorb_count') || 0;
+    $STATE->assignValue(absorb_count => ++$absorb_counter, 'global');
+    if ($absorb_counter > $LaTeXML::ABSORB_LIMIT) {
+      Fatal('timeout', 'absorb_limit', $self,
+        "Whatsit absorb limit of $LaTeXML::ABSORB_LIMIT exceeded, infinite loop?"); } }
+
   return $document->openText($self->toString, $document->getNodeFont($document->getElement)); }
 
 sub unlist {

--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -296,6 +296,15 @@ sub beAbsorbed {
   $self->normalizeAlignment;
   my @rows = @{ $$self{rows} };
   return unless @rows;
+
+  # Guard via the absorb limit to avoid infinite loops
+  if ($LaTeXML::ABSORB_LIMIT) {
+    my $absorb_counter = $STATE->lookupValue('absorb_count') || 0;
+    $STATE->assignValue(absorb_count => ++$absorb_counter, 'global');
+    if ($absorb_counter > $LaTeXML::ABSORB_LIMIT) {
+      Fatal('timeout', 'absorb_limit', $self,
+        "Whatsit absorb limit of $LaTeXML::ABSORB_LIMIT exceeded, infinite loop?"); } }
+
   # We _should_ attach boxes to the alignment and rows,
   # but (ATM) we've only got sensible boxes for the cells.
   &{ $$self{openContainer} }($document, ($attr ? %$attr : ()),
@@ -1309,6 +1318,3 @@ Public domain software, produced as part of work done by the
 United States Government & not subject to copyright in the US.
 
 =cut
-
-
-

--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -121,6 +121,15 @@ sub beAbsorbed {
   my ($self, $document) = @_;
   my $string = $$self{string};
   my $mode   = $$self{properties}{mode} || 'text';
+
+  # Guard via the absorb limit to avoid infinite loops
+  if ($LaTeXML::ABSORB_LIMIT) {
+    my $absorb_counter = $STATE->lookupValue('absorb_count') || 0;
+    $STATE->assignValue(absorb_count => ++$absorb_counter, 'global');
+    if ($absorb_counter > $LaTeXML::ABSORB_LIMIT) {
+      Fatal('timeout', 'absorb_limit', $self,
+        "Whatsit absorb limit of $LaTeXML::ABSORB_LIMIT exceeded, infinite loop?"); } }
+
   return (((defined $string) && ($string ne '')) || $$self{properties}{width}    # ?
     ? ($mode eq 'math'
       ? $document->insertMathToken($string, %{ $$self{properties} })

--- a/lib/LaTeXML/Core/Definition/Conditional.pm
+++ b/lib/LaTeXML/Core/Definition/Conditional.pm
@@ -57,6 +57,9 @@ sub invoke_conditional {
   # Keep a stack of the conditionals we are processing.
   my $ifid = $STATE->lookupValue('if_count') || 0;
   $STATE->assignValue(if_count => ++$ifid, 'global');
+  if ($LaTeXML::IF_LIMIT and $ifid > $LaTeXML::IF_LIMIT) {
+    Fatal('timeout', 'if_limit', $self,
+      "Conditional limit of $LaTeXML::IF_LIMIT exceeded, infinite loop?"); }
   local $LaTeXML::IFFRAME = { token => $LaTeXML::CURRENT_TOKEN, start => $gullet->getLocator,
     parsing => 1, elses => 0, ifid => $ifid };
   $STATE->unshiftValue(if_stack => $LaTeXML::IFFRAME);

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -291,6 +291,9 @@ sub readToken {
     if ($LaTeXML::TOKEN_LIMIT and $$self{progress} > $LaTeXML::TOKEN_LIMIT) {
       Fatal('timeout', 'token_limit', $self,
         "Token limit of $LaTeXML::TOKEN_LIMIT exceeded, infinite loop?"); }
+    if ($LaTeXML::PUSHBACK_LIMIT and scalar(@{ $$self{pushback} }) > $LaTeXML::PUSHBACK_LIMIT) {
+      Fatal('timeout', 'pushback_limit', $self,
+        "Pushback limit of $LaTeXML::PUSHBACK_LIMIT exceeded, infinite loop?"); }
     # Wow!!!!! See TeX the Program \S 309
     if ((defined $token)
       && !$LaTeXML::ALIGN_STATE    # SHOULD count nesting of { }!!! when SCANNED (not digested)

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -200,6 +200,15 @@ sub beAbsorbed {
   # Significant time is consumed here, and associated with a specific CS,
   # so we should be profiling as well!
   # Hopefully the csname is the same that was charged in the digestioned phase!
+
+  # Guard via the absorb limit to avoid infinite loops
+  if ($LaTeXML::ABSORB_LIMIT) {
+    my $absorb_counter = $STATE->lookupValue('absorb_count') || 0;
+    $STATE->assignValue(absorb_count => ++$absorb_counter, 'global');
+    if ($absorb_counter > $LaTeXML::ABSORB_LIMIT) {
+      Fatal('timeout', 'absorb_limit', $self,
+        "Whatsit absorb limit of $LaTeXML::ABSORB_LIMIT exceeded, infinite loop?"); } }
+
   my $defn     = $self->getDefinition;
   my $profiled = $STATE->lookupValue('PROFILING') && $defn->getCS;
   LaTeXML::Core::Definition::startProfiling($profiled, 'absorb') if $profiled;

--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -732,7 +732,7 @@ sub node_to_lexeme_full {
 # Elements that directly represent a lexeme, or intended operation with a syntactic role (such as a postscript),
 # can proceed to building the lexeme from the leaf node.
     my $lexeme = $self->node_to_lexeme($node);
-    if ($role =~ /^(UNDER|OVER)ACCENT$/) {
+    if ($role && $role =~ /^(UNDER|OVER)ACCENT$/) {
       # over¯ and under¯ are the lexeme names of choice for \overline and \underline
       $lexeme = lc($1) . $lexeme; }
     return $lexeme; }
@@ -1368,7 +1368,7 @@ sub NewFormula {
 sub NewList {
   my (@stuff) = @_;
   # drop placeholder token for missing trailing punct, if any
-  if (scalar(@stuff) > 1 && (p_getTokenMeaning($stuff[-1]) eq 'absent')) {
+  if (scalar(@stuff) > 1 && ((p_getTokenMeaning($stuff[-1]) || '') eq 'absent')) {
     pop(@stuff); }
   if (@stuff == 1) {
     return $stuff[0]; }

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4729,6 +4729,7 @@ DefEnvironment('{picture} Pair OptionalPair',
 
 DefMacroI(T_CS('\Gin@driver'), undef, Tokens());
 
+DefMacro('\@killglue',     '\unskip\@whiledim \lastskip >\z@\do{\unskip}');
 DefMacro('\put Until:){}', '\lx@pic@put#1){#2\relax}');
 DefConstructor('\lx@pic@put Pair{}',
   "<ltx:g transform='#transform'"

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2467,21 +2467,21 @@ DefConstructor('\lx@stackrel{}{}',
 # the type of letter, greek, symbol, etc.
 # Apparently, with the normal TeX setup, these fonts don't really merge,
 # rather they override all of family, series and shape.
-DefConstructor('\mathrm{}', '#1', bounded => 1, requireMath => 1,
+DefConstructor('\mathrm{}', '#1', bounded => 1, requireMath => 1, locked => 1,
   font => { family => 'serif', series => 'medium', shape => 'upright' });
-DefConstructor('\mathit{}', '#1', bounded => 1, requireMath => 1,
+DefConstructor('\mathit{}', '#1', bounded => 1, requireMath => 1, locked => 1,
   font => { shape => 'italic', family => 'serif', series => 'medium' });
-DefConstructor('\mathbf{}', '#1', bounded => 1, requireMath => 1,
+DefConstructor('\mathbf{}', '#1', bounded => 1, requireMath => 1, locked => 1,
   font => { series => 'bold', family => 'serif', shape => 'upright' });
-DefConstructor('\mathsf{}', '#1', bounded => 1, requireMath => 1,
+DefConstructor('\mathsf{}', '#1', bounded => 1, requireMath => 1, locked => 1,
   font => { family => 'sansserif', series => 'medium', shape => 'upright' });
-DefConstructor('\mathtt{}', '#1', bounded => 1, requireMath => 1,
+DefConstructor('\mathtt{}', '#1', bounded => 1, requireMath => 1, locked => 1,
   font => { family => 'typewriter', series => 'medium', shape => 'upright' });
-DefConstructor('\mathcal{}', '#1', bounded => 1, requireMath => 1,
+DefConstructor('\mathcal{}', '#1', bounded => 1, requireMath => 1, locked => 1,
   font => { family => 'caligraphic', series => 'medium', shape => 'upright' });
-DefConstructor('\mathscr{}', '#1', bounded => 1, requireMath => 1,
+DefConstructor('\mathscr{}', '#1', bounded => 1, requireMath => 1, locked => 1,
   font => { family => 'script', series => 'medium', shape => 'upright' });
-DefConstructor('\mathnormal{}', '#1', bounded => 1, requireMath => 1,
+DefConstructor('\mathnormal{}', '#1', bounded => 1, requireMath => 1, locked => 1,
   font => { family => 'math', shape => 'italic', series => 'medium' });
 
 DefMacroI('\fontsubfuzz',  undef, '.4pt');

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1884,6 +1884,12 @@ DefPrimitive('\copy Number', sub {
     my $stuff = LookupValue($box);
     ($stuff ? $stuff->unlist : ()); });
 
+DefPrimitive('\vsplit Number Match:to Dimension', sub {
+    # analog to \box for now.
+    my $box   = 'box' . $_[1]->valueOf;
+    my $stuff = LookupValue($box);
+    ($stuff ? $stuff->unlist : ()); });
+
 sub revert_spec {
   my ($whatsit, $keyword) = @_;
   my $value = $whatsit->getProperty($keyword);

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -324,7 +324,7 @@ DefConstructor('\lx@ams@marksplitinalign', sub {
     $capture->setAttribute(align   => 'center'); },
   # Skip a column (for left/right alignment)
   afterDigest => sub { LookupValue('Alignment')->nextColumn; return; },
-  reversion => '', sizer => 0);
+  reversion   => '', sizer => 0);
 
 DefMacro('\split',
   '\if@in@ams@align\lx@ams@marksplitinalign\fi'
@@ -706,8 +706,8 @@ DefConstructor('\eqref Semiverbatim', "(<ltx:ref labelref='#label' _force_font='
 DefMacro('\thetag{}', '{\rm #1}');
 
 # Section 3.11.3 Subordinate numbering sequences.
-DefMacro('\subequations',    '\lx@equationgroup@subnumbering@begin');
-DefMacro('\endsubequations', '\lx@equationgroup@subnumbering@end');
+DefMacro('\subequations',    '\lx@equationgroup@subnumbering@begin', locked => 1);
+DefMacro('\endsubequations', '\lx@equationgroup@subnumbering@end',   locked => 1);
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Section 4: Miscellaneous mathematical features
@@ -893,7 +893,7 @@ DefConstructor('\boxed@text{}',
     . "#1"
     . "</ltx:XMath>"
     . "</ltx:Math>",
-  mode => 'math', bounded => 1,
+  mode         => 'math', bounded => 1,
   beforeDigest => sub {
     Let("\\\\", '\@block@cr'); },
   alias => '\boxed');
@@ -1199,7 +1199,7 @@ DefConstructor('\sideset{}{}{}', sub {
       Warn('expected', '<sub/supserscript>', $document,
         "Expected a sub/superscript in the postscripts of \\sideset",
         "Got " . Stringify($nonscript));
-      $document->insertElement('ltx:XMWrap', $nonscript); }     # Append, afterwards
+      $document->insertElement('ltx:XMWrap', $nonscript); }    # Append, afterwards
 });
 
 sub sidesetWrap {

--- a/lib/LaTeXML/Package/icml_support.sty.ltxml
+++ b/lib/LaTeXML/Package/icml_support.sty.ltxml
@@ -40,6 +40,8 @@ DefEnvironment('{icmlauthorlist}', '#body');
 
 # \icmlauthor{author}{labels}
 DefMacro('\icmlauthor{}{}', '\author{#1}');
+DefConstructor('\@@@address{}', "^ <ltx:contact role='address'>#1</ltx:contact>");
+DefMacro('\icmladdress{}', '\@add@to@frontmatter{ltx:creator}{\@@@address{#1}}');
 # \icmlaffiliation{label}{address}
 DefMacro('\icmlaffiliation{}{}', '');
 # \icmlcorrespondingauthor{author}{email}

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -77,6 +77,12 @@ DefKeyVal('LTXML', 'zoomout', 'Number', '', code => sub {
 DefKeyVal('LTXML', 'tokenlimit', 'Number', '', code => sub {
     $LaTeXML::TOKEN_LIMIT = int(ToString($_[1]));
     return; });
+DefKeyVal('LTXML', 'iflimit', 'Number', '', code => sub {
+    $LaTeXML::IF_LIMIT = int(ToString($_[1]));
+    return; });
+DefKeyVal('LTXML', 'absorblimit', 'Number', '', code => sub {
+    $LaTeXML::ABSORB_LIMIT = int(ToString($_[1]));
+    return; });
 
 ProcessOptions(inorder => 1, keysets => ['LTXML']);
 #======================================================================

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -83,6 +83,9 @@ DefKeyVal('LTXML', 'iflimit', 'Number', '', code => sub {
 DefKeyVal('LTXML', 'absorblimit', 'Number', '', code => sub {
     $LaTeXML::ABSORB_LIMIT = int(ToString($_[1]));
     return; });
+DefKeyVal('LTXML', 'pushbacklimit', 'Number', '', code => sub {
+    $LaTeXML::PUSHBACK_LIMIT = int(ToString($_[1]));
+    return; });
 
 ProcessOptions(inorder => 1, keysets => ['LTXML']);
 #======================================================================

--- a/lib/LaTeXML/Package/subeqn.sty.ltxml
+++ b/lib/LaTeXML/Package/subeqn.sty.ltxml
@@ -1,0 +1,26 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  subeqn.sty                                                         | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@nist.gov>                          #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+# Basic subequation support for arXiv:
+
+DefMacro('\subequations',    '\lx@equationgroup@subnumbering@begin', locked => 1);
+DefMacro('\endsubequations', '\lx@equationgroup@subnumbering@end',   locked => 1);
+
+#**********************************************************************
+
+1;


### PR DESCRIPTION
I combined a few diverse bits in what is hopefully my last "tour of the territory" PR for arXiv before we start the big run.

* misc macros added: `\vsplit`, `\icmladdress`, `\@killglue`
* added a small binding for subeqn.sty
* locked the math font directives such as `\mathbf`
* silenced a couple of cosmetic perl "undef value" warnings from recent commits
* new guards following `tokenlimit` from #1736 - `iflimit` and `absorblimit`, which allow to catch some out-of-memory errors early, as well as reduce timeouts in those two code paths down to ~5 minutes.

Guard values that I've used that get the large books to pass:
 * tokenlimit: `99,999,999`
 * iflimit: `199,999`
 * absorblimit: `1,099,999`
 * pushbacklimit: `99,999`

The absorb limit value may be a little tight, it is just enough to get the 11 chapter book for arXiv:2105.10386 to pass through successfully.

Using these for e.g. arXiv:math/0408299, I now see:
```
Fatal:timeout:if_limit Conditional limit of 199999 exceeded, infinite loop?
	at TeX.pool.ltxml; line 748
	In Core::Definition::Conditional[\ifdim ... /home/deyan/perl5/lib/perl5/LaTeXML/Package/TeX.pool.ltxml; line 748
Conversion complete: 1 warning; 1 error; 1 fatal error; 1 missing file[diagram] (See /tmp/import_1992965.latexml.log)
Status:conversion:3

real	5m24.539s
user	5m21.697s
sys	0m2.680s
```

for a reasonable early-stop outcome. I am also going to up the latexml RAM limit to 5 GB in the latexml workers, again to get the big books passing without issue.

Edit: I also added a limit to pushback size, which is quite efficient in catching the "fork bomb" cases early, at least the ones which accumulate in the Gullet pushback - and I'm assuming that is most of the cases we're likely to spot in arXiv