### PR TITLE
new \lxRequireResource

### DIFF
--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -145,9 +145,11 @@ DefConstructor('\lxRef Semiverbatim {}',
 
 #======================================================================
 # Resources
-# \lxResource[options]{name}
-#  RequireResource($name,%options);
-
+# \lxRequireResource[options]{name}
+#   options: type (mime-type), media (?), ...
+DefPrimitive('\lxRequireResource OptionalKeyVals {}', sub {
+    my ($stomach, $kv, $path) = @_;
+    RequireResource(ToString($path), ($kv ? $kv->getHash : ())); });
 #======================================================================
 # Page customization
 #  options to create or customize


### PR DESCRIPTION
New `\lxRequireResource[options]{source}` to require resources, such as javascript, css, potentially others in future.  Typical option `type=text/javascript`, unless it can be inferred from the source extension.

Fixes #1721