### PR TITLE
Allow deep recursion in kludge on large formulas

### DIFF
--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -560,6 +560,7 @@ sub parse_kludge {
   return; }
 
 sub parse_kludgeScripts_rec {
+  no warnings 'recursion';
   my ($self, $x, $y, @more) = @_;
   my @acc = ();
   while (defined $y) {


### PR DESCRIPTION
I stumbled on a curious deep recursion Fatal error
```
Fatal:perl:deep_recursion Deep recursion on subroutine "LaTeXML::MathParser::parse_kludgeScripts_rec" at /home/deyan/perl5/lib/perl5/LaTeXML/MathParser.pm line 578.
	at String; line 0 col 0 - line 0 col 0
	Stack Trace:
		LaTeXML::MathParser=HASH(0x55c112074fe0)->parse_kludgeScripts_rec(ARRAY(0x55c1121feb30),ARRAY(0x55c112102560),ARRAY(0x55c1120c3dc8),ARRAY(0x55c1120be400),ARRAY(0x55c11213eef0),ARRAY(0x55c1120f0928),ARRAY(0x55c1121020e0),ARRAY(0x55c1121024e8),ARRAY(0x55c1120f0e20),...) @ /home/deyan/perl5/lib/perl5/LaTeXML/MathParser.pm line 578
```

with a real formula from arXiv is a minimal example:
```tex
\documentclass[11pt,reqno]{amsart}
\usepackage{amsmath,amssymb,amsthm,amsfonts}
\def\ZZ{\mathbb{Z}}
\def\R{\mathbb{R}}
\begin{document}

\begin{equation*}
\begin{split}
\partial^{k}_{x}V_{tt}\partial^k_{x}V_t=&\frac12\frac{d}{dt}|\partial^k_{x}V_{t}|^2,\\[2mm]
-\partial^{k}_{x}(p'(\bar{\rho})V_x)_{x}\partial^k_{x}V_t=&-\partial^{k}_{x}(p''(\bar{\rho})\bar{\rho}_xV_x)\partial^k_{x}V_t-\partial^{k}_{x}(p'(\bar{\rho})V_{xx})\partial^k_{x}V_t\\
=&-\partial^{k}_{x}(p''(\bar{\rho})\bar{\rho}_xV_x)\partial^k_{x}V_t-p'(\bar{\rho})\partial^{k}_{x}V_{xx}\partial^k_{x}V_t-\sum_{\ell<k}C_{k}^{\ell}\partial^{k-\ell}_{x}(p'(\bar{\rho}))\partial_{x}^{\ell}V_{xx} \partial_{x}^{k}V_{t}\\
=&-\left(p'(\bar{\rho})\partial^{k}_{x}V_{x}\partial^k_{x}V_t\right)_x+p''(\bar{\rho})\bar{\rho}_x\partial^{k}_{x}V_{x}\partial^k_{x}V_t+p'(\bar{\rho})\partial^{k}_{x}V_{x}\partial^k_{x}V_{xt}\\
&-\partial^{k}_{x}(p''(\bar{\rho})\bar{\rho}_xV_x)\partial^k_{x}V_t-\sum_{\ell<k}C_{k}^{\ell}\partial^{k-\ell}_{x}(p'(\bar{\rho}))\partial_{x}^{\ell}V_{xx} \partial_{x}^{k}V_{t}\\
=&-\left(p'(\bar{\rho})\partial^{k}_{x}V_{x}\partial^k_{x}V_t\right)_x+p''(\bar{\rho})\bar{\rho}_x\partial^{k}_{x}V_{x}\partial^k_{x}V_t+\frac{1}{2}\frac{d}{dt}\left(p'(\bar{\rho})(\partial^k_{x}V_{x})^2\right)\\
&-\frac{1}{2} p''(\bar{\rho})\bar{\rho}_{t}\left(\partial^k_{x}V_{x}\right)^2-\partial^{k}_{x}(p''(\bar{\rho})\bar{\rho}_xV_x)\partial^k_{x}V_t-\sum_{\ell<k}C_{k}^{\ell}\partial^{k-\ell}_{x}(p'(\bar{\rho}))\partial_{x}^{\ell}V_{xx} \partial_{x}^{k}V_{t},
\end{split}
\end{equation*}

\end{document}
```

Clearly, some (most?) of these excessively long formulas, would fail to parse and go the "kludge" route. So allowing the deep recursion appears necessary? 

Is there any other algorithmic technique to avoid recursing while also supporting longer formulas in kludge?

Simply asking perl to look the other way is a one-liner PR, which fixes this case upto a regular Warning document.