### PR TITLE
Imagefix

### DIFF
--- a/lib/LaTeXML/Package/graphics.sty.ltxml
+++ b/lib/LaTeXML/Package/graphics.sty.ltxml
@@ -234,18 +234,6 @@ DefConstructor('\graphicspath DirectoryList', sub {
 DefMacro('\includegraphics OptionalMatch:* [][] Semiverbatim',
   '\@includegraphics#1[#2][#3]{#4}');
 
-sub graphics_get_candidates {
-  my ($path, $kv) = @_;
-  $path = ToString($path); $path =~ s/^\s+//; $path =~ s/\s+$//;
-  $path =~ s/^("+)(.+)\g1$/$2/;                           # unwrap if in quotes
-  my $searchpaths = LookupValue('GRAPHICSPATHS');
-  if (my $svgpath = $kv && $kv->getValue('svgpath')) {    # Doesn't belong here!!!
-    push(@$searchpaths, ToString($svgpath)); }
-  my @candidates = pathname_findall($path, types => ['*'], paths => $searchpaths);
-  if (my $base = LookupValue('SOURCEDIRECTORY')) {
-    @candidates = map { pathname_relative($_, $base) } @candidates; }
-  return ($path, @candidates); }
-
 sub graphicS_options {
   my ($starred, $option1, $option2) = @_;
   my $bb = ($option2
@@ -273,7 +261,7 @@ DefConstructor('\@includegraphics OptionalMatch:* [][] Semiverbatim',
   properties => sub {
     my ($stomach, $starred, $op1, $op2, $graphic) = @_;
     my $options = graphicS_options($starred, $op1, $op2);
-    my ($path, @candidates) = graphics_get_candidates($graphic);
+    my ($path, @candidates) = image_candidates(ToString($graphic));
     (graphic => $path,
       candidates => join(',', @candidates),
       options    => $options); },

--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -53,7 +53,7 @@ DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbat
   properties => sub {
     my ($stomach, $starred, $kv, $graphic) = @_;
     my $options = graphicX_options($starred, $kv);
-    my ($path, @candidates) = graphics_get_candidates($graphic);
+    my ($path, @candidates) = image_candidates(ToString($graphic));
     (path => $path,
       candidates => join(',', @candidates),
       options    => $options); },

--- a/lib/LaTeXML/Package/psfrag.sty.ltxml
+++ b/lib/LaTeXML/Package/psfrag.sty.ltxml
@@ -80,7 +80,7 @@ DefConstructor('\lx@psfrag@includegraphics OptionalMatch:* [][] Semiverbatim',
   properties => sub {
     my ($stomach, $starred, $op1, $op2, $graphic) = @_;
     my $options = graphicS_options($starred, $op1, $op2);
-    my ($path, @candidates) = graphics_get_candidates($graphic);
+    my ($path, @candidates) = image_candidates(ToString($graphic));
     my $ifpicture = psfrag_requirepicture(@candidates);
     (graphic => $path,
       candidates => join(',', @candidates),
@@ -102,7 +102,7 @@ DefConstructor('\lx@psfrag@includegraphicx OptionalMatch:* OptionalKeyVals:Gin S
   properties => sub {
     my ($stomach, $starred, $kv, $graphic) = @_;
     my $options = graphicX_options($starred, $kv);
-    my ($path, @candidates) = graphics_get_candidates($graphic);
+    my ($path, @candidates) = image_candidates(ToString($graphic));
     my $ifpicture = psfrag_requirepicture(@candidates);
     (path => $path,
       candidates => join(',', @candidates),
@@ -124,7 +124,7 @@ DefConstructor('\lx@psfrag@epsfbox[] Semiverbatim',
     my ($stomach, $bb, $graphic) = @_;
     my $clip    = LookupValue('epsf_clip');
     my $options = ($clip ? ($bb ? "viewport=$bb, clip" : "clip") : '');
-    my ($path, @candidates) = graphics_get_candidates($graphic);
+    my ($path, @candidates) = image_candidates(ToString($graphic));
     my $ifpicture = psfrag_requirepicture(@candidates);
     (graphic => $path,
       candidates => join(',', @candidates),

--- a/lib/LaTeXML/Package/pstricks.sty.ltxml
+++ b/lib/LaTeXML/Package/pstricks.sty.ltxml
@@ -537,7 +537,8 @@ sub DefSimplePSConstructor {
 ####################################################################################
 
 DefEnvironment('{pspicture} [Float] PSCoord OptionalPSCoord',
-  "<ltx:picture baseline='#1' width='#pxwidth' height='#pxheight'>"
+  "<ltx:picture baseline='#1' width='#pxwidth' height='#pxheight'"
+    . " fill='none' stroke='none'>"
     . "?#need(<ltx:g transform='#transform'>)"
     . "#body"
     . "?#need(</ltx:g>)"
@@ -741,10 +742,8 @@ DefPSConstructor('\psellipse', 'PSCoord PSCoord',
   "<ltx:ellipse $PSLineAttr x='#x' y='#y' rx='#rx' ry='#ry' fill='#fill' />",
   attributes => [qw(fill linecolor linewidth dash)],
   properties => sub {
-    my $c = $_[1]->getArg(2) || ZeroPair;
-    my $r = $_[1]->getArg(3);
-##    $c  ? $_[1]->setProperties(center => $c, radii => $r)
-##      :   $_[1]->setProperties(center => ZeroPair, radii => $r); },
+    my $c = $_[2] || ZeroPair;
+    my $r = $_[3];
     (x => $c->getX->pxValue, y => $c->getY->pxValue,
       rx => $r->getX->pxValue, ry => $r->getY->pxValue); });
 
@@ -783,8 +782,21 @@ DefPSConstructor('\parabola', 'PSCoord PSCoord',
   "<ltx:parabola $PSLineAttr x0='#x0' y0='#y0' x1='#x1' y1='#y1'/>",
   attributes => [qw(linecolor linewidth dash)],
   properties => sub {
-    (x0 => $_[3]->getX->pxValue, y0 => $_[3]->getX->pxValue,
-      x1 => $_[4]->getX->pxValue, y1 => $_[4]->getY->pxValue); });
+    (x0 => $_[2]->getX->pxValue, y0 => $_[2]->getY->pxValue,
+      x1 => $_[3]->getX->pxValue, y1 => $_[3]->getY->pxValue); });
+
+DefPSConstructor('\parabola', 'PSCoord PSCoord',
+  "<ltx:bezier $PSLineAttr #!ARROWS showpoints='#showpoints' points='#path' fill='#fill'/>",
+  attributes  => [qw(linecolor linewidth dash showpoints)],
+  afterDigest => sub {
+    my ($stomach, $whatsit) = @_;
+    my $p0 = $whatsit->getArg(3);
+    my $p1 = $whatsit->getArg(4);
+    my ($x0, $y0, $x1, $y1) = ($p0->getX->pxValue, $p0->getY->pxValue,
+      $p1->getX->pxValue, $p1->getY->pxValue);
+    my ($xc, $yc) = (2 * $x1 - $x0, 2 * $y1 - $y0);
+    # want in svg d => "M$x0,$y0 Q$x0,$yc $xc,$y0"
+    $whatsit->setProperty(path => "$x0,$y0 $x1,$yc $xc,$y0"); });
 
 DefPSConstructor('\pscurve', 'PSCoordList',
   "<ltx:curve $PSLineAttr #!ARROWS points='&ptValue(#3)'"
@@ -831,7 +843,7 @@ DefPSConstructor('\psdots', 'PSCoordList',
 
 # NOTE: ignores gridwidth, gridcolor, griddots, gridlabels, gridlabelcolor, subgriddiv,
 #       subgridwidth, subgridcolor, subgriddots
-DefSimplePSConstructor('\psgrid', 'PSCoord PSCoord PSCoord',
+DefSimplePSConstructor('\psgrid', 'OptionalPSCoord OptionalPSCoord OptionalPSCoord',
   "<ltx:grid x0='#x0' y0='#y0' x1='#x1' y1='#y1' x2='#x2' y2='#y2'"
     . " xunit='&ptValue(#xunit)' yunit='&ptValue(#yunit)' />",
   attributes => [qw(xunit yunit

--- a/lib/LaTeXML/Package/svg.sty.ltxml
+++ b/lib/LaTeXML/Package/svg.sty.ltxml
@@ -38,8 +38,11 @@ DefKeyVal('Gin', 'pdflatex', '', '');
 DefKeyVal('Gin', 'pdftops',  '', '');
 DefKeyVal('Gin', 'convert',  '', '');
 
-# This should set graphicspath...
-DefKeyVal('Gin', 'svgpath', '', '');
+DefKeyVal('Gin', 'svgpath', '', '', code => sub {
+    my $root = $STATE->lookupValue('SOURCEDIRECTORY') || '';
+    my $path = pathname_absolute(pathname_canonical(ToString($_[1])), $root);
+    PushValue(GRAPHICSPATHS => $path); });
+
 # DefConstructor('\graphicspath DirectoryList', sub {
 #     my ($document, $paths) = @_;
 #     foreach my $dir ($paths->getValues) {

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
@@ -150,6 +150,9 @@
             <xsl:value-of select="concat('vertical-align:-',@imagedepth,'px')"/>
           </xsl:if>
         </xsl:with-param>
+        <xsl:with-param name="extra_classes">
+          <xsl:if test="not(@imagesrc)">ltx_missing ltx_missing_image</xsl:if>
+        </xsl:with-param>
       </xsl:call-template>
       <xsl:if test="@imagewidth">
         <xsl:attribute name='width'>


### PR DESCRIPTION
A few more image related fixes, avoiding several Fatal errors
* migrate graphics' `graphics_get_candidates` to the more reusable `Util::Image::image_candidates`
* Add classes `ltx_missing` and `ltx_missing_image` so that missing `ltx:graphics` imagesrc can be recognized & informatively styled
* interim fixes to pstricks to handle ellipses and parabolas

Fixes #1733