### PR TITLE
scaffold of support for \vdotswithin

### DIFF
--- a/lib/LaTeXML/Package/mathtools.sty.ltxml
+++ b/lib/LaTeXML/Package/mathtools.sty.ltxml
@@ -639,11 +639,17 @@ DefMacro('\Aboxed{}', '#1');
 # TODO: Make this actually do something
 DefMacro('\ArrowBetweenLines[]',                   '');
 DefMacro('\csname ArrowBetweenLines*\endcsname[]', '');
-DefMacro('\vdotswithin{}',                         '');
-DefMacro('\shortvdotswithin{}',                    '');
-DefMacro('\csname shortvdotswithin*\endcsname{}',  '');
-DefMacro('\MTFlushSpaceAbove',                     '');
-DefMacro('\MTFlushSpaceBelow',                     '');
+DefMacro('\vdotswithin{}', '\mathmakebox[\widthof{\ensuremath{{}#1{}}}][c]{\vdots}');
+DefMacro('\shortvdotswithin{}',
+  '\MTFlushSpaceAbove
+  & \vdotswithin{#1}
+  \MTFlushSpaceBelow');
+DefMacro('\csname shortvdotswithin*\endcsname{}',
+  '\MTFlushSpaceAbove
+  \vdotswithin{#1} &
+  \MTFlushSpaceBelow');
+DefMacro('\MTFlushSpaceAbove', '');
+DefMacro('\MTFlushSpaceBelow', '\\\\');
 
 ## 3.5
 Let('\shortintertext', '\@ams@intertext');

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -7453,9 +7453,26 @@ Then a switch of tag forms.</p>
             </MathBranch>
           </MathFork>
         </equation>
-        <equation xml:id="S12.Ex88">
+        <equation xml:id="S12.Ex87">
           <MathFork>
-            <Math tex="\displaystyle=c" text="absent = c" xml:id="S12.Ex88.m2">
+            <Math tex="\displaystyle\mathmakebox[\widthof{{}={}}][c]{\vdots}" text="vdots" xml:id="S12.Ex87.m2">
+              <XMath>
+                <XMTok name="vdots" role="ID">⋮</XMTok>
+              </XMath>
+            </Math>
+            <MathBranch>
+              <td/>
+              <td align="left"><Math mode="inline" tex="\displaystyle\mathmakebox[\widthof{{}={}}][c]{\vdots}" text="vdots" xml:id="S12.Ex87.m1">
+                  <XMath>
+                    <XMTok name="vdots" role="ID">⋮</XMTok>
+                  </XMath>
+                </Math></td>
+            </MathBranch>
+          </MathFork>
+        </equation>
+        <equation xml:id="S12.Ex89">
+          <MathFork>
+            <Math tex="\displaystyle=c" text="absent = c" xml:id="S12.Ex89.m2">
               <XMath>
                 <XMApp>
                   <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -7466,7 +7483,7 @@ Then a switch of tag forms.</p>
             </Math>
             <MathBranch>
               <td/>
-              <td align="left"><Math mode="inline" tex="\displaystyle=c" text="absent = c" xml:id="S12.Ex88.m1">
+              <td align="left"><Math mode="inline" tex="\displaystyle=c" text="absent = c" xml:id="S12.Ex89.m1">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -7478,9 +7495,26 @@ Then a switch of tag forms.</p>
             </MathBranch>
           </MathFork>
         </equation>
-        <equation xml:id="S12.Ex89">
+        <equation xml:id="S12.Ex90">
           <MathFork>
-            <Math tex="\displaystyle=d" text="absent = d" xml:id="S12.Ex89.m2">
+            <Math tex="\displaystyle\mathmakebox[\widthof{{}={}}][c]{\vdots}" text="vdots" xml:id="S12.Ex90.m2">
+              <XMath>
+                <XMTok name="vdots" role="ID">⋮</XMTok>
+              </XMath>
+            </Math>
+            <MathBranch>
+              <td/>
+              <td align="left"><Math mode="inline" tex="\displaystyle\mathmakebox[\widthof{{}={}}][c]{\vdots}" text="vdots" xml:id="S12.Ex90.m1">
+                  <XMath>
+                    <XMTok name="vdots" role="ID">⋮</XMTok>
+                  </XMath>
+                </Math></td>
+            </MathBranch>
+          </MathFork>
+        </equation>
+        <equation xml:id="S12.Ex91">
+          <MathFork>
+            <Math tex="\displaystyle=d" text="absent = d" xml:id="S12.Ex91.m2">
               <XMath>
                 <XMApp>
                   <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -7491,7 +7525,7 @@ Then a switch of tag forms.</p>
             </Math>
             <MathBranch>
               <td/>
-              <td align="left"><Math mode="inline" tex="\displaystyle=d" text="absent = d" xml:id="S12.Ex89.m1">
+              <td align="left"><Math mode="inline" tex="\displaystyle=d" text="absent = d" xml:id="S12.Ex91.m1">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="equals" role="RELOP">=</XMTok>


### PR DESCRIPTION
Fixes #1672 .

It is a partial upgrade (the centering of the vdots is not *yet* supported). The issue description seemed to be happy with that as a first step, so here it is.

Minimal example from the mathtools docs:
```tex
\documentclass{article}
\usepackage{mathtools}
\begin{document}

\begin{align*}
a &= b \\
& \vdotswithin{=} \\
& = c \\
\shortvdotswithin{=}
& = d
\end{align*}
\end{document}
```

before:
<img src="https://user-images.githubusercontent.com/348975/146646380-f6d89bb8-0043-4971-8d41-a1650cf4072d.png" width=400>

after:
<img src="https://user-images.githubusercontent.com/348975/146646355-ac620a69-2353-4b59-8e03-00b396607d57.png" width=400>
