### PR TITLE
Add tcolorbox.sty and l3keys2e.sty

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -548,6 +548,7 @@ lib/LaTeXML/Package/keyval.sty.ltxml
 lib/LaTeXML/Package/kvdefinekeys.sty.ltxml
 lib/LaTeXML/Package/kvoptions.sty.ltxml
 lib/LaTeXML/Package/kvsetkeys.sty.ltxml
+lib/LaTeXML/Package/l3keys2e.sty.ltxml
 lib/LaTeXML/Package/lastpage.sty.ltxml
 lib/LaTeXML/Package/latexml.sty.ltxml
 lib/LaTeXML/Package/latexsym.sty.ltxml
@@ -693,6 +694,7 @@ lib/LaTeXML/Package/tablefootnote.sty.ltxml
 lib/LaTeXML/Package/tabularx.sty.ltxml
 lib/LaTeXML/Package/tabulary.sty.ltxml
 lib/LaTeXML/Package/tcilatex.tex.ltxml
+lib/LaTeXML/Package/tcolorbox.sty.ltxml
 lib/LaTeXML/Package/textcase.sty.ltxml
 lib/LaTeXML/Package/textcomp.sty.ltxml
 lib/LaTeXML/Package/texvc.sty.ltxml

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4644,6 +4644,7 @@ DefConstructor('\parbox[] OptionalUndigested OptionalUndigested {Dimension} VBox
 DefMacroI('\@parboxrestore', undef, Tokens());
 
 DefConditional('\if@minipage');
+DefMacro('\@setminipage', '');
 DefEnvironment('{minipage}[][][]{Dimension}', sub {
     my ($document, $attachment, $b, $c, $width, %props) = @_;
     my $vattach = translateAttachment($attachment);

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -66,6 +66,7 @@ DefMacroI('\AmS',     undef, "AmS");
 
 DefConditional('\ifmeasuring@');    # but we won't use it?
 DefConditional('\iftagsleft@');     # but we won't use it?
+DefConditional('\if@fleqn');        # but we won't use it?
 Let('\notag', '\nonumber');
 
 DefMacro('\tag OptionalMatch:* {}',

--- a/lib/LaTeXML/Package/l3keys2e.sty.ltxml
+++ b/lib/LaTeXML/Package/l3keys2e.sty.ltxml
@@ -1,0 +1,20 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  l3keys2e.sty                                                       | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <bruce.miller@nist.gov>                         #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+# Should just work?
+InputDefinitions('l3keys2e', type => 'sty', noltxml => 1);
+1;

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -258,6 +258,8 @@ DefConstructor('\@@listings@block {} {}',
     my $data = encode_base64($listings_data, '');    # NO linebreaking!
     $whatsit->setProperties(data => $data, datamimetype => 'text/plain', dataencoding => 'base64', layout => 'vertical'); });
 
+DefMacro('\lst@HRefStepCounter{}', '');
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Low Level String stuff
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/LaTeXML/Package/multicol.sty.ltxml
+++ b/lib/LaTeXML/Package/multicol.sty.ltxml
@@ -36,5 +36,6 @@ DefRegister('\multicolovershoot'    => Dimension('2pt'));
 DefRegister('\multicolundershoot'   => Dimension('2pt'));
 DefRegister('\multicolpretolerance' => Number(-1));
 DefRegister('\multicoltolerance'    => Number(9999));
+DefRegister('\doublecol@number'     => Number(0));
 
 1;

--- a/lib/LaTeXML/Package/tcolorbox.sty.ltxml
+++ b/lib/LaTeXML/Package/tcolorbox.sty.ltxml
@@ -1,0 +1,26 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  tcolorbox                                                          | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@nist.gov>                          #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+# used in tcbbreakable.code.tex assuming it was defined? so:
+DefRegister('\doublecol@number' => Number(0));
+
+RequirePackage('expl3');
+RequirePackage('xparse');
+
+InputDefinitions('tcolorbox', type => 'sty', noltxml => 1);
+
+1;


### PR DESCRIPTION
It turns out we can get mostly correct behavior when enabling raw interpretation for tcolorbox.sty. It is a [0.43%](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/warning/missing%5Ffile?all=true) contributor to the total  missing_file entries in arXiv.

I added a few partially related macros and registers, which get [2110.06581](https://ar5iv.org/html/2110.06581) fully passing, as well as most of the official [tcolorbox-example.tex](http://mirrors.ctan.org/macros/latex/contrib/tcolorbox/tcolorbox-example.tex), but with lipsum removed (see #1762 for that piece).

With a little further love and care we may be able to perfectly emulate all pieces of tcolorbox.sty. This PR is already 80-90% of the way there, but I won't have the strength to immediately muscle through the remaining pieces. Code related to expl3 is very tricky to understand and debug, likely best done together with the lipsum.sty fixes.

The exact piece of tcolorbox-example.tex that worked (with secondary malformed errors) is:
<details>

```tex
%% The LaTeX package tcolorbox - version 5.0.2 (2022/01/07)
%% tcolorbox-example.tex: an example for tcolorbox
%%
%% -------------------------------------------------------------------------------------------
%% Copyright (c) 2006-2021 by Prof. Dr. Dr. Thomas F. Sturm <thomas dot sturm at unibw dot de>
%% -------------------------------------------------------------------------------------------
%%
%% This work may be distributed and/or modified under the
%% conditions of the LaTeX Project Public License, either version 1.3
%% of this license or (at your option) any later version.
%% The latest version of this license is in
%%   http://www.latex-project.org/lppl.txt
%% and version 1.3 or later is part of all distributions of LaTeX
%% version 2005/12/01 or later.
%%
%% This work has the LPPL maintenance status `author-maintained'.
%%
%% This work consists of all files listed in README
%%
% arara: pdflatex: {  }
% arara: pdflatex: { synctex: yes }
%
\documentclass{article}
\usepackage{tikz,l3keys2e,xparse,lmodern}
\usepackage[most]{tcolorbox}

\begin{document}

%----------------------------------------------------------
\section{Colored boxes}

\begin{tcolorbox}[colback=red!5!white,colframe=red!75!black]
  My box.
\end{tcolorbox}

\begin{tcolorbox}[colback=blue!5!white,colframe=blue!75!black,title=My title]
  My box with my title.
\end{tcolorbox}

\begin{tcolorbox}[colback=green!5!white,colframe=green!75!black]
  Upper part of my box.
  \tcblower
  Lower part of my box.
\end{tcolorbox}

\begin{tcolorbox}[colback=yellow!5!white,colframe=yellow!50!black,
  colbacktitle=yellow!75!black,title=My title]
  I can do this also with a title.
  \tcblower
  Lower part of my box.
\end{tcolorbox}

\begin{tcolorbox}[colback=yellow!10!white,colframe=red!75!black,lowerbox=invisible,
  savelowerto=\jobname_ex.tex]
  Now, we play hide and seek. Where is the lower part?
  \tcblower
  I'm invisible until you find me.
\end{tcolorbox}

\begin{tcolorbox}[colback=yellow!10!white,colframe=red!75!black,title=Here I am]
  \input{\jobname_ex.tex}
\end{tcolorbox}


\begin{tcolorbox}[enhanced,sharp corners=uphill,
    colback=blue!50!white,colframe=blue!25!black,coltext=yellow,
    fontupper=\Large\bfseries,arc=6mm,boxrule=2mm,boxsep=5mm,
    borderline={0.3mm}{0.3mm}{white}]
  Funny settings.
\end{tcolorbox}


\begin{tcolorbox}[enhanced,frame style image=blueshade.png,
  opacityback=0.75,opacitybacktitle=0.25,
  colback=blue!5!white,colframe=blue!75!black,
  title=My title]
  This box is filled with an external image.\par
  Title and interior are made partly transparent to show the image.
\end{tcolorbox}


\begin{tcolorbox}[enhanced,attach boxed title to top center={yshift=-3mm,yshifttext=-1mm},
  colback=blue!5!white,colframe=blue!75!black,colbacktitle=red!80!black,
  title=My title,fonttitle=\bfseries,
  boxed title style={size=small,colframe=red!50!black} ]
  This box uses a \textit{boxed title}. The box of the title can
  be formatted independently from the main box.
\end{tcolorbox}


\clearpage
%----------------------------------------------------------
\section{\LaTeX-Examples}

\begin{tcblisting}{colback=red!5!white,colframe=red!75!black}
This is a \LaTeX\ example:
\begin{equation}
\sum\limits_{i=1}^n i = \frac{n(n+1)}{2}.
\end{equation}
\end{tcblisting}


\begin{tcblisting}{colback=red!5!white,colframe=red!75!black,listing side text,
  title=Side by side,fonttitle=\bfseries}
This is a \LaTeX\ example:
\begin{equation}
\sum\limits_{i=1}^n i = \frac{n(n+1)}{2}.
\end{equation}
\end{tcblisting}


%----------------------------------------------------------
\section{Theorems}

\newtcbtheorem[auto counter,number within=section]{theo}%
  {Theorem}{fonttitle=\bfseries\upshape, fontupper=\slshape,
     arc=0mm, colback=blue!5!white,colframe=blue!75!black}{theorem}

\begin{theo}{Summation of Numbers}{summation}
  For all natural number $n$ it holds:
  \begin{equation}
  \tcbhighmath{\sum\limits_{i=1}^n i = \frac{n(n+1)}{2}.}
  \end{equation}
\end{theo}

We have given Theorem \ref{theorem:summation} on page \pageref{theorem:summation}.

\newtcbtheorem[use counter from=theo]{antheo}%
  {Theorem}{theorem style=change,oversize,enlarge top by=1mm,enlarge bottom by=1mm,
    enhanced jigsaw,interior hidden,fuzzy halo=1mm with green,
     fonttitle=\bfseries\upshape,fontupper=\slshape,
     colframe=green!75!black,coltitle=green!50!blue!75!black}{antheorem}

\begin{antheo}{Summation of Numbers}{summation}
  For all natural number $n$ it holds:
  \begin{equation}
  \tcbhighmath{\sum\limits_{i=1}^n i = \frac{n(n+1)}{2}.}
  \end{equation}
\end{antheo}

%----------------------------------------------------------
\section{Watermarks}

\begin{tcolorbox}[enhanced,watermark graphics=Basilica_5.png,
  watermark opacity=0.3,watermark zoom=0.9,
  colback=green!5!white,colframe=green!75!black,
  fonttitle=\bfseries, title=Box with a watermark picture]
  Here, you see my nice box with a picture as a watermark.
  This picture is automatically resized to fit the dimensions
  of my box. Instead of a picure, some text could be used or
  arbitrary graphical code. See the documentation for more options.
\end{tcolorbox}

%----------------------------------------------------------
\section{Boxes in boxes}
\begin{tcolorbox}[colback=yellow!10!white,colframe=yellow!50!black,
  every box/.style={fonttitle=\bfseries},title=Box]
  \begin{tcolorbox}[enhanced,colback=red!10!white,colframe=red!50!black,
    colbacktitle=red!85!black,
    title=Box inside box,drop fuzzy shadow]
    \begin{tcolorbox}[beamer,colframe=blue!50!black,title=Box inside box inside box]
      And now for something completely different: Boxes!\par\medskip
      \newtcbox{\mybox}[1][]{nobeforeafter,tcbox raise base,colframe=green!50!black,colback=green!10!white,
        sharp corners,top=1pt,bottom=1pt,before upper=\strut,#1}
      \mybox[rounded corners=west]{This} \mybox{is} \mybox{another} \mybox[rounded corners=east]{box.}
    \end{tcolorbox}
  \end{tcolorbox}
\end{tcolorbox}



%----------------------------------------------------------
\section{Breakable Boxes}
% \begin{tcolorbox}[enhanced jigsaw,breakable,pad at break*=1mm,
%   colback=blue!5!white,colframe=blue!75!black,title=Breakable box,
%   watermark color=white,watermark text=\Roman{tcbbreakpart}]
%   lipsum 1
  
%   lipsum 2
  
%   lipsum 3
% \end{tcolorbox}

% %----------------------------------------------------------
\clearpage
\section{Fit Boxes}

% \begin{tcolorbox}[enhanced,fit to height=10cm,
%   colback=green!25!black!10!white,colframe=green!75!black,title=Fit box (10cm),
%   drop fuzzy shadow,watermark color=white,watermark text=Fit]
%   lipsum 1
  
%   lipsum 2
  
%   lipsum 3
% \end{tcolorbox}

% \begin{tcolorbox}[enhanced,fit to height=5cm,
%   colback=green!25!black!10!white,colframe=green!75!black,title=Fit box (5cm),
%   drop fuzzy shadow,watermark color=white,watermark text=Fit]
%   lipsum 1
  
%   lipsum 2
  
%   lipsum 3
% \end{tcolorbox}

%----------------------------------------------------------
\begin{tcolorbox}[tile,size=fbox,boxsep=2mm,boxrule=0pt,
    colback=blue!20!black,colbacktitle=yellow!40!black,
    phantom={\thispagestyle{empty}},
    title=\section{Rasters of Boxes},spread=-1cm]
  \begin{tcbitemize}[raster columns=3,raster rows=4,raster equal skip=2mm,
      raster height=\tcbtextheight,
      title={Box~\thetcbrasternum},fonttitle=\bfseries,
      enhanced,colframe=blue!50,colback=blue!5]
    \tcbitem A
    \tcbitem[flip title={interior hidden}] B
    \tcbitem[colbacktitle=blue!40!black] C
    \tcbitem[colbacktitle=blue!40!black,flip title] D
    \tcbitem[beamer] E
    \tcbitem[tile,colbacktitle=red!40!black] F
    \tcbitem[tile,colbacktitle=red!40!black,flip title={sharp corners}] G
    \tcbitem[blankest]
      \begin{tcbitemize}[raster columns=2,raster rows=2,raster height=\tcbtextheight,
          tile,halign=center,valign=center,fontupper=\bfseries\Huge,before upper=\strut,
          colback=green!20]
        \tcbitem a
        \tcbitem b
        \tcbitem c
        \tcbitem d
      \end{tcbitemize}
    \tcbitem[widget] I
    \tcbitem[frame style image=goldshade,opacityback=0.5,colback=white] J
    \tcbitem[frame style image=blueshade,opacityback=0.5,colback=white,
      center title,flip title={frame hidden,opacityback=0.25,colback=black}] K
    \tcbitem[octogon arc,arc is angular,halign=center,valign=center,
      detach title,watermark text={\tcbtitletext}] L
  \end{tcbitemize}
\end{tcolorbox}
\end{document}
```

</details>