### PR TITLE
Disabled todonotes should not create notes

### DIFF
--- a/lib/LaTeXML/Package/todonotes.sty.ltxml
+++ b/lib/LaTeXML/Package/todonotes.sty.ltxml
@@ -38,5 +38,11 @@ DefMacro('\todototoc',         '');
 DefMacro('\listoftodos',       '');
 DefMacro('\@todo[]{}',         '');
 
+DeclareOption('disable', sub {
+    DefMacro('\todo{}', '', locked => 1);
+});
+
+ProcessOptions();
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;


### PR DESCRIPTION
This was reported for ar5iv [here](https://github.com/dginev/ar5iv/issues/24), as potentially harmful -- published articles with "disabled" todonotes should have the notes hidden.

Easy patch I think, ready for review.