### PR TITLE
guard \theendbibliography from \let

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3833,6 +3833,8 @@ sub beforeDigestBibliography {
   AssignValue(inPreamble => 0); Digest('\@lx@inbibliographytrue');
   DefMacro('\bibliographystyle{}', '');
   DefMacro('\bibliography {}',     '');
+  # avoid \let-based redefinitions of the ending.
+  Let('\endthebibliography', '\saved@endthebibliography');
   ResetCounter('@bibitem');
   return; }
 
@@ -4005,6 +4007,7 @@ DefConstructorI('\endthebibliography', undef, sub {
     $_[0]->maybeCloseElement('ltx:biblist');
     $_[0]->maybeCloseElement('ltx:bibliography'); },
   locked => 1);
+Let('\saved@endthebibliography', '\endthebibliography');
 # auto close the bibliography and contained biblist.
 Tag('ltx:biblist',      autoClose => 1);
 Tag('ltx:bibliography', autoClose => 1);


### PR DESCRIPTION
Looking at recent uses of acl.sty, we have some rather custom tricks, such as:
```tex
\let\endthebibliography=\endlist
```

Which, naturally, causes a latexml error since the opening will not match the close. The beginning is redefined via `\def` in this package, which we succeed in guarding with the macro lock -- but the ending slips through, so we end up mismatching.

Well, it will slip through no more - at least in the cases where it is redefined before `{thebibliography}` begins.