### PR TITLE
use TeXbook definition of \vfootnote

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -6683,11 +6683,16 @@ DefConstructor('\footnote{}{}',
     $whatsit->setProperty(($change ? 'prenote' : 'mark') => $mark);
     return; });
 # Until we can do the "v" properly:
-DefMacro('\vfootnote', '\footnote');
-DefMacro('\fo@t',      '\ifcat\bgroup\noexpand\next \let\next\f@@t  \else\let\next\f@t\fi \next');
-DefMacro('\f@@t',      '\bgroup\aftergroup\@foot\let\next');
-DefMacro('\f@t{}',     '#1\@foot');
-DefMacro('\@foot',     '\strut\egroup');
+DefMacro('\vfootnote{}', '\insert\footins\bgroup'
+    . '\interlinepenalty=\interfootnotelinepenalty'
+    . '\splittopskip=\ht\strutbox'
+    . '\splitmaxdepth=\dp\strutbox \floatingpenalty=20000'
+    . '\leftskip=0pt \rightskip=0pt \spaceskip=0pt \xspaceskip=0pt'
+    . '\textindent{#1}\footstrut\futurelet\next\fo@t');
+DefMacro('\fo@t',  '\ifcat\bgroup\noexpand\next \let\next\f@@t  \else\let\next\f@t\fi \next');
+DefMacro('\f@@t',  '\bgroup\aftergroup\@foot\let\next');
+DefMacro('\f@t{}', '#1\@foot');
+DefMacro('\@foot', '\strut\egroup');
 
 DefPrimitiveI('\footstrut', undef, undef);
 DefRegister('\footins' => Number(0));


### PR DESCRIPTION
I certainly wanted to _pretend_ `\vfootnote` was just a slightly different take on \footnote, but the low-level realities don't really let me.

\footnote is realized _via_ `\vfootnote` internally, but when authors in arXiv used to take advantage of the vertical variant, they did so bravely, as in:
```tex
...is an affine $X_L$-scheme.
${}^1$ $\vfootnote{1} {This is a more practical, refined, and general definition
  than any other one that relies on codimension $1$ statements on complements.
  See Remark 6.3 (a) below.}$ Thus...
```
from arXiv:math/0205199, (line-breaks mine)

That document hit a Fatal with 100 Errors, due to the math modes going out of whack - as of course they would, looking at how adventurous the author was wish switching in-and-out of them, relying on TeX's rigid logic.

So, for such classic uses to work in latexml, the only choice that seems possible on my end is to use the official TeXbook definition. Which is what this PR does - leading to a more robust conversion, even if the generated markup is rather lacking.