### PR TITLE
Epsf

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -605,6 +605,7 @@ lib/LaTeXML/Package/newtxtext.sty.ltxml
 lib/LaTeXML/Package/ngerman.sty.ltxml
 lib/LaTeXML/Package/nicefrac.sty.ltxml
 lib/LaTeXML/Package/nil.ldf.ltxml
+lib/LaTeXML/Package/nomencl.sty.ltxml
 lib/LaTeXML/Package/nopageno.sty.ltxml
 lib/LaTeXML/Package/ntheorem.sty.ltxml
 lib/LaTeXML/Package/numprint.sty.ltxml

--- a/lib/LaTeXML/Package/emulateapj.sty.ltxml
+++ b/lib/LaTeXML/Package/emulateapj.sty.ltxml
@@ -26,6 +26,7 @@ my $saved_fig = LookupDefinition(T_CS('\fig'));
 
 # Seems to be equivalent.
 RequirePackage('aastex', withoptions => 1);
+RequirePackage('epsf');
 # ... Well, almost...
 DefMacroI('\LongTables', undef, '');
 Let('\begin{deluxetable*}', '\begin{deluxetable}');

--- a/lib/LaTeXML/Package/epsf.sty.ltxml
+++ b/lib/LaTeXML/Package/epsf.sty.ltxml
@@ -40,16 +40,24 @@ EOTeX
 
 DefPrimitive('\epsfclipon',  sub { AssignValue(epsf_clip => 1); return; });
 DefPrimitive('\epsfclipoff', sub { AssignValue(epsf_clip => 0); return; });
-DefConstructor('\epsfbox[] Semiverbatim', sub {
+
+DefConstructor('\epsfbox[] Semiverbatim',
+  "<ltx:graphics graphic='#graphic' candidates='#candidates' options='#options'/>",
+  sizer      => \&image_graphicx_sizer,
+  properties => sub {
     my ($document, $bb, $graphic) = @_;
-    my $clip = LookupValue('epsf_clip');
+    my $clip    = LookupValue('epsf_clip');
     my $options = ($clip ? ($bb ? "viewport=$bb, clip" : "clip") : '');
-    $graphic = ToString($graphic); $graphic =~ s/^\s+//; $graphic =~ s/\s+$//;
-    my @candidates = pathname_findall($graphic, types => ['*'], paths => LookupValue('GRAPHICSPATHS'));
-    if (my $base = LookupValue('SOURCEDIRECTORY')) {
-      @candidates = map { pathname_relative($_, $base) } @candidates; }
-    $document->insertElement('ltx:graphics', undef, graphic => $graphic,
-      candidates => join(',', @candidates), options => $options); });
+    my ($file, @candidates) = image_candidates(ToString($graphic));
+    my $w = LookupRegister('\epsfxsize');
+    my $h = LookupRegister('\epsfysize');
+    if ($w->valueOf > 0) {
+      $options .= ($options ? ',' : '') . 'width=' . ToString($w); }
+    if ($h->valueOf > 0) {
+      $options .= ($options ? ',' : '') . 'height=' . ToString($h); }
+    (graphic => $file,
+      candidates => join(',', @candidates),
+      options    => $options); });
 
 Let('\epsfgetlitbb', '\epsfbox');
 Let('\epsfnormal',   '\epsfbox');

--- a/lib/LaTeXML/Package/nomencl.sty.ltxml
+++ b/lib/LaTeXML/Package/nomencl.sty.ltxml
@@ -1,0 +1,21 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  nomencl                                                            | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+InputDefinitions('nomencl', type => 'sty', noltxml => 1);
+
+1;
+


### PR DESCRIPTION
This fixes a problem with epsfbox not respecting the requested size (`\epsfxsize,\epsfysize`), and also that apparently emulateapj includes epsf.  There's also a gratuitous new binding for `nomencl`; it's not heavily used, but it optionally loads several other packages, so simply loading "dependencies" is error prone.

@dginev; you can go ahead & merge if you're happy with it, and need it.