### PR TITLE
Arxiv malformed

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1504,10 +1504,18 @@ sub setEnumerationStyle {
     DefMacroI('\labelenum' . $level, undef, Tokens(T_BEGIN, @out, T_END)); }
   return; }
 
+# End paragraphs, like \par, but only if within an item's text
+DefConstructorI('\preitem@par', undef, sub {
+    my ($document, %props) = @_;
+    if (!$props{inPreamble} && !$document->getNodeQName($document->getElement(), 'ltx:itemize')) {
+      $document->maybeCloseElement('ltx:p');
+      $document->maybeCloseElement('ltx:para'); } },
+  alias => '\par');
+
 # id, but NO refnum (et.al) attributes on itemize \item ...
 # unless the optional tag argument was given!
 # We'll make the <ltx:tag> from either the optional arg, or from \labelitemi..
-DefMacro('\itemize@item', '\par\itemize@item@');
+DefMacro('\itemize@item', '\preitem@par\itemize@item@');
 DefConstructor('\itemize@item@ OptionalUndigested',
   "<ltx:item xml:id='#id' itemsep='#itemsep'>#tags",
   properties => sub { RefStepItemCounter($_[1]); });
@@ -1515,7 +1523,7 @@ DefConstructor('\inline@itemize@item OptionalUndigested',
   "<ltx:inline-item xml:id='#id'>#tags",
   properties => sub { RefStepItemCounter($_[1]); });
 
-DefMacro('\enumerate@item', '\par\enumerate@item@');
+DefMacro('\enumerate@item', '\preitem@par\enumerate@item@');
 DefConstructor('\enumerate@item@ OptionalUndigested',
   "<ltx:item xml:id='#id' itemsep='#itemsep'>#tags",
   properties => sub { RefStepItemCounter($_[1]); });
@@ -1523,7 +1531,7 @@ DefConstructor('\inline@enumerate@item OptionalUndigested',
   "<ltx:inline-item xml:id='#id'>#tags",
   properties => sub { RefStepItemCounter($_[1]); });
 
-DefMacro('\description@item', '\par\description@item@');
+DefMacro('\description@item', '\preitem@par\description@item@');
 DefConstructor('\description@item@ OptionalUndigested',
   "<ltx:item xml:id='#id' itemsep='#itemsep'>#tags",
   properties => sub { RefStepItemCounter($_[1]); });
@@ -1691,10 +1699,14 @@ DefMacro('\list{}{}',
 '\let\@listctr\@empty#2\ifx\@listctr\@empty\usecounter{}\fi\expandafter\def\csname fnum@\@listctr\endcsname{#1}\lx@list');
 DefMacro('\endlist', '\endlx@list');
 
-DefConstructor('\lx@list DigestedBody',
-  "<ltx:itemize>#1</ltx:itemize>",
+# Start an anonymous list (often misused)
+DefConstructor('\lx@list',
+  "<ltx:itemize>",
   beforeDigest => sub { $_[0]->bgroup; });
-DefPrimitive('\endlx@list', sub { $_[0]->egroup; });
+# Close the anonymous list if we're still within one.
+DefConstructor('\endlx@list', sub {
+    $_[0]->maybeCloseElement('ltx:itemize'); },
+  beforeDigest => sub { $_[0]->egroup; });
 
 DefConstructor('\list@item OptionalUndigested',
   "<ltx:item xml:id='#id' itemsep='#itemsep'>#tags",
@@ -1703,17 +1715,13 @@ DefConstructor('\list@item OptionalUndigested',
 # This isn't quite right, although it seems right for deep, internal uses with a single \item.
 # Perhaps we need to check trivlist's afterwards and if they are just a single item,
 # reduce it to an ltx:p ??
-# DefMacro('\trivlist@item[]', '');
-# DefEnvironment('{trivlist}',
-#   '<ltx:p>#body</ltx:p>',
-#   beforeDigest => sub { Let('\item', '\trivlist@item'); });
-
-DefEnvironment('{trivlist}',
-  "<ltx:itemize>#body</ltx:itemize>",
-  properties      => sub { beginItemize('trivlist'); },
-  beforeDigestEnd => sub { Digest('\par'); });
-
-DefMacro('\trivlist@item', '\par\trivlist@item@');
+DefConstructor('\trivlist',
+  "<ltx:itemize _autoclose='1'>",
+  properties => sub { beginItemize('trivlist'); });
+DefConstructor('\endtrivlist', sub {
+    $_[0]->maybeCloseElement('ltx:itemize'); },
+  beforeDigest => sub { Digest('\par'); });
+DefMacro('\trivlist@item', '\preitem@par\trivlist@item@');
 DefConstructor('\trivlist@item@ OptionalUndigested',
   "<ltx:item xml:id='#id' itemsep='#itemsep'>"
     . "<ltx:tags><ltx:tag>#tag</ltx:tag></ltx:tags>",    # At least an empty tag! ?
@@ -4013,9 +4021,15 @@ DefMacro('\lx@mung@bibliography{}', sub {
         T_CS('\let'), T_CS('\end{' . $tag . '}'), T_CS('\end{thebibliography}')); }
     # else ? it probably isn't going to work??
     # Now, try to open {thebibliography}
-    push(@tokens, Invocation('\begin', Tokenize('thebibliography'), Tokens()));
+    push(@tokens, T_CS('\lx@mung@bibliography@pre'), Invocation('\thebibliography'), Tokens());
     return Tokens(@tokens); });
-
+DefConstructor('\lx@mung@bibliography@pre', sub {
+    my ($document) = @_;
+    my $parent     = $document->getNode;
+    my $tag        = $document->getNodeQName($parent);
+    if ($tag =~ /^ltx:(?:itemize|enumerate|description)$/) {
+      $document->maybeCloseElement($tag); }    # Or even remove (if empty)?
+    return; });
 DefConstructorI('\lx@bibnewblock', undef, "<ltx:bibblock>");
 Let('\newblock', '\lx@bibnewblock');
 Tag('ltx:bibitem',  autoClose => 1);

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3635,7 +3635,6 @@ DefConstructor('\@@tabular@{Dimension}[] Undigested DigestedBody',
 DefPrimitive('\@end@tabular@', sub { $_[0]->egroup; });
 Let('\multicolumn', '\@multicolumn');
 
-DefPrimitiveI('\hline', undef, undef);    # Redefined inside tabular
 # A weird bit that sometimes gets invoked by Cargo Cult programmers...
 # to \noalign in the defn of \hline! Bizarre! (see latex.ltx)
 # However, the really weird thing is the way this provides the } to close the argument

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3765,9 +3765,6 @@ sub beforeDigestBibliography {
   AssignValue(inPreamble => 0); Digest('\@lx@inbibliographytrue');
   DefMacro('\bibliographystyle{}', '');
   DefMacro('\bibliography {}',     '');
-  DefConstructorI('\endthebibliography', undef,
-    "</ltx:biblist></ltx:bibliography>",
-    locked => 1);
   ResetCounter('@bibitem');
   return; }
 
@@ -3936,8 +3933,9 @@ DefConstructorI('\thebibliography', undef,
   locked          => 1);
 
 # Close the bibliography
-DefConstructorI('\endthebibliography', undef,
-  "</ltx:biblist></ltx:bibliography>",
+DefConstructorI('\endthebibliography', undef, sub {
+    $_[0]->maybeCloseElement('ltx:biblist');
+    $_[0]->maybeCloseElement('ltx:bibliography'); },
   locked => 1);
 # auto close the bibliography and contained biblist.
 Tag('ltx:biblist',      autoClose => 1);
@@ -3958,6 +3956,12 @@ sub setupPseudoBibitem {
   Let('\item', '\item@in@bibliography');
   # And protect from redefinitions.
   Let('\newblock', '\lx@bibnewblock');
+  my $gullet = $STATE->getStomach->getGullet;
+  # Risky, but when bibliography immediatesly starts with text (no implied \par)
+  if (my $token = $gullet->readNonSpace) {
+    $gullet->unread($token);
+    if (!$token->isExecutable) {
+      $gullet->unread(T_CS('\par')); } }
   return; }
 
 DefMacroI('\par@in@bibliography', undef, sub {
@@ -4029,7 +4033,8 @@ DefConstructor('\lx@mung@bibliography@pre', sub {
     if ($tag =~ /^ltx:(?:itemize|enumerate|description)$/) {
       $document->maybeCloseElement($tag); }    # Or even remove (if empty)?
     return; });
-DefConstructorI('\lx@bibnewblock', undef, "<ltx:bibblock>");
+DefConstructorI('\lx@bibnewblock', undef, sub {
+    $_[0]->openElement('ltx:bibblock') if $_[0]->isOpenable('ltx:bibblock'); });
 Let('\newblock', '\lx@bibnewblock');
 Tag('ltx:bibitem',  autoClose => 1);
 Tag('ltx:bibblock', autoClose => 1);

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -224,8 +224,9 @@ DefConstructor('\references',
   afterDigest  => sub { beginBibliography($_[1]); }
 );
 
-DefConstructor('\endreferences',
-  "</ltx:biblist></ltx:bibliography>");
+DefConstructor('\endreferences', sub {
+    $_[0]->maybeCloseElement('ltx:biblist');
+    $_[0]->maybeCloseElement('ltx:bibliography'); });
 
 Let('\reference', '\bibitem');
 

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2458,20 +2458,15 @@ DefConstructor('\ltx@special@graphics OptionalKeyVals:SpecialPS Semiverbatim',
         $angle = ToString($angle);
         $options .= ',' if $options;
         $options .= "angle=$angle"; }
-      my $voffset = $kv->getValue('voffset');
+      my $voffset = $kv->getValue('voffset') || 0;
       $voffset = $voffset && int(ToString($voffset));
-      my $hoffset = $kv->getValue('hoffset');
+      my $hoffset = $kv->getValue('hoffset') || 0;
       $hoffset = $hoffset && int(ToString($hoffset));
       if ($voffset || $hoffset) {
-        my ($left, $bottom, $right, $top) = (0, 0, 0, 0);
-        # STRANGE: I get best results by applying the offsets as >0 TRIMs to both axes,
-        #          rather than as single-axis offset (via negative value trim).
-        $voffset = -$voffset if $voffset < 0;
-        $bottom  = $top = $voffset;
-        $hoffset = -$hoffset if $hoffset < 0;
-        $left    = $right = $hoffset;
+        my $left   = -$hoffset;
+        my $bottom = -$voffset;
         $options .= "," if $options;
-        $options .= "trim=$left $bottom $right $top,clip=true"; } }
+        $options .= "trim=$left $bottom 0 0,clip=true"; } }
     (options => $options, path => $path, candidates => join(',', @candidates)); },
   mode => 'text');
 # Since these ultimately generate external resources, it can be useful to have a handle on them.

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2717,7 +2717,7 @@ DefConstructor('\hidden@noalign{}', '#1',
     my $preserve = grep { $_->getProperty('alignmentPreserve'); } $_[1]->unlist;
     (alignmentSkippable => 1, alignmentPreserve => $preserve); });
 
-DefMacro('\@alignment@hline', '\noalign{\@@alignment@hline}');
+DefMacro('\hline', '\noalign{\@@alignment@hline}');
 DefConstructorI('\@@alignment@hline', undef, '',
   afterDigest => sub {
     if (my $alignment = LookupValue('Alignment')) {
@@ -2989,8 +2989,7 @@ sub alignmentBindings {
     properties     => {%properties});
   AssignValue(Alignment => $alignment);
   Debug("Halign $alignment: New " . $template->show) if $LaTeXML::DEBUG{halign};
-  Let('\hline', '\@alignment@hline');
-  Let(T_MATH,   ($ismath ? '\@dollar@in@mathmode' : '\@dollar@in@textmode'));
+  Let(T_MATH, ($ismath ? '\@dollar@in@mathmode' : '\@dollar@in@textmode'));
   return; }
 
 DefMacroI('\@row@before',    undef, undef);

--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -268,8 +268,9 @@ DefConstructor('\references',
     . "<ltx:title>#title</ltx:title>"
     . "<ltx:biblist>",
   afterDigest => sub { beginBibliography($_[1]); });
-DefConstructor('\endreferences',
-  "</ltx:biblist></ltx:bibliography>");
+DefConstructor('\endreferences', sub {
+    $_[0]->maybeCloseElement('ltx:biblist');
+    $_[0]->maybeCloseElement('ltx:bibliography'); });
 
 Let('\reference', '\bibitem');
 

--- a/lib/LaTeXML/Package/cleveref.sty.ltxml
+++ b/lib/LaTeXML/Package/cleveref.sty.ltxml
@@ -20,8 +20,11 @@ use LaTeXML::Package;
 # We won't yet support the optional arg to the redefined \label...
 Let(T_CS('\lx@cleverref@save@label'), T_CS('\label'));
 DefMacro('\lx@cleverref@label[]', '\lx@cleverref@save@label');
+my $amswasloaded = LookupValue('amsmath.sty_loaded');
+# Pretend amsmath already loaded (if it will be), to avoid pointless error
+AssignValue('amsmath.sty_loaded' => 1);
 InputDefinitions('cleveref', type => 'sty', noltxml => 1);
-
+AssignValue('amsmath.sty_loaded' => $amswasloaded);
 # Now define it back.
 AtBeginDocument(sub {
     Let(T_CS('\label'), T_CS('\lx@cleverref@label')); });

--- a/lib/LaTeXML/Package/deluxetable.sty.ltxml
+++ b/lib/LaTeXML/Package/deluxetable.sty.ltxml
@@ -84,10 +84,10 @@ DefMacro('\twocolhead{}', '\multicolumn{2}{c}{\hss #1 \hss}');
 DefMacro('\nocolhead{}',  '\multicolumn{1}{h}{#1}');
 DefMacro('\dcolhead{}',   '\multicolumn{1}{c}{$\relax#1$}');
 
-DefMacro('\nl',          '\\\\[0pt]');                       # Obsolete form
-DefMacro('\nextline',    '\\\\[0pt]');                       # Obsolete form
-DefMacro('\tablevspace', '\\\\[0pt]');                       # Obsolete form
-DefMacro('\tablebreak',  '\\\\[0pt]');                       # Obsolete form
+DefMacro('\nl',            '\\\\[0pt]');                     # Obsolete form
+DefMacro('\nextline',      '\\\\[0pt]');                     # Obsolete form
+DefMacro('\tablevspace{}', '\noalign{\vskip#1}');            # Obsolete form
+DefMacro('\tablebreak',    '\\\\[0pt]');                     # Obsolete form
 
 #======================================================================
 # 2.15.3 Content of deluxetable

--- a/lib/LaTeXML/Package/emulateapj.cls.ltxml
+++ b/lib/LaTeXML/Package/emulateapj.cls.ltxml
@@ -23,50 +23,6 @@ use LaTeXML::Package;
 # Seems to be equivalent.
 LoadClass('aastex', withoptions => 1);
 RequireResource('ltx-apj.css');
-# ... Well, almost...
-DefMacroI('\LongTables', undef, '');
-Let('\begin{deluxetable*}', '\begin{deluxetable}');
-Let('\end{deluxetable*}',   '\end{deluxetable}');
-
-Let('\BeginEnvironment', '\begin');
-Let('\EndEnvironment',   '\end');
-
-# Hopefully, nobody is using these for real...
-DefMacro('\BeforeBegin{}{}', '');
-DefMacro('\BeforeEnd{}{}',   '');
-DefMacro('\AfterBegin{}{}',  '');
-DefMacro('\AfterEnd{}{}',    '');
-
-DefMacro('\ApjSectionMarkInTitle{}',         '{#1.\ }');
-DefMacro('\ApjSectionpenalty',               '0');
-DefMacro('\AppendixApjSectionMarkInTitle{}', '{#1.\ }');
-
-DefMacro('\NullCom{}', '');
-DefMacroI('\apjsecfont',        undef, '\small');
-DefMacroI('\lastfootnote',      undef, '\small');
-DefMacroI('\lastpagefootnote',  undef, '\small');
-DefMacroI('\lastpagefootnotes', undef, '\small');
-DefMacro('\tableheadfrac{}', '');
-DefMacro('\tabletypesize{}', '');
-Let('\tablefontsize', '\tabletypesize');
-
-DefMacro('\subtitle', '');
-
-DefMacro('\submitted{}',   '\@add@frontmatter{ltx:date}[role=submitted]{#1}');
-DefMacro('\journalinfo{}', '\@add@frontmatter{ltx:note}[role=journal]{#1}');
-
-DefMacro('\keywordsname', 'Subject headings');
-
-# Vertical analogs of llap, rlap
-DefMacro('\ulap{}', '\hbox{#1}');
-DefMacro('\dlap{}', '\hbox{#1}');
-
-Let('\tabcaption', '\caption');
-
-DefMacro('\format@title@section{}',    '\lx@tag[][.\space]{\thesection}#1');
-DefMacro('\format@title@subsection{}', '\lx@tag[][.\space]{\thesubsection}#1');
-DefMacro('\format@title@figure{}',     '\lx@tag[][.\@@emdash\space]{\lx@fnum@@{figure}}#1');
-DefMacro('\format@title@table{}',      '\lx@tag{\lx@fnum@@{table}}#1');
-
+RequirePackage('emulateapj');
 # #======================================================================
 1;

--- a/lib/LaTeXML/Package/emulateapj.sty.ltxml
+++ b/lib/LaTeXML/Package/emulateapj.sty.ltxml
@@ -22,6 +22,50 @@ use LaTeXML::Package;
 #**********************************************************************
 # Seems to be equivalent.
 RequirePackage('aastex', withoptions => 1);
+# ... Well, almost...
+DefMacroI('\LongTables', undef, '');
+Let('\begin{deluxetable*}', '\begin{deluxetable}');
+Let('\end{deluxetable*}',   '\end{deluxetable}');
+
+Let('\BeginEnvironment', '\begin');
+Let('\EndEnvironment',   '\end');
+
+# Hopefully, nobody is using these for real...
+DefMacro('\BeforeBegin{}{}', '');
+DefMacro('\BeforeEnd{}{}',   '');
+DefMacro('\AfterBegin{}{}',  '');
+DefMacro('\AfterEnd{}{}',    '');
+
+DefMacro('\ApjSectionMarkInTitle{}',         '{#1.\ }');
+DefMacro('\ApjSectionpenalty',               '0');
+DefMacro('\AppendixApjSectionMarkInTitle{}', '{#1.\ }');
+
+DefMacro('\NullCom{}', '');
+DefMacroI('\apjsecfont',        undef, '\small');
+DefMacroI('\lastfootnote',      undef, '\small');
+DefMacroI('\lastpagefootnote',  undef, '\small');
+DefMacroI('\lastpagefootnotes', undef, '\small');
+DefMacro('\tableheadfrac{}', '');
+DefMacro('\tabletypesize{}', '');
+Let('\tablefontsize', '\tabletypesize');
+
+DefMacro('\subtitle', '');
+
+DefMacro('\submitted{}',   '\@add@frontmatter{ltx:date}[role=submitted]{#1}');
+DefMacro('\journalinfo{}', '\@add@frontmatter{ltx:note}[role=journal]{#1}');
+
+DefMacro('\keywordsname', 'Subject headings');
+
+# Vertical analogs of llap, rlap
+DefMacro('\ulap{}', '\hbox{#1}');
+DefMacro('\dlap{}', '\hbox{#1}');
+
+Let('\tabcaption', '\caption');
+
+DefMacro('\format@title@section{}',    '\lx@tag[][.\space]{\thesection}#1');
+DefMacro('\format@title@subsection{}', '\lx@tag[][.\space]{\thesubsection}#1');
+DefMacro('\format@title@figure{}',     '\lx@tag[][.\@@emdash\space]{\lx@fnum@@{figure}}#1');
+DefMacro('\format@title@table{}',      '\lx@tag{\lx@fnum@@{table}}#1');
 
 # #======================================================================
 1;

--- a/lib/LaTeXML/Package/natbib.sty.ltxml
+++ b/lib/LaTeXML/Package/natbib.sty.ltxml
@@ -483,7 +483,10 @@ DefMacro('\shortcites Semiverbatim', '');
 #   \bibitem[\protect\citename{Jones et al., }1990]{key}...
 #   \harvarditem[Jones et al.]{Jones, Baker, and Williams}{1990}{key}...
 
-DefMacro('\bibitem', '\reset@natbib@cites\refstepcounter{@bibitem}\@ifnextchar[{\@lbibitem}{\@lbibitem[\the@bibitem]}', locked => 1);
+DefMacro('\bibitem',
+##         '\reset@natbib@cites\refstepcounter{@bibitem}\@ifnextchar[{\@lbibitem}{\@lbibitem[\the@bibitem]}',
+  '\reset@natbib@cites\refstepcounter{@bibitem}\@ifnextchar[{\@lbibitem}{\@lbibitem[]}',
+  locked => 1);
 
 RawTeX(<<'EOTeX');
 %%%
@@ -508,7 +511,8 @@ RawTeX(<<'EOTeX');
     \expandafter\NAT@apalk#1, , \@nil{#5}\else
     \NAT@wrout{\the@bibitem}{#2}{#1}{#3}{#5}\fi}
 \def\NAT@apalk#1, #2, #3\@nil#4{%
-  \if\relax#2\relax\NAT@wrout{#1}{}{}{}{#4}\else\NAT@wrout{\the@bibitem}{#2}{#1}{}{#4}\fi}
+%  \if\relax#2\relax\NAT@wrout{#1}{}{}{}{#4}\else\NAT@wrout{\the@bibitem}{#2}{#1}{}{#4}\fi}
+  \NAT@wrout{\the@bibitem}{#2}{#1}{}{#4}}
 %%%%
 EOTeX
 # Sometimes, perversely, redefined, so re-redefine them now...
@@ -516,6 +520,81 @@ DefPrimitiveI('\reset@natbib@cites', undef, sub {
     Let('\citeauthoryear', '\natbib@citeauthoryear');
     Let('\astroncite',     '\natbib@astroncite');
     Let('\citename',       '\natbib@citename'); });
+
+# Kinda rediculous simulating this here (we can almost pull it off in TeX)
+# but the TeX tends to be quite brittle in the wilds of arXiv, so...
+DefMacro('\lx@NAT@parselabel{}{}', sub {
+    my ($gullet, $label, $key) = @_;
+    my ($number, $year, $authors, $fullauthors);
+    my $bare   = 1;
+    my @tokens = $label->unlist;
+    shift(@tokens) if Equals(T_CS('\protect'), $tokens[0]);    # Ignore \protect
+    if ($tokens[0] && ($tokens[0]->getCatcode == CC_CS)) {
+      my $cs = $tokens[0];
+      my ($a1, $a2);
+      if (Equals(T_CS('\citeauthoryear'), $cs)) {
+        # \bibitem[\protect\citeauthoryear{Jones, Baker, and Williams}{Joneset al.}{1990}]{key}
+        # \bibitem[\protect\citeauthoryear{Jones et al.}{1990}]{key}...
+        shift(@tokens);
+        ($a1, @tokens) = NAT_peel_arg(@tokens);
+        ($a2, @tokens) = NAT_peel_arg(@tokens);
+        if (@tokens) {
+          $fullauthors = $a1; $authors = $a2; $year = Tokens(@tokens); $bare = 0; }
+        else {
+          $authors = $a1; $year = $a2; $bare = 0; } }
+      elsif (Equals(T_CS('\astroncite'), $cs)) {
+        # \bibitem[\protect\astroncite{Jones et al.}{1990}]{key}...
+        shift(@tokens);
+        ($a1, @tokens) = NAT_peel_arg(@tokens);
+        ($a2, @tokens) = NAT_peel_arg(@tokens);
+        $authors = $a1; $year = $a2; $bare = 0; }
+      elsif (Equals(T_CS('\citename'), $cs)) {
+        # \bibitem[\protect\citename{Jones et al., }1990]{key}...
+        shift(@tokens);
+        ($a1, @tokens) = NAT_peel_arg(@tokens);
+        $authors = $a1; $year = Tokens(@tokens); $bare = 0; } }
+    if ($bare) {
+      @tokens = Expand($label)->unlist;
+      # \bibitem[Jones et al.(1990)]{key}...
+      # \bibitem[Jones et al.(1990)Jones, Baker, and Williams]{key}...
+      # \bibitem[Jones et al., 1990]{key}...
+      my @arg = ();
+      while (@tokens && !T_OTHER('(')->equals($tokens[0])) {
+        push(@arg, shift(@tokens)); }
+      shift(@tokens);
+      my @year = ();
+      while (@tokens && !T_OTHER(')')->equals($tokens[0])) {
+        push(@year, shift(@tokens)); }
+      shift(@tokens);
+      if (!@year) {
+        while (@arg && ($arg[-1]->getCatcode == CC_OTHER)
+          && ($arg[-1]->getString =~ /\d/)) {    # or even digits only?
+          unshift(@year, pop(@arg)); }
+        #pop(@arg);
+      }
+      $authors = Tokens(@arg); $year = Tokens(@year); $fullauthors = Tokens(@tokens); }
+##    Debug("NATLABEL: ".ToString($label)." #=".ToString($number)." y=".ToString($year)
+##          ." a=".ToString($authors)." f=".ToString($fullauthors)." k=".ToString($key));
+    return Invocation(T_CS('\NAT@wrout'), ($number || T_CS('\the@bibitem')), $year,
+      $authors, $fullauthors, $key) });
+
+sub NAT_peel_arg {
+  my (@tokens) = @_;
+  my @arg = ();
+  if (!@tokens) {
+    return; }
+  elsif (@tokens && ($tokens[0]->getCatcode != CC_BEGIN)) {
+    return (pop(@tokens), @tokens); }
+  else {
+    my $level = 1;
+    shift(@tokens);
+    while (my $t = shift(@tokens)) {
+      my $cc = $t->getCatcode;
+      $level++ if $cc == CC_BEGIN;
+      $level-- if $cc == CC_END;
+      last unless $level > 0;
+      push(@arg, $t); }
+    return (Tokens(@arg), @tokens); } }
 
 # By this time, \NAT@wrout should look like:
 # \NAT@wrout{number}{year}{authors}{fullauthors}{bibkey}
@@ -549,7 +628,9 @@ DefConstructor('\NAT@@wrout{}{}{}{}{} Semiverbatim',
 # see arXiv:cond-mat/0003435 for
 # an infinite loop we run into when this isn't locked
 # \@@lbibitem is a DefConstructor, so the connection should be kept
-DefMacro('\@lbibitem[]{}', '\@@lbibitem{#2}\NAT@ifcmd#1(@)(@)\@nil{#2}\newblock', locked => 1);
+DefMacro('\@lbibitem[]{}',
+  #    '\@@lbibitem{#2}\NAT@ifcmd#1(@)(@)\@nil{#2}\newblock', locked => 1);
+  '\@@lbibitem{#2}\lx@NAT@parselabel{#1}{#2}\newblock', locked => 1);
 
 # Similar to the one defined in LaTeX.pool, but the bibtag's have been setup above.
 DefConstructor('\@@lbibitem Semiverbatim',

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -1081,8 +1081,7 @@ sub tikzAlignmentBindings {
     isMath         => $ismath,
     properties     => {%properties});
   AssignValue(Alignment => $alignment);
-  Let('\hline', '\@alignment@hline');
-  Let(T_MATH,   ($ismath ? '\@dollar@in@mathmode' : '\@dollar@in@textmode'));
+  Let(T_MATH, ($ismath ? '\@dollar@in@mathmode' : '\@dollar@in@textmode'));
   return; }
 
 # Note that pgf *seems* to have set the coordinate system to the center(?) (w/ \pgfsys@transformcm)

--- a/lib/LaTeXML/Package/revtex4_support.sty.ltxml
+++ b/lib/LaTeXML/Package/revtex4_support.sty.ltxml
@@ -194,8 +194,10 @@ DefConstructor('\references',
     beforeDigestBibliography(); },
   afterDigest => sub { beginBibliography($_[1]); }, locked => 1);
 
-DefConstructor('\endreferences',
-  "</ltx:biblist></ltx:bibliography>", locked => 1);
+DefConstructor('\endreferences', sub {
+    $_[0]->maybeClose('ltx:biblist');
+    $_[0]->maybeClose('ltx:bibliography'); },
+  locked => 1);
 # bibliography and biblist are already set as autoClose.
 
 #======================================================================

--- a/t/babel/numprints.xml
+++ b/t/babel/numprints.xml
@@ -811,16 +811,16 @@ vs.
       <tabular class="ltx_guessed_headers" vattach="middle">
         <thead>
           <tr>
-            <td align="char:." thead="column row">without braces</td>
-            <td align="char:." thead="column row">with braces</td>
-            <td align="char:." thead="column">with braces and box</td>
-            <td align="char:." thead="column">with braces, exp, and box</td>
+            <td align="char:." border="t" thead="column row">without braces</td>
+            <td align="char:." border="t" thead="column">with braces</td>
+            <td align="char:." border="t" thead="column">with braces and box</td>
+            <td align="char:." border="t" thead="column">with braces, exp, and box</td>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td align="char:." thead="row">error</td>
-            <td align="char:." thead="row">abc def <Math mode="inline" tex="\numprint{12,3e3}" text="12,3e3" xml:id="S3.p4.m1">
+            <td align="char:." border="t" thead="row">error</td>
+            <td align="char:." border="t">abc def <Math mode="inline" tex="\numprint{12,3e3}" text="12,3e3" xml:id="S3.p4.m1">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="12,3e3" role="NUMBER">12,3e3</XMTok>
@@ -845,7 +845,7 @@ vs.
                   </XMDual>
                 </XMath>
               </Math> rt</td>
-            <td align="char:."><text align="left" width="35.0pt">abc def </text><Math mode="inline" tex="\numprint{12,3e3}" text="12,3e3" xml:id="S3.p4.m2">
+            <td align="char:." border="t"><text align="left" width="35.0pt">abc def </text><Math mode="inline" tex="\numprint{12,3e3}" text="12,3e3" xml:id="S3.p4.m2">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="12,3e3" role="NUMBER">12,3e3</XMTok>
@@ -870,7 +870,7 @@ vs.
                   </XMDual>
                 </XMath>
               </Math> rt</td>
-            <td align="char:."><text align="left" width="35.0pt">abc def </text><Math mode="inline" tex="\numprint{12,3e3}" text="12,3e3" xml:id="S3.p4.m3">
+            <td align="char:." border="t"><text align="left" width="35.0pt">abc def </text><Math mode="inline" tex="\numprint{12,3e3}" text="12,3e3" xml:id="S3.p4.m3">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="12,3e3" role="NUMBER">12,3e3</XMTok>
@@ -913,7 +913,7 @@ vs.
                   </XMDual>
                 </XMath>
               </Math>txt</td>
-            <td align="char:." thead="row">more <Math mode="inline" tex="\numprint{45,1}" text="45,1" xml:id="S3.p4.m5">
+            <td align="char:.">more <Math mode="inline" tex="\numprint{45,1}" text="45,1" xml:id="S3.p4.m5">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="45,1" role="NUMBER">45,1</XMTok>
@@ -963,7 +963,7 @@ vs.
               </Math> txt</td>
           </tr>
           <tr>
-            <td align="char:." thead="row">notblu<Math mode="inline" tex="\numprint{e45,1}" text="e45,1" xml:id="S3.p4.m8">
+            <td align="char:." border="b t" thead="row">notblu<Math mode="inline" tex="\numprint{e45,1}" text="e45,1" xml:id="S3.p4.m8">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="e45,1" role="NUMBER">e45,1</XMTok>
@@ -975,7 +975,7 @@ vs.
                   </XMDual>
                 </XMath>
               </Math>txt</td>
-            <td align="char:." thead="row"><text color="#0000FF">blue <Math mode="inline" tex="\numprint{45,1}" text="45,1" xml:id="S3.p4.m9">
+            <td align="char:." border="b t"><text color="#0000FF">blue <Math mode="inline" tex="\numprint{45,1}" text="45,1" xml:id="S3.p4.m9">
                   <XMath>
                     <XMDual>
                       <XMTok font="italic" meaning="45,1" role="NUMBER">45,1</XMTok>
@@ -991,7 +991,7 @@ vs.
                     </XMDual>
                   </XMath>
                 </Math> txt</text></td>
-            <td align="char:."><text align="left" color="#0000FF" width="35.0pt">blue </text><Math mode="inline" tex="\numprint{45,1}" text="45,1" xml:id="S3.p4.m10">
+            <td align="char:." border="b t"><text align="left" color="#0000FF" width="35.0pt">blue </text><Math mode="inline" tex="\numprint{45,1}" text="45,1" xml:id="S3.p4.m10">
                 <XMath>
                   <XMDual>
                     <XMTok color="#0000FF" font="italic" meaning="45,1" role="NUMBER">45,1</XMTok>
@@ -1007,7 +1007,7 @@ vs.
                   </XMDual>
                 </XMath>
               </Math><text color="#0000FF"> txt</text></td>
-            <td align="char:."><text align="left" color="#0000FF" width="35.0pt">blue </text><Math mode="inline" tex="\numprint{45,1}" text="45,1" xml:id="S3.p4.m11">
+            <td align="char:." border="b t"><text align="left" color="#0000FF" width="35.0pt">blue </text><Math mode="inline" tex="\numprint{45,1}" text="45,1" xml:id="S3.p4.m11">
                 <XMath>
                   <XMDual>
                     <XMTok color="#0000FF" font="italic" meaning="45,1" role="NUMBER">45,1</XMTok>
@@ -1031,9 +1031,9 @@ vs.
       <tabular vattach="middle">
         <tbody>
           <tr>
-            <td align="left">normal:</td>
-            <td align="char:."><text class="ltx_number"><text align="right" width="68.3pt">123,456,123,456</text><text align="left" width="17.8pt">.123</text>×10<sup>12</sup></text></td>
-            <td align="char:."><Math mode="inline" tex="\numprint{123456123456.123e12}" text="123456123456.123e12" xml:id="S3.p5.m1">
+            <td align="left" border="t">normal:</td>
+            <td align="char:." border="t"><text class="ltx_number"><text align="right" width="68.3pt">123,456,123,456</text><text align="left" width="17.8pt">.123</text>×10<sup>12</sup></text></td>
+            <td align="char:." border="t"><Math mode="inline" tex="\numprint{123456123456.123e12}" text="123456123456.123e12" xml:id="S3.p5.m1">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="123456123456.123e12" role="NUMBER">123456123456.123e12</XMTok>
@@ -1082,9 +1082,9 @@ vs.
             <td/>
           </tr>
           <tr>
-            <td align="left">bold extended:</td>
-            <td align="char:."><text class="ltx_number" font="bold"><text align="right" width="68.3pt">123,456,123,456</text><text align="left" width="17.8pt">.123</text>×10<sup>12</sup></text></td>
-            <td align="char:."><Math mode="inline" tex="\numprint{123456123456.123e12}" text="123456123456.123e12" xml:id="S3.p5.m2">
+            <td align="left" border="b">bold extended:</td>
+            <td align="char:." border="b"><text class="ltx_number" font="bold"><text align="right" width="68.3pt">123,456,123,456</text><text align="left" width="17.8pt">.123</text>×10<sup>12</sup></text></td>
+            <td align="char:." border="b"><Math mode="inline" tex="\numprint{123456123456.123e12}" text="123456123456.123e12" xml:id="S3.p5.m2">
                 <XMath>
                   <XMDual>
                     <XMTok font="bold italic" meaning="123456123456.123e12" role="NUMBER">123456123456.123e12</XMTok>
@@ -1134,7 +1134,7 @@ vs.
       <tabular class="ltx_guessed_headers" vattach="middle">
         <tbody>
           <tr>
-            <td align="char:." thead="row">before <Math mode="inline" tex="\numprint{123456123456.123e12}" text="123456123456.123e12" xml:id="S3.p6.m1">
+            <td align="char:." border="t" thead="row">before <Math mode="inline" tex="\numprint{123456123456.123e12}" text="123456123456.123e12" xml:id="S3.p6.m1">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="123456123456.123e12" role="NUMBER">123456123456.123e12</XMTok>
@@ -1180,7 +1180,7 @@ vs.
                   </XMDual>
                 </XMath>
               </Math> after</td>
-            <td align="char:."><Math mode="inline" tex="\numprint{12.12345}" text="12.12345" xml:id="S3.p6.m2">
+            <td align="char:." border="t"><Math mode="inline" tex="\numprint{12.12345}" text="12.12345" xml:id="S3.p6.m2">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="12.12345" role="NUMBER">12.12345</XMTok>
@@ -1207,7 +1207,7 @@ vs.
                   </XMDual>
                 </XMath>
               </Math></td>
-            <td align="char:."><Math mode="inline" tex="\numprint{123456.23e1}" text="123456.23e1" xml:id="S3.p6.m3">
+            <td align="char:." border="t"><Math mode="inline" tex="\numprint{123456.23e1}" text="123456.23e1" xml:id="S3.p6.m3">
                 <XMath>
                   <XMDual>
                     <XMTok color="#0000FF" font="italic" meaning="123456.23e1" role="NUMBER">123456.23e1</XMTok>
@@ -1245,7 +1245,7 @@ vs.
               </Math></td>
           </tr>
           <tr>
-            <td align="char:." thead="row">before <Math mode="inline" tex="\numprint{12345.123e12}" text="12345.123e12" xml:id="S3.p6.m4">
+            <td align="char:." border="b" thead="row">before <Math mode="inline" tex="\numprint{12345.123e12}" text="12345.123e12" xml:id="S3.p6.m4">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="12345.123e12" role="NUMBER">12345.123e12</XMTok>
@@ -1285,7 +1285,7 @@ vs.
                   </XMDual>
                 </XMath>
               </Math> after</td>
-            <td align="char:."><Math mode="inline" tex="\numprint{12.1}" text="12.1" xml:id="S3.p6.m5">
+            <td align="char:." border="b"><Math mode="inline" tex="\numprint{12.1}" text="12.1" xml:id="S3.p6.m5">
                 <XMath>
                   <XMDual>
                     <XMTok font="italic" meaning="12.1" role="NUMBER">12.1</XMTok>
@@ -1312,7 +1312,7 @@ vs.
                   </XMDual>
                 </XMath>
               </Math></td>
-            <td align="char:."><Math mode="inline" tex="\numprint{14561234.562e12}" text="14561234.562e12" xml:id="S3.p6.m6">
+            <td align="char:." border="b"><Math mode="inline" tex="\numprint{14561234.562e12}" text="14561234.562e12" xml:id="S3.p6.m6">
                 <XMath>
                   <XMDual>
                     <XMTok color="#0000FF" font="italic" meaning="14561234.562e12" role="NUMBER">14561234.562e12</XMTok>
@@ -1352,11 +1352,6 @@ vs.
                 </XMath>
               </Math></td>
           </tr>
-          <tr>
-            <td align="char:." thead="row">before  after</td>
-            <td align="char:."/>
-            <td align="char:."/>
-          </tr>
         </tbody>
       </tabular>
     </para>
@@ -1364,7 +1359,7 @@ vs.
       <tabular vattach="middle">
         <tbody>
           <tr>
-            <td align="char:."><Math mode="inline" tex="\numprint[N/mm^{2}]{12345.123}" text="12345.123 * (N / m) * m ^ 2" xml:id="S3.p7.m1">
+            <td align="char:." border="t"><Math mode="inline" tex="\numprint[N/mm^{2}]{12345.123}" text="12345.123 * (N / m) * m ^ 2" xml:id="S3.p7.m1">
                 <XMath>
                   <XMDual>
                     <XMApp>
@@ -1498,7 +1493,7 @@ vs.
               </Math></td>
           </tr>
           <tr>
-            <td align="char:."><Math mode="inline" tex="\numprint[N/mm^{2}]{4.3}" text="4.3 * (N / m) * m ^ 2" xml:id="S3.p7.m4">
+            <td align="char:." border="b"><Math mode="inline" tex="\numprint[N/mm^{2}]{4.3}" text="4.3 * (N / m) * m ^ 2" xml:id="S3.p7.m4">
                 <XMath>
                   <XMDual>
                     <XMApp>


### PR DESCRIPTION
This PR fixes a variety of problems revealed as Error/Malformed in the recent arXiv run; typically things like `ltx:section` appearing out of place due to mismanagement of lists, itemizations, bibliographies, tables and such.

Still some tempting candidates to look at ...