### PR TITLE
Recognize graphic names with type-like suffixes

### DIFF
--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -137,6 +137,11 @@ sub findGraphicFile {
     # Find all acceptable image files, in order of search paths
     my ($dir, $name, $reqtype) = pathname_split($source);
     # Ignore the requested type? Or should it increase desirability?
+    #
+    # If this is *NOT* a known graphics type, it would be best to treat it as
+    # a name suffix (e.g. name.1 from name.1.png)
+    if (defined($reqtype) && !(grep { $_ eq lc($reqtype) } $$self{graphics_types})) {
+      $name .= ".$reqtype"; }
     my $file  = pathname_concat($dir, $name);
     my @paths = pathname_findall($file, paths => $LaTeXML::Post::Graphics::SEARCHPATHS,
       # accept empty type, incase bad type name, but actual file's content is known type.


### PR DESCRIPTION
Something I thought we had fixed before, but arXiv is painfully unforgiving of (people's filenames...). Example with a PNG file named `my.1.png`:
```tex
\documentclass{article}
\usepackage{graphicx}

\begin{document}

\includegraphics{my.1.png}

\end{document}
```

Apparently this case is saved in the `graphic` attribute as `my.1`, which is then used in post-processing. But that passes through `pathname_split` during `Graphics::findGraphicFile`, mostly to obtain the directory in absolute-pathname cases. And then the `1` from `my.1` gets detached into `$reqtype` and discarded -- mostly since the code didn't expect the custom dotted suffixes.

This patch is _a_ fix, not sure if the best one. Feedback welcome!