### PR TITLE
add \csarg from comment.sty

### DIFF
--- a/lib/LaTeXML/Package/IEEEtran.cls.ltxml
+++ b/lib/LaTeXML/Package/IEEEtran.cls.ltxml
@@ -100,7 +100,7 @@ RawTeX(<<'EoTeX');
 
 \DeclareOption{nofonttune}{\CLASSOPTIONnofonttunetrue}
 \DeclareOption{captionsoff}{\CLASSOPTIONcaptionsofftrue}
-\DeclareOption{comsoc}{\CLASSOPTIONcomsoctrue\CLASSOPTIONcompsocfalse\CLASSOPTIONtransmagfalse}
+\DeclareOption{comsoc}{\CLASSOPTIONcomsoctrue\CLASSOPTIONcompsocfalse\CLASSOPTIONtransmagfalse\RequirePackage{newtxmath}}
 \DeclareOption{compsoc}{\CLASSOPTIONcomsocfalse\CLASSOPTIONcompsoctrue\CLASSOPTIONtransmagfalse}
 \DeclareOption{transmag}{\CLASSOPTIONtransmagtrue\CLASSOPTIONcomsocfalse\CLASSOPTIONcompsocfalse}
 \DeclareOption{romanappendices}{\CLASSOPTIONromanappendicestrue}

--- a/lib/LaTeXML/Package/comment.sty.ltxml
+++ b/lib/LaTeXML/Package/comment.sty.ltxml
@@ -54,5 +54,7 @@ DefPrimitive('\excludecomment{}',     \&defineExcluded);
 DefPrimitive('\specialcomment{}{}{}', \&defineIncluded);
 #DefPrimitive('\processcomment{}{}{}{}',);
 
+DefMacro('\csarg{}{}', '\expandafter#1\csname#2\endcsname');
+
 #**********************************************************************
 1;


### PR DESCRIPTION
One-line PR that recovers `arXiv:1905.05970` back from the land of the Fatals to an almost fully functioning Error-status document.

I copied the macro definition as-is from its .sty file