### PR TITLE
load \jobname.rty for revtex4-1, when present

### DIFF
--- a/lib/LaTeXML/Package/revtex4-1.cls.ltxml
+++ b/lib/LaTeXML/Package/revtex4-1.cls.ltxml
@@ -57,4 +57,9 @@ LoadClass('article');
 RequirePackage('revtex4_support');
 map { RequirePackage($_) } @revtex_toload;
 
+# check for \jobname.rty
+my $jobname = ToString(Expand(T_CS('\jobname')));
+if (my $rty_file = FindFile($jobname, type => 'rty', noltxml => 1)) {
+  InputDefinitions($jobname, type => 'rty', noltxml => 1); }
+
 1;


### PR DESCRIPTION
Today I found out that revtex4-1.cls unconditionally loads a `\jobname.rty` file with custom definitions, when it is available on disk.

And of course I found that out by investigating an arXiv document's Fatal status, namely `1305.1045`, which has the files:
```
 chgauge.pdf             
 smodel.bbl              
 smodel.rty              
 smodel.tex   
```

This PR simply adds the check to revtex4-1.cls.ltxml and loads the `.rty` file when it is available. 