### PR TITLE
No math check for \infer in proof.sty?

### DIFF
--- a/lib/LaTeXML/Package/proof.sty.ltxml
+++ b/lib/LaTeXML/Package/proof.sty.ltxml
@@ -68,7 +68,7 @@ DefMacro('\infer OptionalMatch:* OptionalMatch:= [] {}{}', sub {
           Invocation(T_CS('\lx@proof@bars'), $double, I_arg(1)),
           I_arg(3))),
       $lower, Invocation(T_CS('\lx@proof@split@and'), $uppers), $label);
-    return (LookupValue('IN_MATH') ? $cmd : Tokens(T_MATH, $cmd, T_MATH)); });
+    return $cmd; });
 
 # Similar, no bars, label (if any) replaces the bars
 DefMacro('\deduce [] {}{}', sub {
@@ -78,5 +78,5 @@ DefMacro('\deduce [] {}{}', sub {
       I_apply({}, I_symbol({ meaning => $meaning }), I_arg(1), I_arg(2)),
       Invocation(T_CS('\lx@proof@stack'), I_arg(2), $label, I_arg(1)),
       $lower, Invocation(T_CS('\lx@proof@split@and'), $uppers));
-    return (LookupValue('IN_MATH') ? $cmd : Tokens(T_MATH, $cmd, T_MATH)); });
+    return $cmd; });
 1;

--- a/lib/LaTeXML/Package/proof.sty.ltxml
+++ b/lib/LaTeXML/Package/proof.sty.ltxml
@@ -68,7 +68,7 @@ DefMacro('\infer OptionalMatch:* OptionalMatch:= [] {}{}', sub {
           Invocation(T_CS('\lx@proof@bars'), $double, I_arg(1)),
           I_arg(3))),
       $lower, Invocation(T_CS('\lx@proof@split@and'), $uppers), $label);
-    return $cmd; });
+    return Tokens(T_CS('\ensuremath'), T_BEGIN, $cmd, T_END); });
 
 # Similar, no bars, label (if any) replaces the bars
 DefMacro('\deduce [] {}{}', sub {
@@ -78,5 +78,5 @@ DefMacro('\deduce [] {}{}', sub {
       I_apply({}, I_symbol({ meaning => $meaning }), I_arg(1), I_arg(2)),
       Invocation(T_CS('\lx@proof@stack'), I_arg(2), $label, I_arg(1)),
       $lower, Invocation(T_CS('\lx@proof@split@and'), $uppers));
-    return $cmd; });
+    return Tokens(T_CS('\ensuremath'), T_BEGIN, $cmd, T_END); });
 1;


### PR DESCRIPTION
I find myself missing a test for the current math-enabling treatment of `\infer` in proof.sty.

Until I manage to dig one out, here is a minimal test of something that is breaking with the current binding, but works just fine if its return value is simplified:
<details>

```tex
\documentclass{article}
\usepackage{amsmath}
\usepackage{proof}
\usepackage[usenames,dvipsnames,svgnames,table]{xcolor}
\def\InputModeColorName{MidnightBlue}
\def\OutputModeColorName{Maroon}
\newcommand\InputMode[1]{{\color{\InputModeColorName}{#1}}}
\newcommand\OutputMode[1]{{\color{\OutputModeColorName}{#1}}}
\newcommand\sequent[2]{\ensuremath{\InputMode{#1}\gg#2}}
\newcommand\infers[2]{\ensuremath{\InputMode{#1}\Rightarrow{\OutputMode{#2}}}}
\newcommand\isset[1]{\ensuremath{\InputMode{#1}\;\mathit{type}}}
\newcommand\tyunit{\ensuremath{\mathsf{unit}}}
\newcommand\eisset[2]{\ensuremath{\InputMode{#1}=\InputMode{#2}\;\mathit{type}}}
\newcommand\ver[2]{\ensuremath{\InputMode{#1}\in\InputMode{#2}}}
\newcommand\ever[3]{\ensuremath{\InputMode{#1}=\InputMode{#2}\in\InputMode{#3}}}
\begin{document}
\begin{gather*}
  \infer{
    \sequent\Gamma\isset\tyunit
  }{
  }\qquad
  \infer{
    \sequent\Gamma\eisset{\tyunit}{\tyunit}
  }{
  }\\[6pt]
\end{gather*}
\end{document}
```

</details>

With the math treatment removed, I get [1512.01837](https://ar5iv.org/html/1512.01837) passing with "no obvious problems" -- well, it also needs to be allowed to read in `bussproofs.sty` raw, which would be a separate PR. For now the bussproofs part is something I'll only keep for the `arxmliv-bindings` repo.

I'm not sure if *not* checking for math mode will break other documents, in which case the PR has the wrong solution - a more robust "ensuremath" treatment would be needed instead.