### PR TITLE
Psfrag

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -609,6 +609,7 @@ lib/LaTeXML/Package/nopageno.sty.ltxml
 lib/LaTeXML/Package/ntheorem.sty.ltxml
 lib/LaTeXML/Package/numprint.sty.ltxml
 lib/LaTeXML/Package/ot4.fontmap.ltxml
+lib/LaTeXML/Package/overpic.sty.ltxml
 lib/LaTeXML/Package/palatino.sty.ltxml
 lib/LaTeXML/Package/paralist.sty.ltxml
 lib/LaTeXML/Package/parskip.sty.ltxml

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -444,6 +444,10 @@ sub assemble_postprocessors {
     if ($picimages) {
       require LaTeXML::Post::PictureImages;
       push(@procs, LaTeXML::Post::PictureImages->new(%OPTIONS)); }
+    else {
+      require LaTeXML::Post::PictureImages;
+      push(@procs, LaTeXML::Post::PictureImages->new(empty_only => 1, %OPTIONS)); }
+
     if ($dographics) {
       require LaTeXML::Post::Graphics;
       my @g_options = ();

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -484,7 +484,7 @@ sub convert_post {
     }
     else {
       require LaTeXML::Post::PictureImages;
-      push(@procs, LaTeXML::Post::PictureImages->new(empty_only => 1, %OPTIONS)); }
+      push(@procs, LaTeXML::Post::PictureImages->new(empty_only => 1, %PostOPS)); }
 
     if ($$opts{dographics}) {
       # TODO: Rethink full-fledged graphics support

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -482,6 +482,10 @@ sub convert_post {
       require LaTeXML::Post::PictureImages;
       push(@procs, LaTeXML::Post::PictureImages->new(%PostOPS));
     }
+    else {
+      require LaTeXML::Post::PictureImages;
+      push(@procs, LaTeXML::Post::PictureImages->new(empty_only => 1, %OPTIONS)); }
+
     if ($$opts{dographics}) {
       # TODO: Rethink full-fledged graphics support
       require LaTeXML::Post::Graphics;

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1082,8 +1082,8 @@ DefMacro('\@dbltoplist',   '');
 DefMacro('\@dbldeferlist', '');
 DefMacro('\@startcolumn',  '');
 # Style parameters from Fig. C.3, p.182
-DefRegister('\paperheight'     => Dimension(0));
-DefRegister('\paperwidth'      => Dimension(0));
+DefRegister('\paperheight'     => Dimension('8.5in'));
+DefRegister('\paperwidth'      => Dimension('11in'));
 DefRegister('\textheight'      => Dimension(0));
 DefRegister('\textwidth'       => Dimension('6in'));
 DefRegister('\topmargin'       => Dimension(0));
@@ -5095,7 +5095,7 @@ DefMacro('\multiput Pair Pair {}{}', sub {
 Tag('ltx:picture',
   afterOpen => sub {
     my ($document, $node, $thing) = @_;
-    if ($thing) {
+    if ($thing && !$node->getAttribute('tex')) {
       $document->setAttribute($node, tex => UnTeX($thing)); } });
 
 Tag('ltx:g', afterClose => sub {

--- a/lib/LaTeXML/Package/algorithm2e.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithm2e.sty.ltxml
@@ -64,8 +64,8 @@ DefEnvironment('{algorithm}[]',
     . "</ltx:listing></ltx:float>",
   properties   => { layout => 'vertical' },
   beforeDigest => sub {
-    Digest(T_CS('\@ResetCounterIfNeeded'));
-    Digest(T_CS('\algocf@linesnumbered'));
+    DigestIf(T_CS('\@ResetCounterIfNeeded'));
+    DigestIf(T_CS('\algocf@linesnumbered'));
     Let('\par',    '\lx@algo@par');
     Let('\parbox', '\lx@algo@parbox');
     Let("\\\\",    '\lx@algo@par');
@@ -79,7 +79,7 @@ DefEnvironment('{algorithm}[]',
     beforeFloat('algorithm');
   },
   afterDigest => sub {
-    if (ToString(Digest(T_CS('\algocf@style'))) =~ /box/) {
+    if (ToString(DigestIf(T_CS('\algocf@style'))) =~ /box/) {
       $_[1]->setProperty(frame => 'boxed'); }
     afterFloat($_[1]); },
   afterConstruct => sub { addFloatFrames($_[0], $_[1]->getProperty('frame')); }

--- a/lib/LaTeXML/Package/graphics.sty.ltxml
+++ b/lib/LaTeXML/Package/graphics.sty.ltxml
@@ -71,6 +71,7 @@ sub graphics_scaledbox_insert {
 DefConstructor('\Gscale@box {Float} [Float] {}', sub {
     my ($document, $scale, $yscale, $box, %props) = @_;
     graphics_scaledbox_insert($document, %props); },
+  alias      => '\scalebox',
   properties => sub {
     my ($stomach, $xscale, $yscale, $box) = @_;
     graphics_scaledbox_props($box, $xscale, $yscale || $xscale); },
@@ -98,6 +99,7 @@ DefConstructor('\Gscale@box@dddd {Dimension}{Dimension}{Dimension}{Dimension} {}
 DefConstructor('\Gscale@@box {} {GraphixDimension}{GraphixDimension} {}', sub {
     my ($document, $heighttype, $width, $height, $box, %props) = @_;
     graphics_scaledbox_insert($document, %props); },
+  reversion  => '\resizebox{#2}{#3}{#4}',
   properties => sub {
     my ($stomach, $heighttype, $width, $height, $box) = @_;
     my ($xscale, $yscale)                             = (1, 1);
@@ -232,19 +234,47 @@ DefConstructor('\graphicspath DirectoryList', sub {
 DefMacro('\includegraphics OptionalMatch:* [][] Semiverbatim',
   '\@includegraphics#1[#2][#3]{#4}');
 
+sub graphics_get_candidates {
+  my ($path, $kv) = @_;
+  $path = ToString($path); $path =~ s/^\s+//; $path =~ s/\s+$//;
+  $path =~ s/^("+)(.+)\g1$/$2/;                           # unwrap if in quotes
+  my $searchpaths = LookupValue('GRAPHICSPATHS');
+  if (my $svgpath = $kv && $kv->getValue('svgpath')) {    # Doesn't belong here!!!
+    push(@$searchpaths, ToString($svgpath)); }
+  my @candidates = pathname_findall($path, types => ['*'], paths => $searchpaths);
+  if (my $base = LookupValue('SOURCEDIRECTORY')) {
+    @candidates = map { pathname_relative($_, $base) } @candidates; }
+  return ($path, @candidates); }
+
+sub graphicS_options {
+  my ($starred, $option1, $option2) = @_;
+  my $bb = ($option2
+    ? ToString($option1) . " " . ToString($option2)
+    : ($option1 ? "0 0 " . ToString($option1) : ''));
+  $bb =~ s/,/ /g;
+  my $options = ($starred ? ($bb ? "viewport=$bb, clip" : "clip") : '');
+  return $options; }
+
+sub graphicX_options {
+  my ($starred, $kv) = @_;
+  my $options = ToString($kv);
+  $options .= ',clip=true' if $starred;
+  my $keepaspect;
+  $options .= ',';
+  $keepaspect = 1 if $options =~ s/width=,//;
+  $keepaspect = 1 if $options =~ s/height=,//;
+  if ($keepaspect) { $options .= 'keepaspectratio=true'; }
+  else             { $options =~ s/,$//; }
+  return $options; }
+
 DefConstructor('\@includegraphics OptionalMatch:* [][] Semiverbatim',
   "<ltx:graphics graphic='#graphic' candidates='#candidates' options='#options'/>",
   sizer      => \&image_graphicx_sizer,
   properties => sub {
     my ($stomach, $starred, $op1, $op2, $graphic) = @_;
-    my $bb = ($op2 ? ToString($op1) . " " . ToString($op2) : ($op1 ? "0 0 " . ToString($op1) : ''));
-    $bb =~ s/,/ /g;
-    my $options = ($starred ? ($bb ? "viewport=$bb, clip" : "clip") : '');
-    $graphic = ToString($graphic); $graphic =~ s/^\s+//; $graphic =~ s/\s+$//;
-    my @candidates = pathname_findall($graphic, types => ['*'], paths => LookupValue('GRAPHICSPATHS'));
-    if (my $base = LookupValue('SOURCEDIRECTORY')) {
-      @candidates = map { pathname_relative($_, $base) } @candidates; }
-    (graphic => $graphic,
+    my $options = graphicS_options($starred, $op1, $op2);
+    my ($path, @candidates) = graphics_get_candidates($graphic);
+    (graphic => $path,
       candidates => join(',', @candidates),
       options    => $options); },
   alias => '\includegraphics');

--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -51,23 +51,9 @@ DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbat
   sizer      => \&image_graphicx_sizer,
   scope      => 'global',
   properties => sub {
-    my ($stomach, $starred, $kv, $path) = @_;
-    $path = ToString($path); $path =~ s/^\s+//; $path =~ s/\s+$//;
-    $path =~ s/^("+)(.+)\g1$/$2/;                           # unwrap if in quotes
-    my $searchpaths = LookupValue('GRAPHICSPATHS');
-    if (my $svgpath = $kv && $kv->getValue('svgpath')) {    # Doesn't belong here!!!
-      push(@$searchpaths, ToString($svgpath)); }
-    my @candidates = pathname_findall($path, types => ['*'], paths => $searchpaths);
-    if (my $base = LookupValue('SOURCEDIRECTORY')) {
-      @candidates = map { pathname_relative($_, $base) } @candidates; }
-    my $options = ToString($kv);
-    $options .= ',clip=true' if $starred;
-    my $keepaspect;
-    $options .= ',';
-    $keepaspect = 1 if $options =~ s/width=,//;
-    $keepaspect = 1 if $options =~ s/height=,//;
-    if ($keepaspect) { $options .= 'keepaspectratio=true'; }
-    else             { $options =~ s/,$//; }
+    my ($stomach, $starred, $kv, $graphic) = @_;
+    my $options = graphicX_options($starred, $kv);
+    my ($path, @candidates) = graphics_get_candidates($graphic);
     (path => $path,
       candidates => join(',', @candidates),
       options    => $options); },

--- a/lib/LaTeXML/Package/overpic.sty.ltxml
+++ b/lib/LaTeXML/Package/overpic.sty.ltxml
@@ -1,0 +1,41 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  overpic                                                            | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+use LaTeXML::Util::Image;
+
+# Create an EMPTY picture environment, but with the tex attribute containing the
+# necessary code for LaTeX to generate an image.
+DefEnvironment('{overpic} OptionalKeyVals:Gin Semiverbatim',
+  "<ltx:picture width='#width' height='#height' origin-x='#origin-x' origin-y='#origin-y'"
+    . " fill='none' stroke='none' unitlength='#unitlength'"
+    . " tex='#tex'>"
+    . "</ltx:picture>",
+  afterDigestBody => sub {
+    my ($stomach, $whatsit) = @_;
+    my ($kv, $graphic)      = $whatsit->getArgs();
+    my $gwhatsit = Digest(Invocation(T_CS('\@includegraphicx'), undef, $kv, $graphic));
+    my ($w, $h, $d, $cw, $ch, $cd) = $gwhatsit->getSize;
+    $whatsit->setProperties(
+      tex    => UnTeX(Tokens($whatsit->revert)),
+      width  => $w, height  => $h, depth  => $d,
+      cwidth => $w, cheight => $h, cdepth => $d);
+    return; });
+
+# Need {Overpic}, too, but it doesn't take an image, but random TeX
+# I suspect that will need an entirely different strategy!
+# And since it's used in only 3 papers on arXiv, it hardly seems worth it...
+
+1;

--- a/lib/LaTeXML/Package/psfrag.sty.ltxml
+++ b/lib/LaTeXML/Package/psfrag.sty.ltxml
@@ -16,35 +16,143 @@ use warnings;
 use LaTeXML::Package;
 use LaTeXML::Util::Image;
 
-#**********************************************************************
-# STUB BINDING!
-#   Basically a NO-OP binding to avoid errors in olrder arXiv docs.
-# psfrag is a cool hack that allows the author to enhance thier graphics
-# by REPLACING bits of postscript figures with TeX formatted stuff.
-# The big question for LaTeXML is:
-#   What is the Web or XML analog or simulation of that?
-# There are several, unappealing options to simulate:
-#  * Contrive an svg overlay of the graphic
-#    IFF we knew the desired positions of the fragments
-#  * Do surgery on the postscript (embedding what?) and
-#    then rasterizing the image to png, losing all XML/MathML/semantics...
-#  other?
-# Or, we could simply fudge them:
-#  * Ignore the fragments (with warning).
-#  * Add a footnote, or better, add to a figure caption, or ...
+#======================================================================
+# Would be lovely to overlay SVG, MathML, Images etc
+# but kinda impractical to hope to align things the same way as LaTeX would.
+# So, we just punt all of it to LaTeX to create a composite image
 
-#
-# For now, just warn and go.
-DefMacro('\psfrag@warning', sub {
-    my ($gullet) = @_;
-    Warn('psfrag', 'psfrag', $gullet, "PSFrag fragments are being converted to footnotes.");
+# Store fragments for later use
+AssignValue(saved_psfragments => Tokens());
+AssignValue(psfrag_scan_all   => LookupValue('2.09_COMPATIBILITY'));
+AssignValue(psfrag_scan       => 0);
+DeclareOption('209mode', sub { AssignValue(psfrag_scan_all => 1); });
+DeclareOption('2emode',  sub { AssignValue(psfrag_scan_all => 0); });
+DeclareOption('scanall', sub { AssignValue(psfrag_scan_all => 1); });
+
+ProcessOptions();
+
+sub save_psfrag {
+  my (@stuff) = @_;
+  # NOT global!!!  And defer expansion of the leading CS
+  AssignValue(saved_psfragments =>
+      Tokens(LookupValue('saved_psfragments')->unlist, T_CS('\noexpand'), @stuff));
+  return; }
+
+sub unsave_psfrag {
+  return Tokens(Digest(LookupValue('saved_psfragments'))->revert); }
+
+# NOT a constructor since probably args should not be digested yet(?)
+DefPrimitive('\psfrag OptionalMatch:* Semiverbatim [][][][]{}', sub {
+    my ($stomach, $star, $a, $b, $c, $d, $e, $f) = @_;
+    save_psfrag(Invocation(T_CS('\lx@delayed@psfrag'), $star, $a, $b, $c, $d, $e, $f));
     return; });
+DefConstructor('\lx@delayed@psfrag OptionalMatch:* Semiverbatim [][][][]{}', '',
+  alias => '\psfrag');
 
-# This would be much nicer if we could at least tell which figures were affected
-# and add the notes to the captions!
-DefMacro('\psfrag OptionalMatch:* {}[][][][]{}',
-  '\psfrag@warning\global\let\psfrag@warning\relax'
-    . '\footnote{A PSFrag replacing \texttt{#2} by #7 was dropped.}');
+DefConstructor('\psfragscanon', '',
+  afterDigest => sub {
+    save_psfrag(T_CS('\psfragscanon'));
+    AssignValue(psfrag_scan => 1); });
+DefConstructor('\psfragscanoff', '',
+  afterDigest => sub {
+    save_psfrag(T_CS('\psfragscanoff'));
+    AssignValue(psfrag_scan => 0); });
+
+# AVOID using ltx:picture instead of ltx:graphic
+# unless there actually are some psfrags defined, OR embedded fragments was explicitly enabled.
+# (faster, probably more reliable image conversion)
+sub psfrag_requirepicture {
+  my (@candidates) = @_;
+  my $have_ps = 0;
+  if (scalar(@candidates) == 1) {
+    my $type = image_type(pathname_absolute($candidates[0], LookupValue('SOURCEDIRECTORY')));
+    $have_ps = ($type eq 'ps') || ($type eq 'eps'); }
+  my $have_frags = scalar(LookupValue('saved_psfragments')->unlist);
+  my $scan_on    = LookupValue('psfrag_scan') || LookupValue('psfrag_scan_all');
+  return $have_ps && ($have_frags || $scan_on); }
+
+# For graphics version of \includegraphics
+DefConstructor('\lx@psfrag@includegraphics OptionalMatch:* [][] Semiverbatim',
+  "?#pic(<ltx:picture width='#width' height='#height' unitlength='#unitlength' tex='#tex'/>)"
+    . "(<ltx:graphics graphic='#path' candidates='#candidates' options='#options'/>)",
+  alias      => '\includegraphics',
+  sizer      => \&image_graphicx_sizer,
+  properties => sub {
+    my ($stomach, $starred, $op1, $op2, $graphic) = @_;
+    my $options = graphicS_options($starred, $op1, $op2);
+    my ($path, @candidates) = graphics_get_candidates($graphic);
+    my $ifpicture = psfrag_requirepicture(@candidates);
+    (graphic => $path,
+      candidates => join(',', @candidates),
+      options    => $options,
+      pic        => $ifpicture); },
+  afterDigest => sub {
+    my ($stomach, $whatsit) = @_;
+    my ($w, $h, $d) = $whatsit->getSize;
+    AssignValue(psfrag_scan => 0, 'global');
+    $whatsit->setProperties(tex => UnTeX(Tokens(unsave_psfrag(), $whatsit->revert)),
+      width => $w, height => $h, depth => $d); });
+
+# For graphicx version of \includegraphics
+DefConstructor('\lx@psfrag@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbatim',
+  "?#pic(<ltx:picture width='#width' height='#height' unitlength='#unitlength' tex='#tex'/>)"
+    . "(<ltx:graphics graphic='#path' candidates='#candidates' options='#options'/>)",
+  alias      => '\includegraphics',
+  sizer      => \&image_graphicx_sizer,
+  properties => sub {
+    my ($stomach, $starred, $kv, $graphic) = @_;
+    my $options = graphicX_options($starred, $kv);
+    my ($path, @candidates) = graphics_get_candidates($graphic);
+    my $ifpicture = psfrag_requirepicture(@candidates);
+    (path => $path,
+      candidates => join(',', @candidates),
+      options    => $options,
+      pic        => $ifpicture); },
+  afterDigest => sub {
+    my ($stomach, $whatsit) = @_;
+    my ($w, $h, $d) = $whatsit->getSize;
+    AssignValue(psfrag_scan => 0, 'global');
+    $whatsit->setProperties(tex => UnTeX(Tokens(unsave_psfrag(), $whatsit->revert)),
+      width => $w, height => $h, depth => $d); });
+
+DefConstructor('\lx@psfrag@epsfbox[] Semiverbatim',
+  "?#pic(<ltx:picture width='#width' height='#height' unitlength='#unitlength' tex='#tex'/>)"
+    . "(<ltx:graphics graphic='#path' candidates='#candidates' options='#options'/>)",
+  alias      => '\epsfbox',
+  sizer      => \&image_graphicx_sizer,
+  properties => sub {
+    my ($stomach, $bb, $graphic) = @_;
+    my $clip    = LookupValue('epsf_clip');
+    my $options = ($clip ? ($bb ? "viewport=$bb, clip" : "clip") : '');
+    my ($path, @candidates) = graphics_get_candidates($graphic);
+    my $ifpicture = psfrag_requirepicture(@candidates);
+    (graphic => $path,
+      candidates => join(',', @candidates),
+      options    => $options,
+      pic        => $ifpicture); },
+  afterDigest => sub {
+    my ($stomach, $whatsit) = @_;
+    my ($w, $h, $d) = $whatsit->getSize;
+    AssignValue(psfrag_scan => 0, 'global');
+    $whatsit->setProperties(tex => UnTeX(Tokens(unsave_psfrag(), $whatsit->revert)),
+      width => $w, height => $h, depth => $d); });
+
+# Just for grouping
+DefEnvironment('{psfrags}', '#body');
+
+# Note that if psfrag is loaded, ANY eps figure may have embedded TeX
+# that needs to be processed by LaTeX, so really needs to end up as ltx:picture
+AtBeginDocument(<<'EoTeX');
+\@ifundefined{@includegraphics}{}{
+\global\let\lx@orig@includegraphics\@includegraphics
+\global\let\@includegraphics\lx@psfrag@includegraphics}
+\@ifundefined{@includegraphicx}{}{
+\global\let\lx@orig@includegraphicx\@includegraphicx
+\global\let\@includegraphicx\lx@psfrag@includegraphicx}
+\@ifundefined{epsfbox}{}{
+\global\let\lx@orig@epsfbox\epsfbox
+\global\let\epsfbox\lx@psfrag@epsfbox}
+EoTeX
 
 #**********************************************************************
 1;

--- a/lib/LaTeXML/Package/txfonts.sty.ltxml
+++ b/lib/LaTeXML/Package/txfonts.sty.ltxml
@@ -66,60 +66,60 @@ DefMath('\iiiintop', "\x{2A0C}", meaning => 'quadruple-integral', role => 'INTOP
 
 # Following made with combining clockwise or counter clockwise overlay
 DefMath('\oiiintclockwise', "\x{222D}\x{20D9}",
-  meaning => 'triple-clockwise-contour-integral', role => 'INTOP',
+  meaning   => 'triple-clockwise-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
 DefMath('\oiiintclockwiseop', "\x{222D}\x{20D9}",
-  meaning => 'triple-clockwise-contour-integral', role => 'INTOP',
-  scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
+  meaning   => 'triple-clockwise-contour-integral', role      => 'INTOP',
+  scriptpos => 'mid',                               mathstyle => \&doVariablesizeOp);
 DefMath('\varoiiintclockwise', "\x{222D}\x{20D9}",
-  meaning => 'triple-clockwise-contour-integral', role => 'INTOP',
+  meaning   => 'triple-clockwise-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
 DefMath('\varoiiintclockwiseop', "\x{222D}\x{20D9}",
-  meaning => 'triple-clockwise-contour-integral', role => 'INTOP',
-  scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
+  meaning   => 'triple-clockwise-contour-integral', role      => 'INTOP',
+  scriptpos => 'mid',                               mathstyle => \&doVariablesizeOp);
 DefMath('\oiiintctrclockwise', "\x{222D}\x{20DA}",
-  meaning => 'triple-counterclockwise-contour-integral', role => 'INTOP',
+  meaning   => 'triple-counterclockwise-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
 DefMath('\oiiintctrclockwiseop', "\x{222D}\x{20DA}",
-  meaning => 'triple-counterclockwise-contour-integral', role => 'INTOP',
-  scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
+  meaning   => 'triple-counterclockwise-contour-integral', role      => 'INTOP',
+  scriptpos => 'mid',                                      mathstyle => \&doVariablesizeOp);
 DefMath('\varoiiintctrclockwise', "\x{222D}\x{20DA}",
-  meaning => 'triple-counterclockwise-contour-integral', role => 'INTOP',
+  meaning   => 'triple-counterclockwise-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
 DefMath('\varoiiintctrclockwiseop', "\x{222D}\x{20DA}",
-  meaning => 'triple-counterclockwise-contour-integral', role => 'INTOP',
-  scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
+  meaning   => 'triple-counterclockwise-contour-integral', role      => 'INTOP',
+  scriptpos => 'mid',                                      mathstyle => \&doVariablesizeOp);
 
 DefMath('\oiiint', "\x{2230}",
-  meaning => 'triple-contour-integral', role => 'INTOP',
+  meaning   => 'triple-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
 DefMath('\oiiintop', "\x{2230}",
-  meaning => 'triple-contour-integral', role => 'INTOP',
-  scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
+  meaning   => 'triple-contour-integral', role      => 'INTOP',
+  scriptpos => 'mid',                     mathstyle => \&doVariablesizeOp);
 DefMath('\oiintclockwise', "\x{222C}\x{20D9}",
-  meaning => 'double-clockwise-contour-integral', role => 'INTOP',
+  meaning   => 'double-clockwise-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
 DefMath('\oiintclockwiseop', "\x{222C}\x{20D9}",
-  meaning => 'double-clockwise-contour-integral', role => 'INTOP',
-  scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
+  meaning   => 'double-clockwise-contour-integral', role      => 'INTOP',
+  scriptpos => 'mid',                               mathstyle => \&doVariablesizeOp);
 DefMath('\varoiintclockwise', "\x{222C}\x{20D9}",
-  meaning => 'double-clockwise-contour-integral', role => 'INTOP',
+  meaning   => 'double-clockwise-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
 DefMath('\varoiintclockwiseop', "\x{222C}\x{20D9}",
-  meaning => 'double-clockwise-contour-integral', role => 'INTOP',
-  scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
+  meaning   => 'double-clockwise-contour-integral', role      => 'INTOP',
+  scriptpos => 'mid',                               mathstyle => \&doVariablesizeOp);
 DefMath('\oiintctrclockwise', "\x{222C}\x{20DA}",
-  meaning => 'double-counterclockwise-contour-integral', role => 'INTOP',
+  meaning   => 'double-counterclockwise-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
 DefMath('\oiintctrclockwiseop', "\x{222C}\x{20DA}",
-  meaning => 'double-counterclockwise-contour-integral', role => 'INTOP',
-  scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
+  meaning   => 'double-counterclockwise-contour-integral', role      => 'INTOP',
+  scriptpos => 'mid',                                      mathstyle => \&doVariablesizeOp);
 DefMath('\varoiintctrclockwise', "\x{222C}\x{20DA}",
-  meaning => 'double-counterclockwise-contour-integral', role => 'INTOP',
+  meaning   => 'double-counterclockwise-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
 DefMath('\varoiintctrclockwiseop', "\x{222C}\x{20DA}",
-  meaning => 'double-counterclockwise-contour-integral', role => 'INTOP',
-  scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
+  meaning   => 'double-counterclockwise-contour-integral', role      => 'INTOP',
+  scriptpos => 'mid',                                      mathstyle => \&doVariablesizeOp);
 
 DefMath('\oiint', "\x{222F}", meaning => 'double-contour-integral', role => 'INTOP',
   mathstyle => \&doVariablesizeOp);
@@ -140,13 +140,18 @@ DefMath('\varointclockwiseop', "\x{2232}", meaning => 'clockwise-contour-integra
 DefMath('\varointctrclockwise', "\x{2233}", meaning => 'counter-clockwise-contour-integral',
   role => 'INTOP', mathstyle => \&doVariablesizeOp);
 DefMath('\varointctrclockwiseop', "\x{2233}", meaning => 'counter-clockwise-contour-integral',
-  role => 'INTOP',
+  role      => 'INTOP',
   scriptpos => 'mid', mathstyle => \&doVariablesizeOp);
 # \sqiiint
 # \sqiint
 DefMath('\sqint', "\x{2A16}", role => 'INTOP', meaning => 'square-contour-integral',
   mathstyle => \&doVariablesizeOp);
 # \varprod
+
+DefMathI('\bigsqcap', undef, "\x{2A05}",
+  role      => 'SUMOP',
+  scriptpos => \&doScriptpos,
+  mathstyle => \&doVariablesizeOp);
 
 #================================================================================
 # See LaTeX Symbol list, Table 29 --- also in amsfonts
@@ -210,7 +215,7 @@ DefMath('\multimapdotbothB', "\x{22B7}", role => 'RELOP');
 #DefMath('\multimapdotinv',      "\x{}",             role=>'RELOP');
 DefMath('\multimapinv', "\x{27DC}",         role    => 'RELOP');
 DefMath('\napproxeq',   "\x{224A}\x{0338}", meaning => 'not-approximately-equals', role => 'RELOP');
-DefMath('\nasymp',      "\x{226D}",         meaning => 'not-equivalent-to', role => 'RELOP');
+DefMath('\nasymp',      "\x{226D}",         meaning => 'not-equivalent-to',        role => 'RELOP');
 DefMath('\nbacksim',    "\x{223D}\x{0337}", role    => 'RELOP');
 DefMath('\nbacksimeq',  "\x{224C}\x{0338}", role    => 'RELOP');
 DefMath('\nBumpeq',     "\x{224E}\x{0338}", role    => 'RELOP');

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -391,7 +391,9 @@ $packages
 \\makeatletter
 \\setlength{\\hoffset}{0pt}\\setlength{\\voffset}{0pt}
 \\setlength{\\textwidth}{${w}pt}
-\\thispagestyle{empty}\\pagestyle{empty}\\title{}\\author{}\\date{}
+\\thispagestyle{empty}\\pagestyle{empty}\\title{}\\date{}
+% Careful with revtex4
+\\\@ifundefined{\@author\@def}{\\author{}}{}
 \\newcount\\lxImageNumber\\lxImageNumber=0\\relax
 \\newbox\\lxImageBox
 \\newdimen\\lxImageBoxSep

--- a/lib/LaTeXML/Post/PictureImages.pm
+++ b/lib/LaTeXML/Post/PictureImages.pm
@@ -16,6 +16,11 @@ use warnings;
 use LaTeXML::Post;
 use base qw(LaTeXML::Post::LaTeXImages);
 
+# Options:
+#  resource_directory
+#  resource_prefix
+#  use_dvipng
+#  empty_only : process only ltx:picture w/o children (but with tex attribute)
 sub new {
   my ($class, %options) = @_;
   $options{resource_directory} = 'pic' unless defined $options{resource_directory};
@@ -39,7 +44,10 @@ sub find_documentclass_and_packages {
 # Return the list of Picture nodes.
 sub toProcess {
   my ($self, $doc) = @_;
-  return $doc->findnodes('//ltx:picture'); }
+  my @nodes = $doc->findnodes('//ltx:picture');
+  if ($$self{empty_only}) {
+    @nodes = grep { !$_->hasChildNodes; } @nodes; }
+  return @nodes; }
 
 # Return the TeX string to format the image for this node.
 sub extractTeX {
@@ -66,8 +74,8 @@ sub setTeXImage {
   #  $node->setAttribute(height => $height . "pt");
   # But, since the inner image (of whatever format) will already get a size,
   # it's probably safer to just remove those attributes?
-  $node->removeAttribute('width');
-  $node->removeAttribute('height');
+  #  $node->removeAttribute('width');
+  #  $node->removeAttribute('height');
   return; }
 
 # Definitions needed for processing inline & display picture images


### PR DESCRIPTION
This PR arranges for empty `ltx:picture` elements (that have a tex attribute) to generate an image via LaTeX, whether or not the `--pictureimages` commandline switch is used. (If they are non-empty, the content determines the conversion, depending on (possibly) other post-processors).

This technique allows us to improve the `psfrag` bindng by collecting `\psfrag` calls to be used with an `\includegraphics` (or `\epsfbox`) and get LaTeX to combine them into a single image, rather than discard them.

It also allows us to write a binding for the `overpic` package.

Along the way, a few other random bugs were fixed.