### PR TITLE
Avoid deep recursion by locking \@eqnnum

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1962,7 +1962,7 @@ DefMacroI('\normalsfcodes', undef, Tokens());
 #======================================================================
 # C.7.1 Math Mode Environments
 #======================================================================
-DefMacroI('\@eqnnum', undef, '(\theequation)');
+DefMacroI('\@eqnnum', undef, '(\theequation)', locked => 1);
 DefMacro('\fnum@equation', '\@eqnnum');
 
 # Redefined from TeX.pool, since with LaTeX we presumably have a more complete numbering system


### PR DESCRIPTION
Fixes `arXiv:gr-qc/0405052` by locking one more internal macro.

We simply aren't prepared to interpret raw in the low-level equation numbering machinery, and documents hit 100 Errors rather quickly when they try.