### PR TITLE
Fallback to case-insensitive path search

### DIFF
--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -141,12 +141,6 @@ sub findGraphicFile {
     my @paths = pathname_findall($file, paths => $LaTeXML::Post::Graphics::SEARCHPATHS,
       # accept empty type, incase bad type name, but actual file's content is known type.
       types => ['', $self->getGraphicsSourceTypes]);
-    # Fallback: if we couldn't find a single file, do the search again, assuming
-    # a case-insensitive file system
-    if (!@paths) {
-      @paths = pathname_findall_nocase($file, paths => $LaTeXML::Post::Graphics::SEARCHPATHS,
-        # accept empty type, incase bad type name, but actual file's content is known type.
-        types => ['', $self->getGraphicsSourceTypes]); }
     my ($best, $bestpath) = (-1, undef);
     # Now, find the first image that is either the correct type,
     # or has the most desirable type mapping

--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -141,6 +141,12 @@ sub findGraphicFile {
     my @paths = pathname_findall($file, paths => $LaTeXML::Post::Graphics::SEARCHPATHS,
       # accept empty type, incase bad type name, but actual file's content is known type.
       types => ['', $self->getGraphicsSourceTypes]);
+    # Fallback: if we couldn't find a single file, do the search again, assuming
+    # a case-insensitive file system
+    if (!@paths) {
+      @paths = pathname_findall_nocase($file, paths => $LaTeXML::Post::Graphics::SEARCHPATHS,
+        # accept empty type, incase bad type name, but actual file's content is known type.
+        types => ['', $self->getGraphicsSourceTypes]); }
     my ($best, $bestpath) = (-1, undef);
     # Now, find the first image that is either the correct type,
     # or has the most desirable type mapping

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -327,7 +327,7 @@ sub pathname_findall {
     # To allow arbitrarily cased spellings,
     # lowercase the target path and all candidate paths
     $pathname = lc($pathname);
-    @paths    = grep { -f $_ } grep { lc($_) =~ /$pathname/ } keys %star_candidates; }
+    @paths    = grep { -f $_ } grep { lc($_) =~ /\Q$pathname\E/ } keys %star_candidates; }
   return @paths; }
 
 # It's presumably cheep to concatinate all the pathnames,

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -317,15 +317,16 @@ sub pathname_findall {
   return unless $pathname;
   my @paths = grep { -f $_ } candidate_pathnames($pathname, %options);
   if (!@paths) {    # Fallback:
-     # To allow arbitrarily cased spellings,
-     # lowercase the target path and all candidate paths
-    $pathname = lc($pathname);
+        # This is a bit of a slow call, but really quite OK to run in rare fallback cases
+        # an average arXiv article may return with ~50-100 pathnames when looking for '*' graphics
+    my ($pathdir, $name, $type) = pathname_split($pathname);
     my %star_candidates = ();
-    # This is a bit of a slow call, but really quite OK to run in rare fallback cases
-    # an average arXiv article may return with ~50-100 pathnames when looking for '*' graphics
-    for my $c (candidate_pathnames('*', %options)) {
+    for my $c (candidate_pathnames($pathdir ? "$pathdir/*" : '*', %options)) {
       $star_candidates{$c} = 1; }
-    @paths = grep { -f $_ } grep { lc($_) =~ /$pathname/ } keys %star_candidates; }
+    # To allow arbitrarily cased spellings,
+    # lowercase the target path and all candidate paths
+    $pathname = lc($pathname);
+    @paths    = grep { -f $_ } grep { lc($_) =~ /$pathname/ } keys %star_candidates; }
   return @paths; }
 
 # It's presumably cheep to concatinate all the pathnames,

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -377,18 +377,18 @@ sub candidate_pathnames {
   # Now, combine; precedence to leading directories.
   foreach my $dir (@dirs) {
     opendir(DIR, $dir) or next;
-    for my $local_file (readdir(DIR)) {
+    my @dir_files = readdir(DIR);
+    closedir(DIR);
+    for my $local_file (@dir_files) {
       for my $regex_pair (@regexes) {
         my ($i_regex, $regex) = @$regex_pair;
         if ($local_file =~ m/$i_regex/) {
           my $full_file = pathname_concat($dir, $local_file);
           push(@nocase_paths, $full_file);
-          # Always check if a strict match also exists on disk:
-          if (($local_file =~ m/$regex/) && (-f $full_file)) {
+          if ($local_file =~ m/$regex/) {
             # if we are only interested in the first match, return it:
             return ($full_file) if $options{findfirst};
-            push(@paths, $full_file); } } } }
-    closedir(DIR); }
+            push(@paths, $full_file); } } } } }
   # Fallback: if no strict matches were found, return any existing case-insensitive matches
   # Defer the -f check until we are sure we need it, to keep the usual cases fast.
   return @paths ? @paths : grep { -f $_ } @nocase_paths; }

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -391,7 +391,7 @@ sub candidate_pathnames {
             push(@paths, $full_file); } } } } }
   # Fallback: if no strict matches were found, return any existing case-insensitive matches
   # Defer the -f check until we are sure we need it, to keep the usual cases fast.
-  return @paths ? @paths : grep { -f $_ } @nocase_paths; }
+  return @paths ? @paths : @nocase_paths; }
 
 #======================================================================
 our $kpsewhich      = which($ENV{LATEXML_KPSEWHICH} || 'kpsewhich');

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -307,30 +307,17 @@ sub pathname_installation {
 sub pathname_find {
   my ($pathname, %options) = @_;
   return unless $pathname;
+  $options{findfirst} = 1;
   my @paths = candidate_pathnames($pathname, %options);
-  foreach my $path (@paths) {
-    return $path if -f $path; }
-  return; }
+  return $paths[0]; }
 
 sub pathname_findall {
   my ($pathname, %options) = @_;
   return unless $pathname;
-  my @paths = grep { -f $_ } candidate_pathnames($pathname, %options);
-  if (!@paths) {    # Fallback:
-        # This is a bit of a slow call, but really quite OK to run in rare fallback cases
-        # an average arXiv article may return with ~50-100 pathnames when looking for '*' graphics
-    my ($pathdir, $name, $type) = pathname_split($pathname);
-    my %star_candidates = ();
-    my $star_query      = $pathdir ? pathname_concat($pathdir, "*") : '*';
-    for my $c (candidate_pathnames($star_query, %options)) {
-      $star_candidates{$c} = 1; }
-    # To allow arbitrarily cased spellings,
-    # lowercase the target path and all candidate paths
-    $pathname = lc($pathname);
-    @paths    = grep { -f $_ } grep { lc($_) =~ /\Q$pathname\E/ } keys %star_candidates; }
-  return @paths; }
+  $options{findfirst} = undef;
+  return candidate_pathnames($pathname, %options); }
 
-# It's presumably cheep to concatinate all the pathnames,
+# It's presumably cheap to concatinate all the pathnames,
 # relative to the cost of testing for files,
 # and this simplifies overall.
 sub candidate_pathnames {
@@ -370,26 +357,41 @@ sub candidate_pathnames {
         push(@exts, '.' . $ext); } } }
   push(@exts, '') unless @exts;
 
-  my @paths = ();
+  my @paths        = ();
+  my @nocase_paths = ();
+  # Precompute the intended regexes to apply
+  my @regexes = ();
+  foreach my $ext (@exts) {
+    if ($name eq '*') {    # Unfortunately, we've got to test the file system NOW...
+      if ($ext eq '.*') {    # everything, except hidden files
+        push(@regexes, [qr/^[^.]/, qr/^[^.]/]); }
+      else {
+        push(@regexes, [qr/\Q$ext\E$/i,
+            qr/\Q$ext\E$/]); } }
+    elsif ($ext eq '.*') {
+      push(@regexes, [qr/^\Q$name\E\.\w+$/i,
+          qr/^\Q$name\E\.\w+$/]); }
+    else {
+      push(@regexes, [qr/^\Q$name\E\Q$ext\E$/i,
+          qr/^\Q$name\E\Q$ext\E$/]); } }
   # Now, combine; precedence to leading directories.
   foreach my $dir (@dirs) {
-    foreach my $ext (@exts) {
-      if ($name eq '*') {    # Unfortunately, we've got to test the file system NOW...
-        if ($ext eq '.*') {    # everything
-          opendir(DIR, $dir) or next;
-          push(@paths, map { pathname_concat($dir, $_) } grep { !/^\./ } readdir(DIR));
-          closedir(DIR); }
-        else {
-          opendir(DIR, $dir) or next;    # ???
-          push(@paths, map { pathname_concat($dir, $_) } grep { /\Q$ext\E$/ } readdir(DIR));
-          closedir(DIR); } }
-      elsif ($ext eq '.*') {             # Unfortunately, we've got to test the file system NOW...
-        opendir(DIR, $dir) or next;      # ???
-        push(@paths, map { pathname_concat($dir, $_) } grep { /^\Q$name\E\.\w+$/ } readdir(DIR));
-        closedir(DIR); }
-      else {
-        push(@paths, pathname_concat($dir, $name . $ext)); } } }
-  return @paths; }
+    opendir(DIR, $dir) or next;
+    for my $local_file (readdir(DIR)) {
+      for my $regex_pair (@regexes) {
+        my ($i_regex, $regex) = @$regex_pair;
+        if ($local_file =~ m/$i_regex/) {
+          my $full_file = pathname_concat($dir, $local_file);
+          push(@nocase_paths, $full_file);
+          # Always check if a strict match also exists on disk:
+          if (($local_file =~ m/$regex/) && (-f $full_file)) {
+            # if we are only interested in the first match, return it:
+            return ($full_file) if $options{findfirst};
+            push(@paths, $full_file); } } } }
+    closedir(DIR); }
+  # Fallback: if no strict matches were found, return any existing case-insensitive matches
+  # Defer the -f check until we are sure we need it, to keep the usual cases fast.
+  return @paths ? @paths : grep { -f $_ } @nocase_paths; }
 
 #======================================================================
 our $kpsewhich      = which($ENV{LATEXML_KPSEWHICH} || 'kpsewhich');

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -33,8 +33,7 @@ use File::Copy;
 use File::Which;
 use Cwd;
 use base qw(Exporter);
-our @EXPORT = qw( &pathname_find
-  &pathname_findall &pathname_findall_nocase &pathname_kpsewhich
+our @EXPORT = qw( &pathname_find &pathname_findall &pathname_kpsewhich
   &pathname_make &pathname_canonical
   &pathname_split &pathname_directory &pathname_name &pathname_type
   &pathname_timestamp
@@ -316,21 +315,17 @@ sub pathname_find {
 sub pathname_findall {
   my ($pathname, %options) = @_;
   return unless $pathname;
-  my @paths = candidate_pathnames($pathname, %options);
-  return grep { -f $_ } @paths; }
-
-sub pathname_findall_nocase {
-  my ($pathname, %options) = @_;
-  return unless $pathname;
-  # To allow arbitrarily cased spellings,
-  # lowercase the target path and all candidate paths
-  $pathname = lc($pathname);
-  my %star_candidates = ();
-  # This is a bit of a slow call, but really quite OK to run in rare fallback cases
-  # an average arXiv article may return with ~50-100 pathnames when looking for '*' graphics
-  for my $c (candidate_pathnames('*', %options)) {
-    $star_candidates{$c} = 1; }
-  my @paths = grep { -f $_ } grep { lc($_) =~ /$pathname/ } keys %star_candidates;
+  my @paths = grep { -f $_ } candidate_pathnames($pathname, %options);
+  if (!@paths) {    # Fallback:
+     # To allow arbitrarily cased spellings,
+     # lowercase the target path and all candidate paths
+    $pathname = lc($pathname);
+    my %star_candidates = ();
+    # This is a bit of a slow call, but really quite OK to run in rare fallback cases
+    # an average arXiv article may return with ~50-100 pathnames when looking for '*' graphics
+    for my $c (candidate_pathnames('*', %options)) {
+      $star_candidates{$c} = 1; }
+    @paths = grep { -f $_ } grep { lc($_) =~ /$pathname/ } keys %star_candidates; }
   return @paths; }
 
 # It's presumably cheep to concatinate all the pathnames,

--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -321,7 +321,8 @@ sub pathname_findall {
         # an average arXiv article may return with ~50-100 pathnames when looking for '*' graphics
     my ($pathdir, $name, $type) = pathname_split($pathname);
     my %star_candidates = ();
-    for my $c (candidate_pathnames($pathdir ? "$pathdir/*" : '*', %options)) {
+    my $star_query      = $pathdir ? pathname_concat($pathdir, "*") : '*';
+    for my $c (candidate_pathnames($star_query, %options)) {
       $star_candidates{$c} = 1; }
     # To allow arbitrarily cased spellings,
     # lowercase the target path and all candidate paths


### PR DESCRIPTION
Debugging with [2105.04404](https://ar5iv.org/html/2105.04404), I noticed an image that was failing to get picked up.

The author wrote:
```tex
\includegraphics[width=0.9\textwidth]{illu_blur_MNIST.pdf}
```

but included the file `illu_blur_mnist.pdf`. Naturally,  pdflatex finds the file despite the discrepancy in case, while latexml didn't - as we're looking for exact matches.

To add a simple and effective patch, I created a fallback sub `pathname_findall_nocase`, which takes the slow route of checking all paths, normalized to lowercase, for the desired one, also normalized to lowercase.

Hopefully this catch improves the visuals for all kinds of arXiv articles that were authored on case-insensitive file systems.