### PR TITLE
Fix #1831: Make \hyperref expand first argument

### DIFF
--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -151,7 +151,7 @@ DefRegister('\pdfcompresslevel', Number(0));
 # Additional User Macros
 
 # \href{url}{text}
-DefMacro('\href Verbatim {}', '\@@Url\href{}{}{#1}{#2}');
+DefMacro('\href {} {}', '\@@Url\href{}{}{#1}{#2}');
 
 # \url{url} from url.sty... well sorta
 # It's slightly different in that it expands the argument

--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -151,7 +151,7 @@ DefRegister('\pdfcompresslevel', Number(0));
 # Additional User Macros
 
 # \href{url}{text}
-DefMacro('\href {} {}', '\@@Url\href{}{}{#1}{#2}');
+DefMacro('\href Semiverbatim {}', '\@@Url\href{}{}{#1}{#2}');
 
 # \url{url} from url.sty... well sorta
 # It's slightly different in that it expands the argument


### PR DESCRIPTION
As reported in #1831, hyperref treats the first argument as 'Verbatim' and does not expand it.
This PR fixes the issue by making it a regular argument.