### PR TITLE
neutralize \scalebox outside of pspicture

### DIFF
--- a/lib/LaTeXML/Package/pstricks.sty.ltxml
+++ b/lib/LaTeXML/Package/pstricks.sty.ltxml
@@ -554,7 +554,8 @@ DefEnvironment('{pspicture} [Float] PSCoord OptionalPSCoord',
     $whatsit->setProperties(need => 1, transform => $org->ptValue,
       pxwidth  => $c1->getX->subtract($c0->getX)->pxValue,
       pxheight => $c1->getY->subtract($c0->getY)->pxValue);
-    Let('\par', '\relax');
+    Let('\par',        '\relax');
+    Let('\@@scalebox', '\@@@scalebox');
     return; });
 
 DefEnvironment('{pspicture*} [Float] PSCoord PSCoord',
@@ -1025,7 +1026,8 @@ DefConstructor('\rotatedown {}', "<ltx:g transform='rotate(180)'> #1 </ltx:g>",
 
 DefPrimitive('\@@@ackscale{}', sub { ackTransform('scale(' . ToString($_[1]) . ')'); });
 DefMacro('\scalebox{}{}', '{\@@@ackscale{#1}\@@scalebox{#1}{#2}}');
-DefConstructor('\@@scalebox {} {}', "<ltx:g transform='scale(#1)'> #2 </ltx:g>");
+Let('\@@scalebox', '\@secondoftwo');
+DefConstructor('\@@@scalebox {} {}', "<ltx:g transform='scale(#1)'> #2 </ltx:g>");
 
 DefConstructor('\scaleboxto PSCoord {}', "<ltx:g scaleto='&ptValue(#1)'>#2</ltx:g>");
 


### PR DESCRIPTION
`arXiv:math/0109128` was dying with 100 Errors for a curious reason - `\scalebox` from pstricks.sty.

It turns out that macro is fully usable without a pspicture, and LaTeXML kept firing schema errors each time an `ltx:g` was attempted to be inserted into an XMTok. One example being:

```tex
\newcommand{\simplex}{{\scalebox{1.3}{\color{gray}\blacktriangle}}}
```

This PR simply disables/neutralizes the scaling in non-pspicture contexts, which recovers that article to an Error status.