### PR TITLE
Possible to use aa.cls with amsmath.sty {cases}

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -5167,6 +5167,7 @@ DefMacroI('\verbatim@font', undef,
   '\fontfamily{\ttdefault}\fontseries{\mddefault}\fontshape{\updefault}\selectfont');
 
 Let('\reset@font', '\normalfont');
+DefMacro('\@fontswitch{}{}', '\ifmmode #2\relax\else #1 \fi');
 
 DefPrimitive('\selectfont', sub {
     my $family = ToString(Expand(T_CS('\f@family')));

--- a/lib/LaTeXML/Package/aa.cls.ltxml
+++ b/lib/LaTeXML/Package/aa.cls.ltxml
@@ -53,6 +53,7 @@ DefMacro('\pmatrix{}',
 # also don't use the amsmath cases
 DefMacro('\cases{}',
   '\lx@gen@plain@cases{meaning=cases,left=\@left\{,conditionmode=text,style=\textstyle}{#1}');
-
+# but allow reloading amsmath.sty if {cases} was really needed (arXiv:astro-ph/0203101)
+AssignValue('amsmath.sty.ltxml_loaded', undef, 'global');
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;


### PR DESCRIPTION
We have arXiv:astro-ph/0203101 using aa.cls with amsmath.sty {cases}, as in:
```tex
\documentclass[]{aa520}           
\usepackage{natbib,amssymb,amsmath,curves,epsfig}
% ...
\begin{equation}
\iota(i)\equ
\begin{cases}
i-\hlf &\text{for\quad} \beta_i > 0 \,, \\
i+\hlf &\text{else}\,. \\
\end{cases} 
\end{equation}
```

However, the `aa.cls.ltxml` binding, through `aa_support.sty.ltxml`, loads `amsmath.sty` and then disables its cases environment, reverting it back to a simple macro `\cases{}`. That leaves us in a bit of a pickle - 100 errors starting from misinterpreted align `&` chars.

Rather than refactoring aa_support - which is used in a wide variety of helpful arXiv nooks and crannies, I think a pragmatic change is to hide the fact that amsmath.sty was loaded when relying on aa.cls itself. Simple and gets the job done?