### PR TITLE
Avoid divisions by zero in Number, 2022 edition

### DIFF
--- a/lib/LaTeXML/Common/Number.pm
+++ b/lib/LaTeXML/Common/Number.pm
@@ -111,12 +111,12 @@ sub multiply {
 # Truncating division
 sub divide {
   my ($self, $other) = @_;
-  return (ref $self)->new(int($self->valueOf / (ref $other ? $other->valueOf : $other))); }
+  return (ref $self)->new(int($self->valueOf / ((ref $other ? $other->valueOf : $other) || $EPSILON))); }
 
 # Rounding division
 sub divideround {
   my ($self, $other) = @_;
-  return (ref $self)->new(int(0.5 + $self->valueOf / (ref $other ? $other->valueOf : $other))); }
+  return (ref $self)->new(int(0.5 + $self->valueOf / ((ref $other ? $other->valueOf : $other) || $EPSILON))); }
 
 sub stringify {
   my ($self) = @_;
@@ -222,4 +222,3 @@ Public domain software, produced as part of work done by the
 United States Government & not subject to copyright in the US.
 
 =cut
-


### PR DESCRIPTION
This PR does **not** claim we shouldn't be fixing the underlying problems that lead to these divisions by zero. We should!

But in the meantime, we may get some Error-ing documents convert to their end, without perl dies.