### PR TITLE
improve the TeX.pool \item

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -4970,8 +4970,9 @@ sub alignLine {
   return; }
 
 # These should be 0 width, but perhaps also shifted?
-DefMacro('\llap{}', '\hbox to 0pt{#1}');
-DefMacro('\rlap{}', '\hbox to 0pt{#1}');
+DefMacro('\llap{}', '\hbox to 0pt{\hss#1}');
+DefMacro('\rlap{}', '\hbox to 0pt{#1\hss}');
+
 DefMacroI('\m@th', undef, '\mathsurround=0pt ');
 
 # \strutbox
@@ -4989,19 +4990,15 @@ DefMacroI('\settabs', undef, undef);
 #======================================================================
 # TeX Book, Appendix B. p. 355
 
-DefPrimitive('\hang', undef);
-
 # TODO: \item, \itemitem not done!
 # This could probably be adopted from LaTeX, if the <itemize> could auto-open
 # and close!
-DefConstructor('\item{}',     '#1');
-DefConstructor('\itemitem{}', '#1');
-
-DefMacro('\textindent{}', '#1');
-
-# Conceivably this should enclose the next para in a block?
-# Or add attribute to it? Or...
-DefPrimitiveI('\narrower', undef, undef);
+DefMacro('\hang',         '\hangindent\parindent');
+DefMacro('\item',         '\par\hang\textindent');
+DefMacro('\itemitem',     '\par\indent \hangindent2\parindent \textindent');
+DefMacro('\textindent{}', '\indent\llap{#1\enspace}\ignorespaces');
+DefMacro('\narrower', '\advance\leftskip by\parindent'
+    . '\advance\rightskip by\parindent');
 
 #----------------------------------------------------------------------
 # General support for Front Matter.


### PR DESCRIPTION
The PR simply uses the definitions from the TeXbook for `\item` and its neighboring definitions in the pre-latex TeX.pool setting.

The created markup is not "modern", but is better than the simpler stubs, at least in providing the intended vertical layout for the items.

As an example of the current behavior, see the single line references at:
https://ar5iv.labs.arxiv.org/html/hep-th/9601178#id2519.4.1

With the underlying TeX:
<details>

```tex
\centerline{\bf REFERENCES}
\item{[1]}  E. Martinec, Phys. Lett. ${\underline{B171}}$ (1986) 189 - 194
\item{[2]}   R. Kallosh and A. Morosov, Phys. Lett. ${\underline{B207}}$ (1988)
164 - 168
\hfil\break
A. Restuccia and J. G. Taylor, Phys. Rep. ${\underline{174}}$ (1989) 283 - 407
\item{[3]}   N. Berkovits, Nucl. Phys. ${\underline{174}}$ (1989) 283 - 407
\item{[4]}   S. Davis, `Modular Invariance and the Finiteness of Superstring
Theory', Cambridge preprint, DAMTP-R/94/27, hep-th/9503231
\item{[5]}   B. R. Greene, K. H. Kirklin, P. J. Miron and G. G. Ross,
Nucl. Phys. ${\underline {B292}}$ (1987) 606 - 652
\hfil\break
P. S. Aspinwall, B. R. Greene, K. H. Kirklin and P. J. Miron, Nucl. Phys.
${\underline {B294}}$ (1987) 193 - 222
\item{[6]}  S. W. Hawking, `The path-integral approach to quantum gravity' in
\hfil\break
${\underline {General~Relativity:
An~Einstein~Centenary~Survey}}$, ed. by S. W. Hawking and
W. Israel (Cambridge: Cambridge University Press, 1979) 746 - 789
\item{[7]}  A. B. Zamalodchikov, JETP Letters, ${\underline{43}}$, JETP
Letters,
${\underline{43}}$ (1986) 731
\hfil\break
C. Vafa, Phys. Lett. ${\underline{B212}}$ (1988) 28 - 32
\hfil\break
N. E. Mavromatos and J. L. Miramontes, PHys. Lett. ${\underline{B212}}$ (1989)
33 - 40
\item{[8]}  E. Witten, Nucl. Phys. ${\underline {B268}}$ (1986) 253 - 294
\item{[9]}  A. Connes, Commun. Math. Phys. ${\underline {117}}$ (1988)
             673 - 683
\item{[10]}  A. Le Clair and C. Vafa, Nucl. Phys. ${\underline {B401}}$ (1993)
            413 - 454
\item{[11]}  S. Doplicher and J. E. Roberts, Commun. Math. Phys. ${\underline
             {131}}$ (1990) 51 - 107
\item{[12]}  S. Davis, J. Geometry and Physics, ${\underline 4}$ (1987) 405 -
415
\item{[13]}  W. Nahm, `An Octonionic Generalization of Yang-Mills', CERN
preprint TH-2489 (1978)
\item{[14]}  R. Dundarer, F. Gursey and C.-H. Tze Nucl. Phys.
${\underline{B266}}$ (1985) 440 - 450
\item{[15]}  S. Davis, ICTP High-Energy Physics Seminar (1986)
\item{[16]}  M. Duff and M. Blencowe, Nucl. Phys. ${\underline{B310}}$ (1988)
387 - 404
\item{[17]}  D. Husemoller, ${\underline {Fibre~Bundles}}$ (New York:
Springer-Verlag, 1966)
\item{[18]}  J. F. Adams,  Annals of Math. ${\underline {75}}$ (1962) 602 -632
\item{[19]}  M. Kervaire, Proc. Nat. Acad. Sci. USA (1958) 280 - 283
\item{[20]}  T. Brzezinski and S. Majid, Commun. Math. Phys.
${\underline{157}}$
(1993) 591 - 638
\item{[21]}  M. Djurdjevic, `Quantum Principal Bundles'
hep-th/9311029
\item{[22]}  J. Dieudonne, ${\underline{Foundations~of~Modern~Analysis}}$ (New
York:Academic
 Press, 1969)
\item{[23]}  A. Salam and J. Strathdee, Ann. Phys. (1982) 316 -352
\item{[24]}  C. C. Lassig and G. C. Joshi, `An Octonionic Gauge Theory'
Univ. Melbourne preprint UM-P/09; RCHEP-95/05, hep-th/9503189
\item{[25]}  P. Libermann, J. Diff. Geom. ${\underline 8}$ (1973) 511 - 537
\item{[26]}  J. Wolf, J. Diff. Geom. ${\underline 6}$ (1972) 317 - 342;
${\underline 7}$ (1972) 19 - 44
\item{[27]}  G. Domokos and S. Kovesi-Domokos, Il. Nuovo Cimento
${\underline{44A}}$ (1978) 318 - 329
\item{[28]}  B. de Wit and H. Nicolai, Nucl. Phys. ${\underline {B
281}}$ (1987) 211 - 240
\item{[29]}  C. A. Manogue and J. Schray, J. Math. Phys. ${\underline{34}}$(8)
(1993) 3746 - 3767
\item{[30]}  A. Ritz and G. C. Joshi, `A Non-associative Deformation of
Yang-Mills Gauge Theory' University of Melbourne preprint, UM-P-95/69,
RCHEP-95/18
\item{[31]}  S. Okubo, ${\underline{Introduction~to~Octonion~and~Other
{}~Non-Associative~Algebras~in}}$
\hfil\break
${\underline{~Physics}}$,
 Montroll Memorial Lecture
Series in Mathematical Physics, Vol. 2
\hfil\break
(Cambridge: Cambridge University Press,
1995)
\item{[32]}  G. M. Dixon, ${\underline{Division~Algebras:~Octonions,
{}~Quaternions,~Complex~Numbers}}$
\hfil\break
${\underline{and~the~Algebraic~Design~of~Physics}}$
(Dordrecht: Kluwer Academic Publishers,
\hfil\break
 1994)
\item{[33]}  N. Manton, Annals of Physics, ${\underline{167}}$ (1986) 328 - 353
\item{[34]}  N. Manton, Nucl. Phys. ${\underline{B158}}$ (1979) 141 - 153
\item{[35]}  R. Jackiw, ${\underline{Diverse~Topics~in~Theoretical~and~
Mathematical~Physics}}$
\hfil\break
(Singapore: World Scientific Publishing Comany, 1995)
\item{[36]}  E. Witten, Nucl. Phys. ${\underline{B443}}$ (1995) 85 - 126
\item{[37]}  E. Witten, `Heterotic and Type I String Dynamics from
Eleven Dimensions', Princeton preprint, IASSNS-HEP-95-86, PUPT-1571,
hep-th/9510209
\item{[38]}  C. Pope and N. Warner, Phys. Lett. ${\underline{B150}}$ (1985)
352 - 356
\item{[39]}  B. de Wit and H. Nicolai, Nucl. Phys. ${\underline{B255}}$
(1985) 29 - 62
\item{[40]}  S. Coleman, J. Wess and B. Zumino, Phys. Rev.
${\underline {D177}}$(5) (1969) 2239 - 2247
\item{[41]}  Kuang-Chao Chou, Tung-Sheng Tu and Tu-Nan Yean, Vol.{\rm XXII}
No. 1, Scientia Sinica (1979) 37 - 52
\item{[42]}  E. Witten, Phys. Lett. ${\underline{B155}}$ (1985) 151 - 154
\item{[43]}  M. Gunaydin and H. Nicolai, `Seven Dimensional Octonionic
Yang-Mills Instanton and its Extension to an Heterotic String Soliton'
Pennsylvania preprint PSU-TH-157
\item{[44]}  J. Harvey and A. Strominger, Phys. Rev. Lett.
${\underline{66}}$ (1991) 549 - 551
\item{[45]}  M. J. Duff, G. W. Gibbons and P. K. Townsend, `Macroscopic
superstrings as interpolating solitons', University of Cambridge preprint,
DAMTP/R-93/5
\item{[46]}  N. Berkovits, Phys. Lett. ${\underline{B247}}$ (1990) 45 - 49
\item{[47]}  M. Cederwall, Phys. Lett. ${\underline{B266}}$ (1989) 45 - 47
\item{[48]}  C. A. Manogue and A. Sudbery, Phys. Rev. ${\underline{D40}}$
(1989) 4073 - 4077
\item{[49]}  A. Sudbery, J. Phys. A ${\underline{17}}$ (1984) 939 - 955
\item{[50]}  K.-W. Chung and A. Sudbery, Phys. Lett. ${\underline{B198}}$
(1987) 161 - 164
\item{[51]}  M. Cederwall, `Introduction to Division Algebras, Sphere Algebras
and Twistors', Talk presented at the Theoretical Physics Network Meeting
at NORDITA, Copenhagen, September, 1993
\item{[52]}  M. Cederwall, J. Math. Phys. ${\underline{33}}$ (1992) 388 - 393
\item{[53]}  M. Cederwall and C. R. Preitschopf, Commun. Math. Phys.
${\underline{167}}$ (1995) 373 - 393
\item{[54]}  N. Berkovits, Nucl. Phys. ${\underline{B358}}$ (1991) 169 - 180
\item{[55]}  L. Brink, M. Cederwall and C. R. Preitschopf, Phys. Lett.
${\underline{B311}}$ (1993) 76 - 82
\item{[56]}  E. Witten, Nucl. Phys. ${\underline{B266}}$ (1986) 245 - 264
\item{[57]}  S. Majid, ${\underline{Foundations~of~Quantum~Group~Theory}}$
(Cambridge: Cambridge University Press, 1994)
\item{[58]}  S. Majid, Int. J. Mod. Phys. A ${\underline 5}$  (1990) 1 - 91
\item{[59]}  P. Schupp, `Cartan~Calculus:~Differential~Geometry~
for~Quantum~Groups', Fermi Summer School on Quantum Groups, Varenna (1994),
Munich preprint, LMU-TPW-94-8, hep-th/9408170
\hfil\break
P. Ascheri and P. Schupp, `Vector Fields on Quantum Groups', Pisa preprint
IFUP-TH 15/95, Munich preprint LMU-TPW 94-14
\item{[60]}  S. Okubo, Hadronic Journal, ${\underline {1}}$ (1978) 1250 - 1278
\hfil\break
S. Okubo, Hadronic Journal, ${\underline {1}}$ (1978) 1432 - 1465
\item{[61]}  C. Chevalley, ${\underline{Algebraic~Theory~of~Spinors}}$
(New York: Columbia University Press, 1954)
\item{[62]}  P. Goddard, W. Nahm, D. I. Olive, H. Ruegg and A. Schwimmer,
Commun. Math. Phys. ${\underline {112}}$ (1987) 385 - 408

\end
```

</details>

Example rendering from the PR:
<img width=400 src="https://user-images.githubusercontent.com/348975/156800083-1881fb33-70eb-496a-b7d1-f217f87cca62.png">