### PR TITLE
add \affilnum in OmniBus

### DIFF
--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -87,6 +87,8 @@ DefMacro('\altaffilmark{}', sub {
     map { (T_CS('\@altaffilmark'), T_BEGIN, @$_, T_END) } SplitTokens($marks, T_OTHER(',')); });
 DefConstructor('\@altaffilmark{}',
   "?#1(<ltx:note role='affiliationmark' mark='#1'/> )()");
+Let('\affilnum', '\@altaffilmark');
+
 DefConstructor('\altaffiltext{}{}',
   "?#2(<ltx:note role='affiliationtext' mark='#1'>#2</ltx:note>)()");
 


### PR DESCRIPTION
Spotted an easy macro that adds a literal mark in some newer journal styles, added it to OmniBus. 

This also requires [dedicated css rules](https://github.com/dginev/ar5iv-css/commit/d8e77ba0a0aae8116663fd52a89c4a51e6bd0a6a) for the arxiv preview, which disable the interactivity in these verbatim cases.

[example article](https://ar5iv.org/html/2111.14377)