### PR TITLE
More rigour in package fallback

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2009,14 +2009,17 @@ our @find_fallback_suffixes = (
   'arx', 'arxiv',     'conference', 'workshop',
   'tmp', 'alternate', 'preprint',   'fixed',
   # arbitrary 1,2-letter trailing markers
-  '\w\w?',
+  # tragically this is too general:
+  # -- tikz-cd.sty is a real package
+  # '\w\w?',
+  #
   # version-oriented suffixes
   '[vV]?[-_.\d]+',
   # mixed
   'old',      'new',    'final', 'clean',
   'mine',     'priv',   'rev',   'mod',
   'modified', 'edited', 'custom',
-  'altered',
+  'altered',  'rtx'
 );
 # suffixes without a separator
 our @find_fallback_glued_suffixes = (

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2006,8 +2006,8 @@ sub FindFile_aux {
 # suffixes preceded by a separator
 our @find_fallback_suffixes = (
   # arxiv-specific suffixes
-  'arx', 'arxiv', 'conference', 'workshop',
-  'tmp', 'alternate',
+  'arx', 'arxiv',     'conference', 'workshop',
+  'tmp', 'alternate', 'preprint',   'fixed',
   # arbitrary 1,2-letter trailing markers
   '\w\w?',
   # version-oriented suffixes
@@ -2021,10 +2021,15 @@ our @find_fallback_suffixes = (
 # suffixes without a separator
 our @find_fallback_glued_suffixes = (
   # version-oriented suffixes
-  '[vV]?[-_.\d]+');
+  '[vV]?[-_.\d]+',
+  # long domain-specific words
+  # that DO NOT conflict with names of packages
+  # e.g. we have no binding matching '*arxiv*'
+  'arxiv'
+);
 our @find_fallback_prefixes = (
   # see e.g. astro-ph/0002461 for rw_
-  'rw', 'my'
+  'rw', 'my', 'preprint',
 );
 
 sub FindFile_fallback {

--- a/t/002_unit_findfile.t
+++ b/t/002_unit_findfile.t
@@ -24,6 +24,7 @@ my @supported_filename_patterns = qw(
   amsmath_05_2019.sty amsmath052019.sty amsmath_052019.sty amsmath05_2019.sty amsmath05-2019.sty
   amsmath_arxiv.sty amsmath2_arxiv.sty amsmath2019_arxiv.sty amsmath_05-2019_arxiv.sty amsmath_05-2019_arxiv.sty
   amsmath95.sty amsmath_conference.sty amsmath2019_conference.sty amsmath_v2-workshop.sty
+  amsmath3-id.sty my-amsmath_ed.sty amsmath-arxiv-v2021.sty amsmath62_rev.sty amsmath3248731.sty amsmath.mod.sty
 );
 
 # Make sure the main file is available first

--- a/t/002_unit_findfile.t
+++ b/t/002_unit_findfile.t
@@ -22,9 +22,11 @@ SetVerbosity(-2);
 my @supported_filename_patterns = qw(
   amsmath2.sty amsmath3-1.sty amsmathv2.sty amsmath_v2.sty amsmath2019.sty amsmath_v2019.sty amsmath_2019.sty
   amsmath_05_2019.sty amsmath052019.sty amsmath_052019.sty amsmath05_2019.sty amsmath05-2019.sty
-  amsmath_arxiv.sty amsmath2_arxiv.sty amsmath2019_arxiv.sty amsmath_05-2019_arxiv.sty amsmath_05-2019_arxiv.sty
-  amsmath95.sty amsmath_conference.sty amsmath2019_conference.sty amsmath_v2-workshop.sty
-  amsmath3-id.sty my-amsmath_ed.sty amsmath-arxiv-v2021.sty amsmath62_rev.sty amsmath3248731.sty amsmath.mod.sty
+  amsmath_arxiv.sty amsmath_arXiv.sty amsmath2_arxiv.sty amsmath2019_arxiv.sty 
+  amsmath_05-2019_arxiv.sty amsmath_05-2019_arxiv.sty amsmath95.sty amsmath_conference.sty 
+  amsmath2019_conference.sty amsmath_v2-workshop.sty amsmath3-id.sty my-amsmath_ed.sty 
+  amsmath-arxiv-v2021.sty amsmath62_rev.sty amsmath3248731.sty amsmath.mod.sty
+  amsmath_modified_2016.sty preprint_amsmath.sty amsmath_preprint.sty amsmath3-r.sty
 );
 
 # Make sure the main file is available first

--- a/t/002_unit_findfile.t
+++ b/t/002_unit_findfile.t
@@ -24,9 +24,13 @@ my @supported_filename_patterns = qw(
   amsmath_05_2019.sty amsmath052019.sty amsmath_052019.sty amsmath05_2019.sty amsmath05-2019.sty
   amsmath_arxiv.sty amsmath_arXiv.sty amsmath2_arxiv.sty amsmath2019_arxiv.sty 
   amsmath_05-2019_arxiv.sty amsmath_05-2019_arxiv.sty amsmath95.sty amsmath_conference.sty 
-  amsmath2019_conference.sty amsmath_v2-workshop.sty amsmath3-id.sty my-amsmath_ed.sty 
+  amsmath2019_conference.sty amsmath_v2-workshop.sty
   amsmath-arxiv-v2021.sty amsmath62_rev.sty amsmath3248731.sty amsmath.mod.sty
-  amsmath_modified_2016.sty preprint_amsmath.sty amsmath_preprint.sty amsmath3-r.sty
+  amsmath_modified_2016.sty preprint_amsmath.sty amsmath_preprint.sty 
+);
+# we could generalize further...
+my @unsupported_filename_patterns = qw(
+  amsmath3-r.sty amsmath3-id.sty my-amsmath_ed.sty 
 );
 
 # Make sure the main file is available first
@@ -38,5 +42,8 @@ for my $name (@supported_filename_patterns) {
   my $path = LaTeXML::Package::FindFile_fallback($name,[]);
   like($path, qr/amsmath\.sty\.ltxml$/, "$name did not resolve as amsmath.sty.ltxml");
 }
-
+for my $name (@unsupported_filename_patterns) {
+  my $path = LaTeXML::Package::FindFile_fallback($name,[]);
+  is(!$path, 1, "$name should not have resolved as amsmath.sty.ltxml, got $path");
+}
 done_testing();


### PR DESCRIPTION
We discussed this recently in our group meeting, and I claimed fallbacks were implemented - but indeed rather limited in what they did. I spotted a case that could've used a mildly better application of the regexes, and also a handful of simple cases that could be swept in with an easy rule or two.

Here's a minimal example of what the PR could do that couldn't be done before:
```tex
\documentclass{svjour3-id}
\usepackage{my-emulateapj_ed,amsmath-arxiv-v2021,aastex62_rev}
```
induces:
```
Info:fallback:svjour3-id.cls Interpreted 3-id as a versioned package/class name, falling back to generic svjour.cls at test.tex; line 2 col 11

Info:fallback:my-emulateapj_ed.sty Interpreted my-..._ed as a versioned package/class name, falling back to generic emulateapj.sty at test.tex; line 3 col 6

Info:fallback:amsmath-arxiv-v2021.sty Interpreted -arxiv-v2021 as a versioned package/class name, falling back to generic amsmath.sty at test.tex; line 3 col 6

Info:fallback:aastex62_rev.sty Interpreted 62_rev as a versioned package/class name, falling back to generic aastex.sty at test.tex; line 3 col 6
```

If I wanted to really properly develop this feature today (do I? maybe I do! someone should encourage/discourage me), I would proceed to collect *ALL* missing_file names from [their report](https://corpora.mathweb.org/corpus/arxmliv/tex_to_html/warning/missing_file?all=true), then intersect their names with the names of supported bindings, and turn that smaller list into a unit test. The Perfect fallback function should be able to take any custom name from arXiv and find its latexml equivalent. This PR isn't even half of the way there I fear. But it re-starts the ball rolling 👍🏻 