### PR TITLE
[WIP] Use U+2016 for fences in norms (and similar)

### DIFF
--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -723,7 +723,7 @@ sub merge {
   $flags     = ($$self[10] || 0) | $flags;
 
   if (my $scale = $options{scale}) {
-    $size = $scale * $size; }
+    $size = $scale * $size if $size; }
   # Set the mathstyle, and also the size from the mathstyle
   # But we may need to scale that size against the existing or requested size.
   my $stylescale = ($$self[3] ? $$self[3] / $stylesize{ $$self[9] || 'display' } : 1);

--- a/lib/LaTeXML/Core/Rewrite.pm
+++ b/lib/LaTeXML/Core/Rewrite.pm
@@ -19,12 +19,16 @@ use LaTeXML::Common::XML;
 
 sub new {
   my ($class, $mode, @specs) = @_;
-  my @clauses = ();
+  my @clauses     = ();
+  my $after_parse = 0;
   while (@specs) {
     my ($op, $pattern) = (shift(@specs), shift(@specs));
-    push(@clauses, ['uncompiled', $op, $pattern]); }
+    if ($op eq 'after_parse') {
+      $after_parse = $pattern; }
+    else {
+      push(@clauses, ['uncompiled', $op, $pattern]); } }
   return bless {
-    mode => $mode, math => ($mode eq 'math'), clauses => [@clauses], labels => {}
+    mode => $mode, math => ($mode eq 'math'), clauses => [@clauses], labels => {}, after_parse => $after_parse
   }, $class; }
 
 sub clauses {
@@ -501,7 +505,7 @@ sub domToXPath_rec {
 # Return quoted string, but note: XPath doesn't provide sensible way to slashify ' or "
 sub quoteXPathLiteral {
   my ($string) = @_;
-  if    ($string !~ /'/) { return "'" . $string . "'"; }
+  if ($string !~ /'/)    { return "'" . $string . "'"; }
   elsif ($string !~ /"/) { return '"' . $string . '"'; }
   else { return 'concat(' . join(',"\'",', map { "'" . $_ . "'"; } split(/'/, $string)) . ')'; } }
 

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2750,8 +2750,9 @@ sub DefColorModel {
 # Defining Rewrite rules that act on the DOM
 # These are applied after the document is completely constructed
 my $rewrite_options = {    # [CONSTANT]
-  label      => 1, scope   => 1, xpath  => 1, match  => 1,
-  attributes => 1, replace => 1, regexp => 1, select => 1 };
+  label       => 1, scope   => 1, xpath  => 1, match  => 1,
+  attributes  => 1, replace => 1, regexp => 1, select => 1,
+  after_parse => 1 };
 
 sub DefRewrite {
   my (@specs) = @_;

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -6804,6 +6804,27 @@ DefMathRewrite(xpath => 'descendant-or-self::ltx:XMWrap['
     $document->getNode->appendChild($replacement);
   });
 
+# If we have a 'norm', use \x{2016} for the fences
+DefMathRewrite(xpath => 'descendant-or-self::ltx:XMDual['
+    . './ltx:XMApp[1]/ltx:XMTok[1][@meaning="norm"] and ./ltx:XMWrap]',
+  replace => sub {
+    my ($document, $node) = @_;
+    my ($content, $pres) = element_nodes($node);
+    my @pres_nodes = element_nodes($pres);
+    my ($left_fence, $right_fence) = ($pres_nodes[0], $pres_nodes[-1]);
+    if (($left_fence->getAttribute('role') || '') eq 'VERTBAR') {
+      $left_fence->removeAttribute('meaning');
+      $left_fence->removeAttribute('name');
+      $left_fence->removeChildNodes();
+      $left_fence->appendText("\x{2016}");
+      $right_fence->removeAttribute('meaning');
+      $right_fence->removeAttribute('name');
+      $right_fence->removeChildNodes();
+      $right_fence->appendText("\x{2016}"); }
+    $document->getNode->appendChild($node);
+    return; },
+  after_parse => 1);
+
 DefMacro('\hiderel{}', "#1");    # Just ignore, for now...
 
 DefMathI('\to', undef, "\x{2192}", role => 'ARROW'); # RIGHTWARDS ARROW??? a bit more explicitly relation-like?

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -1876,7 +1876,7 @@ Then a switch of tag forms.</p>
                 </XMApp>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                 <XMArray xml:id="S4.Ex30.m1.1">
                   <XMRow>
                     <XMCell align="center">
@@ -1915,7 +1915,7 @@ Then a switch of tag forms.</p>
                     </XMCell>
                   </XMRow>
                 </XMArray>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -2081,7 +2081,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex33.m1.1">
                     <XMRow>
                       <XMCell align="center">
@@ -2106,7 +2106,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
               <XMDual>
@@ -2118,7 +2118,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex33.m1.2">
                     <XMRow>
                       <XMCell align="right">
@@ -2143,7 +2143,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
             </XMApp>
@@ -2259,7 +2259,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex35.m1.1">
                     <XMRow>
                       <XMCell align="center">
@@ -2291,7 +2291,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
               <XMDual>
@@ -2303,7 +2303,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex35.m1.2">
                     <XMRow>
                       <XMCell align="right">
@@ -2335,7 +2335,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
             </XMApp>
@@ -2451,7 +2451,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex37.m1.1">
                     <XMRow>
                       <XMCell align="left">
@@ -2483,7 +2483,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
               <XMDual>
@@ -2495,7 +2495,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex37.m1.2">
                     <XMRow>
                       <XMCell align="right">
@@ -2527,7 +2527,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
             </XMApp>

--- a/t/ams/matrix.xml
+++ b/t/ams/matrix.xml
@@ -172,7 +172,7 @@
               </XMApp>
             </XMApp>
             <XMWrap>
-              <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+              <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
               <XMArray xml:id="S0.Ex6.m1.1">
                 <XMRow>
                   <XMCell align="center">
@@ -188,7 +188,7 @@
                   </XMCell>
                 </XMRow>
               </XMArray>
-              <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+              <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
             </XMWrap>
           </XMDual>
         </XMath>

--- a/t/complex/physics.xml
+++ b/t/complex/physics.xml
@@ -296,9 +296,9 @@
                       <XMRef idref="S1.Ex4.m1.4"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                      <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex4.m1.4">a</XMTok>
-                      <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                      <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -308,9 +308,9 @@
                       <XMRef idref="S1.Ex4.m1.5"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok fontsize="160%" meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                      <XMTok fontsize="160%" role="VERTBAR">‖</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex4.m1.5">a</XMTok>
-                      <XMTok fontsize="160%" meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                      <XMTok fontsize="160%" role="VERTBAR">‖</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -320,13 +320,13 @@
                       <XMRef idref="S1.Ex4.m1.6"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                      <XMTok role="VERTBAR">‖</XMTok>
                       <XMApp xml:id="S1.Ex4.m1.6">
                         <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
                         <XMTok font="italic" role="UNKNOWN">X</XMTok>
                         <XMTok font="italic" role="UNKNOWN">Y</XMTok>
                       </XMApp>
-                      <XMTok meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                      <XMTok role="VERTBAR">‖</XMTok>
                     </XMWrap>
                   </XMDual>
                 </XMWrap>

--- a/t/math/sampler.xml
+++ b/t/math/sampler.xml
@@ -1411,7 +1411,7 @@ are not currently tested.</p>
                     </XMApp>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                    <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                     <XMArray xml:id="S4.E22.m1.3">
                       <XMRow>
                         <XMCell align="center">
@@ -1436,7 +1436,7 @@ are not currently tested.</p>
                         </XMCell>
                       </XMRow>
                     </XMArray>
-                    <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                    <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                   </XMWrap>
                 </XMDual>
                 <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
@@ -1449,7 +1449,7 @@ are not currently tested.</p>
                     </XMApp>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                    <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                     <XMArray xml:id="S4.E22.m1.4">
                       <XMRow>
                         <XMCell align="right">
@@ -1474,7 +1474,7 @@ are not currently tested.</p>
                         </XMCell>
                       </XMRow>
                     </XMArray>
-                    <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                    <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMWrap>

--- a/t/parse/parens.xml
+++ b/t/parse/parens.xml
@@ -587,13 +587,13 @@
                 <XMRef idref="S5.Ex23.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                 <XMApp xml:id="S5.Ex23.m1.1">
                   <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
                   <XMTok font="italic" role="ID">a</XMTok>
                   <XMTok font="italic" role="ID">b</XMTok>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -608,13 +608,13 @@
                 <XMRef idref="S5.Ex24.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
                 <XMApp xml:id="S5.Ex24.m1.1">
                   <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
                   <XMTok font="italic" role="ID">a</XMTok>
                   <XMTok font="italic" role="ID">b</XMTok>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="VERTBAR" stretchy="true">‖</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>


### PR DESCRIPTION
### Description 
An interesting, and surprising, discussion transpired online about what the appropriate Unicode character is for norms written with double vertical lines. It's a bit non-linear to follow, but it [starts here](https://twitter.com/gro_tsen/status/1497209167949488136).

A helpful reference as part of it was the [Unicode Technical report #25](https://www.unicode.org/reports/tr25/), which makes clear (screenshot in the details).

<details> 

<img width=600 src="https://user-images.githubusercontent.com/348975/155775833-4ed61524-41ca-4dc5-9d6b-ad608a94b814.png">

</details>

In summary, we should be using U+2016 when we recognize the "circumfix", i.e. fenced, cases. Currently we only use the U+2225 character that is only meant for (infix) operators.

### Approach

1. Rewrite after parse
    The most important missing piece was the ability to define Rewrite rules *after* MathParsing has completed. We are only aware of a "norm" use of these double-vertical-line characters (usually via the `\|` macro) when MathParsing has *completed* fully.
    To this end, I added a new option to rewrites, called `after_parse`, and postponed executing all rewrite rules with that option set to the end of the core processing, just before finalizing.

2. A simple rewrite rule can find the "norm" duals and swap the XMTok elements holding the fences.
3. I needed a guard in Font.pm that avoids scaling characters without known size in the metric tables. 
    - Maybe there is a better way to actually include metrics for the new use of U+2016 ?
4. Finally, I updated any tests using these notations from expecting `∥` to expecting the new `‖`