### PR TITLE
Make \label not disappear on reversion, except for tex strings

### DIFF
--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -715,7 +715,7 @@ sub merge {
   $shape     = $$self[2] if (!defined $shape)  || ($oflags & $FLAG_FORCE_SHAPE);
   $size      = $$self[3] if (!defined $size);
   $color     = $$self[4] if (!defined $color);
-  $bg        = $$self[5] if (!defined $bg);
+  $bg        = $$self[5] if (!exists $options{background});
   $opacity   = $$self[6] if (!defined $opacity);
   $encoding  = $$self[7] if (!defined $encoding);
   $language  = $$self[8] if (!defined $language);

--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -502,7 +502,7 @@ sub computeStringSize {
     $w += int($cw * $size);
     if (my $kern = $chars[0] && $$metric{kerns}{ $char . $chars[0] }) {
       $w += int($size * $kern); }
-    if ($ismath) {
+    if ($ismath && $ci) {
       $w += int($size * $ci); }
     $h = max($h, int($ch * $size));
     $d = max($d, int($cd * $size)); }

--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -415,10 +415,11 @@ sub normalize_cell_sizes {
             . ") size " . showSize($cw, $ch, $cd)
             . " Boxes=" . ToString($boxes)) if $LaTeXML::DEBUG{halign} && $LaTeXML::DEBUG{size};
         my $empty =
-          ((!$cw) || $cw->valueOf < 1)
-          || (((!$ch) || $ch->valueOf < 1)
-          && ((!$cd) || $cd->valueOf < 1))
-          || !(grep { !$_->getProperty('isSpace'); } $boxes->unlist);
+          (((!$cw) || $cw->valueOf < 1)
+            || (((!$ch) || $ch->valueOf < 1)
+            && ((!$cd) || $cd->valueOf < 1))
+            || !(grep { !$_->getProperty('isSpace'); } $boxes->unlist)
+          ) && !preservedBoxes($boxes);
         $$cell{cwidth}  = $w || Dimension(0);
         $$cell{cheight} = $h || Dimension(0);
         $$cell{cdepth}  = $d || Dimension(0);

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -324,6 +324,7 @@ sub egroup {
 sub begingroup {
   my ($self) = @_;
   pushStackFrame($self, 1);
+  $LaTeXML::ALIGN_STATE++;                      # Should this ALSO be done for \begingroup????
   return; }
 
 sub endgroup {
@@ -334,6 +335,7 @@ sub endgroup {
       $self->currentFrameMessage); }
   else {                                         # Don't pop if there's an error; maybe we'll recover?
     popStackFrame($self, 1); }
+  $LaTeXML::ALIGN_STATE--;                       # Should this ALSO be done for \endgroup???
   return; }
 
 #======================================================================

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2138,7 +2138,7 @@ Tag('ltx:Math', afterOpen => sub { GenerateID(@_, 'm'); });
 # They provide an environment to wrap around equations,
 # which hijack the equation counter to sub-number within the group.
 DefConstructor('\lx@equationgroup@subnumbering@begin',
-  "<ltx:equationgroup xml:id='#id'>#tags",
+  "<ltx:equationgroup xml:id='#id'>",
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my %eqn   = RefStepCounter('equation');
@@ -2205,9 +2205,10 @@ DefPrimitive('\@equationgroup@numbering RequiredKeyVals', sub {
 # ========================================
 # Some special kinds of rows...
 DefConditionalI('\if@in@firstcolumn', undef, sub {
-    my $x = LookupValue('Alignment');
-    $x = ($x ? $x->currentColumnNumber : 9);
-    $x < 2; });
+    my $alignment = LookupValue('Alignment');
+    my $n         = ($alignment ? $alignment->currentColumnNumber : 9);
+    return ($alignment && (($alignment->currentColumnNumber < 2) || !$$alignment{in_row})); });
+
 # A bit more defensiveness, since people abuse eqnarray so badly.
 # Eg. &&\lefteqn{...}  whatever?!?!
 DefMacro('\lefteqn{}',
@@ -2236,9 +2237,6 @@ DefMacro('\csname endeqnarray*\endcsname',
 
 DefPrimitive('\@eqnarray@bindings', sub {
     eqnarrayBindings(); });
-
-DefPrimitiveI('\eqnarray@row@before', undef, sub { beforeEquation(); });
-DefPrimitiveI('\eqnarray@row@after',  undef, sub { afterEquation(); });
 
 DefPrimitiveI('\eqnarray@row@before@', undef, sub { beforeEquation(); });
 DefPrimitiveI('\eqnarray@row@after@',  undef, sub { afterEquation(); });
@@ -2286,7 +2284,7 @@ sub eqnarrayBindings {
 
 # A \label preceding \lefteqn throws of the implied \omit,e tc; so wrap in \hidden@align
 DefMacro('\lx@eqnarray@label Semiverbatim',
-'\ifnum1>\@alignment@column\hidden@noalign{\lx@eqnarray@save@label{#1}}\else\lx@eqnarray@save@label{#1}\fi');
+  '\hidden@noalign{\lx@eqnarray@save@label{#1}}');
 
 DefConstructor('\@@eqnarray SkipSpaces DigestedBody',
   '#1',

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3626,7 +3626,8 @@ DefConstructor('\label Semiverbatim', sub {
       my %labels = map { ($_ => 1) } $label, split(/\s+/, $node->getAttribute('labels') || '');
       $document->setAttribute($node, labels => join(' ', sort keys %labels));
       $document->setNode($savenode); } },
-  reversion   => '',
+  reversion => sub {    # disappear from tex/content-tex strings, but NOT in general reversion!
+    (defined $LaTeXML::DUAL_BRANCH ? () : Tokens(T_CS('\label'), T_BEGIN, Revert($_[1]), T_END)); },
   properties  => { alignmentSkippable => 1, alignmentPreserve => 1 },
   afterDigest => sub {
     MaybeNoteLabel($_[1]->getArg(1));

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2656,7 +2656,9 @@ DefMacroI('\tabularnewline', undef, '\cr');    # ???
 
 # Like \noalign, takes an arg; handled within alignment processing.
 # But doesn't create a pseudo-row (??? Or does it?; is it still needed?)
-DefPrimitiveI('\hidden@noalign', undef);
+DefConstructor('\hidden@noalign{}', '#1',
+  reversion  => '',
+  properties => { alignmentSkippable => 1 });
 
 DefMacro('\@alignment@hline', '\noalign{\@@alignment@hline}');
 DefConstructorI('\@@alignment@hline', undef, '',
@@ -3047,7 +3049,7 @@ sub digestAlignmentColumn {
         return ($r, T_CS('\cr'), 'cr'), undef; }    # Pretend this is a whole row???
       elsif (Equals($token, T_CS('\hidden@noalign'))) {    # \puts something in vertical list
         Debug("Halign $alignment: COLUMN invisible noalign") if $LaTeXML::DEBUG{halign};
-        $stomach->digest($gullet->readArg); }              # Purely for side effect!
+        push(@LaTeXML::LIST, $stomach->invokeToken($token)); }
       else {
         last; } }
     Debug("Halign $alignment: COLUMN end scan at " . Stringify($token)) if $LaTeXML::DEBUG{halign};
@@ -3078,7 +3080,7 @@ sub digestAlignmentColumn {
             $token, $type, $hidden); } }
       elsif (Equals($token, T_CS('\hidden@noalign'))) {    # \puts something in vertical list
         Debug("Halign $alignment: COLUMN invisible noalign") if $LaTeXML::DEBUG{halign};
-        $stomach->digest($gullet->readArg); }
+        push(@LaTeXML::LIST, $stomach->invokeToken($token)); }
       else {    # Else, we're getting some actual content for the column
         Debug("Halign $alignment: COLUMN invoking " . Stringify($token)) if $LaTeXML::DEBUG{halign};
         push(@LaTeXML::LIST, $stomach->invokeToken($token));
@@ -3105,41 +3107,13 @@ sub trimColumnTemplate {
   while (scalar(@pre) && scalar(@tokens)) {
     my $t = shift(@pre);
     if ($t->equals($tokens[0])) {
-      shift(@tokens);
-      if ($t->equals(T_CS('\hidden@noalign'))) {
-        @tokens = shiftArg(@tokens);
-        @pre    = shiftArg(@pre); } } }
+      shift(@tokens); } }
   while (scalar(@post) && scalar(@tokens)) {
     my $t = pop(@post);
     if ($t->equals($tokens[-1])) {
-      pop(@tokens);
-## This would need to detect \hidden@noalign IN FRONT of the balanced {}!!! else put the "arg" back
-##      if ($t->equals(T_CS('\hidden@noalign'))) { # DOH!!! This can't work; trigger on "}" ?????
-##        @tokens = popArg(@tokens);
-##        @post   = popArg(@post); }
-  } }
+      pop(@tokens); } }
   Debug("  Trimmed: " . ToString(Tokens(@tokens))) if $LaTeXML::DEBUG{halign};
   return Tokens(@tokens); }
-
-sub shiftArg {
-  my (@tokens) = @_;
-  my $level = 0;
-  while (my $t = shift(@tokens)) {
-    my $cc = $$t[1];
-    if    ($cc == CC_BEGIN) { $level++; }
-    elsif ($cc == CC_END)   { $level--; }
-    last if $level <= 0; }
-  return @tokens; }
-
-sub popArg {
-  my (@tokens) = @_;
-  my $level = 0;
-  while (my $t = pop(@tokens)) {
-    my $cc = $$t[1];
-    if    ($cc == CC_END)   { $level++; }
-    elsif ($cc == CC_BEGIN) { $level--; }
-    last if $level <= 0; }
-  return @tokens; }
 
 # Given the boxes for an alignment cell,
 # extract & remove the various fills and rules from the ends to annotate the cell structure
@@ -6517,6 +6491,8 @@ DefPrimitive('\lx@gen@cases@bindings RequiredKeyVals:lx@GEN', sub {
               T_CS('\hfil')) }]),
       'math');
     Let("\\\\", '\@alignment@newline');
+    DefMacro('\@row@before', '');    # Don't inherit counter stepping from containing environments
+    DefMacro('\@row@after',  '');
 });
 
 DefMacro('\lx@gen@plain@cases{}{}',

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2658,7 +2658,10 @@ DefMacroI('\tabularnewline', undef, '\cr');    # ???
 # But doesn't create a pseudo-row (??? Or does it?; is it still needed?)
 DefConstructor('\hidden@noalign{}', '#1',
   reversion  => '',
-  properties => { alignmentSkippable => 1 });
+  properties => sub {
+    # Sometimes, we're smuggling stuff that needs to be carried into the XML.
+    my $preserve = grep { $_->getProperty('alignmentPreserve'); } $_[1]->unlist;
+    (alignmentSkippable => 1, alignmentPreserve => $preserve); });
 
 DefMacro('\@alignment@hline', '\noalign{\@@alignment@hline}');
 DefConstructorI('\@@alignment@hline', undef, '',

--- a/lib/LaTeXML/Package/colortbl.sty.ltxml
+++ b/lib/LaTeXML/Package/colortbl.sty.ltxml
@@ -32,7 +32,9 @@ RequirePackage('array');
 # cell & column seem to work out by themselves, but getting row to override
 # needs a bit of help:
 DefConditional('\if@@rowcolored', sub { LookupValue('tabular_row_color'); });
-DefPrimitive('\@clearrowcolor', sub { AssignValue(tabular_row_color => undef, 'global'); });
+DefPrimitive('\@clearrowcolor', sub {
+    MergeFont(background => undef);
+    AssignValue(tabular_row_color => undef, 'global'); });
 AddToMacro('\@tabular@row@after', '\hidden@noalign{\@clearrowcolor}');
 
 AddToMacro('\@tabular@column@before', '\@userowcolor');
@@ -50,7 +52,8 @@ DefMacro('\columncolor[]{}[][]',
 
 # \rowcolor[<model>]{<color>}
 # Set the background color, and arrange for it to attach to the ltx:td
-DefMacro('\rowcolor[]{}', '\ifx.#1.\pagecolor{#2}\else\pagecolor[#1]{#2}\fi\@setrowcolor');
+DefMacro('\rowcolor[]{}',
+  '\hidden@noalign{\ifx.#1.\pagecolor{#2}\else\pagecolor[#1]{#2}\fi\@setrowcolor}');
 
 # \cellcolor[<model>]{<color>}
 # Set the background color (we should already be in a cell),
@@ -62,7 +65,8 @@ DefConstructor('\@setrowcolor', sub {
     my ($document, %props) = @_;
     if (my $bg = $props{background}) {    # only set if explicitly set a color
       if (my $node = $document->findnode('ancestor-or-self::ltx:tr', $document->getNode)) {
-        $document->setAttribute($node, backgroundcolor => $bg); } } },
+        if (!$node->hasAttribute('backgroundcolor')) {
+          $document->setAttribute($node, backgroundcolor => $bg); } } } },
   afterDigest => sub { my $bg = $_[1]->getProperty('font')->getBackground;
     $_[1]->setProperty(background => $bg);
     AssignValue(tabular_row_color => $bg, 'global'); },

--- a/lib/LaTeXML/Package/xcolor.sty.ltxml
+++ b/lib/LaTeXML/Package/xcolor.sty.ltxml
@@ -742,7 +742,8 @@ DefConstructor('\@tabular@row@before@xcolor', sub {
     my ($document, %props) = @_;
     if (my $bg = $props{background}) {    # only set if explicitly set a color
       if (my $node = $document->findnode('ancestor-or-self::ltx:tr', $document->getNode)) {
-        $document->setAttribute($node, backgroundcolor => $bg); } }
+        if (!$node->hasAttribute('backgroundcolor')) {
+          $document->setAttribute($node, backgroundcolor => $bg); } } }
     return; },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;

--- a/t/alignment/colortbls.xml
+++ b/t/alignment/colortbls.xml
@@ -212,8 +212,7 @@ or by adding some negative space (in a ”“noalign” between rows.</text></td
             <td align="center" border="r">two</td>
           </tr>
           <tr backgroundcolor="#FF0000">
-            <td align="left" border="l r" thead="row"><text backgroundcolor="#FF0000">
-three</text></td>
+            <td align="left" border="l r" thead="row"><text backgroundcolor="#FF0000">three</text></td>
             <td align="center" border="r"><text backgroundcolor="#FF0000">four</text></td>
           </tr>
         </tbody>
@@ -241,8 +240,7 @@ three</text></td>
             <td align="center" backgroundcolor="#0000FF" border="r"><text backgroundcolor="#0000FF">two</text></td>
           </tr>
           <tr backgroundcolor="#FF0000">
-            <td align="left" border="l r" thead="row"><text backgroundcolor="#FF0000">
-three</text></td>
+            <td align="left" border="l r" thead="row"><text backgroundcolor="#FF0000">three</text></td>
             <td align="center" border="r"><text backgroundcolor="#FF0000">four</text></td>
           </tr>
         </tbody>
@@ -256,8 +254,7 @@ three</text></td>
             <td align="center" backgroundcolor="#0000FF" border="r"><text backgroundcolor="#0000FF">two</text></td>
           </tr>
           <tr backgroundcolor="#FF0000">
-            <td align="left" border="l r" thead="row"><text backgroundcolor="#FF0000">
-three</text></td>
+            <td align="left" border="l r" thead="row"><text backgroundcolor="#FF0000">three</text></td>
             <td align="center" backgroundcolor="#00FF00" border="r"><text backgroundcolor="#00FF00">four</text></td>
           </tr>
         </tbody>

--- a/t/ams/amsdisplay.xml
+++ b/t/ams/amsdisplay.xml
@@ -843,10 +843,6 @@
   <para xml:id="p2">
     <p>Sub-numbered equations</p>
     <equationgroup xml:id="S0.E14">
-      <tags>
-        <tag>(14)</tag>
-        <tag role="refnum">14</tag>
-      </tags>
       <equation xml:id="S0.E14.1">
         <tags>
           <tag>(14a)</tag>
@@ -890,10 +886,6 @@
   <para xml:id="p3">
     <p>Subnumbered, but some unnumbered (before/after) or tagged explicitly (before/after)</p>
     <equationgroup xml:id="S0.E15">
-      <tags>
-        <tag>(15)</tag>
-        <tag role="refnum">15</tag>
-      </tags>
       <equation xml:id="S0.E15.1">
         <tags>
           <tag>(15a)</tag>

--- a/t/graphics/xcolors.xml
+++ b/t/graphics/xcolors.xml
@@ -281,8 +281,7 @@ A=100*13 = 1300pt;</p>
             <td align="left" border="t"><text backgroundcolor="#FFFF80">row 2</text></td>
           </tr>
           <tr backgroundcolor="#BFBFFF">
-            <td align="left" border="t"><text backgroundcolor="#BFBFFF">
-test</text></td>
+            <td align="left" border="t"><text backgroundcolor="#BFBFFF">test</text></td>
             <td align="left" border="t"><text backgroundcolor="#BFBFFF">row 3</text></td>
           </tr>
           <tr backgroundcolor="#FFFF80">


### PR DESCRIPTION
So, it appears that reversion is getting used for more substantial things than creating tex/content-tex strings for math & images, so we have to be more careful about what disappears and when. Ultimately may need a more fundamental fix, but this works for the most obvious case.

fixes #1703