### PR TITLE
MUST make @ other during latex image processing

### DIFF
--- a/lib/LaTeXML/Post/LaTeXImages.pm
+++ b/lib/LaTeXML/Post/LaTeXImages.pm
@@ -420,8 +420,7 @@ sub pre_preamble {
   # when are the empty defaults needed?
   if ($class ne 'article') {
     $result_add_to_body .= "\\title{}\\date{}\n"; }
-  # Keep @ as a letter in the body, as internal bits such as \@@toccaption can sneak through.
-  #$result_add_to_body .= "\\makeatother\n";
+  $result_add_to_body .= "\\makeatother\n";
 
   my $result_preamble = <<"EOPreamble";
 \\batchmode


### PR DESCRIPTION
As it says; leaving "@" as letter breaks cases where it's expected to be other.  If there are "@" letter cases leaking into the image sources, those are bugs that need to be fixed.

[I'll probably merge this in shortly, but making a PR to draw attention to it]