### PR TITLE
[arXiv] avoid malformed \nocite, short titles in OmniBus

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4197,7 +4197,11 @@ DefMacro('\cite[] Semiverbatim', sub {
         ($post ? ($ns, T_SPACE, $post) : ()), $close)); });
 
 # NOTE: Eventually needs to be recognized by MakeBibliography
-DefConstructor('\nocite Semiverbatim',
+# For now, defer until document end.
+DefMacro('\nocite{}', sub {
+    PushValue('@at@end@document', (T_CS('\lx@mark@nocite'), T_BEGIN, $_[1], T_END));
+    return (); });
+DefConstructor('\lx@mark@nocite Semiverbatim',
   "<ltx:cite><ltx:bibref show='nothing' bibrefs='#bibrefs' inlist='#bibunit'/></ltx:cite>",
   properties => sub {
     (bibrefs => CleanBibKey($_[1]),

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1099,7 +1099,8 @@ DefRegister('\baselinestretch' => Dimension(0));
 
 # See frontmatter support in TeX.ltxml
 Let('\@title', '\@empty');
-DefMacro('\title{}', '\def\@title{#1}\@add@frontmatter{ltx:title}{#1}', locked => 1);
+DefMacro('\title[]{}', '\if.#1.\else\def\shorttitle{#1}\@add@frontmatter{ltx:toctitle}{#1}\fi'
+    . '\def\@title{#2}\@add@frontmatter{ltx:title}{#2}', locked => 1);
 
 DefMacro('\@date', '\@empty');
 DefMacro('\date{}',

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -59,8 +59,12 @@ DefEnvironment('{frontmatter}', '#body');
 DefEnvironment('{mainmatter}',  '#body');
 DefEnvironment('{backmatter}',  '#body');
 
-DefMacro('\shorttitle{}',  '\@add@frontmatter{ltx:toctitle}{#1}');
-DefMacro('\subtitle{}',    '\@add@frontmatter{ltx:subtitle}{#1}');
+DefMacro('\shorttitle{}', '\@add@frontmatter{ltx:toctitle}{#1}');
+DefMacro('\subtitle{}',   '\@add@frontmatter{ltx:subtitle}{#1}');
+DefMacro('\title[]{}',
+  '\if.#1.\else\def\shorttitle{#1}\@add@frontmatter{ltx:toctitle}{#1}\fi'
+    . '\@add@frontmatter{ltx:title}{#2}');
+
 DefMacro('\shortauthor{}', '');
 DefRegister('\titlerunning',  Tokens());
 DefRegister('\authorrunning', Tokens());

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -61,9 +61,6 @@ DefEnvironment('{backmatter}',  '#body');
 
 DefMacro('\shorttitle{}', '\@add@frontmatter{ltx:toctitle}{#1}');
 DefMacro('\subtitle{}',   '\@add@frontmatter{ltx:subtitle}{#1}');
-DefMacro('\title[]{}',
-  '\if.#1.\else\def\shorttitle{#1}\@add@frontmatter{ltx:toctitle}{#1}\fi'
-    . '\def\@title{#2}\@add@frontmatter{ltx:title}{#2}', locked => 1);
 
 DefMacro('\shortauthor{}', '');
 DefRegister('\titlerunning',  Tokens());

--- a/lib/LaTeXML/Package/OmniBus.cls.ltxml
+++ b/lib/LaTeXML/Package/OmniBus.cls.ltxml
@@ -63,7 +63,7 @@ DefMacro('\shorttitle{}', '\@add@frontmatter{ltx:toctitle}{#1}');
 DefMacro('\subtitle{}',   '\@add@frontmatter{ltx:subtitle}{#1}');
 DefMacro('\title[]{}',
   '\if.#1.\else\def\shorttitle{#1}\@add@frontmatter{ltx:toctitle}{#1}\fi'
-    . '\@add@frontmatter{ltx:title}{#2}');
+    . '\def\@title{#2}\@add@frontmatter{ltx:title}{#2}', locked => 1);
 
 DefMacro('\shortauthor{}', '');
 DefRegister('\titlerunning',  Tokens());

--- a/lib/LaTeXML/Package/article.cls.ltxml
+++ b/lib/LaTeXML/Package/article.cls.ltxml
@@ -48,7 +48,11 @@ RequireResource('ltx-article.css');
 
 AddToMacro(T_CS('\maketitle'), T_CS('\ltx@authors@oneline'));
 
-DefMacro('\@ptsize', '0');    # should depend on options...
+DefMacro('\@ptsize',    '0');        # should depend on options...
+DefMacro('\@pnumwidth', '1.55em');
+DefMacro('\@tocrmarg',  '2.55em');
+DefMacro('\@dotsep',    '4.5');
+
 RawTeX(<<'EOTeX');
 \newif\if@restonecol
 \newif\if@titlepage

--- a/lib/LaTeXML/Package/chapterbib.sty.ltxml
+++ b/lib/LaTeXML/Package/chapterbib.sty.ltxml
@@ -56,7 +56,7 @@ DefEnvironment('{cbunit}', '#body',
     AssignValue(CITE_UNIT       => (LookupValue('CITE_UNIT_GLOBAL') ? 'bibliography ' . $unit : $unit));
     return; });
 
-DefMacro('\bibliography Semiverbatim', '
-\lx@ifusebbl{#1}{\input{\jobname.bbl}}{\lx@bibliography[\lx@cb@unitname]{#1}}');
+DefMacro('\bibliography Semiverbatim',
+  '\lx@ifusebbl{#1}{\input{\jobname.bbl}}{\lx@bibliography[\lx@cb@unitname]{#1}}');
 
 1;

--- a/lib/LaTeXML/Package/chapterbib.sty.ltxml
+++ b/lib/LaTeXML/Package/chapterbib.sty.ltxml
@@ -56,6 +56,7 @@ DefEnvironment('{cbunit}', '#body',
     AssignValue(CITE_UNIT       => (LookupValue('CITE_UNIT_GLOBAL') ? 'bibliography ' . $unit : $unit));
     return; });
 
-DefMacro('\bibliography Semiverbatim', '\lx@bibliography[\lx@cb@unitname]{#1}');
+DefMacro('\bibliography Semiverbatim', '
+\lx@ifusebbl{#1}{\input{\jobname.bbl}}{\lx@bibliography[\lx@cb@unitname]{#1}}');
 
 1;

--- a/lib/LaTeXML/Package/natbib.sty.ltxml
+++ b/lib/LaTeXML/Package/natbib.sty.ltxml
@@ -447,6 +447,8 @@ Let('\bibstyle@unsrtnat', '\bibstyle@plainnat');
 #======================================================================
 # 2.12 Other Formatting Options
 # mostly ignored...
+DefMacro('\bibname',     'Bibliography');
+DefMacro('\refname',     'References');
 DefMacro('\bibsection',  '');
 DefMacro('\bibpreamble', '');
 DefMacro('\bibfont',     '');


### PR DESCRIPTION
Fixes for 2110.02279 and 1811.01740, also reported [in ar5iv](https://github.com/dginev/ar5iv/issues/38).

The changed pieces are:

* `\begin{thebibliography}{} \nocite{*}` was causing malformed errors, so I deferred the XML construction for `\nocite` to the document end, where a paragraph should be easy to auto-open. I also tried floating up, but that felt more fragile.

* I hit two other unsupported cases where `\title[]{}` was used with an optional argument. One was due to an unrecognized class, so I added the argument to OmniBus. But the other was due to a raw-interpreted unknown package that redefines `\title`. Since we are using `locked => 1` in LaTeX.pool (which is reasonable+mostly robust), I think we should allow the optional argument for any latex article. Nothing is really lost, as the argument is well - optional.

* some small copy-over additions to natbib.sty and article.cls for raw interpretations
* the special arxiv treatment for bbl-only interpretation was not passed in chapterbib.sty, so I did so - and recovered the references in 1811.01740.

That's all! Fixes the two articles.