### PR TITLE
Allow standard fences as author name embellishments

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1120,14 +1120,14 @@ Tag('ltx:personname', afterClose => sub {
       if ($first->nodeType == XML_TEXT_NODE) {
         my $first_text = $first->data;
         my $new_text   = $first_text;
-        $new_text =~ s/^\W+//;
+        $new_text =~ s/^[^\w)(}{\]\[]]+//;
         if ($first_text ne $new_text) {
           $first->setData($new_text); } } }
     if (my $last = $node->lastChild) {
       if ($last->nodeType == XML_TEXT_NODE) {
         my $last_text = $last->data;
         my $new_text  = $last_text;
-        $new_text =~ s/\W+$//;
+        $new_text =~ s/[^\w)(}{\]\[]+$//;
         if ($last_text ne $new_text) {
           $last->setData($new_text); } } }
     return; });


### PR DESCRIPTION
This PR allows standard fences at the start/end positions of `ltx:personname` content.

In international author names in arXiv, sometimes there are cases where a second language is written as a parenthetical. An example is:

```tex
\author{Jian-Ming Tang (湯健銘)}
```

The current regex I had written that avoids issues with commas and other punctuation, was also removing the trailing fence, creating a rather unpleasant string that is only open but not closed.

I keep wondering whether a blacklist is better than a whitelist, and switched again. In a simple world I would only remove comma characters, but there is more possible noise... For now let's just allow the fences?

Ready for review.