### PR TITLE
Silence pointless enumitem errors

### DIFF
--- a/lib/LaTeXML/Package/enumitem.sty.ltxml
+++ b/lib/LaTeXML/Package/enumitem.sty.ltxml
@@ -68,9 +68,6 @@ DefKeyVal('enumitem', 'endpenalty',   'Number');
 DefKeyVal('enumitem', 'noitemsep',    '', 'true');
 DefKeyVal('enumitem', 'nolistsep',    '', 'true');
 
-DefMacroI('\KV@enumitem@nolistsep@default', undef, Tokens());
-DefMacroI('\KV@enumitem@noitemsep@default', undef, Tokens());
-
 # Code
 #   before=code, after=code
 DefKeyVal('enumitem', 'before', 'UndigestedKey');    # TODO ?

--- a/lib/LaTeXML/Package/enumitem.sty.ltxml
+++ b/lib/LaTeXML/Package/enumitem.sty.ltxml
@@ -65,8 +65,8 @@ DefKeyVal('enumitem', 'widest',       'UndigestedKey');
 DefKeyVal('enumitem', 'beginpenalty', 'Number');
 DefKeyVal('enumitem', 'midpenalty',   'Number');
 DefKeyVal('enumitem', 'endpenalty',   'Number');
-DefKeyVal('enumitem', 'noitemsep',    'UndigestedKey');
-DefKeyVal('enumitem', 'nolistsep',    'UndigestedKey');
+DefKeyVal('enumitem', 'noitemsep',    '', 'true');
+DefKeyVal('enumitem', 'nolistsep',    '', 'true');
 
 DefMacroI('\KV@enumitem@nolistsep@default', undef, Tokens());
 DefMacroI('\KV@enumitem@noitemsep@default', undef, Tokens());

--- a/lib/LaTeXML/Package/enumitem.sty.ltxml
+++ b/lib/LaTeXML/Package/enumitem.sty.ltxml
@@ -66,6 +66,10 @@ DefKeyVal('enumitem', 'beginpenalty', 'Number');
 DefKeyVal('enumitem', 'midpenalty',   'Number');
 DefKeyVal('enumitem', 'endpenalty',   'Number');
 DefKeyVal('enumitem', 'noitemsep',    'UndigestedKey');
+DefKeyVal('enumitem', 'nolistsep',    'UndigestedKey');
+
+DefMacroI('\KV@enumitem@nolistsep@default', undef, Tokens());
+DefMacroI('\KV@enumitem@noitemsep@default', undef, Tokens());
 
 # Code
 #   before=code, after=code


### PR DESCRIPTION
This PR may be _too_ expedient, but I am not sure I understand the enumitem.sty implementation on my own to do better. Help from @brucemiller will be appreciated (pointing me in the right direction would suffice, if this is the wrong one).

Here is a minimal TeX snippet:
```tex
\documentclass{article}
\usepackage{enumitem}
\begin{document}
\begin{itemize}[nolistsep,noitemsep]
  \item \emph{Epidemiology} - test
\end{itemize}
\end{document}
```

Which produces the error:
```
Error:undefined:\KV@enumitem@noitemsep@default The token T_CS[\KV@enumitem@noitemsep@default] is not defined. at sep.tex; line 4 col 0
```

I am unsure what the actual usefulness of declaring the unused KeyVal options is, but that is done in enumitem.sty.ltxml:
```perl
DefKeyVal('enumitem', 'noitemsep',    'UndigestedKey');
```

Maybe expecting something akin to `noitemsep=value`? `UndigestedKey` does indeed execute gullet's `readArg`. But, the `no` options do not actually take any value...

This error is (surprisingly) the third macro in the current [undefined error report](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/undefined?all=true), at 0.32% of arXiv articles, or ~5800 documents.

---

So, for the patch in the PR, I just defined an empty default value for this macro. I also defined `nolistsep` as a known key, though again - not sure what we're preparing for with those declarations at the moment.