### PR TITLE
avoid tripping over on images ghostscript cant size

### DIFF
--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -288,8 +288,15 @@ sub image_graphicx_complex {
   my $zoomout  = $properties{zoomout}  || 1;
   my ($xprescale, $yprescale) = (1, 1);
 
-  # # Wastefully preread the image to get it's initial size
+  # Wastefully preread the image to get it's initial size
   my ($w0, $h0) = image_size($source);
+  # 16x16 pixels (i.e. icon size) is the minimal viable
+  # size to default to, when ghostscript experiences errors
+  # and returns undefined
+  if (!$w0 || !$h0) {
+    Warn('imageprocessing', "image_size", "ghostscript failed to size $source, returned " . ($w0 || '') . " x " . ($h0 || ''));
+    $w0 = 16 unless $w0;
+    $h0 = 16 unless $h0; }
   Debug("Processing $source initially $w0 x $h0,"
       . "w/ DPI=$dpi, magnify=$magnify, upsample=$upsample, zoomout=$zoomout") if $LaTeXML::DEBUG{images};
   my @transform = @$transform;


### PR DESCRIPTION
Back to normal work mode - this PR is not urgent, and we can discuss at our leisure.

I have now isolated a single article which exhibits a range of problems when processed with ghostscript.

The first, and in a way mildest one, is easy to fix. Namely, we need to guard against the sizing estimate returning empty/undefined. 

The latexml log informs us:
```
Warning:uninitialized:$w0 Use of uninitialized value $w0 in division (/)

at at /usr/local/share/perl/5.32.1/LaTeXML/Util/Image.pm line 309

In Post::Graphics[@0x5609af65ffc8] ->transformGraphic

Fatal:perl:die Perl died

Illegal division by zero at /usr/local/share/perl/5.32.1/LaTeXML/Util/Image.pm line 309.
```

The article in question is `1804.00311`, and I have also tied it together with the #902 issue. Some of the gs conversions take quite long (more than 5 minutes), but - to my surprise - if we avoid this Fatal error we actually get a Warning status conversion for the article.