### PR TITLE
Multicol markers

### DIFF
--- a/lib/LaTeXML/Package/multicol.sty.ltxml
+++ b/lib/LaTeXML/Package/multicol.sty.ltxml
@@ -18,8 +18,16 @@ use LaTeXML::Package;
 # Since this is basically styling, we can ignore the effects.
 
 # Optional arg is sortof a heading, but w/o any particular styling(?)
-DefEnvironment('{multicols}{}[]',  '?#2(<ltx:para><ltx:p>#2</ltx:p><ltx:para>)#body');
-DefEnvironment('{multicols*}{}[]', '?#2(<ltx:para><ltx:p>#2</ltx:p><ltx:para>)#body');
+DefEnvironment('{multicols}{}[]',
+  '?#2(<ltx:para><ltx:p>#2</ltx:p><ltx:para>)'
+    . '<ltx:pagination role="start_#1_columns"/>'
+    . '#body'
+    . '<ltx:pagination role="end_#1_columns"/>');
+DefEnvironment('{multicols*}{}[]',
+  '?#2(<ltx:para><ltx:p>#2</ltx:p><ltx:para>)'
+    . '<ltx:pagination role="start_#1_columns"/>'
+    . '#body'
+    . '<ltx:pagination role="end_#1_columns"/>');
 
 DefMacro('\botmark', Tokens());
 DefMacro('\topmark', Tokens());

--- a/t/structure/columns.xml
+++ b/t/structure/columns.xml
@@ -9,7 +9,9 @@
     <p>HEADING</p>
   </para>
   <para xml:id="p2">
+    <pagination role="start_2_columns"/>
     <p>BODY</p>
+    <pagination role="end_2_columns"/>
   </para>
   <para xml:id="p3">
     <p>one column</p>


### PR DESCRIPTION
This PR adds `ltx:pagination` markers when switching the number of columns using the `multicol` package.  It uses markers rather than wrapping the content, since the multicolumn content does not necessarily nest with the document structure tree (see the discussion in #1711).  Although these markers can't be directly used by CSS, hopefully they will be of some use.

Fixes #1711