### PR TITLE
Metafonts

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -490,7 +490,7 @@ DefConstructor('\lx@note[]{}[]{}',
     . "#4"
     . "</ltx:note>",
   mode         => 'text', bounded => 1,
-  beforeDigest => sub { reenterTextMode(1); Digest('\normalfont'); },
+  beforeDigest => sub { reenterTextMode(1); neutralizeFont(); },
   properties   => sub {
     my $type = ToString($_[2]);
     (role => $type,
@@ -4233,7 +4233,7 @@ sub process_index_phrases {
     ($style || $inlist ? (T_OTHER('['), ($style ? T_OTHER($style) : ()), T_OTHER(']')) : ()),
     ($inlist ? (T_OTHER('['), T_OTHER($inlist), T_OTHER(']')) : ()),
     T_BEGIN, @expansion, T_END);
-  return (T_BEGIN, T_CS('\normalfont'), @expansion, T_END); }
+  return @expansion; }
 
 DefMacro('\index{}', \&process_index_phrases);
 
@@ -4248,7 +4248,8 @@ sub addIndexPhraseKey {
   return; }
 
 DefConstructor('\@index[][]{}', "^<ltx:indexmark style='#1' inlist='#2'>#3</ltx:indexmark>",
-  mode => 'text', reversion => '', sizer => 0);
+  bounded => 1, beforeDigest => sub { reenterTextMode(); neutralizeFont(); },
+  mode    => 'text', reversion => '', sizer => 0);
 
 DefConstructor('\@indexphrase[]{}',
   "<ltx:indexphrase key='#key' _standalone_font='true'>#2</ltx:indexphrase>",

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1944,6 +1944,7 @@ DefParameterType('VBoxContents', sub {
 # This re-binds a number of important control sequences to their default text binding.
 # This is useful within common boxing or footnote macros that can appear within
 # alignments or special environments that have redefined many of these.
+# You'll typically want this within a group or bounded=>1.
 AssignValue(TEXT_MODE_BINDINGS  => []);
 AssignValue(HTEXT_MODE_BINDINGS => []);
 AssignValue(VTEXT_MODE_BINDINGS => []);
@@ -1957,6 +1958,13 @@ sub reenterTextMode {
     @{ LookupValue(($verticalmode ? 'VTEXT_MODE_BINDINGS' : 'HTEXT_MODE_BINDINGS')) },
     @{ LookupValue('TEXT_MODE_BINDINGS') };
   return }
+
+# Similarly, for metadata appearing within peculiar environments, fonts, etc
+# You'll typically want this within a group or bounded=>1.
+sub neutralizeFont {
+  AssignValue(font     => LaTeXML::Common::Font->textDefault(), 'local');
+  AssignValue(mathfont => LaTeXML::Common::Font->mathDefault(), 'local');
+  return; }
 
 sub REF {
   my ($thing, $key) = @_;
@@ -5174,7 +5182,8 @@ DefConstructor('\lx@tag[][][]{}',
 # \lx@tag@intags{role}{stuff}
 DefConstructor('\lx@tag@intags[]{}',
   "<ltx:tag role='#1'>#2</ltx:tag>",
-  bounded        => 1, mode => 'text', beforeDigest => sub { reenterTextMode(); },
+  bounded        => 1, mode => 'text',
+  beforeDigest   => sub { reenterTextMode(); neutralizeFont() },
   afterConstruct => \&removeEmptyElement);
 
 DefConstructor('\lx@tags{}',

--- a/lib/LaTeXML/Package/amsppt.sty.ltxml
+++ b/lib/LaTeXML/Package/amsppt.sty.ltxml
@@ -269,7 +269,7 @@ DefConstructor('\footnote[]{}',
     . "#2"
     . "</ltx:note>",
   mode         => 'text', bounded => 1,
-  beforeDigest => sub { reenterTextMode(1); Digest('\normalfont'); },
+  beforeDigest => sub { reenterTextMode(1); neutralizeFont(); },
   properties   => sub {
     ($_[1]
       ? (mark => $_[1])

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -386,12 +386,9 @@ DefConstructor('\lxDeclare OptionalMatch:* OptionalKeyVals:Declare {}', sub {
         $document->insertElement('ltx:text', $description); }
       $document->closeElement('ltx:declare');
       $document->setNode($save); } },
-  mode => 'text',
-  # Screwy bit to `neutralize' the font in the matches.
-  beforeDigest => sub { AssignValue(font => LaTeXML::Common::Font->textDefault(), 'local');
-    AssignValue(mathfont => LaTeXML::Common::Font->mathDefault(), 'local');
-    return; },
-  afterDigest => sub { my ($stomach, $whatsit) = @_;
+  mode         => 'text',
+  beforeDigest => sub { reenterTextMode(); neutralizeFont(); },
+  afterDigest  => sub { my ($stomach, $whatsit) = @_;
     my ($star, $kv, $pattern) = $whatsit->getArgs;
     return unless $kv;
     CheckOptions("\\lxDeclare keys", $declare_keys, %{ $kv->getKeyVals });

--- a/lib/LaTeXML/Package/revtex4_support.sty.ltxml
+++ b/lib/LaTeXML/Package/revtex4_support.sty.ltxml
@@ -124,7 +124,7 @@ DefConstructor('\endnote[]{}',
     . "#2"
     . "</ltx:note>",
   mode         => 'text', bounded => 1,
-  beforeDigest => sub { reenterTextMode(1); Digest('\normalfont'); },
+  beforeDigest => sub { reenterTextMode(1); neutralizeFont(); },
   properties   => sub {
     ($_[1]
       ? (mark => $_[1])


### PR DESCRIPTION
This PR defines a new `neutralizeFont` helper to be used in metadata macros like `\index`, `\footnote`, etc, in order to reset the font from the current one. This is more complete than digesting `\normalfont`, which only resets the style, but not size, color, etc.

Fixes #1731