### PR TITLE
Auto-load graphicx on \includegraphics for arXiv

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3418,6 +3418,7 @@ DefMacro('\@xdblfloat{}[]',     '\@xfloat{#1}[#2]');
 DefMacro('\@floatplacement',    '');
 DefMacro('\@dblfloatplacement', '');
 
+DefAutoload('includegraphics', 'graphicx.sty.ltxml');
 #======================================================================
 # C.9.2 Marginal Notes
 #======================================================================

--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -43,12 +43,13 @@ DefKeyVal('Gin', 'magnifiable', '', 'true');
 
 # Redefine
 DefMacro('\includegraphics OptionalMatch:* []',
-  '\@ifnextchar[{\@includegraphics#1[#2]}{\@includegraphicx#1[#2]}');
+  '\@ifnextchar[{\@includegraphics#1[#2]}{\@includegraphicx#1[#2]}', scope => 'global');
 
 DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbatim',
   "<ltx:graphics graphic='#path' candidates='#candidates' options='#options'/>",
   alias      => '\includegraphics',
   sizer      => \&image_graphicx_sizer,
+  scope      => 'global',
   properties => sub {
     my ($stomach, $starred, $kv, $path) = @_;
     $path = ToString($path); $path =~ s/^\s+//; $path =~ s/\s+$//;


### PR DESCRIPTION
This PR falls fully in the OmniBus philosophy for recovering hard-to-predict old sources into usable HTML.

Specifically, I spotted the issue at [1804.11029](https://ar5iv.org/log/1804.11029), where seemingly unexplicably `\includegraphics` was failing to get defined. It turns out, this error is based on the dual possibility for arXiv submissions to be processed with the classic latex executable, or the newer pdflatex one -- information which is not part of the sources, but is instead submission metadata only available to arXiv itself. Thus, we can't really predict when and where such cases occur, and latexml's best strategy is (usually) to pretend to be pdflatex in some cases and "something unknown" in others.

In this specific case, we have the code:
```tex
% *** GRAPHICS RELATED PACKAGES ***
%
\ifCLASSINFOpdf
  % \usepackage[pdftex]{graphicx}
  % declare the path(s) where your graphic files are
  % \graphicspath{{../pdf/}{../jpeg/}}
  % and their extensions so you won't have to specify these with
  % every instance of \includegraphics
  % \DeclareGraphicsExtensions{.pdf,.jpeg,.png}
\else
  % or other class option (dvipsone, dvipdf, if not using dvips). graphicx
  % will default to the driver specified in the system graphics.cfg if no
  % driver is specified.
   \usepackage[dvips]{graphicx}
  % declare the path(s) where your graphic files are
   \graphicspath{{../eps/}}
  % and their extensions so you won't have to specify these with
  % every instance of \includegraphics
   \DeclareGraphicsExtensions{.eps}
\fi
```

which could have just as well been commented out inversely, if the pdflatex submission route was taken.

So, my best common sense guess at an upgrade for latexml here is to offer an `AutoLoad` directive for the `\includegraphics` macro specifically, given how it is one of the most standard commands in the latex ecosystem. Which works as expected and avoids the errors - so the PR is ready for review.

At time of writing, I can't imagine a way to improve our code for `\ifCLASSINFOpdf`, in the general arXiv case, without getting access to their submission metadata.

P.S. A nice extra trick is that the related DefMacro definitions in graphicx.sty.ltxml need to be made global in scope, as the fallback triggers deep within the document body, with lots of TeX groups open.