### PR TITLE
Enhancements to the LaTeXImage feature

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4178,7 +4178,8 @@ AssignValue(CITE_UNIT           => undef);
 
 DefMacro('\@cite{}{}', '[{#1\if@tempswa , #2\fi}]');
 DefConstructor('\@@cite []{}', "<ltx:cite ?#1(class='ltx_citemacro_#1')>#2</ltx:cite>",
-  mode => 'text');
+  reversion => '\cite[#1]{#2}',
+  mode      => 'text');
 
 # \@@bibref{what to show}{bibkeys}{phrase1}{phrase2}
 DefConstructor('\@@bibref Semiverbatim Semiverbatim {}{}',

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -133,11 +133,12 @@ DefParameterType('Optional', sub {
   optional  => 1,
   reversion => sub {
     my ($arg, $default, $inner) = @_;
-    if ($arg) {
-      (T_OTHER('['),
-        ($inner ? $inner->revertArguments($arg) : Revert($arg)),
-        T_OTHER(']')); }
-    else { (); } });
+    my @rev_arg = $arg ? (
+      $inner ? $inner->revertArguments($arg) : Revert($arg))
+      : ();
+    if (@rev_arg) {
+      return (T_OTHER('['), @rev_arg, T_OTHER(']')); }
+    else { return (); } });
 
 # This is a peculiar type of argument of the form
 #   <general text> = <filler>{<balanced text><right brace>

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -621,14 +621,17 @@ sub OptionalKeyVals {
     return (KeyVals_aux($gullet, T_OTHER(']'), [$star, $plus, @keyspec])); }
   else { return (undef); } }
 
+sub revert_optional_keyvals {
+  my @r = $_[0] && Revert($_[0]);
+  @r ? (T_OTHER('['), @r, T_OTHER(']')) : (); }
 DefParameterType('OptionalKeyVals', sub { OptionalKeyVals(0, 0, @_); },
-  optional => 1, reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
+  optional => 1, reversion => \&revert_optional_keyvals);
 DefParameterType('OptionalKeyVals*', sub { OptionalKeyVals(1, 0, @_); },
-  optional => 1, reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
+  optional => 1, reversion => \&revert_optional_keyvals);
 DefParameterType('OptionalKeyVals+', sub { OptionalKeyVals(0, 1, @_); },
-  optional => 1, reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
+  optional => 1, reversion => \&revert_optional_keyvals);
 DefParameterType('OptionalKeyVals*+', sub { OptionalKeyVals(1, 1, @_); },
-  optional => 1, reversion => sub { ($_[0] ? (T_OTHER('['), Revert($_[0]), T_OTHER(']')) : ()); });
+  optional => 1, reversion => \&revert_optional_keyvals);
 
 # Not sure that this is the most elegant solution, but...
 # What I'd really like are some sort of parameter modifiers, mathstyle, font... until...?

--- a/lib/LaTeXML/Package/psfrag.sty.ltxml
+++ b/lib/LaTeXML/Package/psfrag.sty.ltxml
@@ -33,6 +33,8 @@ ProcessOptions();
 
 sub save_psfrag {
   my (@stuff) = @_;
+  # avoid saving if nothing given.
+  return unless @stuff;
   # NOT global!!!  And defer expansion of the leading CS
   AssignValue(saved_psfragments =>
       Tokens(LookupValue('saved_psfragments')->unlist, T_CS('\noexpand'), @stuff));
@@ -44,6 +46,12 @@ sub unsave_psfrag {
 # NOT a constructor since probably args should not be digested yet(?)
 DefPrimitive('\psfrag OptionalMatch:* Semiverbatim [][][][]{}', sub {
     my ($stomach, $star, $a, $b, $c, $d, $e, $f) = @_;
+
+    # Guard against empty $$ argument.
+    my @argt = $f->unlist;
+    if (scalar(@argt) == 2 && $argt[0][1] == CC_MATH && $argt[1][1]) {
+      $f = Tokens(); }
+
     save_psfrag(Invocation(T_CS('\lx@delayed@psfrag'), $star, $a, $b, $c, $d, $e, $f));
     return; });
 DefConstructor('\lx@delayed@psfrag OptionalMatch:* Semiverbatim [][][][]{}', '',
@@ -156,4 +164,3 @@ EoTeX
 
 #**********************************************************************
 1;
-

--- a/lib/LaTeXML/Package/psfrag.sty.ltxml
+++ b/lib/LaTeXML/Package/psfrag.sty.ltxml
@@ -34,6 +34,7 @@ ProcessOptions();
 sub save_psfrag {
   my (@stuff) = @_;
   # avoid saving if nothing given.
+  @stuff = @stuff && Expand(@stuff);
   return unless @stuff;
   # NOT global!!!  And defer expansion of the leading CS
   AssignValue(saved_psfragments =>
@@ -96,7 +97,10 @@ DefConstructor('\lx@psfrag@includegraphics OptionalMatch:* [][] Semiverbatim',
     my ($stomach, $whatsit) = @_;
     my ($w, $h, $d) = $whatsit->getSize;
     AssignValue(psfrag_scan => 0, 'global');
-    $whatsit->setProperties(tex => UnTeX(Tokens(unsave_psfrag(), $whatsit->revert)),
+    my $untex = UnTeX(Tokens(unsave_psfrag(), $whatsit->revert));
+    $untex =~ s/%\n//g;
+    $untex =~ s/\n/ /g;
+    $whatsit->setProperties(tex => $untex,
       width => $w, height => $h, depth => $d); });
 
 # For graphicx version of \includegraphics
@@ -118,7 +122,10 @@ DefConstructor('\lx@psfrag@includegraphicx OptionalMatch:* OptionalKeyVals:Gin S
     my ($stomach, $whatsit) = @_;
     my ($w, $h, $d) = $whatsit->getSize;
     AssignValue(psfrag_scan => 0, 'global');
-    $whatsit->setProperties(tex => UnTeX(Tokens(unsave_psfrag(), $whatsit->revert)),
+    my $untex = UnTeX(Tokens(unsave_psfrag(), $whatsit->revert));
+    $untex =~ s/%\n//g;
+    $untex =~ s/\n/ /g;
+    $whatsit->setProperties(tex => $untex,
       width => $w, height => $h, depth => $d); });
 
 DefConstructor('\lx@psfrag@epsfbox[] Semiverbatim',
@@ -140,7 +147,10 @@ DefConstructor('\lx@psfrag@epsfbox[] Semiverbatim',
     my ($stomach, $whatsit) = @_;
     my ($w, $h, $d) = $whatsit->getSize;
     AssignValue(psfrag_scan => 0, 'global');
-    $whatsit->setProperties(tex => UnTeX(Tokens(unsave_psfrag(), $whatsit->revert)),
+    my $untex = UnTeX(Tokens(unsave_psfrag(), $whatsit->revert));
+    $untex =~ s/%\n//g;
+    $untex =~ s/\n/ /g;
+    $whatsit->setProperties(tex => $untex,
       width => $w, height => $h, depth => $d); });
 
 # Just for grouping

--- a/lib/LaTeXML/Package/psfrag.sty.ltxml
+++ b/lib/LaTeXML/Package/psfrag.sty.ltxml
@@ -46,12 +46,10 @@ sub unsave_psfrag {
 # NOT a constructor since probably args should not be digested yet(?)
 DefPrimitive('\psfrag OptionalMatch:* Semiverbatim [][][][]{}', sub {
     my ($stomach, $star, $a, $b, $c, $d, $e, $f) = @_;
-
     # Guard against empty $$ argument.
     my @argt = $f->unlist;
-    if (scalar(@argt) == 2 && $argt[0][1] == CC_MATH && $argt[1][1]) {
+    if ((scalar(@argt) == 2) && ($argt[0][1] == CC_MATH) && ($argt[1][1] == CC_MATH)) {
       $f = Tokens(); }
-
     save_psfrag(Invocation(T_CS('\lx@delayed@psfrag'), $star, $a, $b, $c, $d, $e, $f));
     return; });
 DefConstructor('\lx@delayed@psfrag OptionalMatch:* Semiverbatim [][][][]{}', '',

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -372,8 +372,13 @@ sub pre_preamble {
 
   foreach my $pkgdata (@classdata) {
     my ($package, $package_options) = @$pkgdata;
-    $package_options = "[$package_options]" if $package_options && ($package_options !~ /^\[.*\]$/);
-    $packages .= "\\usepackage$package_options\{$package\}\n"; }
+    if ($oldstyle) {
+      next if $package =~ /latexml/;    # some packages are incompatible.
+      $package .= ".sty" unless $package =~ /\.sty$/;
+      $packages .= "\\input\{$package\}\n"; }
+    else {
+      $package_options = "[$package_options]" if $package_options && ($package_options !~ /^\[.*\]$/);
+      $packages .= "\\usepackage$package_options\{$package\}\n"; } }
 
   my $w   = ceil($$self{maxwidth} * $pts_per_pixel);                      # Page Width in points.
   my $gap = ($$self{padding} + $$self{clippingfudge}) * $pts_per_pixel;

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -383,13 +383,15 @@ sub pre_preamble {
   my $dest            = $doc->getDestination;
   my $description     = ($dest ? "% Destination $dest" : "");
   my $pts_per_pixel   = 72.27 / $$self{DPI} / $$self{magnification};
+  my %loaded_check    = ();
 
   foreach my $pkgdata (@classdata) {
     my ($package, $package_options) = @$pkgdata;
+    next if $loaded_check{$package};
+    $loaded_check{$package} = 1;
     if ($oldstyle) {
       next if $package =~ /latexml/;    # some packages are incompatible.
-      $package .= ".sty" unless $package =~ /\.sty$/;
-      $packages .= "\\input{$package}\n"; }
+      $packages .= "\\RequirePackage{$package}\n"; }
     else {
       if ($package eq 'english') {
         $packages .= "\\usepackage[english]{babel}\n"; }
@@ -409,7 +411,7 @@ sub pre_preamble {
   $result_add_to_body .= "\\let\\\@\@toccaption\\\@gobble\n\\let\\\@\@caption\\\@gobble\n"
     . "\\renewcommand{\\cite}[2][]{}\n\\newcommand{\\\@\@bibref}[4]{}\n";
   # class-specific conditions:
-  if ($class eq 'JHEP') {
+  if ($class =~ /^JHEP$/i) {
     $class = 'article'; }
   elsif ($class =~ /revtex/) {
     # Careful with revtex4

--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -406,7 +406,8 @@ sub pre_preamble {
   # Some classes are too picky: thanks but no thanks
   my $result_add_to_body = "\\makeatletter\\thispagestyle{empty}\\pagestyle{empty}\n";
   # neutralize caption macros
-  $result_add_to_body .= "\\let\\\@\@toccaption\\\@gobble\n\\let\\\@\@caption\\\@gobble\n";
+  $result_add_to_body .= "\\let\\\@\@toccaption\\\@gobble\n\\let\\\@\@caption\\\@gobble\n"
+    . "\\renewcommand{\\cite}[2][]{}\n\\newcommand{\\\@\@bibref}[4]{}\n";
   # class-specific conditions:
   if ($class eq 'JHEP') {
     $class = 'article'; }


### PR DESCRIPTION
First, the defeating conclusion of my investigation here. It appears that providing a robust, predictable and full-featured capability for latex-based image production for arXiv, is essentially equally difficult to writing the bindings for that in Perl.

The intricacies I can enumerate after digging my teeth into this for a day:
 - establishing the exact package setup a paper expects,
 - ensure all custom arXiv assets are available on disk, 
 - collecting all relevant macro definitions and auxiliary files (e.g. `\begin{document}\input{mymacros}`) is undecidable in general
 - which executable should be used also needs robust heuristics. Currently we only use `latex`, but any use of PNG, JPG or PDF image assets requires `pdflatex`.
 - making sure UnTeX produce a TeX string that is as usable as the original input string is also tricky

---
On the mildly positive side, I did fix a handful of documents. For ~20 I tested, I fixed ~50-60%, when the problems were simple.
 - Adding some obvious assets - see the contents of [arxmliv-bindings/supported_originals](https://github.com/dginev/arxmliv-bindings/tree/main/supported_originals)
 - Avoiding empty optional arguments in reversions -- by actually checking if the reverted tokens were empty. `[]` can actually break in some old .sty packages which only expect the square brackets when they hold content.
 - protecting some spaces in UnTeX. I saw a case where `\\scriptscriptstyle\nx` lost the `\n` newline char and lead to a single macro `\scriptscriptstylex` which was undefined.
 - Some internal `\@@` macros didn't have a meaningful part to play in the picture. Or were impossible to emulate in vacuum - such as \@@cite.
 - Reversions with empy math could be stripped out for \psfrag, i.e. `{$$}` could instead be a simple empty arg `{}`
 - certain packages require even an empty `\abstract{}` or `\title{}` to be placed after `\begin{document}`, or the raise a latex error. So I made a provision for "in_body" definitions, when preparing the ltxmlimg.tex file.
 - loading english.sty raw via latex in texlive 2021 raises an error, so I mapped that to `\usepackage[english]{babel}`
 - using `JHEP.cls` has a whole lot of required macros that must exist, or errors are raised, so I instead mapped that back to article.cls - which works just fine.
 - I moved some latex safeguards that are for a specific class to only be added when that class is used.

Overall, every second paper I tested with seemed to have some very specific discrepancy. I kept thinking that each fix I landed only fixes a handful of articles in arXiv, and there will be many more articles left unfixed that need something similar - but impossible to generalize.

So, after all this, I think I will stop. LaTeX images appear equally difficult/hopeless as writing enough perl to emulate that process well in latexml itself.