### PR TITLE
fix: autblk.sty.ltxml float marker 

### DIFF
--- a/lib/LaTeXML/Package/authblk.sty.ltxml
+++ b/lib/LaTeXML/Package/authblk.sty.ltxml
@@ -37,11 +37,11 @@ DefMacro('\lx@ab@author[]{}',
     . '{\@personname{#2}\lx@authormark{\if.#1.\the@affil\else#1\fi}}');
 
 DefConstructor('\lx@authormark{}',
-  "?#mark(^<ltx:contact role='affiliationmark' _mark='#mark'></ltx:contact>)()",
+  "^?#mark(<ltx:contact role='affiliationmark' _mark='#mark'></ltx:contact>)()",
   properties => sub { (mark => ToString($_[1])); });
 
 DefConstructor('\affil[]{}',
-  "?#2(^ <ltx:note mark='#mark' role='affiliationtext'>#2</ltx:note>)()",
+  "^?#2(<ltx:note mark='#mark' role='affiliationtext'>#2</ltx:note>)()",
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $mark = $whatsit->getArg(1);


### PR DESCRIPTION
An oversight on my part, not realizing the `^` float marker in replacement strings must be in the leading position.

As a result the arXiv rerun has a number of literal `^` chars deposited in the frontmatter of articles using autblk, which will have to be rerun.

[example article](https://ar5iv.org/html/1709.02756)