### PR TITLE
Column flex fixes

### DIFF
--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -71,10 +71,11 @@ sub new {
   $$self{level}          = $STATE->getFrameDepth;
   $$self{properties}     = {} unless $$self{properties};
   # Copy any attribute width, height, depth to main properties.
+  # BUT remove them from XML attributes!!! (?)
   if (my $attributes = $$self{properties}{attributes}) {
-    $$self{properties}{width}  = $$attributes{width}  if $$attributes{width};
-    $$self{properties}{height} = $$attributes{height} if $$attributes{height};
-    $$self{properties}{depth}  = $$attributes{depth}  if $$attributes{depth}; }
+    foreach my $key (qw(width height depth)) {
+      if (my $val = $$attributes{$key}) {
+        $$self{properties}{$key} = $val; delete $$attributes{$key}; } } }
   return $self; }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/LaTeXML/Package/JHEP.cls.ltxml
+++ b/lib/LaTeXML/Package/JHEP.cls.ltxml
@@ -90,8 +90,8 @@ DefMacro('\DOUBLEFIGURE[]{}{}{}{}',
 DefEnvironment('{@half@doublefigure}',
   "<ltx:figure xml:id='#id' inlist='#inlist' width='0.45%'>#body</ltx:figure>"
     . "#tags",
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest => sub { RescueCaptionCounters('figure', $_[1]); });
+  beforeDigest => sub { beforeFloat('figure'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefMacro('\DOUBLETABLE[]{}{}{}{}',
   '\begin{table}[#1]'
@@ -101,8 +101,8 @@ DefMacro('\DOUBLETABLE[]{}{}{}{}',
 DefEnvironment('{@half@doubletable}',
   "<ltx:table xml:id='#id' inlist='#inlist' width='0.45%'>#body</ltx:table>"
     . "#tags",
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'table'); },
-  afterDigest => sub { RescueCaptionCounters('table', $_[1]); });
+  beforeDigest => sub { beforeFloat('table'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 # Redefine since JHEP has no width argument
 # (what width should be used?)
@@ -111,9 +111,9 @@ DefEnvironment('{floatingfigure}[]',
     . "#tags"
     . "#body"
     . "</ltx:figure>",
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest => sub { RescueCaptionCounters('figure', $_[1]); },
-  properties => sub {
+  beforeDigest => sub { beforeFloat('figure'); },
+  afterDigest  => sub { afterFloat($_[1]); },
+  properties   => sub {
     (float => (ToString($_[1] || LookupValue('floatfltpos')) =~ /^(v|r)/ ? 'right' : 'left')); });
 
 DefEnvironment('{floatingtable}[]',
@@ -121,9 +121,9 @@ DefEnvironment('{floatingtable}[]',
     . "#tags"
     . "#body"
     . "</ltx:table>",
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'table'); },
-  afterDigest => sub { RescueCaptionCounters('table', $_[1]); },
-  properties => sub {
+  beforeDigest => sub { beforeFloat('table'); },
+  afterDigest  => sub { afterFloat($_[1]); },
+  properties   => sub {
     (float => (ToString($_[1] || LookupValue('floatfltpos')) =~ /^(v|r)/ ? 'right' : 'left')); });
 
 #======================================================================
@@ -182,9 +182,9 @@ DefMacro('\ijtp{}{}{}', '\@spires{IJTPB\%2CB#1\%2C#3}{{\it Int.\ J.\ Theor.\ Phy
 DefMacro('\invm{}{}{}', '\@spires{INVMB\%2C#1\%2C#3}{{\it Invent.\ Math.\ }{\bf #1} (#2) #3}');
 DefMacro('\jag{}{}{}',  '\@spires{00124\%2C#1\%2C#3}{{\it J.\ Alg.\ Geom.\ }{\bf #1} (#2) #3}');
 DefMacro('\jams{}{}{}', '\@spires{00052\%2C#1\%2C#3}{{\it J.\ Am.\ Math.\ Soc.\ }{\bf #1} (#2) #3}');
-DefMacro('\jap{}{}{}', '\@spires{JAPIA\%2C#1\%2C#3}{{\it J.\ Appl.\ Phys.\ }{\bf #1} (#2) #3}');
-DefMacro('\jdg{}{}{}', '\@spires{JDGEA\%2C#1\%2C#3}{{\it J.\ Diff.\ Geom.\ }{\bf #1} (#2) #3}');
-DefMacro('\jgp{}{}{}', '\@spires{JGPHE\%2C#1\%2C#3}{{\it J.\ Geom.\ Phys.\ }{\bf #1} (#2) #3}');
+DefMacro('\jap{}{}{}',  '\@spires{JAPIA\%2C#1\%2C#3}{{\it J.\ Appl.\ Phys.\ }{\bf #1} (#2) #3}');
+DefMacro('\jdg{}{}{}',  '\@spires{JDGEA\%2C#1\%2C#3}{{\it J.\ Diff.\ Geom.\ }{\bf #1} (#2) #3}');
+DefMacro('\jgp{}{}{}',  '\@spires{JGPHE\%2C#1\%2C#3}{{\it J.\ Geom.\ Phys.\ }{\bf #1} (#2) #3}');
 DefMacro('\jhep{}{}{}', '\href{http://jhep.sissa.it/stdsearch?paper=#1\%28#2\%29#3}{{\it J. High Energy Phys.\ }{\bf #1} (#2) #3}');
 DefMacro('\jmp{}{}{}',  '\@spires{JMAPA\%2C#1\%2C#3}{{\it J.\ Math.\ Phys.\ }{\bf #1} (#2) #3}');
 DefMacro('\joth{}{}{}', '\@spires{JOTHE\%2C#1\%2C#3}{{\it J.\ Operator Theory }{\bf #1} (#2) #3}');

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3209,7 +3209,7 @@ DefConstructor('\@@generic@caption[]{}', "<ltx:text class='ltx_caption'>#2</ltx:
 
 sub add_subfigure_row_breaks {
   my ($document, $node, $whatsit, @contents) = @_;
-  my $textwidth     = $whatsit->getProperty('floatwidth') || Dimension('345pt')->valueOf();
+  my $textwidth     = ($whatsit->getProperty('floatwidth') || Dimension('345pt'))->valueOf();
   my $current_width = 0;
   my @new_contents  = ();
   for my $block (@contents) {

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4636,7 +4636,6 @@ DefEnvironment('{minipage}[][][]{Dimension}', sub {
   sizer      => '#body',
   mode       => 'text',
   properties => sub { (
-      layout  => 'vertical',
       width   => $_[4],
       vattach => translateAttachment($_[1])); },
   beforeDigest => sub {

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3130,18 +3130,21 @@ DefMacro('\format@title@font@figure', '\format@title@font@float');
 DefMacro('\format@title@font@table',  '\format@title@font@float');
 
 # stubs for the latex float internals
-for my $float (qw(@float @dblfloat)) {
-  DefEnvironmentI($float, '[]{}',
-    "<ltx:float xml:id='#id' inlist='#inlist' ?#1(placement='#1') class='ltx_float_#2'>"
-      . "#body"
-      . "</ltx:float>",
-    properties       => { layout => 'vertical' },
-    afterDigestBegin => sub {
-      DefMacroI('\@captype', undef, ToString($_[1]->getArg(2)));
-      return; },
-    afterDigest => sub {
-      RescueCaptionCounters(ToString(Expand(T_CS('\@captype'))), $_[1]);
-      return; }); }
+DefEnvironmentI('@float', '[]{}',
+  "<ltx:float xml:id='#id' inlist='#inlist' ?#1(placement='#1') class='ltx_float_#2'>"
+    . "#body"
+    . "</ltx:float>",
+  properties        => { layout => 'vertical' },
+  beforeDigestBegin => sub { beforeFloat(ToString($_[1]->getArg(2))); },
+  afterDigest       => sub { afterFloat($_[1]); });
+DefEnvironmentI('@dblfloat', '[]{}',
+  "<ltx:float xml:id='#id' inlist='#inlist' ?#1(placement='#1') class='ltx_float_#2'>"
+    . "#body"
+    . "</ltx:float>",
+  properties        => { layout => 'vertical' },
+  beforeDigestBegin => sub { beforeFloat(ToString($_[1]->getArg(2)), double => 1); },
+  afterDigest       => sub { afterFloat($_[1]); });
+
 # Could perhaps parameterize further with a separator?
 DefMacro('\format@title@figure{}', '\lx@tag[][: ]{\lx@fnum@@{figure}}#1');
 DefMacro('\format@title@table{}',  '\lx@tag[][: ]{\lx@fnum@@{table}}#1');
@@ -3206,7 +3209,7 @@ DefConstructor('\@@generic@caption[]{}', "<ltx:text class='ltx_caption'>#2</ltx:
 
 sub add_subfigure_row_breaks {
   my ($document, $node, $whatsit, @contents) = @_;
-  my $textwidth     = (LookupRegister('\textwidth') || Dimension('345pt'))->valueOf();
+  my $textwidth     = $whatsit->getProperty('floatwidth') || Dimension('345pt')->valueOf();
   my $current_width = 0;
   my @new_contents  = ();
   for my $block (@contents) {
@@ -3215,25 +3218,7 @@ sub add_subfigure_row_breaks {
       # reset bookkeeping on prior breaks, be they author-deposited or computed
       $current_width = 0; }
     else {
-      # TODO: A tricky bit to consider here is graphics sized to \columnwidth
-      # which isn't yet accurately emulated in latexml itself.
-      # so where two or more graphics may have been expected in the PDF,
-      # latexml would only allow one as the \columnwidth would be defaulted to \textwidth.
-      my $block_width = $block->getAttribute('width');
-      # If we have an author annotation of the width, it will appear as an XML attribute,
-      # and should take precedence over the underlying asset width of the image blob
-      if (!$block_width) {
-        if (my $options = $block->getAttribute('options')) {
-          if ($options =~ /width=([^ "]+)/) {
-            $block_width = $1; } } }
-      if ($block_width) {
-        # if we found an attribute, deserialize back into an internal sp number
-        $block_width = Dimension($block_width)->valueOf; }
-      else {
-        # if no width directive was provided, infer it from the internal contents
-        my $block_box = $document->getNodeBox($block);
-        $block_width = $block_box->getWidth->valueOf(); }
-
+      my $block_width = $document->getNodeBox($block)->getWidth->valueOf();
       if (@new_contents && ($current_width + $block_width > $textwidth)) {
         # break when we exceed the line width, to keep close with the PDF arrangement
         my $break = $document->insertElementBefore($block, 'break', 'class' => 'ltx_break');
@@ -3301,23 +3286,39 @@ DefConstructor('\@@caption{}', "^^<ltx:caption>#1</ltx:caption>", sizer => 0);
 DefConstructor('\@@toccaption{}', "^^<ltx:toccaption>#1</ltx:toccaption>",
   sizer => 0);
 
+sub beforeFloat {
+  my ($type, %options) = @_;
+  #Debug("FLOAT begin $type". join(',',map { $_."=".ToString($options{$_}); } sort keys %options));
+  DefMacroI('\@captype', undef, $type);
+  AssignRegister('\hsize' => LookupDimension($options{double} ? '\textwidth' : '\columnwidth'));
+  return; }
+
+sub afterFloat {
+  my ($whatsit) = @_;
+  my $type = ToString(Expand(T_CS('\@captype')));
+  #Debug("FLOAT end $type");
+  $whatsit->setProperty(floatwidth => LookupRegister('\hsize'));
+  RescueCaptionCounters($type, $whatsit);
+  return; }
+
 DefEnvironment('{figure}[]',
   "<ltx:figure xml:id='#id' inlist='#inlist' ?#1(placement='#1')>"
     . "#tags"
     . "#body"
     . "</ltx:figure>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest  => sub { RescueCaptionCounters('figure', $_[1]); },
+  beforeDigest => sub { beforeFloat('figure'); },
+  afterDigest  => sub { afterFloat($_[1]); },
   locked       => 1);
+
 DefEnvironment('{figure*}[]',
   "<ltx:figure xml:id='#id' inlist='#inlist' ?#1(placement='#1')>"
     . "#tags"
     . "#body"
     . "</ltx:figure>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest  => sub { RescueCaptionCounters('figure', $_[1]); },
+  beforeDigest => sub { beforeFloat('figure', double => 1); },
+  afterDigest  => sub { afterFloat($_[1]); },
   locked       => 1);
 DefEnvironment('{table}[]',
   "<ltx:table xml:id='#id' inlist='#inlist' ?#1(placement='#1')>"
@@ -3325,8 +3326,8 @@ DefEnvironment('{table}[]',
     . "#body"
     . "</ltx:table>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'table'); },
-  afterDigest  => sub { RescueCaptionCounters('table', $_[1]); },
+  beforeDigest => sub { beforeFloat('table'); },
+  afterDigest  => sub { afterFloat($_[1]); },
   locked       => 1);
 DefEnvironment('{table*}[]',
   "<ltx:table xml:id='#id' inlist='#inlist' ?#1(placement='#1')>"
@@ -3334,8 +3335,8 @@ DefEnvironment('{table*}[]',
     . "#body"
     . "</ltx:table>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'table'); },
-  afterDigest  => sub { RescueCaptionCounters('table', $_[1]); },
+  beforeDigest => sub { beforeFloat('table', double => 1); },
+  afterDigest  => sub { afterFloat($_[1]); },
   locked       => 1);
 
 # There are some floating figure/table packages that define environments

--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -180,16 +180,16 @@ DefEnvironment('{plate}[]',
     . "#tags"
     . "#body"
     . "</ltx:float>",
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'plate'); },
-  afterDigest  => sub { RescueCaptionCounters('plate', $_[1]); });
+  beforeDigest => sub { beforeFloat('plate'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefEnvironment('{plate*}[]',
   "<ltx:float xml:id='#id' inlist='#inlist' ?#1(placement='#1') class='ltx_float_plate'>"
     . "#tags"
     . "#body"
     . "</ltx:float>",
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'plate'); },
-  afterDigest  => sub { RescueCaptionCounters('plate', $_[1]); });
+  beforeDigest => sub { beforeFloat('plate', double => 1); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefMacro('\platewidth{Dimension}', '');                    # Ignorable?
 DefMacro('\platenum{}',            '\def\theplate{#1}');

--- a/lib/LaTeXML/Package/acmart.cls.ltxml
+++ b/lib/LaTeXML/Package/acmart.cls.ltxml
@@ -139,8 +139,8 @@ DefEnvironment('{teaserfigure}[]',
     . "#body"
     . "</ltx:figure>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest  => sub { RescueCaptionCounters('figure', $_[1]); });
+  beforeDigest => sub { beforeFloat('figure'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefEnvironment('{marginfigure}[]',
   "<ltx:figure xml:id='#id' inlist='#inlist' class='ltx_marginfigure' ?#1(placement='#1')>"
@@ -148,8 +148,8 @@ DefEnvironment('{marginfigure}[]',
     . "#body"
     . "</ltx:figure>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest  => sub { RescueCaptionCounters('figure', $_[1]); });
+  beforeDigest => sub { beforeFloat('figure'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefEnvironment('{margintable}[]',
   "<ltx:table xml:id='#id' inlist='#inlist' class='ltx_margintable' ?#1(placement='#1')>"
@@ -157,8 +157,8 @@ DefEnvironment('{margintable}[]',
     . "#body"
     . "</ltx:table>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'table'); },
-  afterDigest  => sub { RescueCaptionCounters('table', $_[1]); });
+  beforeDigest => sub { beforeFloat('table'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefMacroI('\sidebarname',  undef, 'Sidebar');
 DefMacroI('\fnum@sidebar', undef, '\sidebarname\nobreakspace\thesidebar');

--- a/lib/LaTeXML/Package/algorithm2e.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithm2e.sty.ltxml
@@ -76,12 +76,12 @@ DefEnvironment('{algorithm}[]',
 
     #    Let('\vtop','\relax');      # ?
     DefMacro('\;', '\ifmmode\@mathsemicolon\else\@endalgoln\fi');
-    DefMacroI('\@captype', undef, 'algorithm');
+    beforeFloat('algorithm');
   },
   afterDigest => sub {
     if (ToString(Digest(T_CS('\algocf@style'))) =~ /box/) {
       $_[1]->setProperty(frame => 'boxed'); }
-    RescueCaptionCounters('algorithm', $_[1]); },
+    afterFloat($_[1]); },
   afterConstruct => sub { addFloatFrames($_[0], $_[1]->getProperty('frame')); }
 );
 

--- a/lib/LaTeXML/Package/article.cls.ltxml
+++ b/lib/LaTeXML/Package/article.cls.ltxml
@@ -24,10 +24,13 @@ foreach my $option (qw(10pt 11pt 12pt
   final draft
   oneside twoside
   openright openany
-  onecolumn twocolumn
   notitlepage titlepage)) {
   DeclareOption($option, undef); }
 
+DeclareOption('onecolumn',
+  '\@twocolumnfalse\columnwidth\textwidth');
+DeclareOption('twocolumn',
+  '\@twocolumntrue\columnwidth\textwidth\advance\columnwidth-\columnsep\divide\columnwidth2\relax');
 DeclareOption('openbib', sub {
     RequireResource(undef, type => 'text/css', content => '.ltx_bibblock{display:block;}'); });
 DeclareOption('leqno', sub { AssignMapping('DOCUMENT_CLASSES', ltx_leqno => 1); });

--- a/lib/LaTeXML/Package/book.cls.ltxml
+++ b/lib/LaTeXML/Package/book.cls.ltxml
@@ -24,9 +24,12 @@ foreach my $option (qw(10pt 11pt 12pt
   final draft
   oneside twoside
   openright openany
-  onecolumn twocolumn
   notitlepage titlepage)) {
   DeclareOption($option, undef); }
+DeclareOption('onecolumn',
+  '\@twocolumnfalse\columnwidth\textwidth');
+DeclareOption('twocolumn',
+  '\@twocolumntrue\columnwidth\textwidth\advance\columnwidth-\columnsep\divide\columnwidth2\relax');
 DeclareOption('openbib', sub {
     RequireResource(undef, type => 'text/css', content => '.ltx_bibblock{display:block;}'); });
 DeclareOption('leqno', sub { AssignMapping('DOCUMENT_CLASSES', ltx_leqno => 1); });
@@ -61,7 +64,7 @@ NewCounter('subsection',    'section',       idprefix => 'SS',  nested => ['subs
 NewCounter('subsubsection', 'subsection',    idprefix => 'SSS', nested => ['paragraph']);
 NewCounter('paragraph',     'subsubsection', idprefix => 'P',   nested => ['subparagraph']);
 NewCounter('subparagraph', 'paragraph', idprefix => 'SP', nested => ['equation', 'figure', 'table']);
-NewCounter('footnote', 'chapter');
+NewCounter('footnote',     'chapter');
 
 DefMacro('\thepart',          '\Roman{part}');
 DefMacro('\thechapter',       '\arabic{chapter}');

--- a/lib/LaTeXML/Package/elsart_support.sty.ltxml
+++ b/lib/LaTeXML/Package/elsart_support.sty.ltxml
@@ -97,8 +97,8 @@ DefEnvironment('{algorithm}',
     . "#tags"
     . "#body",
   afterConstruct => sub { $_[0]->maybeCloseElement('ltx:theorem'); },
-  beforeDigest   => sub { DefMacroI('\@captype', undef, 'algorithm'); },
-  afterDigest    => sub { RescueCaptionCounters('algorithm', $_[1]); });
+  beforeDigest   => sub { beforeFloat('algorithm'); },
+  afterDigest    => sub { afterFloat($_[1]); });
 
 RawTeX('\newenvironment{pf}{\begin{@proof}[\proofname]}{\end{@proof}}');
 

--- a/lib/LaTeXML/Package/float.sty.ltxml
+++ b/lib/LaTeXML/Package/float.sty.ltxml
@@ -58,8 +58,8 @@ DefPrimitive('\newfloat{}{}{}[]', sub {
         . "#body"
         . "</ltx:float>",
       properties     => { layout => 'vertical' },
-      beforeDigest   => sub { DefMacroI('\@captype', undef, $type); },
-      afterDigest    => sub { RescueCaptionCounters($type, $_[1]); },
+      beforeDigest   => sub { beforeFloat($type); },
+      afterDigest    => sub { afterFloat($_[1]); },
       afterConstruct => sub { addFloatFrames($_[0], $style); });
     DefEnvironmentI("$type*", "[]",
       "<ltx:float xml:id='#id' ?#1(placement='#1') inlist='#inlist' class='ltx_float_$type'>"
@@ -67,8 +67,8 @@ DefPrimitive('\newfloat{}{}{}[]', sub {
         . "#body"
         . "</ltx:float>",
       properties     => { layout => 'vertical' },
-      beforeDigest   => sub { DefMacroI('\@captype', undef, $type); },
-      afterDigest    => sub { RescueCaptionCounters($type, $_[1]); },
+      beforeDigest   => sub { beforeFloat($type, double => 1); },
+      afterDigest    => sub { afterFloat($_[1]); },
       afterConstruct => sub { addFloatFrames($_[0], $style); });
 });
 ## ??? DefMacro('\plain','');

--- a/lib/LaTeXML/Package/floatfig.sty.ltxml
+++ b/lib/LaTeXML/Package/floatfig.sty.ltxml
@@ -32,9 +32,9 @@ DefEnvironment('{floatingfigure}[]{Dimension}',
     . "#tags"
     . "#body"
     . "</ltx:figure>",
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest => sub { RescueCaptionCounters('figure', $_[1]); },
-  properties => sub {
+  beforeDigest => sub { beforeFloat('figure'); },
+  afterDigest  => sub { afterFloat($_[1]); },
+  properties   => sub {
     (float => (ToString($_[1] || LookupValue('floatfltpos')) =~ /^(v|r)/ ? 'right' : 'left'),
       pctwidth => toPercent($_[2])); });
 

--- a/lib/LaTeXML/Package/floatflt.sty.ltxml
+++ b/lib/LaTeXML/Package/floatflt.sty.ltxml
@@ -35,9 +35,9 @@ DefEnvironment('{floatingfigure}[]{Dimension}',
     . "#tags"
     . "#body"
     . "</ltx:figure>",
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest => sub { RescueCaptionCounters('figure', $_[1]); },
-  properties => sub {
+  beforeDigest => sub { beforeFloat('figure'); },
+  afterDigest  => sub { afterFloat($_[1]); },
+  properties   => sub {
     (float => (ToString($_[1] || LookupValue('floatfltpos')) =~ /^(v|r)/ ? 'right' : 'left'),
       pctwidth => toPercent($_[2])); });
 
@@ -46,9 +46,9 @@ DefEnvironment('{floatingtable}[]{Dimension}',
     . "#tags"
     . "#body"
     . "</ltx:table>",
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'table'); },
-  afterDigest => sub { RescueCaptionCounters('table', $_[1]); },
-  properties => sub {
+  beforeDigest => sub { beforeFloat('table'); },
+  afterDigest  => sub { afterFloat($_[1]); },
+  properties   => sub {
     (float => (ToString($_[1] || LookupValue('floatfltpos')) =~ /^(v|r)/ ? 'right' : 'left'),
       pctwidth => toPercent($_[2])); });
 

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -228,10 +228,8 @@ DefConstructor('\@listings {}',
     . "#1"
     . "</ltx:float>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'lstlisting'); },
-  afterDigest  => sub {
-    my ($stomach, $whatsit) = @_;
-    RescueCaptionCounters('lstlisting', $whatsit); });
+  beforeDigest => sub { beforeFloat('lstlisting'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 # Unnumbered form, but with caption
 # \@listings <classes> <formatted>
@@ -244,10 +242,8 @@ DefConstructor('\@@listings {}',
     my %props = RefStepID('lstlisting');
     $props{layout} = 'vertical';
     return %props; },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'lstlisting'); },
-  afterDigest  => sub {
-    my ($stomach, $whatsit) = @_;
-    RescueCaptionCounters('lstlisting', $whatsit); });
+  beforeDigest => sub { beforeFloat('lstlisting'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefConstructor('\@@listings@block {} {}',
 "<ltx:listing class='ltx_lstlisting' data='#data' datamimetype='#datamimetype' dataencoding='#dataencoding'>#2</ltx:listing>",

--- a/lib/LaTeXML/Package/newfloat.sty.ltxml
+++ b/lib/LaTeXML/Package/newfloat.sty.ltxml
@@ -67,16 +67,17 @@ DefPrimitive('\DeclareFloatingEnvironment OptionalKeyVals {}', sub {
         . "#body"
         . "</ltx:float>",
       properties   => { layout => 'vertical' },
-      beforeDigest => sub { DefMacroI('\@captype', undef, $type); },
-      afterDigest  => sub { RescueCaptionCounters($type, $_[1]); });
+      beforeDigest => sub { beforeFloat($type); },
+      afterDigest  => sub { afterFloat($_[1]); });
+
     DefEnvironmentI("$type*", "[]",
       "<ltx:float xml:id='#id' ?#1(placement='#1') inlist='#inlist' class='ltx_float_$type'>"
         . "#tags"
         . "#body"
         . "</ltx:float>",
       properties   => { layout => 'vertical' },
-      beforeDigest => sub { DefMacroI('\@captype', undef, $type); },
-      afterDigest  => sub { RescueCaptionCounters($type, $_[1]); });
+      beforeDigest => sub { beforeFloat($type, double => 1); },
+      afterDigest  => sub { afterFloat($_[1]); });
 });
 
 # \ForEachFloatingEnvironment{code{#1}}

--- a/lib/LaTeXML/Package/report.cls.ltxml
+++ b/lib/LaTeXML/Package/report.cls.ltxml
@@ -24,9 +24,12 @@ foreach my $option (qw(10pt 11pt 12pt
   final draft
   oneside twoside
   openright openany
-  onecolumn twocolumn
   notitlepage titlepage)) {
   DeclareOption($option, undef); }
+DeclareOption('onecolumn',
+  '\@twocolumnfalse\columnwidth\textwidth');
+DeclareOption('twocolumn',
+  '\@twocolumntrue\columnwidth\textwidth\advance\columnwidth-\columnsep\divide\columnwidth2\relax');
 DeclareOption('openbib', sub {
     RequireResource(undef, type => 'text/css', content => '.ltx_bibblock{display:block;}'); });
 DeclareOption('leqno', sub { AssignMapping('DOCUMENT_CLASSES', ltx_leqno => 1); });
@@ -61,7 +64,7 @@ NewCounter('subsection',    'section',       idprefix => 'SS',  nested => ['subs
 NewCounter('subsubsection', 'subsection',    idprefix => 'SSS', nested => ['paragraph']);
 NewCounter('paragraph',     'subsubsection', idprefix => 'P',   nested => ['subparagraph']);
 NewCounter('subparagraph', 'paragraph', idprefix => 'SP', nested => ['equation', 'figure', 'table']);
-NewCounter('footnote', 'chapter');
+NewCounter('footnote',     'chapter');
 
 DefMacro('\thepart',          '\Roman{part}');
 DefMacro('\thechapter',       '\arabic{chapter}');

--- a/lib/LaTeXML/Package/rotating.sty.ltxml
+++ b/lib/LaTeXML/Package/rotating.sty.ltxml
@@ -98,12 +98,9 @@ DefEnvironment('{sidewaysfigure}[]',
     . "#tags"
     . "#body"
     . "</ltx:figure>",
-  properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest  => sub {
-    my ($stomach, $whatsit) = @_;
-    RescueCaptionCounters('figure', $whatsit);
-    return; },
+  properties      => { layout => 'vertical' },
+  beforeDigest    => sub { beforeFloat('figure'); },
+  afterDigest     => sub { afterFloat($_[1]); },
   afterDigestBody => sub {
     my ($stomach, $whatsit) = @_;
     $whatsit->setProperties(rotatedProperties($whatsit->getBody, 90)); });
@@ -118,8 +115,8 @@ DefEnvironment('{sidewaysfigure*}[]',
     . "#body"
     . "</ltx:figure>",
   properties      => { layout => 'vertical' },
-  beforeDigest    => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest     => sub { RescueCaptionCounters('figure', $_[1]); },
+  beforeDigest    => sub { beforeFloat('figure', double => 1); },
+  afterDigest     => sub { afterFloat($_[1]); },
   afterDigestBody => sub {
     my ($stomach, $whatsit) = @_;
     $whatsit->setProperties(rotatedProperties($whatsit->getBody, 90)); });
@@ -133,9 +130,10 @@ DefEnvironment('{sidewaystable}[]',
     . "#tags"
     . "#body"
     . "</ltx:table>",
-  properties      => { layout => 'vertical' },
-  beforeDigest    => sub { DefMacroI('\@captype', undef, 'table'); },
-  afterDigest     => sub { RescueCaptionCounters('table', $_[1]); },
+  properties   => { layout => 'vertical' },
+  beforeDigest => sub { beforeFloat('table'); },
+  afterDigest  => sub { afterFloat($_[1]); },
+
   afterDigestBody => sub {
     my ($stomach, $whatsit) = @_;
     $whatsit->setProperties(rotatedProperties($whatsit->getBody, 90)); });
@@ -149,9 +147,10 @@ DefEnvironment('{sidewaystable*}[]',
     . "#tags"
     . "#body"
     . "</ltx:table>",
-  properties      => { layout => 'vertical' },
-  beforeDigest    => sub { DefMacroI('\@captype', undef, 'table'); },
-  afterDigest     => sub { RescueCaptionCounters('table', $_[1]); },
+  properties   => { layout => 'vertical' },
+  beforeDigest => sub { beforeFloat('table', double => 1); },
+  afterDigest  => sub { afterFloat($_[1]); },
+
   afterDigestBody => sub {
     my ($stomach, $whatsit) = @_;
     $whatsit->setProperties(rotatedProperties($whatsit->getBody, 90)); });

--- a/lib/LaTeXML/Package/subcaption.sty.ltxml
+++ b/lib/LaTeXML/Package/subcaption.sty.ltxml
@@ -55,32 +55,35 @@ DefEnvironment('{subfigure}[]{Dimension}',
     . "#body"
     . "</ltx:figure>",
   properties   => sub { (layout => 'vertical', width => $_[2]); },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'subfigure'); },
-  afterDigest  => sub { RescueCaptionCounters('subfigure', $_[1]); });
+  beforeDigest => sub { beforeFloat('subfigure'); },
+  afterDigest  => sub { afterFloat($_[1]); });
+
 DefEnvironment('{subfigure*}[]{Dimension}',
   "^<ltx:figure xml:id='#id' inlist='#inlist' ?#1(placement='#1')>"
     . "#tags"
     . "#body"
     . "</ltx:figure>",
   properties   => sub { (layout => 'vertical', width => $_[2]); },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'subfigure'); },
-  afterDigest  => sub { RescueCaptionCounters('subfigure', $_[1]); });
+  beforeDigest => sub { beforeFloat('subfigure', double => 1); },
+  afterDigest  => sub { afterFloat($_[1]); });
+
 DefEnvironment('{subtable}[]{Dimension}',
   "^<ltx:table xml:id='#id' inlist='#inlist' ?#1(placement='#1')>"
     . "#tags"
     . "#body"
     . "</ltx:table>",
   properties   => sub { (layout => 'vertical', width => $_[2]); },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'subtable'); },
-  afterDigest  => sub { RescueCaptionCounters('subtable', $_[1]); });
+  beforeDigest => sub { beforeFloat('subtable'); },
+  afterDigest  => sub { afterFloat($_[1]); });
+
 DefEnvironment('{subtable*}[]{Dimension}',
   "^<ltx:table xml:id='#id' inlist='#inlist' ?#1(placement='#1')>"
     . "#tags"
     . "#body"
     . "</ltx:table>",
   properties   => sub { (layout => 'vertical', width => $_[2]); },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'subtable'); },
-  afterDigest  => sub { RescueCaptionCounters('subtable', $_[1]); });
+  beforeDigest => sub { beforeFloat('subtable', double => 1); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 #======================================================================
 # \subcaptionbox[list]{caption}[width][innerpos]{contents}

--- a/lib/LaTeXML/Package/subfig.sty.ltxml
+++ b/lib/LaTeXML/Package/subfig.sty.ltxml
@@ -55,11 +55,10 @@ DefPrimitive('\newsubfloat[]{}', sub {
         . "#body"
         . "</$type>",
       properties   => { layout => 'vertical' },
-      beforeDigest => sub { DefMacroI('\@captype', undef, 'sub' . $name); },
+      beforeDigest => sub { beforeFloat('sub' . $name); },
       afterDigest  => sub {
-        RescueCaptionCounters('sub' . $name, $_[1]);
-        SetCounter('sub' . $name . '@save', CounterValue('sub' . $name));
-      });
+        afterFloat($_[1]);
+        SetCounter('sub' . $name . '@save', CounterValue('sub' . $name)); });
     return; });
 
 # \DeclareCaptionListOfFormat{kv}{code}

--- a/lib/LaTeXML/Package/subfigure.sty.ltxml
+++ b/lib/LaTeXML/Package/subfigure.sty.ltxml
@@ -154,8 +154,9 @@ DefEnvironment('{@subfigure}',
     . "#body"
     . "</ltx:figure>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'subfigure'); },
-  afterDigest  => sub { RescueCaptionCounters('subfigure', $_[1]); });
+  beforeDigest => sub { beforeFloat('subfigure'); },
+  afterDigest  => sub { afterFloat($_[1]); });
+
 DefMacro('\subtable[][]{}',
   '\begin{@subtable}'
     . '\iftabletopcap\else\addtocounter{table}{1}\fi'
@@ -174,8 +175,8 @@ DefEnvironment('{@subtable}',
     . "#body"
     . "</ltx:table>",
   properties   => { layout => 'vertical' },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'subtable'); },
-  afterDigest  => sub { RescueCaptionCounters('subtable', $_[1]); });
+  beforeDigest => sub { beforeFloat('subtable'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefMacro('\subref OptionalMatch:* Semiverbatim', '\ref{#1}');
 

--- a/lib/LaTeXML/Package/subfloat.sty.ltxml
+++ b/lib/LaTeXML/Package/subfloat.sty.ltxml
@@ -39,10 +39,10 @@ DefEnvironment('{subfigures}',
     . "#tags"
     . "#body"
     . "</ltx:figure>",
-  properties => sub { RefStepCounter('figure'); },    # No caption (?)
+  properties   => sub { RefStepCounter('figure'); },    # No caption (?)
   beforeDigest => sub {
     Let('\themainfigure', '\thefigure');
-    DefMacroI('\@captype', undef, 'figure');
+    beforeFigure('figure');
     # redefine figure!
     DefEnvironment('{figure}[]',
       "<ltx:figure xml:id='#id' ?#1(placement='#1')>"    # NO inlist for subfigures!(?)
@@ -50,20 +50,18 @@ DefEnvironment('{subfigures}',
         . "#body"
         . "</ltx:figure>",
       properties   => { layout => 'vertical' },
-      beforeDigest => sub { DefMacroI('\@captype', undef, 'subfloatfigure'); },
-      afterDigest  => sub { RescueCaptionCounters('subfloatfigure', $_[1]); });
+      beforeDigest => sub { beforeFloat('subfloatfigure'); },
+      afterDigest  => sub { afterFloat($_[1]); });
     DefEnvironment('{figure*}[]',
       "<ltx:figure xml:id='#id' ?#1(placement='#1')>"
         . "#tags"
         . "#body"
         . "</ltx:figure>",
       properties   => { layout => 'vertical' },
-      beforeDigest => sub { DefMacroI('\@captype', undef, 'subfloatfigure'); },
-      afterDigest  => sub { RescueCaptionCounters('subfloatfigure', $_[1]); });
-
+      beforeDigest => sub { beforeFloat('subfloatfigure', double => 1); },
+      afterDigest  => sub { afterFloat($_[1]); });
   },
-  afterDigest => sub { RescueCaptionCounters('figure', $_[1]); }
-);
+  afterDigest => sub { afterFloat($_[1]); });
 
 DefMacro('\fnum@subtable', '(\thesubtable)');
 DefEnvironment('{subtables}',
@@ -71,10 +69,10 @@ DefEnvironment('{subtables}',
     . "#tags"
     . "#body"
     . "</ltx:table>",
-  properties => sub { RefStepCounter('table'); },    # No caption (?)
+  properties   => sub { RefStepCounter('table'); },    # No caption (?)
   beforeDigest => sub {
     Let('\themaintable', '\thetable');
-    DefMacroI('\@captype', undef, 'table');
+    beforeFigure('table');
     # redefine table!
     DefEnvironment('{table}[]',
       "<ltx:table xml:id='#id' ?#1(placement='#1')>"    # NO inlist for subtables! (?)
@@ -82,19 +80,18 @@ DefEnvironment('{subtables}',
         . "#body"
         . "</ltx:table>",
       properties   => { layout => 'vertical' },
-      beforeDigest => sub { DefMacroI('\@captype', undef, 'subfloattable'); },
-      afterDigest  => sub { RescueCaptionCounters('subfloattable', $_[1]); });
+      beforeDigest => sub { beforeFloat('subfloattable'); },
+      afterDigest  => sub { afterFloat($_[1]); });
     DefEnvironment('{table*}[]',
       "<ltx:table xml:id='#id' ?#1(placement='#1')>"
         . "#tags"
         . "#body"
         . "</ltx:table>",
       properties   => { layout => 'vertical' },
-      beforeDigest => sub { DefMacroI('\@captype', undef, 'subfloattable'); },
-      afterDigest  => sub { RescueCaptionCounters('subfloattable', $_[1]); });
-
+      beforeDigest => sub { beforeFloat('subfloattable', double => 1); },
+      afterDigest  => sub { afterFloat($_[1]); });
   },
-  afterDigest => sub { RescueCaptionCounters('table', $_[1]); });
+  afterDigest => sub { afterFloat($_[1]); });
 
 #======================================================================
 1;

--- a/lib/LaTeXML/Package/wrapfig.sty.ltxml
+++ b/lib/LaTeXML/Package/wrapfig.sty.ltxml
@@ -28,8 +28,8 @@ DefEnvironment('{wrapfigure} [Number] {} [Dimension] {Dimension}',
     $_[1]->setProperty(float => ($dir eq 'r' ? 'right'
         : ($dir eq 'l' ? 'left'
           : undef))); },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'figure'); },
-  afterDigest => sub { RescueCaptionCounters('figure', $_[1]); });
+  beforeDigest => sub { beforeFloat('figure'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefEnvironment('{wraptable} [Number] {} [Dimension] {Dimension}',
   "<ltx:table xml:id='#id' inlist='#inlist' float='#float'>"
@@ -41,8 +41,8 @@ DefEnvironment('{wraptable} [Number] {} [Dimension] {Dimension}',
     $_[1]->setProperty(float => ($dir eq 'r' ? 'right'
         : ($dir eq 'l' ? 'left'
           : undef))); },
-  beforeDigest => sub { DefMacroI('\@captype', undef, 'table'); },
-  afterDigest => sub { RescueCaptionCounters('table', $_[1]); });
+  beforeDigest => sub { beforeFloat('table'); },
+  afterDigest  => sub { afterFloat($_[1]); });
 
 DefMacro('\WFclear', '\par');
 DefRegister('\wrapoverhang' => Dimension(0));

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-para-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-para-xhtml.xsl
@@ -170,7 +170,7 @@
             </xsl:otherwise>
           </xsl:choose>
           <xsl:text>&#x0A;</xsl:text>
-          <xsl:for-each select="ltx:figure | ltx:table | ltx:tabular | ltx:float | ltx:graphics | ltx:break | ltx:inline-para | ltx:inline-block | ltx:listing | ltx:p">
+          <xsl:for-each select="ltx:figure | ltx:table | ltx:tabular | ltx:float | ltx:graphics | ltx:break | ltx:inline-para | ltx:inline-block | ltx:listing | ltx:p | ltx:rawhtml">
             <xsl:choose>
               <xsl:when test="self::ltx:break">
                 <xsl:element name="div" namespace="{$html_ns}">

--- a/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
+++ b/lib/LaTeXML/resources/javascript/LaTeXML-maybeMathjax.js
@@ -7,7 +7,9 @@
 
     function refreshMath() {
         // Maybe unnecessary, or overkill, but...
-        if (typeof MathJax != "undefined") {
+        if ((typeof MathJax != "undefined")
+            && (typeof MathJax.Hub != "undefined")
+            && (typeof MathJax.Hub.Queue != "undefined")) {
             MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
         }
     }

--- a/t/alignment/supertabular.xml
+++ b/t/alignment/supertabular.xml
@@ -68,7 +68,7 @@
     </tags>
     <toccaption><tag close=" ">2</tag>The ISOGRK3 entity set, wider</toccaption>
     <caption><tag close=": ">Table 2</tag>The ISOGRK3 entity set, wider</caption>
-    <tabular colsep="20.0pt" width="433.6pt">
+    <tabular colsep="20.0pt">
       <thead>
         <tr>
           <td align="left" thead="column"><text font="bold">Entity</text></td>
@@ -171,7 +171,7 @@
     </tags>
     <toccaption><tag close=" ">3</tag>Another table in a minipage</toccaption>
     <caption><tag close=": ">Table 3</tag>Another table in a minipage</caption>
-    <tabular colsep="20.0pt" width="433.6pt">
+    <tabular colsep="20.0pt">
       <thead>
         <tr>
           <td align="left" thead="column"><text font="bold">Entity</text></td>

--- a/t/alignment/tabularstar.xml
+++ b/t/alignment/tabularstar.xml
@@ -5,7 +5,7 @@
   <resource src="LaTeXML.css" type="text/css"/>
   <resource src="ltx-article.css" type="text/css"/>
   <para xml:id="p1">
-    <tabular class="ltx_guessed_headers" vattach="top" width="144.5pt">
+    <tabular class="ltx_guessed_headers" vattach="top">
       <tbody>
         <tr>
           <td align="left" thead="row">a</td>

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -4999,7 +4999,7 @@ Then a switch of tag forms.</p>
                     <XMRef idref="S9.Ex66.m1.1"/>
                     <XMRef idref="S9.Ex66.m1.2"/>
                   </XMApp>
-                  <XMArray name="multlined" vattach="middle" width="28.5pt">
+                  <XMArray name="multlined" vattach="middle">
                     <XMRow>
                       <XMCell align="left">
                         <XMApp enclose="box" xml:id="S9.Ex66.m1.1">
@@ -5047,7 +5047,7 @@ Then a switch of tag forms.</p>
                     <XMRef idref="S9.Ex67.m1.1"/>
                     <XMRef idref="S9.Ex67.m1.2"/>
                   </XMApp>
-                  <XMArray name="multlined" vattach="middle" width="216.8pt">
+                  <XMArray name="multlined" vattach="middle">
                     <XMRow>
                       <XMCell align="left">
                         <XMApp enclose="box" xml:id="S9.Ex67.m1.1">
@@ -5095,7 +5095,7 @@ Then a switch of tag forms.</p>
                     <XMRef idref="S9.Ex68.m1.1"/>
                     <XMRef idref="S9.Ex68.m1.2"/>
                   </XMApp>
-                  <XMArray name="multlined" vattach="middle" width="867.2pt">
+                  <XMArray name="multlined" vattach="middle">
                     <XMRow>
                       <XMCell align="left">
                         <XMApp enclose="box" xml:id="S9.Ex68.m1.1">
@@ -5143,7 +5143,7 @@ Then a switch of tag forms.</p>
                     <XMRef idref="S9.Ex69.m1.1"/>
                     <XMRef idref="S9.Ex69.m1.2"/>
                   </XMApp>
-                  <XMArray name="multlined" vattach="top" width="120.0pt">
+                  <XMArray name="multlined" vattach="top">
                     <XMRow>
                       <XMCell align="left">
                         <XMApp enclose="box" xml:id="S9.Ex69.m1.1">
@@ -5191,7 +5191,7 @@ Then a switch of tag forms.</p>
                     <XMRef idref="S9.Ex70.m1.1"/>
                     <XMRef idref="S9.Ex70.m1.2"/>
                   </XMApp>
-                  <XMArray name="multlined" vattach="bottom" width="120.0pt">
+                  <XMArray name="multlined" vattach="bottom">
                     <XMRow>
                       <XMCell align="left">
                         <XMApp enclose="box" xml:id="S9.Ex70.m1.1">
@@ -5239,7 +5239,7 @@ Then a switch of tag forms.</p>
                     <XMRef idref="S9.Ex71.m1.1"/>
                     <XMRef idref="S9.Ex71.m1.2"/>
                   </XMApp>
-                  <XMArray name="multlined" vattach="middle" width="28.5pt">
+                  <XMArray name="multlined" vattach="middle">
                     <XMRow>
                       <XMCell align="left">
                         <XMApp enclose="box" xml:id="S9.Ex71.m1.1">
@@ -7004,7 +7004,7 @@ Then a switch of tag forms.</p>
                   <XMRef idref="S10.Ex80.m1.36"/>
                 </XMApp>
               </XMApp>
-              <XMArray name="multlined" vattach="middle" width="433.6pt">
+              <XMArray name="multlined" vattach="middle">
                 <XMRow>
                   <XMCell align="left">
                     <XMApp enclose="box" xml:id="S10.Ex80.m1.1">


### PR DESCRIPTION
This PR deals with several issues with the new flex approach to multiple figures/subfigures that turned up with DLMF.

* It adds the bookkeeping to maintain `\columnwidth` (as distinct from `\textwidth`)
* It uses the `\columnwidth` to make decisions about subfigure layout, rather than trying to sniff out an intended size.
* It introduces two helper functions (`beforeFloat` and `afterFloat`) that arrange for the various floats to record the current `\columnwidth` while digesting (since the value at construct-time is no longer the correct one), while distinguishing between single and double column floats.
* It patches the the XSLT to recognize more figure content types (but there is still too much potentially inconsistently duplicated testing in LaTeX.pool and the stylesheets that will cause trouble eventually).