### PR TITLE
add a ltx_tabbing styling hook; \par around {tabbing}

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3354,9 +3354,9 @@ DefRegister('\marginparpush', Dimension(0));
 DefRegister('\tabbingsep' => Dimension(0));
 
 DefMacroI('\tabbing', undef,
-  '\@tabbing@bindings\@@tabbing\@start@alignment');
+  '\par\@tabbing@bindings\@@tabbing\@start@alignment');
 DefMacroI('\endtabbing', undef,
-  '\@finish@alignment\@end@tabbing');
+  '\@finish@alignment\@end@tabbing\par');
 DefPrimitiveI('\@end@tabbing', undef, sub { $_[0]->egroup; });
 DefConstructor('\@@tabbing SkipSpaces DigestedBody',
   '#1',
@@ -3409,7 +3409,9 @@ sub tabbingBindings {
       openRow        => sub { $_[0]->openElement('ltx:tr', @_[1 .. $#_]); },
       closeRow       => sub { $_[0]->closeElement('ltx:tr'); },
       openColumn     => sub { $_[0]->openElement('ltx:td', @_[1 .. $#_]); },
-      closeColumn    => sub { $_[0]->closeElement('ltx:td'); }));
+      closeColumn    => sub { $_[0]->closeElement('ltx:td'); },
+      properties     => { attributes => { 'class' => 'ltx_tabbing' } }));
+
   Let("\\=",              '\@tabbing@tabset');
   Let("\\>",              '\@tabbing@nexttab');
   Let("\\\\",             '\@tabbing@newline');

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -125,6 +125,10 @@ td.ltx_subfloat { width:50%; }
 .ltx_tabular .ltx_tabular { width:100%; }
 .ltx_inline-block { display:inline-block; }
 
+/* tabbing is always a standalone paragraph-level construct */
+.ltx_tabular.ltx_tabbing { 
+  display: table; }
+
 /* avoid padding when aligning adjacent columns, e.g. for split decimals */
 .ltx_norightpad { padding-right:0!important; }
 .ltx_noleftpad  { padding-left:0!important; }

--- a/t/alignment/tabbing.xml
+++ b/t/alignment/tabbing.xml
@@ -5,7 +5,7 @@
   <resource src="LaTeXML.css" type="text/css"/>
   <resource src="ltx-article.css" type="text/css"/>
   <para xml:id="p1">
-    <tabular>
+    <tabular class="ltx_tabbing">
       <tr>
         <td align="left">one</td>
         <td align="left">two</td>
@@ -31,7 +31,7 @@
     </tabular>
   </para>
   <para xml:id="p2">
-    <tabular>
+    <tabular class="ltx_tabbing">
       <tr>
         <td align="left">pc</td>
         <td align="left">Pica = 12pt</td>
@@ -50,7 +50,7 @@
     </tabular>
   </para>
   <para xml:id="p3">
-    <tabular>
+    <tabular class="ltx_tabbing">
       <tr>
         <td align="left"><text font="bold">program</text> test</td>
         <td/>


### PR DESCRIPTION
Fixes #1719 

* adding `\par` breaks around {tabbing}
* adding a `ltx_tabbing` class to hook any custom styling downstream of latexml.