### PR TITLE
Fix `maybeMathjax.js` typo in manual

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -546,7 +546,7 @@ The distribution includes a sample \code{LaTeXML-maybeMathjax.js} which is usefu
 for supporting MathML: it invokes MathJax\footnote{https://mathjax.org}
 to render the mathematics in browsers without native support for MathML.
 \begin{lstlisting}[style=shell]
---javascript=LaTeXML-maybeMathJax.js
+--javascript=LaTeXML-maybeMathjax.js
 \end{lstlisting}
 The option can also reference a remote script; for example to invoke MathJax unconditionally
 from the `cloud':


### PR DESCRIPTION
This PR fixes a small typo in the manual. The capitalization of the `maybeMathjax.js` script in the manual was incorrect.

Thanks to Deyan Ginev and Nasser M. Abbasi for noticing.

See also:

https://github.com/brucemiller/LaTeXML/issues/1845#issuecomment-1091960411
https://lists.informatik.uni-erlangen.de/pipermail/latexml/2022-May/002550.html