### PR TITLE
minor robustness patches for autoloading deluxetable.sty

### DIFF
--- a/lib/LaTeXML/Package/article.cls.ltxml
+++ b/lib/LaTeXML/Package/article.cls.ltxml
@@ -20,7 +20,7 @@ LoadPool('LaTeX');
 # Option handling
 foreach my $option (qw(10pt 11pt 12pt
   letterpaper legalpaper executivepaper a4paper a5paper b5paper
-  landscape
+  landscape flushrt
   final draft
   oneside twoside
   openright openany

--- a/lib/LaTeXML/Package/deluxetable.sty.ltxml
+++ b/lib/LaTeXML/Package/deluxetable.sty.ltxml
@@ -34,9 +34,15 @@ DefMacroI(T_CS('\begin{deluxetable}'), "{}",
   '\set@deluxetable@template{#1}\def\@deluxetable@header{}\begin{table}');
 DefMacroI(T_CS('\end{deluxetable}'), undef, '\spew@tblnotes\end{table}');
 
+DefMacroI(T_CS('\deluxetable'),    undef, T_CS('\begin{deluxetable}'));
+DefMacroI(T_CS('\enddeluxetable'), undef, T_CS('\end{deluxetable}'));
+
 DefMacroI(T_CS('\begin{deluxetable*}'), "{}",
   '\set@deluxetable@template{#1}\def\@deluxetable@header{}\begin{table}');
 DefMacroI(T_CS('\end{deluxetable*}'), undef, '\spew@tblnotes\end{table}');
+
+DefMacroI(T_CS('\deluxetable*'),    undef, T_CS('\begin{deluxetable*}'));
+DefMacroI(T_CS('\enddeluxetable*'), undef, T_CS('\end{deluxetable*}'));
 
 DefMacro('\set@deluxetable@template AlignmentTemplate', sub {
     AssignValue('@deluxetable@template', $_[1]); });


### PR DESCRIPTION
Minor. The `\deluxetable` was the one that flagged to me this was missing.

I also threw in a discardable `flushrt` while I was at the same article.

Recovers a Fatal reached due to 100 unexpected Alignment `&` errors, which were all due to the `\deluxetable` macro not being defined.