### PR TITLE
revisit authblk.sty model

### DIFF
--- a/lib/LaTeXML/Package/authblk.sty.ltxml
+++ b/lib/LaTeXML/Package/authblk.sty.ltxml
@@ -43,7 +43,15 @@ DefMacro('\author[]{}', sub {
 
 DefMacro('\lx@ab@author[]{}',
   '\@add@frontmatter{ltx:creator}[role=author]'
-    . '{\@personname{#2}\lx@authormark{\if.#1.\the@affil\else#1\fi}}');
+    . '{\@personname{#2}\lx@split@authormark{#1}}');
+
+# Preserve the order, where we add an "affiliationmark" element
+# for each numeric mark in the \author[] optional argument
+DefMacro('\lx@split@authormark{}', sub {
+    if (my @marks = split(/\s*,\s*/, ToString($_[1]))) {
+      return (map { T_CS('\lx@authormark'), T_OTHER($_) } @marks); }
+    else {
+      return (T_CS('\lx@authormark'), T_CS('\the@affil')); } });
 
 DefConstructor('\lx@authormark{}',
   "^?#mark(<ltx:contact role='affiliationmark' _mark='#mark'></ltx:contact>)()",
@@ -74,21 +82,12 @@ sub authblkRelocateAffil {
     # the last node wins
     if (my $mark = $affil_node->getAttribute('mark')) {
       $mark_to_affil{$mark} = $affil_node; } }
-  # The most accurate approach here is to go author-by-author,
-  # and attach the affiliations in the *exact order* they were requested
-  # \author[1,7]{A} and \author[7,1]{B} are intended to be presented in that order.
+  # Now process all affiliationmarks
   for my $author_node (@author_nodes) {
-    my @author_marks = split(/\s*,\s*/, ($author_node->getAttribute('_mark') || ''));
-    next unless @author_marks;
     $author_node->setAttribute(role => 'affiliation');
-    my $author_parent = $author_node->parentNode;
-    for my $mark (reverse(@author_marks)) {
-      if (my $affil_node = $mark_to_affil{$mark}) {
-        my $new_contact = $author_node->cloneNode(0);
-        $author_parent->insertAfter($new_contact, $author_node);
-        $document->appendClone($new_contact, $affil_node->childNodes); } }
-    # at the end, unbind each author-mark template node
-    $author_parent->removeChild($author_node); }
+    my $mark = $author_node->getAttribute('_mark') || '';
+    if (my $affil_node = $mark_to_affil{$mark}) {
+      $document->appendClone($author_node, $affil_node->childNodes); } }
   return; }
 
 # we shouldn't need these, but if someone is using them low-level

--- a/lib/LaTeXML/Package/authblk.sty.ltxml
+++ b/lib/LaTeXML/Package/authblk.sty.ltxml
@@ -64,21 +64,31 @@ Tag('ltx:document', afterClose => \&authblkRelocateAffil);
 
 sub authblkRelocateAffil {
   my ($document)   = @_;
-  my @affil_nodes  = $document->findnodes(".//ltx:note[\@role='affiliationtext']");
   my @author_nodes = $document->findnodes(".//ltx:contact[\@role='affiliationmark' and \@_mark]");
+  my @affil_nodes  = $document->findnodes(".//ltx:note[\@role='affiliationtext']");
+  # first, unbind all affiliation text nodes - they get reparented or discarded.
+  my %mark_to_affil = ();
   for my $affil_node (@affil_nodes) {
-    # first, unbind all nodes - they get reparented or discarded.
     $affil_node->parentNode->removeChild($affil_node);
-    # next, see if we can find a new home.
-    if (my $affil_mark = $affil_node->getAttribute('mark')) {
-      # Find authors with same mark.
-      for my $author_node (@author_nodes) {
-        my @author_marks = split(/\s*,\s*/, ($author_node->getAttribute('_mark') || ''));
-        next unless (grep { $_ eq $affil_mark } @author_marks);
-        # An affiliation node may be reused across authors,
-        # but should still get unlinked the first time we reparent it
-        $document->appendClone($author_node, $affil_node);
-        $author_node->setAttribute(role => 'affiliation'); } } }
+    # if we get conflicting marks -- which we shouldn't
+    # the last node wins
+    if (my $mark = $affil_node->getAttribute('mark')) {
+      $mark_to_affil{$mark} = $affil_node; } }
+  # The most accurate approach here is to go author-by-author,
+  # and attach the affiliations in the *exact order* they were requested
+  # \author[1,7]{A} and \author[7,1]{B} are intended to be presented in that order.
+  for my $author_node (@author_nodes) {
+    my @author_marks = split(/\s*,\s*/, ($author_node->getAttribute('_mark') || ''));
+    next unless @author_marks;
+    $author_node->setAttribute(role => 'affiliation');
+    my $author_parent = $author_node->parentNode;
+    for my $mark (reverse(@author_marks)) {
+      if (my $affil_node = $mark_to_affil{$mark}) {
+        my $new_contact = $author_node->cloneNode(0);
+        $author_parent->insertAfter($new_contact, $author_node);
+        $document->appendClone($new_contact, $affil_node->childNodes); } }
+    # at the end, unbind each author-mark template node
+    $author_parent->removeChild($author_node); }
   return; }
 
 sub pruneEmptyAffil {

--- a/lib/LaTeXML/Package/authblk.sty.ltxml
+++ b/lib/LaTeXML/Package/authblk.sty.ltxml
@@ -91,13 +91,6 @@ sub authblkRelocateAffil {
     $author_parent->removeChild($author_node); }
   return; }
 
-sub pruneEmptyAffil {
-  my ($document) = @_;
-  # Some affiliations never get filled, prune them.
-  for my $empty_node ($document->findnodes(".//ltx:contact[\@role='affiliationmark' and not(node()) and not(text())]")) {
-    $document->removeNode($empty_node); }
-  return; }
-
 # we shouldn't need these, but if someone is using them low-level
 # might as well provide them
 DefMacro('\AB@authnote{}',  '\textsuperscript{\normalfont#1}');

--- a/lib/LaTeXML/Package/authblk.sty.ltxml
+++ b/lib/LaTeXML/Package/authblk.sty.ltxml
@@ -25,8 +25,17 @@ DefMacro('\Authsep',   ',');
 DefMacro('\Authand',   ' and ');
 DefMacro('\Authands',  ', and ');
 DefMacro('\authorcr',  '\\\\\Authfont');
+
+# package bookkeeping
 DefConditional('\ifnewaffil');
+DefRegister('\affilsep'  => Dimension('1em'));
+DefRegister('\@affilsep' => Dimension('1em'));
+NewCounter('Maxaffil');
+SetCounter('Maxaffil', Number(2));
+NewCounter('authors');
+NewCounter('affil');
 NewCounter('@affil');
+
 DefMacro('\the@affil', 'affil\arabic{@affil}');
 DefMacro('\author[]{}', sub {
     return map { Invocation(T_CS('\lx@ab@author'), $_[1], Tokens(@$_)) }
@@ -51,19 +60,25 @@ DefConstructor('\affil[]{}',
     $whatsit->setProperty(mark => ToString($mark));
     return; });
 
-Tag('ltx:note',     afterClose => \&authblkRelocateAffil);
-Tag('ltx:document', afterClose => \&pruneEmptyAffil);
+Tag('ltx:document', afterClose => \&authblkRelocateAffil);
 
 sub authblkRelocateAffil {
-  my ($document, $affilnode) = @_;
-  if (($affilnode->getAttribute('role') || '') eq 'affiliationtext') {
-    if (my $mark = $affilnode->getAttribute('mark')) {
+  my ($document)   = @_;
+  my @affil_nodes  = $document->findnodes(".//ltx:note[\@role='affiliationtext']");
+  my @author_nodes = $document->findnodes(".//ltx:contact[\@role='affiliationmark' and \@_mark]");
+  for my $affil_node (@affil_nodes) {
+    # first, unbind all nodes - they get reparented or discarded.
+    $affil_node->parentNode->removeChild($affil_node);
+    # next, see if we can find a new home.
+    if (my $affil_mark = $affil_node->getAttribute('mark')) {
       # Find authors with same mark.
-      my @authors = $document->findnodes(".//ltx:contact[\@role='affiliationmark' and \@_mark='$mark']");
-      foreach my $author (@authors) {
-        $document->appendClone($author, $affilnode->childNodes);
-        $author->setAttribute(role => 'affiliation'); }
-      $affilnode->parentNode->removeChild($affilnode); } }
+      for my $author_node (@author_nodes) {
+        my @author_marks = split(/\s*,\s*/, ($author_node->getAttribute('_mark') || ''));
+        next unless (grep { $_ eq $affil_mark } @author_marks);
+        # An affiliation node may be reused across authors,
+        # but should still get unlinked the first time we reparent it
+        $document->appendClone($author_node, $affil_node);
+        $author_node->setAttribute(role => 'affiliation'); } } }
   return; }
 
 sub pruneEmptyAffil {
@@ -72,6 +87,11 @@ sub pruneEmptyAffil {
   for my $empty_node ($document->findnodes(".//ltx:contact[\@role='affiliationmark' and not(node()) and not(text())]")) {
     $document->removeNode($empty_node); }
   return; }
+
+# we shouldn't need these, but if someone is using them low-level
+# might as well provide them
+DefMacro('\AB@authnote{}',  '\textsuperscript{\normalfont#1}');
+DefMacro('\AB@affilnote{}', '\textsuperscript{\normalfont#1}');
 
 #======================================================================
 1;

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -496,11 +496,9 @@
       <xsl:if test="ltx:contact">
         <xsl:element name="span" namespace="{$html_ns}">
           <xsl:attribute name="class">ltx_author_notes</xsl:attribute>
-          <xsl:element name="span" namespace="{$html_ns}">
-            <xsl:apply-templates select="ltx:contact">
-              <xsl:with-param name="context" select="$innercontext"/>
-            </xsl:apply-templates>
-          </xsl:element>
+          <xsl:apply-templates select="ltx:contact">
+            <xsl:with-param name="context" select="$innercontext"/>
+          </xsl:apply-templates>
         </xsl:element>
       </xsl:if>
       <xsl:apply-templates select="." mode="end">


### PR DESCRIPTION
authblk.sty was a bit too carefree about the many-to-many relationship between authors and affiliations, and the way the marks were written down.

I rewrote the code to do the rearrangement in a single pass, at the end of the document, cloning each affiliation note under each author that uses it. I am a bit uncertain about the intended XML markup for multiple affiliations, so this is still a work in progress, until I get some help from @brucemiller . But once we get that in, I can style it in the CSS and rerun all authblk articles.

Pretty much any authblk.sty paper would be a good test, the one I had in front of me was arXiv:2111.15452 .

The 2021 texlive style file had some extra macros (in particular the \affilsep was used), so I updated the binding coverage as well.