### PR TITLE
allow absorbing active tokens

### DIFF
--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -149,7 +149,7 @@ our @CATCODE_ABSORBABLE = (    # [CONSTANT]
   0, 0, 0, 0,
   0, 0, 0, 0,
   0, 0, 1, 1,
-  1, 0, 1, 0,
+  1, 1, 1, 0,
   0, 0, 0, 0);
 
 sub invokeToken {


### PR DESCRIPTION
This one is highly curious, and may require some mulling over -- since why would it have escaped us so far if what I am about to say is correct?

in `arXiv:cs/0010009`, [download link](https://get.ar5iv.org/source/cs/0010009.zip) we have a Fatal due to 100 Errors of the kind:
```
Error:misdefined:  The token T_ACTIVE[ ] should never reach Stomach! at paper.tex; line 229 col 10
```

But that seems odd? An active token may carry a definition, and the stomach should be perfectly capable of invoking that definition - unless I am misunderstanding the exact timing of that TeX operation.

The simple change of allowing the active tokens to be "absorbable" gets this arXiv article from a Fatal to a "no problem", and the respective active spaces print out the following in HTML:

<img width=600 src="https://user-images.githubusercontent.com/348975/157783054-9c8a50ae-ac4f-4d01-8c32-e79b7c52e4ec.png">

Leaving it here for your consideration.