### PR TITLE
Some additional stubs for setspace.sty

### DIFF
--- a/lib/LaTeXML/Package/setspace.sty.ltxml
+++ b/lib/LaTeXML/Package/setspace.sty.ltxml
@@ -25,6 +25,11 @@ DefEnvironment("{singlespace}",  "#body");
 DefEnvironment("{onehalfspace}", "#body");
 DefEnvironment("{doublespace}",  "#body");
 DefEnvironment("{spacing}{}",    "#body");
+
+DefMacroI('\setstretch',            '{}',  '');
+DefMacroI('\SetSinglespace',        '{}',  '');
+DefMacroI('\setdisplayskipstretch', '{}',  '');
+DefMacroI('\restore@spacing',       undef, '');
 #**********************************************************************
 
 1;


### PR DESCRIPTION
I kept stumbling on some [new articles](https://ar5iv.org/html/2111.00082) that use \setstretch, so looked into what the issue was.

It seems we had a handful of more stubs to add in the setspace.sty binding. Nothing interesting, another easy PR.