### PR TITLE
Add more dependencies for newtxmath.sty

### DIFF
--- a/lib/LaTeXML/Package/newtxmath.sty.ltxml
+++ b/lib/LaTeXML/Package/newtxmath.sty.ltxml
@@ -17,6 +17,15 @@ use LaTeXML::Package;
 
 #================================================================================
 # Load these to get the commands
+RequirePackage('amsmath');
+RequirePackage('ifthen');
+RequirePackage('etoolbox');
+RequirePackage('ifxetex');
+RequirePackage('ifluatex');
+RequirePackage('xkeyval');
+# This package is just a minor typesetting adjustment, skipping for now.
+#RequirePackage('centernot');
+#
 RequirePackage('amssymb');
 RequirePackage('txfonts');
 #================================================================================


### PR DESCRIPTION
Spotted a missing `\binom` for a paper using newtxmath.sty, and subsequently realized the dependencies don't accurately match the ones from the texlive `.sty` file.

So this PR updates them to match - hopefully easy & simple.