### PR TITLE
Svg infrastructure

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4781,14 +4781,6 @@ DefConstructor('\raisebox{Dimension}[Dimension][Dimension]{}',
   beforeDigest => sub { reenterTextMode(); },
   sizer        => sub { raisedSizer($_[0]->getArg(4), $_[0]->getArg(1)); });
 
-sub raisedSizer {
-  my ($box, $y) = @_;
-  my ($w, $h, $d) = $box->getSize;
-  my $z = Dimension(0);
-  $h = $h->add($y)->larger($z);
-  $d = $d->subtract($y)->larger($z);
-  return ($w, $h, $d); }
-
 #**********************************************************************
 # C.14 Pictures and Color
 #**********************************************************************

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2019,6 +2019,11 @@ sub REF {
   my ($thing, $key) = @_;
   return $thing && $$thing{$key}; }
 
+sub inSVG {
+  my $document = $LaTeXML::DOCUMENT;
+  my $context  = $document->getElement;
+  return $context && $document->getNodeQName($context) =~ /^svg:/; }
+
 DefConstructor('\hbox BoxSpecification HBoxContents', sub {
     # "<ltx:text width='#width' _noautoclose='1'>#2</ltx:text>",
     my ($document, $spec, $contents, %props) = @_;
@@ -2057,6 +2062,39 @@ DefConstructor('\hbox BoxSpecification HBoxContents', sub {
     elsif (my $s = GetKeyVal($spec, 'spread')) {
       $whatsit->setWidth($box->getWidth->add($s)); }
     return; });
+
+# Cleanup foreignObjects: remove empty (or only <p/>); and determine size
+Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
+  afterClose => sub {
+    my ($document, $node, $whatsit) = @_;
+    my @fo = element_nodes($node);    # What's in the foreignObject?
+    if (scalar(@fo) == 0) {           # Empty?
+      $document->removeNode($node);    #  just remove whole thing
+      return; }
+    elsif ((scalar(@fo) == 1) && ($document->getNodeQName($fo[0]) eq 'ltx:p')) {    # Single <p/>?
+      my @p_c = element_nodes($fo[0]);
+      if (scalar(@p_c) == 0) {                                                      # or Empty <p/>?
+        $document->removeNode($node);
+        return; }
+      # Else, single ltx:picture or ltx:text ?
+      elsif (scalar(@p_c) == 1) {
+        my $tag = $document->getNodeQName($p_c[0]);
+        if (($tag eq 'ltx:picture') || ($tag eq 'ltx:text')) {
+          my @pic_c = element_nodes($p_c[0]);
+          # With single svg:svg ?
+          if ((scalar(@pic_c) == 1) && ($document->getNodeQName($pic_c[0]) eq 'svg:svg')) {
+            $document->replaceNode($node, element_nodes($pic_c[0]));
+            return; } } } }
+    # Otherwise, we've still got an svg:foreignObject;
+    # Make sure we get a size, in case autoOpen'd
+    if ($whatsit) {
+      my ($w, $h, $d) = $whatsit->getSize;
+      my $y  = $STATE->lookupDefinition(T_CS('\baselineskip'))->valueOf->pxValue;
+      my $ht = $h->add($d);
+      $node->setAttribute(width     => $w->pxValue)  unless $node->hasAttribute('width');
+      $node->setAttribute(height    => $ht->pxValue) unless $node->hasAttribute('height');
+      $node->setAttribute(transform => "matrix(1 0 0 -1 0 $y)");
+      $node->setAttribute(overflow  => 'visible'); } });
 
 # This attempts to be a generalize vbox construction;
 # It tries to figure out whether an ltx:inline-block or ltx:para is needed,
@@ -2186,32 +2224,36 @@ DefParameterType('RuleSpecification', sub {
     $keyvals; },
   optional => 1, undigested => 1);
 
+# \hrule, \vrule are awkward in trying to deal with 3 cases
+#  * as rules within an alignment/table
+#  * as separating lines within text
+#  * as graphical lines within svg
+# and each has different requirements for size
 DefConstructor('\vrule RuleSpecification',
   "?#invisible()(?#isVerticalRule()"
-    . "(<ltx:rule height='&GetKeyVal(#1,height)' depth='&GetKeyVal(#1,depth)'"
-    . " width='&GetKeyVal(#1,width)' color='#color'/>))",
+    . "(?&inSVG()(<svg:path d='M 0 0 L 0 #sheight'/>)"
+    . "(<ltx:rule height='#rheight' depth='#rdepth' width='#rwidth' color='#color'/>)))",
+  afterConstruct => sub {    # NOTE: Only For xy development!
+    Warn('unexpected', 'vrule', $_[0], "Encountered \\vrule in SVG") if inSVG(); },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $dims   = $whatsit->getArg(1);
-    my $width  = GetKeyVal($dims, 'width');
+    my $width  = GetKeyVal($dims, 'width');    # || Dimension('0.4pt');
     my $height = GetKeyVal($dims, 'height');
     my $depth  = GetKeyVal($dims, 'depth');
-    $whatsit->setProperties(width  => $width,  cwidth  => $width)  if $width;
-    $whatsit->setProperties(height => $height, cheight => $height) if $height;
-    $whatsit->setProperties(depth  => $depth,  cdepth  => $depth)  if $depth;
+    $whatsit->setProperties(
+      rwidth  => $width,  cwidth  => $width || Dimension('0.4pt'),
+      rheight => $height, cheight => ($height), sheight => ($height ? $height->pxValue : 0),
+      rdepth  => $depth,  cdepth  => ($depth || Dimension(0)));
     my $w = ($width  ? $width->ptValue  : undef);
     my $h = ($height ? $height->ptValue : undef);
     my $d = ($depth  ? $depth->ptValue  : undef);
-    $h -= $d if $h && $d;    # - ??
-
     if (my $alignment = LookupValue('Alignment')) {
       if (((!defined $h) && (!defined $w)) || ((defined $h) && ($h > 20))
         || ((defined $h) && (defined $w) && ($h > 3 * $w))) {
-        # This isXxxxRule property is to determine if it is used for separating rules within alignments
-        $whatsit->setProperty(isVerticalRule => 1) } }
+        $whatsit->setProperty(isVerticalRule => 1) } }    # Marked as rule within alignment
     elsif ((defined $w) && ($w == 0)) {
-      $whatsit->setProperty(invisible => 1); }
-#####    $dims->setValue(width => '1px') unless defined $w;
+      $whatsit->setProperty(invishible => 1); }
     if (my $color = LookupValue('font')->getColor) {
       if ($color ne 'black') {
         $whatsit->setProperty(color => $color); } }
@@ -2219,32 +2261,29 @@ DefConstructor('\vrule RuleSpecification',
 
 DefConstructor('\hrule RuleSpecification',
   "?#isHorizontalRule()"
-    . "(<ltx:rule height='&GetKeyVal(#1,height)' depth='&GetKeyVal(#1,depth)'"
-    . " width='&GetKeyVal(#1,width)' color='#color'/>)",
-  #     properties=>{isHorizontalRule=>1});
+    . "(?&inSVG()(<svg:path d='M 0 0 L #swidth 0'/>)"
+    . "(<ltx:rule height='#rheight' depth='#rdepth' width='#rwidth' color='#color'/>))",
+  afterConstruct => sub {    # NOTE: Only For xy development!
+    Warn('unexpected', 'hrule', $_[0], "Encountered \\hrule in SVG") if inSVG(); },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $dims   = $whatsit->getArg(1);
     my $width  = GetKeyVal($dims, 'width');
     my $height = GetKeyVal($dims, 'height');
     my $depth  = GetKeyVal($dims, 'depth');
-    $whatsit->setProperties(width  => $width,  cwidth  => $width)  if $width;
-    $whatsit->setProperties(height => $height, cheight => $height) if $height;
-    $whatsit->setProperties(depth  => $depth,  cdepth  => $depth)  if $depth;
+    $whatsit->setProperties(
+      rwidth  => $width  || '100%', cwidth  => $width, swidth => ($width ? $width->pxValue : 0),
+      rheight => $height || '1px',  cheight => ($height || Dimension('0.4pt')),
+      rdepth  => $depth, cdepth => ($depth || Dimension(0)));
     my $w = ($width  ? $width->ptValue  : undef);
     my $h = ($height ? $height->ptValue : undef);
     my $d = ($depth  ? $depth->ptValue  : undef);
-    $h -= $d if $h && $d;    # - ??
-
     if (my $alignment = LookupValue('Alignment')) {
       # What is the intended logic here?
       if (((!defined $h) && (!defined $w)) || ((defined $w) && ($w > 20))
         || ((defined $h) && (defined $w) && ($w > 3 * $h))) {
-        # This isXxxxRule property is to determine if it is used for separating rules within alignments
         $alignment->addLine('t');
-        $whatsit->setProperty(isHorizontalRule => 1) } }
-    $dims->setValue(width  => '100%') unless defined $w;
-    $dims->setValue(height => '1px')  unless defined $h;
+        $whatsit->setProperty(isHorizontalRule => 1) } }    # Marked as rule within alignment
     if (my $color = LookupValue('font')->getColor) {
       if ($color ne 'black') {
         $whatsit->setProperty(color => $color); } }
@@ -2291,9 +2330,13 @@ DefPrimitive('\show Token', sub {
     Note("> " . ($_[1][1] == CC_CS ? ToString($_[1]) . '=' : '') . writableTokens(Expand($stuff)));
     Note($_[0]->getLocator->toString());
     return; });
-DefPrimitive('\showbox Number', undef);
-DefPrimitive('\showlists',      undef);
-DefPrimitive('\showthe Token',  undef);
+DefPrimitive('\showbox Number', sub {
+    my $n     = $_[1]->valueOf;
+    my $stuff = LookupValue('box' . $n);
+    Debug("Box $n = " . ToString($stuff));
+    undef; });
+DefPrimitive('\showlists',     undef);
+DefPrimitive('\showthe Token', undef);
 
 # DefPrimitive('\shipout ??
 DefPrimitive('\ignorespaces SkipSpaces', undef);
@@ -2358,7 +2401,7 @@ sub writableTokens {
 
 DefPrimitive('\message{}', sub {
     my ($stomach, $stuff) = @_;
-    Note(writableTokens(Expand($stuff)));
+    NoteLog(writableTokens(Expand($stuff)));
     return; });
 
 DefRegister('\errhelp' => Tokens());
@@ -2522,7 +2565,23 @@ DefConstructor('\ltx@special@graphics OptionalKeyVals:SpecialPS Semiverbatim',
 Tag('ltx:graphics', afterOpen => sub { GenerateID(@_, 'g'); });
 
 DefPrimitive('\penalty Number', undef);
-DefPrimitive('\kern Dimension', undef);
+
+# \kern is heavily used by xy.
+# Completely HACK version for the moment
+# Note that \kern should add vertical spacing in vertical modes!
+DefConstructor('\kern Dimension', sub {
+    my ($document, $length) = @_;
+    my $parent = $document->getNode;
+    if ($document->getNodeQName($parent) eq 'svg:g') {
+      my $x = $length->pxValue;
+      # HACK HACK HACK
+      my $transform = $parent->getAttribute('transform');
+      $parent->setAttribute(transform => ($transform ? $transform . ' ' : '') . "translate($x,0)");
+    }
+    elsif (inSVG()) {
+      Warn('unexpected', 'kern', $_[0], "Lost kern in SVG " . ToString($length)); }
+});
+
 DefPrimitiveI('\unpenalty', undef, undef);
 DefPrimitiveI('\unkern',    undef, undef);
 ## Worrisome, but...
@@ -3484,11 +3543,27 @@ sub DimensionToSpaces {
 
 DefPrimitiveI('\noboundary', undef, undef);
 
-DefPrimitive('\hskip Glue', sub {
+# \hskip handled similarly to \kern
+# \hskip can be ignored in certain situations...
+DefConstructor('\hskip Glue', sub {
+    my ($document, $length, %props) = @_;
+    my $parent = $document->getNode;
+    #    Debug("HSKIP ".ToString($length)." at ".$document->getNodeQName($parent));
+    if ($document->getNodeQName($parent) eq 'svg:g') {
+      my $x = $length->pxValue;
+      # HACK HACK HACK
+      my $transform = $parent->getAttribute('transform');
+      $parent->setAttribute(transform => ($transform ? $transform . ' ' : '') . "translate($x,0)");
+    }
+    elsif (inSVG()) {
+      Warn('unexpected', 'kern', $_[0], "Lost hskip in SVG " . ToString($length)); }
+
+    else {
+      #      $document->openText(DimensionToSpaces($length), $props{font}); } },
+      $document->absorb(DimensionToSpaces($length)); } },
+  properties => sub {
     my ($stomach, $length) = @_;
-    my $s = DimensionToSpaces($length);
-    Box($s, undef, undef, Invocation(T_CS('\hskip'), $length),
-      width => $length, isSpace => 1); });
+    (width => $length, isSpace => 1); });
 
 DefPrimitive('\mskip MuGlue', sub {
     my ($stomach, $length) = @_;
@@ -3513,15 +3588,28 @@ DefPrimitiveI('\hfill', undef, sub {
 # \raise <dimen> <box>
 # But <box> apparently must really explicitly be an \hbox, \vbox or \vtop (?)
 # OR something that expands into one!!
+sub raisedSizer {
+  my ($box, $y) = @_;
+  my ($w, $h, $d) = $box->getSize;
+  my $z = Dimension(0);
+  $h = $h->add($y)->larger($z);
+  $d = $d->subtract($y)->larger($z);
+  return ($w, $h, $d); }
 
 DefConstructor('\lower Dimension MoveableBox',
-  "<ltx:text yoffset='#y'  _noautoclose='1'>#2</ltx:text>",
+  "?&inSVG()(<svg:g transform='translate(0,#ypx)' _noautoclose='1'>#2</svg:g>)"
+    . "(<ltx:text yoffset='#y'  _noautoclose='1'>#2</ltx:text>)",
+  sizer       => sub { raisedSizer($_[0]->getArg(2), $_[0]->getArg(1)->negate); },
   afterDigest => sub {
-    $_[1]->setProperty(y => $_[1]->getArg(1)->multiply(-1)); });
+    my $y = $_[1]->getArg(1)->multiply(-1);
+    $_[1]->setProperties(y => $y, ypx => $y->pxValue); });
 DefConstructor('\raise Dimension MoveableBox',
-  "<ltx:text yoffset='#y' _noautoclose='1'>#2</ltx:text>",
+  "?&inSVG()(<svg:g transform='translate(0,#ypx)' _noautoclose='1'>#2</svg:g>)"
+    . "(<ltx:text yoffset='#y'  _noautoclose='1'>#2</ltx:text>)",
+  sizer       => sub { raisedSizer($_[0]->getArg(2), $_[0]->getArg(1)); },
   afterDigest => sub {
-    $_[1]->setProperty(y => $_[1]->getArg(1)); });
+    my $y = $_[1]->getArg(1);
+    $_[1]->setProperties(y => $y, ypx => $y->pxValue); });
 
 # \unhbox<8bit>, \unhcopy<8bit>
 DefPrimitive('\unhbox Number', sub {

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -50,9 +50,6 @@ sub SVGNextObject {
 
 sub installPGFCommands {
   # Local definitions.
-  Let(T_CS('\lower'),  T_CS('\lxSVG@lower'));
-  Let(T_CS('\raise'),  T_CS('\lxSVG@raise'));
-  Let(T_CS('\hskip'),  T_CS('\lxSVG@hskip'));
   Let(T_CS('\halign'), T_CS('\lxSVG@halign'));
   Let('\ignorespaces', '\lx@inpgf@ignorespaces');    # Use local defn
   AssignValue(TEXT_MODE_BINDINGS => []);
@@ -127,8 +124,10 @@ DefConstructor('\lxSVG@insertpicture{}', sub {
         . " + " . ToString($cdepth)) if $LaTeXML::DEBUG{pgf};
     Debug("BODY is " . ToString($content)) if $LaTeXML::DEBUG{pgf};
     # Note viewbox is minx, miny, width, height (NOT maxx,maxy!)
-    $whatsit->setProperty(minx     => $minx->pxValue);
-    $whatsit->setProperty(miny     => $miny->pxValue);
+##    $whatsit->setProperty(minx     => $minx->pxValue);
+##    $whatsit->setProperty(miny     => $miny->pxValue);
+    $whatsit->setProperty(minx     => 0);
+    $whatsit->setProperty(miny     => 0);
     $whatsit->setProperty(width    => $width);
     $whatsit->setProperty(height   => $height);
     $whatsit->setProperty(depth    => Dimension(0));
@@ -156,55 +155,6 @@ DefParameterType('SVGMoveableBox', sub {
       && ($box->getDefinition->getCSName =~ /^(\\hbox||)$/);
     $box; });
 
-# Try to avoid errors inserting random boxes (esp. ltx:text)(Is this safe?)
-Tag('svg:switch', autoOpen => 1, autoClose => 1,
-  afterClose => \&collapseSVGSwitch);    # ?
-
-# Remove empty <svg:switch><svg:foreignObject> or those that contain only <p/>
-# Possibly could incorporate the collapse when it contains only svg elements?
-sub collapseSVGSwitch {
-  my ($doc, $node) = @_;
-  my ($fo,  @rest) = element_nodes($node);
-  return if !$fo || ($doc->getNodeQName($fo) ne 'svg:foreignObject')
-    ;    ####    || scalar(@rest);    # Expect single svg:foreignObject
-  my @fo_c = element_nodes($fo);
-  if (scalar(@fo_c) == 0) {    # Empty?
-    if (scalar(@rest)) {       # Extra stuff after empty foreignObject?
-      $doc->replaceNode($node, @rest); }
-    else {
-      $doc->removeNode($node); } }    # Else just remove whole thing
-                                      # Else, single <p> element ?
-  elsif ((scalar(@fo_c) == 1) && ($doc->getNodeQName($fo_c[0]) eq 'ltx:p')) {
-    my @p_c = element_nodes($fo_c[0]);
-    if (scalar(@p_c) == 0) {          # or Empty <p/>?
-      $doc->removeNode($node); }
-    # Else, single ltx:picture or ltx:text ?
-    elsif (scalar(@p_c) == 1) {
-      my $tag = $doc->getNodeQName($p_c[0]);
-      if (($tag eq 'ltx:picture') || ($tag eq 'ltx:text')) {
-        my @pic_c = element_nodes($p_c[0]);
-        # With single svg:svg ?
-        if ((scalar(@pic_c) == 1) && ($doc->getNodeQName($pic_c[0]) eq 'svg:svg')) {
-          $doc->replaceNode($node, element_nodes($pic_c[0])); } }
-  } }
-  return; }
-
-Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
-  afterClose => sub {
-    my ($document, $node, $whatsit) = @_;
-    # Make sure we get a size, in case autoOpen'd
-    if ($whatsit) {
-      my ($w, $h, $d) = $whatsit->getSize;
-      my $font = $whatsit->getFont;
-      my ($fw, $fh, $fd) = $font && $font->getNominalSize;
-      # Fishing for the correct y position (maybe w/o the depth?)
-      my $y  = $STATE->lookupDefinition(T_CS('\baselineskip'))->valueOf->pxValue;
-      my $ht = $h->add($d);
-      $node->setAttribute(width     => $w->pxValue)  unless $node->hasAttribute('width');
-      $node->setAttribute(height    => $ht->pxValue) unless $node->hasAttribute('height');
-      $node->setAttribute(transform => "matrix(1 0 0 -1 0 $y)");
-      $node->setAttribute(overflow  => 'visible'); } });
-
 # Check whether a svg:foreignObject is open,
 # but don't check beyond an svg:svg node, in case we're nested.
 sub foreignObjectCheck {
@@ -216,34 +166,6 @@ sub foreignObjectCheck {
     return $node if $n eq 'svg:foreignObject';
     $node = $node->parentNode; }
   return; }
-
-DefConstructor('\lxSVG@raise Dimension SVGMoveableBox', sub {
-    my ($doc, $dim, $box) = @_;
-    if (foreignObjectCheck($doc)) {
-      $doc->openElement('ltx:text', yoffset => $dim->negate->pxValue . 'px');
-      $doc->absorb($box);
-      $doc->closeElement('ltx:text'); }
-    else { $doc->absorb($box); } },
-  alias => '\raise',
-  sizer => sub { raisedSizer($_[0]->getArg(2), $_[0]->getArg(1)); });
-
-DefConstructor('\lxSVG@lower Dimension SVGMoveableBox', sub {
-    my ($doc, $dim, $box) = @_;
-    if (foreignObjectCheck($doc)) {
-      $doc->openElement('ltx:text', yoffset => $dim->pxValue . 'px');
-      $doc->absorb($box);
-      $doc->closeElement('ltx:text'); }
-    else { $doc->absorb($box); } },
-  alias => '\lower',
-  sizer => sub { raisedSizer($_[0]->getArg(2), $_[0]->getArg(1)->negate); });
-
-DefConstructor('\lxSVG@hskip Glue', sub {
-    my ($doc, $skip) = @_;
-    # but ignored outside of foreighObject doesn't seem right
-    if (foreignObjectCheck($doc)) {
-      $doc->openElement('ltx:text', 'xoffset' => $skip->pxValue . 'px'); } },
-  alias      => '\hskip', sizer => '#1',
-  properties => sub { (width => $_[1], isSpace => 1); });
 
 DefMacroI('\pgf@shift@baseline',         undef, '0pt');
 DefMacroI('\pgf@shift@baseline@smuggle', undef, '0pt');
@@ -1097,8 +1019,9 @@ sub openTikzAlignment {
   my $d          = ($props{cdepth}  && $props{cdepth}->pxValue)  || 0;
   my @rowheights = ($props{rowheights}   ? @{ $props{rowheights} }   : (Dimension(0)));
   my @colwidths  = ($props{columnwidths} ? @{ $props{columnwidths} } : (Dimension(0)));
-  my $x          = $colwidths[0]->pxValue / 2;
-##  my $y          = ($h + $d) - $rowheights[0]->pxValue;
+  my $x          = 0;
+  # This SHOULD be just $h+$d, but the shift is necessary to align
+  # w/additional material outside the \halign ( arrows & such)
   my $y = ($h + $d) - $rowheights[-1]->pxValue / 2;    # HEURISTIC adjustment! half of LAST row!?
   Debug("TIKZ Alignment size $w x $h + $d"
       . "  rows: " . join(',', map { $_->pxValue; } @rowheights)
@@ -1143,30 +1066,22 @@ sub openTikzAlignmentRow {
 sub openTikzAlignmentCol {
   my ($tag, $doc, %props) = @_;
   my $class = 'ltx_tikzmatrix_col' . ($props{class} ? ' ' . $props{class} : '');
-  # MYSTERIOUSLY, $w seems to be HALF the "proper" width...
-  # AND assumes an equivalent \hspace in front !?!?!
-  # HOWEVER, this isn't getting accounted in Alignment.pm, for size/position/whatever
-  # so that anchors (for arrows) still aren't properly positioned!!!
-  # Moreover, the cell's horizontal position should be set according to alignment
-  # which also isn't yet done in Alignment.pm,
-  # and also it is not clear how that gets recognized by TikZ's anchors!
-  my $hw = ($props{cwidth} && $props{cwidth}->pxValue) || 0;
-  my $w  = 2 * $hw;
-  my $h  = ($props{cheight} && $props{cheight}->pxValue) || 0;
-  my $d  = ($props{cdepth}  && $props{cdepth}->pxValue)  || 0;
-  my $x  = ($props{x}       && $props{x}->pxValue)       || 0;
-
-  my $xpos = $x + $hw;
-##  my $xpos  = $x;
-  my $ypos = 0;    #-$h;
-  Debug("TIKZ alignment Cell ($w x $h + $d); x=$x"
+  # BEWARE: pgf places each column at 0 width, preceded by an \hskip width/2
+  # and followed by an extra column of width/2.
+  # Be careful accounting for rowwidths, etc while pruning & positioning in Alignment.pm
+  my $w = ($props{cwidth}  && $props{cwidth}->pxValue)  || 0;
+  my $h = ($props{cheight} && $props{cheight}->pxValue) || 0;
+  my $d = ($props{cdepth}  && $props{cdepth}->pxValue)  || 0;
+  my $x = ($props{x}       && $props{x}->pxValue)       || 0;
+  my $y = 0;
+  Debug("TIKZ alignment Cell ($w x $h + $d); x=$x; "
       . join(',', map { $_ . "=" . ToString($props{$_}); } sort keys %props)) if $LaTeXML::DEBUG{pgf};
   my $col = $doc->openElement($tag, class => $class,
     _scopebegin => 1,
-    transform   => "matrix(1 0 0 -1 $xpos $ypos)",    # NOTE: Flip!!!
+    transform   => "matrix(1 0 0 -1 $x $y)",    # NOTE: Flip!!!
   );
   $doc->insertElement('svg:rect', undef,
-    x => -$hw - 1, y => -$h - 1, width => $w + 2, height => $h + $d + 2, stroke => '#0000FF', fill => 'none')
+    x => -1, y => -$h - 1, width => $w + 2, height => $h + $d + 2, stroke => '#0000FF', fill => 'none')
     if $LaTeXML::DEBUG{pgf};
   return $col; }
 


### PR DESCRIPTION
Generalized the SVG support for various primitives and foreignObject, moved from the pgf driver to TeX.pool.  This allows it's use for xy binding.