### PR TITLE
Add missing use to epsf.sty.ltxml

### DIFF
--- a/lib/LaTeXML/Package/epsf.sty.ltxml
+++ b/lib/LaTeXML/Package/epsf.sty.ltxml
@@ -14,6 +14,7 @@ package LaTeXML::Package::Pool;
 use strict;
 use warnings;
 use LaTeXML::Package;
+use LaTeXML::Util::Image;
 
 #**********************************************************************
 # (See  LaTeXML::Post::Graphics for suggested postprocessing)
@@ -68,4 +69,3 @@ DefPrimitive('\epsfframe',              undef);    # Ignore (?), and process the
 
 #**********************************************************************
 1;
-


### PR DESCRIPTION
Tested with `hep-ph/0009104`, avoids the Fatal
```
Undefined subroutine '&LaTeXML::Package::Pool::image_candidates' called at at /usr/local/share/perl/5.34.0/LaTeXML/Package/epsf.sty.ltxml line 51
```
[found here](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/fatal/misdefined/LaTeXML%3A%3APackage%3A%3APool%3A%3A%5F%5FANON%5F%5F?all=false)

It's fine if we catch more of these - easy to rerun the ones that leave Fatal traces.

Since we are rerunning a whole lot of epsf.sty, I am happy to merge here quickly and update the reruns.