### PR TITLE
avoid infinite loops caused by Errors misdefining \lx@saved@... macros

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2030,10 +2030,8 @@ sub beforeEquation {
         ($numbered ? RefStepCounter($ctr) : RefStepID($ctr)) }, 'global'); }
   else {
     AssignValue(EQUATIONROW_TAGS => {}, 'global'); }
-  Let('\lx@saved@BEGINDISPLAYMATH', '\@@BEGINDISPLAYMATH');
-  Let('\lx@saved@ENDDISPLAYMATH',   '\@@ENDDISPLAYMATH');
-  Let('\@@ENDDISPLAYMATH',          '\lx@eDM@in@equation');
-  Let('\@@BEGINDISPLAYMATH',        '\lx@bDM@in@equation');
+  Let('\@@ENDDISPLAYMATH',   '\lx@eDM@in@equation');
+  Let('\@@BEGINDISPLAYMATH', '\lx@bDM@in@equation');
   return; }
 
 # Note peculiar usages of \[,\],$$ WITHIN displayed math, like {equation}.
@@ -2043,6 +2041,9 @@ sub beforeEquation {
 # sort of text insertion (eg \footnote)!
 # So, we've got to dance around with redefinitions!!
 # SIDE NOTE: \[,\] are really just $$ w/ appropriate error checking!
+Let('\lx@saved@BEGINDISPLAYMATH', '\@@BEGINDISPLAYMATH');
+Let('\lx@saved@ENDDISPLAYMATH',   '\@@ENDDISPLAYMATH');
+
 DefMacro('\lx@bDM@in@equation', '\lx@saved@BEGINDISPLAYMATH\let\@@ENDDISPLAYMATH\lx@saved@ENDDISPLAYMATH');
 DefMacro('\lx@eDM@in@equation',
   '\lx@retract@eqnno\lx@begin@fake@intertext'


### PR DESCRIPTION
This PR avoids one risk of an infinite loop on Error-severity documents. The example I was debugging is `2003.0149`, which has multiple hard aspects left (including yet another infinite loop).

But the one simple loop I could trace looked like:

```
\lx@bDM@in@equation [for \lx@saved@BEGINDISPLAYMATH] ->\lx@saved@BEGINDISPLAYMATH \let \@@ENDDISPLAYMATH \lx@saved@ENDDISPLAYMATH 
\lx@bDM@in@equation [for \lx@saved@BEGINDISPLAYMATH] ->\lx@saved@BEGINDISPLAYMATH \let \@@ENDDISPLAYMATH \lx@saved@ENDDISPLAYMATH 
\lx@bDM@in@equation [for \lx@saved@BEGINDISPLAYMATH] ->\lx@saved@BEGINDISPLAYMATH \let \@@ENDDISPLAYMATH \lx@saved@ENDDISPLAYMATH 
\lx@bDM@in@equation [for \lx@saved@BEGINDISPLAYMATH] ->\lx@saved@BEGINDISPLAYMATH \let \@@ENDDISPLAYMATH \lx@saved@ENDDISPLAYMATH 

...
```

This code was reached after Errors were encountered, so it is not something expected in a properly supported latex file. The root cause is that we allow a re-let of `\lx@saved@BEGINDISPLAYMATH` deeply in code execution, where an environment may have failed to balance in a document where not all macros were defined.

Long story short, refactoring to only ever define these "saved" macros once, globally, before execution starts, avoids the risk of them being misdefined at runtime.

The on bit I am uncertain of is if this breaks some advanced feature with nested environments that rely on display math. But we don't seem to have a test for these, or if we do - it still passes. Maybe @brucemiller can think of a tricky example that this may break?

If not, feel free to merge and gain a tiny bit of extra robustness.