### PR TITLE
acmart.cls updates

### DIFF
--- a/lib/LaTeXML/Package/acmart.cls.ltxml
+++ b/lib/LaTeXML/Package/acmart.cls.ltxml
@@ -35,6 +35,20 @@ RequirePackage('setspace');
 RequirePackage('newtxmath');
 #RequirePackage('manyfoot');
 # RequirePackage('libertine');
+###
+### Added based on acmart.cls in texlive 2020
+RequirePackage('xkeyval');
+#RequirePackage('xstring');
+RequirePackage('iftex');
+RequirePackage('etoolbox');
+RequirePackage('booktabs');
+RequirePackage('refcount');
+RequirePackage('textcase');
+RequirePackage('hyperxmp');
+#RequirePackage('draftwatermark');
+#RequirePackage('cmap');
+#RequirePackage('pbalance');
+RequirePackage('balance');
 
 #======================================================================
 # Various bits of frontmatter
@@ -130,8 +144,8 @@ DefMacro('\acknowledgmentsname', 'Acknowledgements');
 DefConstructor('\acks', "<ltx:acknowledgements name='#name'>",
   properties => sub { (name => Digest(T_CS('\acknowledgmentsname'))); });
 DefConstructor('\endacks', "</ltx:acknowledgements>");
-DefMacro('\grantsponsor Semiverbatim {} Semiverbatim',     "Sponsor #2 \url{#3}");
-DefMacro('\grantnum OptionalSemiverbatim Semiverbatim {}', "Grant \##3");
+DefMacro('\grantsponsor Semiverbatim {} Semiverbatim',     'Sponsor #2 \url{#3}');
+DefMacro('\grantnum OptionalSemiverbatim Semiverbatim {}', 'Grant \##3');
 
 DefEnvironment('{teaserfigure}[]',
   "<ltx:figure xml:id='#id' inlist='#inlist' class='ltx_teaserfigure' ?#1(placement='#1')>"


### PR DESCRIPTION
I spotted that 2111.03657 was using an undefined `\toprule` and after digging through the loaded packages traced that to a booktabs.sty dependency of acmart.cls.

Checking the texlive 2021 version of that file on my disk, I spotted a handful of other bindings we have that it is now loading -- hence the PR.

latexmllint also alerted me of a wrongly escaped `\#` and I realized two of the definitions should have been single-quoted.

All in all, another simple&quick PR.