### PR TITLE
allow x-color spec in \fcolorbox

### DIFF
--- a/lib/LaTeXML/Package/xcolor.sty.ltxml
+++ b/lib/LaTeXML/Package/xcolor.sty.ltxml
@@ -858,6 +858,18 @@ DefPrimitive('\rrshift Variable', sub {
     my ($defn, @args) = @$var;
     $defn->setValue($defn->valueOf(@args)->multiply(0.01), @args); });
 
+#\fcolorbox{name}{text} or \fcolorbox[model]{spec}{text}
+DefConstructor('\fcolorbox[]{}{} Undigested',
+  "<ltx:text framed='rectangle' framecolor='#framecolor'"
+    . " _noautoclose='1'>#text</ltx:text>",
+  bounded     => 1, mode => 'text',
+  afterDigest => sub {
+    my ($stomach, $whatsit) = @_;
+    my ($model, $fspec, $bspec, $text) = $whatsit->getArgs;
+    $whatsit->setProperty(framecolor => ParseXColor($model, $fspec));
+    MergeFont(background => ParseXColor($model, $bspec));
+    $whatsit->setProperty(text => Digest($text)); });
+
 #======================================================================
 # General TeX internals
 #======================================================================


### PR DESCRIPTION
We are reusing the `\fcolorbox` of color.sty, but the xcolor.sty one allows the extended color specification as well. Example input:
```tex
\documentclass{article}
\usepackage{xcolor}
\begin{document}

\fcolorbox{black!5}{orange!30}{My text}

\end{document}
```

I copied over the definition of `\fcolorbox` and allowed the extended by spec by using `ParseXColor` instead of the usual `ParseColor`.