### PR TITLE
deflate the full ZIP output

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -215,15 +215,12 @@ sub get_archive {
       or (print STDERR "Fatal:I/O:$pathname File $pathname is not readable.");
     my $file_contents = <$FH>;
     close($FH);
-    # Only compress the textual files
-    my $compression_level = ($file =~ /css|js|xml|html$/) ?
-      COMPRESSION_DEFLATED
-      : COMPRESSION_STORED;
-    $archive->addString($file_contents, $file,)->desiredCompressionMethod($compression_level); }
+    # Compress all files
+    $archive->addString($file_contents, $file,)->desiredCompressionMethod(COMPRESSION_DEFLATED); }
 
   foreach my $subdir (sort @subdirs) {
     my $current_dir = File::Spec->catdir($directory, $subdir);
-    $archive->addTree($current_dir, $subdir, sub { !/$archive_file_exclusion_regex/ }, COMPRESSION_STORED); }
+    $archive->addTree($current_dir, $subdir, sub { !/$archive_file_exclusion_regex/ }, COMPRESSION_DEFLATED); }
 
   my $payload;
   if ($whatsout =~ /^archive(::zip)?$/) {


### PR DESCRIPTION
Between fixing the path bug that was failing to find graphics, adding the `magnify=2` visual upgrade and arXiv getting quite bigger in 2021, I've ended up rather low on space on my server machines.

Maybe this small PR could be a big help, opting to deflate all assets, rather than only the main HTML one. I definitely had missed the `.log` files, but even `png` assets see a 1-3% size reduction, depending.