### PR TITLE
Add binding for 'ed.sty'

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -452,6 +452,7 @@ lib/LaTeXML/Package/elsart.sty.ltxml
 lib/LaTeXML/Package/elsart_support.sty.ltxml
 lib/LaTeXML/Package/elsart_support_core.sty.ltxml
 lib/LaTeXML/Package/elsarticle.cls.ltxml
+lib/LaTeXML/Package/ed.sty.ltxml
 lib/LaTeXML/Package/expl3.sty.ltxml
 lib/LaTeXML/Package/expl3.ltx.ltxml
 lib/LaTeXML/Package/expl3.pool.ltxml

--- a/lib/LaTeXML/Package/ed.sty.ltxml
+++ b/lib/LaTeXML/Package/ed.sty.ltxml
@@ -1,0 +1,25 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  ed                                                               | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Thanks to Tom Wiesing <tom.wiesing@gmail.com>                       | #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+
+# this just works and produces reasonable output
+InputDefinitions('ed', type => 'sty', noltxml => 1);
+
+#**********************************************************************
+1;


### PR DESCRIPTION
This PR adds a new binding for the 'ed' package found at https://ctan.org/pkg/ed.
The binding can directly read the '.sty' file, and no additional hooks are needed.