### PR TITLE
Stub in some latex3 hooks used in texlive 2020

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -6020,6 +6020,29 @@ RequirePackage('textcomp');
 #
 # For now, a few macros required by other packages will be included:
 DefMacroI(T_CS('\hook_gput_code:nnn'), '{}{}{}', '');
+DefMacro('\NewHook{}',                    '');
+DefMacro('\NewReversedHook{}',            '');
+DefMacro('\NewMirroredHookPair{}{}',      '');
+DefMacro('\ActivateGenericHook{}',        '');
+DefMacro('\DisableGenericHook{}',         '');
+DefMacro('\AddToHook{}[]{}',              '');
+DefMacro('\AddToHookNext{}{}',            '');
+DefMacro('\ClearHookNext{}',              '');
+DefMacro('\RemoveFromHook{}[]',           '');
+DefMacro('\SetDefaultHookLabel{}',        '');
+DefMacro('\PushDefaultHookLabel{}',       '');
+DefMacro('\PopDefaultHookLabel',          '');
+DefMacro('\UseHook{}',                    '');
+DefMacro('\UseOneTimeHook{}',             '');
+DefMacro('\ShowHook{}',                   '');
+DefMacro('\LogHook{}',                    '');
+DefMacro('\DebugHooksOn',                 '');
+DefMacro('\DebugHooksOff',                '');
+DefMacro('\DeclareHookRule{}{}{}{}',      '');
+DefMacro('\DeclareDefaultHookRule{}{}{}', '');
+DefMacro('\ClearHookRule{}{}{}',          '');
+DefMacro('\IfHookEmptyTF{}{}{}',          '');
+DefMacro('\IfHookExistsTF{}{}{}',         '');
 
 #**********************************************************************
 1;

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -6021,12 +6021,6 @@ RequirePackage('textcomp');
 #
 # For now, a few macros required by other packages will be included:
 DefMacroI(T_CS('\hook_gput_code:nnn'), '{}{}{}', '');
-# DefMacroI(T_CS('\sys_if_engine_luatex:T'),'{}','',locked=>1);
-# DefMacroI(T_CS('\sys_if_engine_pdftex:T'),'{}','',locked=>1);
-# DefMacroI(T_CS('\sys_if_engine_xetex:T'),'{}','',locked=>1);
-# DefMacroI(T_CS('\sys_if_engine_luatex:TF'),'{}{}','#2',locked=>1);
-# DefMacroI(T_CS('\sys_if_engine_pdftex:TF'),'{}{}','#2',locked=>1);
-# DefMacroI(T_CS('\sys_if_engine_xetex:TF'),'{}{}','#2',locked=>1);
 DefMacro('\NewHook{}',                    '');
 DefMacro('\NewReversedHook{}',            '');
 DefMacro('\NewMirroredHookPair{}{}',      '');

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2715,6 +2715,7 @@ DefPrimitive('\DeclareFontEncoding{}{}{}', sub {
 DefMacroI('\LastDeclaredEncoding', undef, '');
 DefPrimitive('\DeclareFontSubstitution{}{}{}{}', undef);
 DefPrimitive('\DeclareFontEncodingDefaults{}{}', undef);
+DefPrimitive('\DeclareEncodingSubset{}{}{}',     undef);
 DefMacroI('\LastDeclaredEncoding', undef, Tokens());
 
 DefPrimitive('\SetSymbolFont{}{}{}{}{}{}',   undef);
@@ -6020,6 +6021,12 @@ RequirePackage('textcomp');
 #
 # For now, a few macros required by other packages will be included:
 DefMacroI(T_CS('\hook_gput_code:nnn'), '{}{}{}', '');
+# DefMacroI(T_CS('\sys_if_engine_luatex:T'),'{}','',locked=>1);
+# DefMacroI(T_CS('\sys_if_engine_pdftex:T'),'{}','',locked=>1);
+# DefMacroI(T_CS('\sys_if_engine_xetex:T'),'{}','',locked=>1);
+# DefMacroI(T_CS('\sys_if_engine_luatex:TF'),'{}{}','#2',locked=>1);
+# DefMacroI(T_CS('\sys_if_engine_pdftex:TF'),'{}{}','#2',locked=>1);
+# DefMacroI(T_CS('\sys_if_engine_xetex:TF'),'{}{}','#2',locked=>1);
 DefMacro('\NewHook{}',                    '');
 DefMacro('\NewReversedHook{}',            '');
 DefMacro('\NewMirroredHookPair{}{}',      '');

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -6042,8 +6042,8 @@ DefMacro('\DebugHooksOff',                '');
 DefMacro('\DeclareHookRule{}{}{}{}',      '');
 DefMacro('\DeclareDefaultHookRule{}{}{}', '');
 DefMacro('\ClearHookRule{}{}{}',          '');
-DefMacro('\IfHookEmptyTF{}{}{}',          '');
-DefMacro('\IfHookExistsTF{}{}{}',         '');
+DefMacro('\IfHookEmptyTF{}{}{}',          '#3');
+DefMacro('\IfHookExistsTF{}{}{}',         '#3');
 
 #**********************************************************************
 1;

--- a/lib/LaTeXML/Package/pdfTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/pdfTeX.pool.ltxml
@@ -190,6 +190,8 @@ DefMacro('\quitvmode', '');
 DefPrimitive('\pdfliteral OptionalMatch:direct OptionalMatch:page GeneralText', undef);
 # \special pdfspecial spec
 # \pdfresettimer
+DefPrimitive('\pdfresettimer',           undef);
+DefPrimitive('\pdfresettimerresettimer', undef);
 # \pdfsetrandomseed number
 # \pdfnoligatures font
 # \pdfprimitive control sequence

--- a/lib/LaTeXML/Package/pdfTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/pdfTeX.pool.ltxml
@@ -110,8 +110,9 @@ DefMacro('\pdfunescapehex {}',        '');
 DefMacro('\pdfuniformdeviate Number Token', '');
 DefMacro('\pdfnormaldeviate Token',         '');
 DefMacro('\pdfmdfivesum Number {}',         '');
+DefMacro('\pdffilesize{}',                  '');
 DefMacro('\pdffilemoddate {}',              '');
-# DefMacro('\pdffiledump {}','');
+DefMacro('\pdffiledump {}',                 '');
 # DefMacro('\pdfcolorstackinit {}','');
 
 # Read-only registers

--- a/lib/LaTeXML/Package/pdftexcmds.sty.ltxml
+++ b/lib/LaTeXML/Package/pdftexcmds.sty.ltxml
@@ -17,13 +17,10 @@ use LaTeXML::Package;
 
 #**********************************************************************
 
-#InputDefinitions('pdftexcmds', type => 'sty', noltxml => 1);
+# Everything is in pdfTeX.pool already, and that is already loaded.
+# LoadPool('pdfTeX');
 
 RequirePackage('iftex');
-
-DefPrimitive('\pdffiledump',             undef);
-DefPrimitive('\pdffilesize',             undef);
-DefPrimitive('\pdfresettimerresettimer', undef);
 
 #**********************************************************************
 


### PR DESCRIPTION
First patches for minor errors caught by the sandboxes, due to the upgrade to texlive 2020 in particular. I double-checked the signatures with [lthooks](https://ctan.math.illinois.edu/macros/latex/base/lthooks-doc.pdf)

fixes 2111.00034, and improves the raw interpretation of eso-pic.sty to be trouble-free