### PR TITLE
stub in \DeclareRelease

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -882,6 +882,17 @@ DefMacro('\ProvidesFile{}[]', sub {
     DefMacroI("\\ver@" . ToString($file), undef, $version || Tokens(), scope => 'global');
     return; });
 
+#\DeclareRelease{v4.46}{2020-03-19}{glossaries-2020-03-19.sty}
+DefMacro('\DeclareRelease{}{}{}', sub {
+    my ($stomach, $version, $date, $name) = @_;
+    # anything useful?
+    return (); });
+#\DeclareCurrentRelease{v4.49}{2021-11-01}
+DefMacro('\DeclareCurrentRelease{}{}', sub {
+    my ($stomach, $version, $date) = @_;
+    # anything useful?
+    return (); });
+
 DefPrimitive('\DeclareOption{}{}', sub {
     my ($stomach, $option, $code) = @_;
     ((ToString($option) eq '*') ?


### PR DESCRIPTION
We load `glossaries.sty` raw from the ltxml binding, and in the 2021 texlive that raw file uses:
```tex
\DeclareRelease{v4.46}{2020-03-19}{glossaries-2020-03-19.sty}
\DeclareCurrentRelease{v4.49}{2021-11-01}
```

Maybe we can do something useful with that metadata? Until we figure out what, I suggest a stub is better than an error.