### PR TITLE
Give XSLT more depth

### DIFF
--- a/lib/LaTeXML/Post/XSLT.pm
+++ b/lib/LaTeXML/Post/XSLT.pm
@@ -45,7 +45,7 @@ sub new {
   $stylesheet = $stylesheet && LaTeXML::Common::XML::XSLT->new($stylesheet);
   if ((!ref $stylesheet) || !($stylesheet->can('transform'))) {
     Error('expected', 'stylesheet', undef, "Stylesheet '$stylesheet' is not a usable stylesheet!"); }
-  XML::LibXSLT->max_depth(500);
+  XML::LibXSLT->max_depth(1000);
   $$self{stylesheet} = $stylesheet;
   my %params = ();
   %params                    = %{ $options{parameters} } if $options{parameters};


### PR DESCRIPTION
Example where that was needed is `arXiv:1612.02710`.

With the 500 depth, post-processing died with a Fatal error. With 1000, it succeeded smoothly.