### PR TITLE
Ensure integers in width and height attributes

### DIFF
--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -185,9 +185,15 @@ sub setGraphicSrc {
   my ($self, $node, $src, $width, $height) = @_;
   # If we are on windows, the $src path will be used for a URI context from the 'imagesrc' attribute,
   # so we can already switch it to the canonical slashified form
-  $node->setAttribute('imagesrc',    pathname_to_url($src));
-  $node->setAttribute('imagewidth',  $width)  if defined $width;
-  $node->setAttribute('imageheight', $height) if defined $height;
+  $node->setAttribute('imagesrc', pathname_to_url($src));
+  if (defined $width) {
+    # final formats mostly expect numeric literals to be integers
+    $width = int($width) if ($width =~ /^\d*\.\d*$/);
+    $node->setAttribute('imagewidth', $width); }
+  if (defined $height) {
+    # final formats mostly expect numeric literals to be integers
+    $height = int($height) if ($height =~ /^\d*\.\d*$/);
+    $node->setAttribute('imageheight', $height); }
   if ($width and $height) {
     my $aspect_class = "ltx_img_square";
     if ($width > 1.24 * $height) {


### PR DESCRIPTION
A PR that achieves nothing except making the W3C validator a little happier.

`width` and `height` attributes need to be integers, as can be seen for [cond-mat/0103099](https://ar5iv.org/html/cond-mat/0103099) at [its validator check](https://validator.w3.org/nu/?doc=https%3A%2F%2Far5iv.org%2Fhtml%2Fcond-mat%2F0103099)

<img src="https://user-images.githubusercontent.com/348975/150035547-adc449e8-ce37-4e68-8be9-0b3fdba055bc.png" width=600>

Just use the `int()` cast in a the final attribute placement of Graphics.pm, and we seem better? Works for the example article at least.