### PR TITLE
Variety patchup from arXiv 2021 holiday run

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -359,6 +359,7 @@ lib/LaTeXML/Package/alltt.sty.ltxml
 lib/LaTeXML/Package/ams_core.cls.ltxml
 lib/LaTeXML/Package/ams_support.sty.ltxml
 lib/LaTeXML/Package/amsa.fontmap.ltxml
+lib/LaTeXML/Package/amsaddr.sty.ltxml
 lib/LaTeXML/Package/amsart.cls.ltxml
 lib/LaTeXML/Package/amsb.fontmap.ltxml
 lib/LaTeXML/Package/amsbook.cls.ltxml

--- a/MANIFEST
+++ b/MANIFEST
@@ -436,6 +436,7 @@ lib/LaTeXML/Package/dcolumn.sty.ltxml
 lib/LaTeXML/Package/deluxetable.sty.ltxml
 lib/LaTeXML/Package/diagbox.sty.ltxml
 lib/LaTeXML/Package/ding.fontmap.ltxml
+lib/LaTeXML/Package/doi.sty.ltxml
 lib/LaTeXML/Package/doublespace.sty.ltxml
 lib/LaTeXML/Package/dsfont.sty.ltxml
 lib/LaTeXML/Package/empheq.sty.ltxml

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1128,8 +1128,9 @@ DefMacroI('\maketitle', undef,
     . '\global\let\date\relax'
     . '\global\let\and\relax', locked => 1);
 
-DefMacro('\@thanks',  '\@empty');
-DefMacro('\thanks{}', '\def\@thanks{#1}\lx@make@thanks{#1}');
+DefMacro('\@thanks', '\@empty');
+# make a throwaway optional argument available for OmniBus use
+DefMacro('\thanks[]{}', '\def\@thanks{#2}\lx@make@thanks{#2}');
 DefConstructor('\lx@make@thanks{}', "<ltx:note role='thanks'>#1</ltx:note>");
 
 # Abstract SHOULD have been so simple, but seems to be a magnet for abuse.

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -118,9 +118,8 @@ DefMacro('\indexauthor{}',     Tokens());
 DefMacro('\preface',           Tokens());
 DefMacro('\thankstext',        Tokens());
 DefMacro('\numberofauthors{}', Tokens());
-
-DefMacro('\resumen{}', '\@add@frontmatter{ltx:abstract}{#1}');
-DefMacro('\ion{}{}',   '{#1 \textsc{#2}}');
+DefMacro('\resumen{}',         '\@add@frontmatter{ltx:abstract}{#1}');
+DefMacro('\ion{}{}',           '{#1 \textsc{#2}}');
 Let(T_CS('\fulladdresses'), T_CS('\address'));
 Let(T_CS('\smonth'),        T_CS('\month'));
 Let(T_CS('\syear'),         T_CS('\year'));

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -126,30 +126,34 @@ Let(T_CS('\smonth'),        T_CS('\month'));
 Let(T_CS('\syear'),         T_CS('\year'));
 
 # Comes as both macro with arg, and environment! w/ or w/o "s"!
-DefMacro('\keyword{}',  '\@add@frontmatter{ltx:keywords}{#1}');
 DefMacro('\keywords{}', '\@add@frontmatter{ltx:keywords}{#1}');
 DefMacro('\kword{}',    '\@add@frontmatter{ltx:keywords}{#1}');
 DefMacro('\kwd[]{}',    '\@add@frontmatter{ltx:keywords}{#2, }');
-Let(T_CS('\addto@keywords@list'), T_CS('\keyword'));
 
 # {keyword}, {keywords}
-DefEnvironment('{keywords}', '',
-  afterDigest => sub {
-    my $frontmatter = LookupValue('frontmatter');
-    push(@{ $$frontmatter{'ltx:classification'} },
-      ['ltx:classification', { scheme => 'keywords' }, @LaTeXML::LIST]);
-    return; });
+sub after_digest_keywords {
+  my $frontmatter = LookupValue('frontmatter');
+  push(@{ $$frontmatter{'ltx:classification'} },
+    ['ltx:classification', { scheme => 'keywords' }, @LaTeXML::LIST]);
+  return; }
+DefEnvironment('{keyword}',  '', afterDigest => \&after_digest_keywords);
+DefEnvironment('{keywords}', '', afterDigest => \&after_digest_keywords);
 # Extend to be callable as \keywords{} or \begin{keywords}...
 # Probably want to use this trick more often?
 Let('\lx@begin@keywords', '\keywords');
-DefMacro('\keywords', sub {
-    my ($gullet) = @_;
-    ($gullet->ifNext(T_BEGIN)
-      ? (T_CS('\keywords@onearg'))
-      : (T_CS('\g@addto@macro'), T_CS('\@startsection@hook'), T_CS('\maybe@end@keywords'),
-        T_CS('\lx@begin@keywords'))); });
-DefMacro('\keywords@onearg{}', '\begin{keywords}#1\end{keywords}\let\endkeywords\relax');
+
+sub auto_keywords {
+  my ($gullet) = @_;
+  return ($gullet->ifNext(T_BEGIN)
+    ? (T_CS('\keywords@onearg'))
+    : (T_CS('\g@addto@macro'), T_CS('\@startsection@hook'), T_CS('\maybe@end@keywords'),
+      T_CS('\lx@begin@keywords'))); }
+# see arxiv:math/0601658 for a singular {keyword} example
+DefMacro('\keyword',  \&auto_keywords);
+DefMacro('\keywords', \&auto_keywords);
+DefMacro('\keywords@onearg{}', '\begin{keywords}#1\end{keywords}\let\endkeyword\relax\let\endkeywords\relax');
 DefMacroI('\maybe@end@keywords', undef, '\endkeywords\let\maybe@end@keywords\relax');
+Let(T_CS('\addto@keywords@list'), T_CS('\keyword'));
 
 DefMacro('\classification{}', '\@add@frontmatter{ltx:classification}{#1}');
 DefMacro('\pacs{}',           '\@add@frontmatter{ltx:classification}[scheme=pacs]{#1}');
@@ -162,31 +166,53 @@ DefConstructor('\lx@doi{}', '<ltx:ref href="https:/doi.org/#1">#1</ltx:ref>');
 # from acm_proc_article, is it general enough?
 DefMacro('\category{}{}{}[]', '\@add@frontmatter{ltx:classification}[scheme=category]{#1 #2 #3}\keywords{#4}');
 
+our $omni_theorem_main = <<'EOL';
+\newtheorem{theorem}{Theorem}[section]
+\newtheorem{conjecture}[theorem]{Conjecture}
+\newtheorem{proposition}[theorem]{Proposition}
+\newtheorem{proof}[theorem]{Proof}
+\newtheorem{lemma}[theorem]{Lemma}
+\newtheorem{corollary}[theorem]{Corollary}
+\newtheorem{example}[theorem]{Example}
+\newtheorem{exercise}[theorem]{Exercise}
+\newtheorem{definition}[theorem]{Definition}
+\newtheorem{problem}[theorem]{Problem}
+\newtheorem{question}[theorem]{Question}
+\newtheorem{remark}[theorem]{Remark}
+\newtheorem{solution}[theorem]{Solution}
+\newtheorem{step}[theorem]{Step}
+\newtheorem{note}[theorem]{Note}
+EOL
+# Additional theorem aliases (e.g. autart.cls)
+our $omni_theorem_aux = <<'EOL';
+\newtheorem{thm}{Theorem}
+\newtheorem{cor}[thm]{Corollary}
+\newtheorem{lem}[thm]{Lemma}
+\newtheorem{claim}[thm]{Claim}
+\newtheorem{axiom}[thm]{Axiom}
+\newtheorem{conj}[thm]{Conjecture}
+\newtheorem{fact}[thm]{Fact}
+\newtheorem{hypo}[thm]{Hypothesis}
+\newtheorem{assum}[thm]{Assumption}
+\newtheorem{prop}[thm]{Proposition}
+\newtheorem{crit}[thm]{Criterion}
+\theoremstyle{definition}
+\newtheorem{defn}[thm]{Definition}
+\newtheorem{exmp}[thm]{Example}
+\newtheorem{rem}[thm]{Remark}
+\newtheorem{prob}[thm]{Problem}
+\newtheorem{prin}[thm]{Principle}
+\newtheorem{alg}{Algorithm}
+EOL
+
 for my $env (qw(
   conjecture theorem corollary definition example exercise lemma
-  note problem proof proposition question remark solution)) {
+  note problem proof proposition question remark solution
+  thm cor lem claim axiom conj fact hypo assum prop crit defn exmp rem prob prin alg)) {
   my $beginenv = "\\begin{$env}";
   DefMacroI(T_CS($beginenv), undef, sub {
       RequirePackage('amsthm');
-      return Tokenize(<<"EOL"
-\\newtheorem{theorem}{Theorem}[section]
-\\newtheorem{conjecture}[theorem]{Conjecture}
-\\newtheorem{proposition}[theorem]{Proposition}
-\\newtheorem{proof}[theorem]{Proof}
-\\newtheorem{lemma}[theorem]{Lemma}
-\\newtheorem{corollary}[theorem]{Corollary}
-\\newtheorem{example}[theorem]{Example}
-\\newtheorem{exercise}[theorem]{Exercise}
-\\newtheorem{definition}[theorem]{Definition}
-\\newtheorem{problem}[theorem]{Problem}
-\\newtheorem{question}[theorem]{Question}
-\\newtheorem{remark}[theorem]{Remark}
-\\newtheorem{solution}[theorem]{Solution}
-\\newtheorem{step}[theorem]{Step}
-\\newtheorem{note}[theorem]{Note}
-$beginenv
-EOL
-)->unlist; }); }
+      return Tokenize($omni_theorem_main . $omni_theorem_aux . $beginenv)->unlist; }); }
 for my $new_theorem_alias (qw(\newproclaim \newdef)) {
   DefMacroI(T_CS($new_theorem_alias), undef, sub {
       RequirePackage('amsthm');
@@ -195,7 +221,6 @@ DefAutoload('theoremstyle', 'amsthm.sty.ltxml');
 
 Let('\abstracts', '\abstract');
 Let('\abst',      '\abstract');
-# \editors
 
 # Seems to come in different spellings and often misused!
 DefConstructor('\acknowledgments', "<ltx:acknowledgements name='#name'>",
@@ -227,6 +252,9 @@ DefMacro('\volume{}',           '\@add@frontmatter{ltx:note}[role=volume]{#1}');
 DefMacro('\titlenote{}',        '\@add@frontmatter{ltx:note}[role=titlenote]{#1}');
 DefMacro('\terms{}',            '\@add@frontmatter{ltx:note}[role=terms]{#1}');
 DefMacro('\conferenceinfo{}{}', '\@add@frontmatter{ltx:note}[role=conference]{#1 #2}');
+
+# what useful behavior can we add here? e.g. see arxiv:math/0601658
+DefMacro('\thanksref{}', Tokens());
 
 # rarer variants:
 Let('\CopyrightYear', '\copyrightyear');

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -60,6 +60,7 @@ DefEnvironment('{mainmatter}',  '#body');
 DefEnvironment('{backmatter}',  '#body');
 
 DefMacro('\shorttitle{}',  '\@add@frontmatter{ltx:toctitle}{#1}');
+DefMacro('\subtitle{}',    '\@add@frontmatter{ltx:subtitle}{#1}');
 DefMacro('\shortauthor{}', '');
 DefRegister('\titlerunning',  Tokens());
 DefRegister('\authorrunning', Tokens());
@@ -71,6 +72,7 @@ Let('\runninghead', '\runningtitle');
 DefMacro('\shortauthor{}',  Tokens());
 DefMacro('\authors{}',      Tokens());
 DefMacro('\shortauthors{}', Tokens());
+DefMacro('\alignauthor',    Tokens());
 
 DefConstructor('\@@@email{}{}', "^ <ltx:contact role='#2'>#1</ltx:contact>");
 DefMacro('\email{}', '\@add@to@frontmatter{ltx:creator}{\@@@email{#1}{email}}');
@@ -93,7 +95,8 @@ DefConstructor('\altaffiltext{}{}',
   "?#2(<ltx:note role='affiliationtext' mark='#1'>#2</ltx:note>)()");
 
 DefConstructor('\@@@address{}', "^ <ltx:contact role='address'>#1</ltx:contact>");
-DefMacro('\address[]{}',   '\@add@to@frontmatter{ltx:creator}{\@@@address{#2}}');
+DefMacro('\address[]{}', '\@add@to@frontmatter{ltx:creator}{\@@@address{#2}}');
+Let('\affaddr', '\address');
 DefMacro('\affiliation{}', '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1}}');
 DefRegister('\affilskip' => Dimension(0));
 
@@ -114,8 +117,10 @@ DefMacro('\listofauthors{}',  Tokens());
 DefMacro('\indexauthor{}',    Tokens());
 DefMacro('\preface',          Tokens());
 DefMacro('\thankstext',       Tokens());
-DefMacro('\resumen{}',        '\@add@frontmatter{ltx:abstract}{#1}');
-DefMacro('\ion{}{}',          '{#1 \textsc{#2}}');
+DefMacro('\numberofauthors',  Tokens());
+
+DefMacro('\resumen{}', '\@add@frontmatter{ltx:abstract}{#1}');
+DefMacro('\ion{}{}',   '{#1 \textsc{#2}}');
 Let(T_CS('\fulladdresses'), T_CS('\address'));
 Let(T_CS('\smonth'),        T_CS('\month'));
 Let(T_CS('\syear'),         T_CS('\year'));
@@ -182,6 +187,7 @@ EOL
 DefMacroI(T_CS('\newproclaim'), undef, sub {
     RequirePackage('amsthm');
     return T_CS('\newtheorem'); });
+DefAutoload('theoremstyle', 'amsthm.sty.ltxml');
 
 Let('\abstracts', '\abstract');
 Let('\abst',      '\abstract');
@@ -213,6 +219,8 @@ DefMacro('\issue{}',        '\@add@frontmatter{ltx:note}[role=issue]{#1}');
 DefMacro('\journal{}',      '\@add@frontmatter{ltx:note}[role=journal]{#1}');
 DefMacro('\jname{}',        '\@add@frontmatter{ltx:note}[role=journal]{#1}');
 DefMacro('\volume{}',       '\@add@frontmatter{ltx:note}[role=volume]{#1}');
+DefMacro('\titlenote{}',    '\@add@frontmatter{ltx:note}[role=titlenote]{#1}');
+DefMacro('\terms{}',        '\@add@frontmatter{ltx:note}[role=terms]{#1}');
 
 # work as environment or not...
 DefConstructor('\references',
@@ -232,4 +240,16 @@ Let('\reference', '\bibitem');
 DefMacro('\comment{}',    '');
 DefMacro('\etal',         '\textit{et al.}');
 DefMacro('\firstsection', '');
+
+DefAutoload('align',                       'amsmath.sty.ltxml');
+DefAutoload('subequations',                'amsmath.sty.ltxml');
+DefAutoload('split',                       'amsmath.sty.ltxml');
+DefAutoload('\multline',                   'amsmath.sty.ltxml');
+DefAutoload('\csname multline*\endcsname', 'amsmath.sty.ltxml');
+DefAutoload('numberwithin',                'amsmath.sty.ltxml');
+DefAutoload('deluxetable',                 'deluxetable.sty.ltxml');
+DefAutoload('curraddr',                    'ams_support.sty.ltxml');
+DefAutoload('subjclass',                   'ams_support.sty.ltxml');
+DefAutoload('thechapter',                  'book.cls.ltxml');
+
 1;

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -160,7 +160,7 @@ DefMacro('\doi{}',
 DefConstructor('\lx@doi{}', '<ltx:ref href="https:/doi.org/#1">#1</ltx:ref>');
 
 # from acm_proc_article, is it general enough?
-DefMacro('\category{}{}{}', '\@add@frontmatter{ltx:classification}[scheme=category]{#1 #2 #3}');
+DefMacro('\category{}{}{}[]', '\@add@frontmatter{ltx:classification}[scheme=category]{#1 #2 #3}\keywords{#4}');
 
 for my $env (qw(
   conjecture theorem corollary definition example exercise lemma
@@ -187,9 +187,10 @@ for my $env (qw(
 $beginenv
 EOL
 )->unlist; }); }
-DefMacroI(T_CS('\newproclaim'), undef, sub {
-    RequirePackage('amsthm');
-    return T_CS('\newtheorem'); });
+for my $new_theorem_alias (qw(\newproclaim \newdef)) {
+  DefMacroI(T_CS($new_theorem_alias), undef, sub {
+      RequirePackage('amsthm');
+      return T_CS('\newtheorem'); }); }
 DefAutoload('theoremstyle', 'amsthm.sty.ltxml');
 
 Let('\abstracts', '\abstract');
@@ -213,6 +214,7 @@ DefMacro('\received{}',         '\@add@frontmatter{ltx:date}[role=received]{#1}'
 DefMacro('\revised{}',          '\@add@frontmatter{ltx:date}[role=revised]{#1}');
 DefMacro('\accepted{}',         '\@add@frontmatter{ltx:date}[role=accepted]{#1}');
 DefMacro('\pubyear{}',          '\@add@frontmatter{ltx:date}[role=publication]{#1}');
+DefMacro('\copyrightyear{}',    '\@add@frontmatter{ltx:date}[role=copyright]{#1}');
 DefMacro('\preprint{}',         '\@add@frontmatter{ltx:note}[role=preprint]{#1}');
 DefMacro('\communicated{}',     '\@add@frontmatter{ltx:date}[role=communicated]{#1}');
 DefMacro('\dedicated{}',        '\@add@frontmatter{ltx:note}[role=dedicated]{#1}');
@@ -225,6 +227,13 @@ DefMacro('\volume{}',           '\@add@frontmatter{ltx:note}[role=volume]{#1}');
 DefMacro('\titlenote{}',        '\@add@frontmatter{ltx:note}[role=titlenote]{#1}');
 DefMacro('\terms{}',            '\@add@frontmatter{ltx:note}[role=terms]{#1}');
 DefMacro('\conferenceinfo{}{}', '\@add@frontmatter{ltx:note}[role=conference]{#1 #2}');
+
+# rarer variants:
+Let('\CopyrightYear', '\copyrightyear');
+DefRegister('\confinfo',     Tokens());
+DefRegister('\acmcopyr',     Tokens());
+DefRegister('\copyrightetc', Tokens());
+Let('\crdata', '\acmcopyr');
 
 # work as environment or not...
 DefConstructor('\references',

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -101,23 +101,23 @@ DefMacro('\affiliation{}', '\@add@to@frontmatter{ltx:creator}{\@@@affiliation{#1
 DefRegister('\affilskip' => Dimension(0));
 
 # some rarer name macros that are functionally no-ops for latexml
-DefMacro('\prefix{}',         '#1');
-DefMacro('\suffix{}',         '#1');
-DefMacro('\fnms{}',           '#1');
-DefMacro('\snm{}',            '#1');
-DefMacro('\inits{}',          '#1');
-DefMacro('\printaddresses{}', '#1');
-DefMacro('\printead{}',       Tokens());
-DefMacro('\firstpage{}',      Tokens());
-DefMacro('\lastpage{}',       Tokens());
-DefMacro('\runauthor{}',      Tokens());
-DefMacro('\runtitle{}',       Tokens());
-DefMacro('\corref{}',         Tokens());
-DefMacro('\listofauthors{}',  Tokens());
-DefMacro('\indexauthor{}',    Tokens());
-DefMacro('\preface',          Tokens());
-DefMacro('\thankstext',       Tokens());
-DefMacro('\numberofauthors',  Tokens());
+DefMacro('\prefix{}',          '#1');
+DefMacro('\suffix{}',          '#1');
+DefMacro('\fnms{}',            '#1');
+DefMacro('\snm{}',             '#1');
+DefMacro('\inits{}',           '#1');
+DefMacro('\printaddresses{}',  '#1');
+DefMacro('\printead{}',        Tokens());
+DefMacro('\firstpage{}',       Tokens());
+DefMacro('\lastpage{}',        Tokens());
+DefMacro('\runauthor{}',       Tokens());
+DefMacro('\runtitle{}',        Tokens());
+DefMacro('\corref{}',          Tokens());
+DefMacro('\listofauthors{}',   Tokens());
+DefMacro('\indexauthor{}',     Tokens());
+DefMacro('\preface',           Tokens());
+DefMacro('\thankstext',        Tokens());
+DefMacro('\numberofauthors{}', Tokens());
 
 DefMacro('\resumen{}', '\@add@frontmatter{ltx:abstract}{#1}');
 DefMacro('\ion{}{}',   '{#1 \textsc{#2}}');
@@ -158,6 +158,9 @@ DefMacro('\doi{}',
   '\if@in@preamble{\@add@frontmatter{ltx:classification}[scheme=doi]{#1}'
     . '\else\lx@doi{#1}\fi');
 DefConstructor('\lx@doi{}', '<ltx:ref href="https:/doi.org/#1">#1</ltx:ref>');
+
+# from acm_proc_article, is it general enough?
+DefMacro('\category{}{}{}', '\@add@frontmatter{ltx:classification}[scheme=category]{#1 #2 #3}');
 
 for my $env (qw(
   conjecture theorem corollary definition example exercise lemma
@@ -205,22 +208,23 @@ Let('\endacknowledgements',   '\endacknowledgments');
 Let('\theacknowledgments',    '\acknowledgments');
 Let('\endtheacknowledgments', '\endacknowledgments');
 
-DefMacro('\editors{}',      '\@add@frontmatter{ltx:note}[role=editors]{#1}');
-DefMacro('\received{}',     '\@add@frontmatter{ltx:date}[role=received]{#1}');
-DefMacro('\revised{}',      '\@add@frontmatter{ltx:date}[role=revised]{#1}');
-DefMacro('\accepted{}',     '\@add@frontmatter{ltx:date}[role=accepted]{#1}');
-DefMacro('\pubyear{}',      '\@add@frontmatter{ltx:date}[role=publication]{#1}');
-DefMacro('\preprint{}',     '\@add@frontmatter{ltx:note}[role=preprint]{#1}');
-DefMacro('\communicated{}', '\@add@frontmatter{ltx:date}[role=communicated]{#1}');
-DefMacro('\dedicated{}',    '\@add@frontmatter{ltx:note}[role=dedicated]{#1}');
-DefMacro('\presented{}',    '\@add@frontmatter{ltx:date}[role=presented]{#1}');
-DefMacro('\articletype{}',  '\@add@frontmatter{ltx:note}[role=articletype]{#1}');
-DefMacro('\issue{}',        '\@add@frontmatter{ltx:note}[role=issue]{#1}');
-DefMacro('\journal{}',      '\@add@frontmatter{ltx:note}[role=journal]{#1}');
-DefMacro('\jname{}',        '\@add@frontmatter{ltx:note}[role=journal]{#1}');
-DefMacro('\volume{}',       '\@add@frontmatter{ltx:note}[role=volume]{#1}');
-DefMacro('\titlenote{}',    '\@add@frontmatter{ltx:note}[role=titlenote]{#1}');
-DefMacro('\terms{}',        '\@add@frontmatter{ltx:note}[role=terms]{#1}');
+DefMacro('\editors{}',          '\@add@frontmatter{ltx:note}[role=editors]{#1}');
+DefMacro('\received{}',         '\@add@frontmatter{ltx:date}[role=received]{#1}');
+DefMacro('\revised{}',          '\@add@frontmatter{ltx:date}[role=revised]{#1}');
+DefMacro('\accepted{}',         '\@add@frontmatter{ltx:date}[role=accepted]{#1}');
+DefMacro('\pubyear{}',          '\@add@frontmatter{ltx:date}[role=publication]{#1}');
+DefMacro('\preprint{}',         '\@add@frontmatter{ltx:note}[role=preprint]{#1}');
+DefMacro('\communicated{}',     '\@add@frontmatter{ltx:date}[role=communicated]{#1}');
+DefMacro('\dedicated{}',        '\@add@frontmatter{ltx:note}[role=dedicated]{#1}');
+DefMacro('\presented{}',        '\@add@frontmatter{ltx:date}[role=presented]{#1}');
+DefMacro('\articletype{}',      '\@add@frontmatter{ltx:note}[role=articletype]{#1}');
+DefMacro('\issue{}',            '\@add@frontmatter{ltx:note}[role=issue]{#1}');
+DefMacro('\journal{}',          '\@add@frontmatter{ltx:note}[role=journal]{#1}');
+DefMacro('\jname{}',            '\@add@frontmatter{ltx:note}[role=journal]{#1}');
+DefMacro('\volume{}',           '\@add@frontmatter{ltx:note}[role=volume]{#1}');
+DefMacro('\titlenote{}',        '\@add@frontmatter{ltx:note}[role=titlenote]{#1}');
+DefMacro('\terms{}',            '\@add@frontmatter{ltx:note}[role=terms]{#1}');
+DefMacro('\conferenceinfo{}{}', '\@add@frontmatter{ltx:note}[role=conference]{#1 #2}');
 
 # work as environment or not...
 DefConstructor('\references',

--- a/lib/LaTeXML/Package/aa_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aa_support.sty.ltxml
@@ -347,6 +347,9 @@ DefPrimitiveI('\bbbz',   undef, "\x{2124}");
 DefConstructor('\bib@field@default@adsurl Verbatim',
   "<ltx:bib-url href='#1'>ADS entry</ltx:bib-url>");
 
+# We could probably do more with these if they were used consistently...
+# example use is [\eprint[arXiv]{astro-ph/0212111}], in a bibitem
+DefMacro('\eprint[]{}', '{\tt\if!#1!#2\else#1:#2\fi}');
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Astronomical objects
 

--- a/lib/LaTeXML/Package/ams_support.sty.ltxml
+++ b/lib/LaTeXML/Package/ams_support.sty.ltxml
@@ -110,7 +110,7 @@ DefConstructor('\@@@curraddr{}', "^ <ltx:contact role='current_address'>#1</ltx:
 DefMacro('\curraddr{}', '\@add@to@frontmatter{ltx:creator}{\@@@curraddr{#1}}');
 
 DefConstructor('\@@@email{}', "^ <ltx:contact role='email'>#1</ltx:contact>");
-DefMacro('\email{}', '\@add@to@frontmatter{ltx:creator}{\@@@email{#1}}');
+DefMacro('\email[]{}', '\@add@to@frontmatter{ltx:creator}{\@@@email{#2}}');
 
 DefConstructor('\@@@urladdr{}', "^ <ltx:contact role='url'>#1</ltx:contact>");
 DefMacro('\urladdr{}', '\@add@to@frontmatter{ltx:creator}{\@@@urladdr{#1}}');

--- a/lib/LaTeXML/Package/ams_support.sty.ltxml
+++ b/lib/LaTeXML/Package/ams_support.sty.ltxml
@@ -122,8 +122,9 @@ DefMacro('\dedicatory{}', '\@add@to@frontmatter{ltx:creator}{\@@@dedicatory{#1}}
 DefMacro('\dateposted{}', '\@add@frontmatter{ltx:date}[role=posted]{#1}');
 
 # \thanks{} ( == ack, not latex's \thanks, not in author)
-DefMacro('\thanks{}',
-  '\@add@frontmatter{ltx:acknowledgements}[name={\@ifundefined{thanksname}{}{\thanksname}}]{#1}');
+# make a throwaway optional argument available for OmniBus use
+DefMacro('\thanks[]{}',
+  '\@add@frontmatter{ltx:acknowledgements}[name={\@ifundefined{thanksname}{}{\thanksname}}]{#2}');
 
 DefMacro('\translator[]{}',
   '\@add@frontmatter{ltx:creator}[role=translator]{\@personname{#2}}');

--- a/lib/LaTeXML/Package/amsaddr.sty.ltxml
+++ b/lib/LaTeXML/Package/amsaddr.sty.ltxml
@@ -1,0 +1,24 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  amsaddr.sty                                                        | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@nist.gov>                          #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+
+RequirePackage('ams_support');
+
+#**********************************************************************
+
+1;

--- a/lib/LaTeXML/Package/doi.sty.ltxml
+++ b/lib/LaTeXML/Package/doi.sty.ltxml
@@ -1,0 +1,24 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  doi.sty                                                            | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@nist.gov>                          #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+
+InputDefinitions('doi', type => 'sty', noltxml => 1);
+
+#**********************************************************************
+
+1;

--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -43,12 +43,13 @@ DefKeyVal('Gin', 'magnifiable', '', 'true');
 
 # Redefine
 DefMacro('\includegraphics OptionalMatch:* []',
-  '\@ifnextchar[{\@includegraphics#1[#2]}{\@includegraphicx#1[#2]}');
+  '\@ifnextchar[{\@includegraphics#1[#2]}{\@includegraphicx#1[#2]}', scope => 'global');
 
 DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbatim',
   "<ltx:graphics graphic='#path' candidates='#candidates' options='#options'/>",
   alias      => '\includegraphics',
   sizer      => \&image_graphicx_sizer,
+  scope      => 'global',
   properties => sub {
     my ($stomach, $starred, $kv, $path) = @_;
     $path = ToString($path); $path =~ s/^\s+//; $path =~ s/\s+$//;

--- a/lib/LaTeXML/Package/inst_support.sty.ltxml
+++ b/lib/LaTeXML/Package/inst_support.sty.ltxml
@@ -39,8 +39,9 @@ use LaTeXML::Package;
 # with the same mark number, and copy the institute information into that creator element
 # as an ltx:contact(with @role='institute').
 
-DefMacro('\author{}', sub {
-    map { (T_CS('\lx@author'), T_BEGIN, @$_, T_END) } SplitTokens($_[1], T_CS('\and'), T_OTHER(',')); });
+# add optinal argument for OmniBus use
+DefMacro('\author[]{}', sub {
+    map { (T_CS('\lx@author'), T_BEGIN, @$_, T_END) } SplitTokens($_[2], T_CS('\and'), T_OTHER(',')); });
 
 DefMacro('\@institutemark{}', '\lx@contact{institutemark}{#1}');
 
@@ -78,7 +79,7 @@ DefConstructor('\@in@inst@email{}',
 # This creates the note for each institute.
 DefConstructor('\@add@institute {}',
   "<ltx:note role='institutetext' mark='#mark'>#1</ltx:note>",
-  bounded => 1, beforeDigest => sub { AssignValue(inPreamble => 0); },
+  bounded    => 1, beforeDigest => sub { AssignValue(inPreamble => 0); },
   properties => sub { (mark => ToString(Expand(T_CS('\theinst')))); });
 
 # Reconnecting the institute to the appropriate author:


### PR DESCRIPTION
I looked into a variety of issues this morning, and rapidly patched a number of very easy missing bits from various report levels. 

Feel free to read through and veto anything that seems too brave - I've left the paper names in the commit messages / code comments. 

Mostly extensions to OmniBus itself, a couple of easy bindings, and some optional arguments to standard macros that help in OmniBus use.

At times I wondered whether I should be writing journal-specific bindings, but the utility of adding constructs such as `{thm}` and `{lem}` to OmniBus seems much higher for arXiv, where all kinds of journals may be rediscovering the same constructs.