### PR TITLE
Fix regression in subdir-graphic candidates without extension

### DIFF
--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -140,7 +140,7 @@ sub findGraphicFile {
     #
     # If this is *NOT* a known graphics type, it would be best to treat it as
     # a name suffix (e.g. name.1 from name.1.png)
-    if (defined($reqtype) && !(grep { $_ eq lc($reqtype) } $$self{graphics_types})) {
+    if ((length($reqtype) > 0) && !(grep { $_ eq lc($reqtype) } $$self{graphics_types})) {
       $name .= ".$reqtype"; }
     my $file  = pathname_concat($dir, $name);
     my @paths = pathname_findall($file, paths => $LaTeXML::Post::Graphics::SEARCHPATHS,


### PR DESCRIPTION
... we just can't write enough tests to cover all corner cases

My previous PR #1757 that had started to properly recognize cases where `$reqtype` was a non-standard name suffix such as `.1.png`, was overly permissive with its check for `defined($reqtype)`. 

This regressed a wide range of images within paper subdirectories, in particular one of our old subfigure tests - arxiv:1602.07188

The fix is incredibly easy, just recognize that this case exists and test for `length($reqtype)>0` instead, so that we only append it when there is *some* character in it (including `0`, which would fail a simple boolean test).

The really frustrating part is that this regression slipped in in the first place, and that I only found it by accident when double-checking my CSS for certain subfigures. I think some new tests are overdue on this end - soon!
