### PR TITLE
Vertbars

### DIFF
--- a/lib/LaTeXML/MathGrammar
+++ b/lib/LaTeXML/MathGrammar
@@ -292,12 +292,12 @@ Factor  :
         | preScripted['bigop'] addOpArgs[$item[1]]
         | { ($forbidVertBar ? undef : 1); }
           SINGLEVERTBAR SINGLEVERTBAR absExpression SINGLEVERTBAR SINGLEVERTBAR # || exp || ==> norm
-              addScripts[Fence(CatSymbols($item[2],$item[3],undef,'||',role=>'OPEN'),
+              addScripts[Fence(CatSymbols($item[2],$item[3],undef,"\x{2016}",role=>'OPEN'),
                 $item[4],
-                CatSymbols($item[5],$item[6],undef,'||',role=>'CLOSE'))]
+                CatSymbols($item[5],$item[6],undef,"\x{2016}",role=>'CLOSE'))]
         | { ($forbidVertBar ? undef : 1); }
           VERTBAR absExpression VERTBAR                     # | exp | => absolute-value
-              addScripts[Fence($item[2],$item[3],$item[4])]
+              addScripts[Fence(MorphVertbar($item[2],'OPEN'),$item[3],MorphVertbar($item[4],'CLOSE'))]
         | { ($forbidVertBar ? undef : IsNotationAllowed('QM')); }
           MIDBAR ketExpression RANGLE { SawNotation('QM'); } # | exp > ==> ket
               addScripts[InterpretDelimited(New('ket'),
@@ -326,7 +326,8 @@ aBarearg :
         | preScripted['ATOM_OR_ID'] maybeArgs[$item[1]]
         | preScripted['UNKNOWN'] doubtArgs[$item[1]]
         | NUMBER   addScripts[$item[1]]
-        | VERTBAR absExpression VERTBAR addScripts[Fence($item[1],$item[2],$item[3])]
+        | VERTBAR absExpression VERTBAR
+            addScripts[Fence(MorphVertbar($item[1],'OPEN'),$item[2],MorphVertbar($item[3],'CLOSE'))]
 
 # moreBareargs[$argpart]
 moreBareargs :
@@ -343,7 +344,8 @@ aTrigBarearg :
         | preScripted['ATOM_OR_ID'] maybeArgs[$item[1]]
         | preScripted['UNKNOWN'] doubtArgs[$item[1]]
         | NUMBER   addScripts[$item[1]]
-        | VERTBAR absExpression VERTBAR addScripts[Fence($item[1],$item[2],$item[3])]
+        | VERTBAR absExpression VERTBAR
+          addScripts[Fence(MorphVertbar($item[1],'OPEN'),$item[2],MorphVertbar($item[3],'CLOSE'))]
 
 # moreTrigBareargs[$argpart]
 moreTrigBareargs :
@@ -494,7 +496,8 @@ FormulaNOBar : Formula
 
 # The "such that" that can appear in a sets like {a "such that" predicate(a)}
 # accept vertical bars, and colon
-suchThatOp : MIDDLE | VERTBAR
+suchThatOp : MIDDLE
+         | VERTBAR  { MorphVertbar($item[1],'MIDDLE'); }
          | /METARELOP:colon:\d+/        { Lookup($item[1]); }
 # ================================================================================
 # Function args, etc.
@@ -649,8 +652,9 @@ diffd :
 
 # Punctuation separating function arguments; things marked MIDDLE could
 # also separate arguments
-# With great trepidation, I'm adding VERBAR here
-argPunct : PUNCT | MIDDLE | VERTBAR
+# With great trepidation, I'm adding VERTBAR here
+argPunct : PUNCT | MIDDLE
+         | VERTBAR { MorphVertbar($item[1],'PUNCT'); }
 
 # ================================================================================
 # Operator args, etc.

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -5732,8 +5732,9 @@ DefMathI('\nabla',    undef, "\x{2207}", role => 'OPERATOR');
 DefMathI('\surd',     undef, "\x{221A}", role => 'OPERATOR', meaning => 'square-root');
 DefMathI('\top',      undef, "\x{22A4}", role => 'ADDOP',    meaning => 'top');
 DefMathI('\bot',      undef, "\x{22A5}", role => 'ADDOP',    meaning => 'bottom');
-DefMathI('\|',        undef, "\x{2225}", role => 'VERTBAR', name => '||', meaning => 'parallel-to');
-DefMathI('\angle',    undef, "\x{2220}");
+DefMathI('\|',        undef, "\x{2225}", role => 'VERTBAR',  name    => '||');
+# should get meaning => 'parallel-to' when used as infix, but NOT when for OPEN|CLOSE
+DefMathI('\angle', undef, "\x{2220}");
 
 # NOTE: This is probably the wrong role.
 # Also, should probably carry info about Binding for OpenMath

--- a/t/alignment/ncases.xml
+++ b/t/alignment/ncases.xml
@@ -30,9 +30,9 @@
                         <XMRef idref="S0.E1.m4.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E1.m4.1">x</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                     <XMTok font="italic" role="UNKNOWN">x</XMTok>
@@ -62,9 +62,9 @@
                         <XMRef idref="S0.E1.m1.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E1.m1.1">x</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                     <XMTok meaning="absent"/>
@@ -117,9 +117,9 @@
                         <XMRef idref="S0.E2.m4.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E2.m4.1">x</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                     <XMApp>
@@ -152,9 +152,9 @@
                         <XMRef idref="S0.E2.m1.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E2.m1.1">x</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                     <XMTok meaning="absent"/>
@@ -280,9 +280,9 @@
                         <XMRef idref="S0.E3.2.m4.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.2.m4.1">c</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                   </XMApp>
@@ -326,9 +326,9 @@
                       <XMRef idref="S0.E3.2.m4.3"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="OPEN" stretchy="false">|</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.2.m4.3">c</XMTok>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                 </XMApp>
@@ -339,9 +339,9 @@
                     <XMRef idref="S0.E3.2.m4.4"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="OPEN" stretchy="false">|</XMTok>
                     <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.2.m4.4">d</XMTok>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="false">|</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMApp>
@@ -369,9 +369,9 @@
                           <XMRef idref="S0.E3.2.m2.1"/>
                         </XMApp>
                         <XMWrap>
-                          <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok role="OPEN" stretchy="false">|</XMTok>
                           <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.2.m2.1">c</XMTok>
-                          <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok role="CLOSE" stretchy="false">|</XMTok>
                         </XMWrap>
                       </XMDual>
                     </XMApp>
@@ -422,9 +422,9 @@
                         <XMRef idref="S0.E3.2.m3.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.2.m3.1">c</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                     <XMDual>
@@ -433,9 +433,9 @@
                         <XMRef idref="S0.E3.2.m3.2"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.2.m3.2">d</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                   </XMApp>
@@ -466,9 +466,9 @@
                         <XMRef idref="S0.E3.3.m4.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.3.m4.1">d</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                   </XMApp>
@@ -484,13 +484,13 @@
                             <XMRef idref="S0.E3.3.m4.3"/>
                           </XMApp>
                           <XMWrap>
-                            <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                            <XMTok role="OPEN" stretchy="false">|</XMTok>
                             <XMApp xml:id="S0.E3.3.m4.3">
                               <XMTok meaning="divide" role="MULOP">/</XMTok>
                               <XMTok font="italic" role="UNKNOWN">c</XMTok>
                               <XMTok font="italic" role="UNKNOWN">d</XMTok>
                             </XMApp>
-                            <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                            <XMTok role="CLOSE" stretchy="false">|</XMTok>
                           </XMWrap>
                         </XMDual>
                         <XMApp>
@@ -526,9 +526,9 @@
                       <XMRef idref="S0.E3.3.m4.4"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="OPEN" stretchy="false">|</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.3.m4.4">c</XMTok>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                 </XMApp>
@@ -539,9 +539,9 @@
                     <XMRef idref="S0.E3.3.m4.5"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="OPEN" stretchy="false">|</XMTok>
                     <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.3.m4.5">d</XMTok>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="false">|</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMApp>
@@ -569,9 +569,9 @@
                           <XMRef idref="S0.E3.3.m2.1"/>
                         </XMApp>
                         <XMWrap>
-                          <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok role="OPEN" stretchy="false">|</XMTok>
                           <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.3.m2.1">d</XMTok>
-                          <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok role="CLOSE" stretchy="false">|</XMTok>
                         </XMWrap>
                       </XMDual>
                     </XMApp>
@@ -587,13 +587,13 @@
                               <XMRef idref="S0.E3.3.m2.3"/>
                             </XMApp>
                             <XMWrap>
-                              <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                              <XMTok role="OPEN" stretchy="false">|</XMTok>
                               <XMApp xml:id="S0.E3.3.m2.3">
                                 <XMTok meaning="divide" role="MULOP">/</XMTok>
                                 <XMTok font="italic" role="UNKNOWN">c</XMTok>
                                 <XMTok font="italic" role="UNKNOWN">d</XMTok>
                               </XMApp>
-                              <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                              <XMTok role="CLOSE" stretchy="false">|</XMTok>
                             </XMWrap>
                           </XMDual>
                           <XMApp>
@@ -636,9 +636,9 @@
                         <XMRef idref="S0.E3.3.m3.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.3.m3.1">c</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                     <XMDual>
@@ -647,9 +647,9 @@
                         <XMRef idref="S0.E3.3.m3.2"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E3.3.m3.2">d</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                   </XMApp>
@@ -889,9 +889,9 @@
                         <XMRef idref="S0.E4.3.m6.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E4.3.m6.1">d</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                     <XMApp>
@@ -959,9 +959,9 @@
                           <XMRef idref="S0.E4.3.m2.1"/>
                         </XMApp>
                         <XMWrap>
-                          <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok role="OPEN" stretchy="false">|</XMTok>
                           <XMTok font="italic" role="UNKNOWN" xml:id="S0.E4.3.m2.1">d</XMTok>
-                          <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok role="CLOSE" stretchy="false">|</XMTok>
                         </XMWrap>
                       </XMDual>
                       <XMApp>
@@ -1039,9 +1039,9 @@
                         <XMRef idref="S0.E4.4.m6.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S0.E4.4.m6.1">d</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                     <XMApp>
@@ -1109,9 +1109,9 @@
                           <XMRef idref="S0.E4.4.m2.1"/>
                         </XMApp>
                         <XMWrap>
-                          <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok role="OPEN" stretchy="false">|</XMTok>
                           <XMTok font="italic" role="UNKNOWN" xml:id="S0.E4.4.m2.1">d</XMTok>
-                          <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok role="CLOSE" stretchy="false">|</XMTok>
                         </XMWrap>
                       </XMDual>
                       <XMApp>

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -1837,7 +1837,7 @@ Then a switch of tag forms.</p>
                 </XMApp>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                <XMTok role="OPEN" stretchy="true">|</XMTok>
                 <XMArray xml:id="S4.Ex29.m1.1">
                   <XMRow>
                     <XMCell align="center">
@@ -1856,7 +1856,7 @@ Then a switch of tag forms.</p>
                     </XMCell>
                   </XMRow>
                 </XMArray>
-                <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                <XMTok role="CLOSE" stretchy="true">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -1876,7 +1876,7 @@ Then a switch of tag forms.</p>
                 </XMApp>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="OPEN" stretchy="true">‖</XMTok>
                 <XMArray xml:id="S4.Ex30.m1.1">
                   <XMRow>
                     <XMCell align="center">
@@ -1915,7 +1915,7 @@ Then a switch of tag forms.</p>
                     </XMCell>
                   </XMRow>
                 </XMArray>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="CLOSE" stretchy="true">‖</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -1935,7 +1935,7 @@ Then a switch of tag forms.</p>
                 </XMApp>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                <XMTok role="OPEN" stretchy="true">|</XMTok>
                 <XMArray xml:id="S4.Ex31.m1.1">
                   <XMRow>
                     <XMCell align="left">
@@ -1980,7 +1980,7 @@ Then a switch of tag forms.</p>
                     </XMCell>
                   </XMRow>
                 </XMArray>
-                <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                <XMTok role="CLOSE" stretchy="true">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -2081,7 +2081,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="OPEN" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex33.m1.1">
                     <XMRow>
                       <XMCell align="center">
@@ -2106,7 +2106,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="CLOSE" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
               <XMDual>
@@ -2118,7 +2118,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="OPEN" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex33.m1.2">
                     <XMRow>
                       <XMCell align="right">
@@ -2143,7 +2143,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="CLOSE" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
             </XMApp>
@@ -2259,7 +2259,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="OPEN" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex35.m1.1">
                     <XMRow>
                       <XMCell align="center">
@@ -2291,7 +2291,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="CLOSE" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
               <XMDual>
@@ -2303,7 +2303,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="OPEN" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex35.m1.2">
                     <XMRow>
                       <XMCell align="right">
@@ -2335,7 +2335,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="CLOSE" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
             </XMApp>
@@ -2451,7 +2451,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="OPEN" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex37.m1.1">
                     <XMRow>
                       <XMCell align="left">
@@ -2483,7 +2483,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="CLOSE" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
               <XMDual>
@@ -2495,7 +2495,7 @@ Then a switch of tag forms.</p>
                   </XMApp>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="OPEN" stretchy="true">‖</XMTok>
                   <XMArray xml:id="S4.Ex37.m1.2">
                     <XMRow>
                       <XMCell align="right">
@@ -2527,7 +2527,7 @@ Then a switch of tag forms.</p>
                       </XMCell>
                     </XMRow>
                   </XMArray>
-                  <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                  <XMTok role="CLOSE" stretchy="true">‖</XMTok>
                 </XMWrap>
               </XMDual>
             </XMApp>

--- a/t/ams/matrix.xml
+++ b/t/ams/matrix.xml
@@ -138,7 +138,7 @@
               </XMApp>
             </XMApp>
             <XMWrap>
-              <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+              <XMTok role="OPEN" stretchy="true">|</XMTok>
               <XMArray xml:id="S0.Ex5.m1.1">
                 <XMRow>
                   <XMCell align="center">
@@ -154,7 +154,7 @@
                   </XMCell>
                 </XMRow>
               </XMArray>
-              <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+              <XMTok role="CLOSE" stretchy="true">|</XMTok>
             </XMWrap>
           </XMDual>
         </XMath>
@@ -172,7 +172,7 @@
               </XMApp>
             </XMApp>
             <XMWrap>
-              <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+              <XMTok role="OPEN" stretchy="true">‖</XMTok>
               <XMArray xml:id="S0.Ex6.m1.1">
                 <XMRow>
                   <XMCell align="center">
@@ -188,7 +188,7 @@
                   </XMCell>
                 </XMRow>
               </XMArray>
-              <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+              <XMTok role="CLOSE" stretchy="true">‖</XMTok>
             </XMWrap>
           </XMDual>
         </XMath>

--- a/t/complex/physics.xml
+++ b/t/complex/physics.xml
@@ -93,9 +93,9 @@
                   <XMDual xml:id="S1.Ex1.m1.15">
                     <XMRef idref="S1.Ex1.m1.5"/>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="OPEN" stretchy="true">|</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex1.m1.5">X</XMTok>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="true">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -215,9 +215,9 @@
                   <XMDual xml:id="S1.Ex3.m1.7">
                     <XMRef idref="S1.Ex3.m1.3"/>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="OPEN" stretchy="true">|</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex3.m1.3">x</XMTok>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="true">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -256,9 +256,9 @@
                       <XMRef idref="S1.Ex4.m1.1"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="OPEN" stretchy="true">|</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex4.m1.1">a</XMTok>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="true">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -268,9 +268,9 @@
                       <XMRef idref="S1.Ex4.m1.2"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok fontsize="160%" role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok fontsize="160%" role="OPEN" stretchy="false">|</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex4.m1.2">a</XMTok>
-                      <XMTok fontsize="160%" role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok fontsize="160%" role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -280,13 +280,13 @@
                       <XMRef idref="S1.Ex4.m1.3"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="OPEN" stretchy="false">|</XMTok>
                       <XMApp xml:id="S1.Ex4.m1.3">
                         <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
                         <XMTok font="italic" role="UNKNOWN">X</XMTok>
                         <XMTok font="italic" role="UNKNOWN">Y</XMTok>
                       </XMApp>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -296,9 +296,9 @@
                       <XMRef idref="S1.Ex4.m1.4"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                      <XMTok role="OPEN" stretchy="true">‖</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex4.m1.4">a</XMTok>
-                      <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                      <XMTok role="CLOSE" stretchy="true">‖</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -308,9 +308,9 @@
                       <XMRef idref="S1.Ex4.m1.5"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok fontsize="160%" meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                      <XMTok fontsize="160%" name="||" role="OPEN">‖</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S1.Ex4.m1.5">a</XMTok>
-                      <XMTok fontsize="160%" meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                      <XMTok fontsize="160%" name="||" role="CLOSE">‖</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -320,13 +320,13 @@
                       <XMRef idref="S1.Ex4.m1.6"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                      <XMTok name="||" role="OPEN">‖</XMTok>
                       <XMApp xml:id="S1.Ex4.m1.6">
                         <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
                         <XMTok font="italic" role="UNKNOWN">X</XMTok>
                         <XMTok font="italic" role="UNKNOWN">Y</XMTok>
                       </XMApp>
-                      <XMTok meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                      <XMTok name="||" role="CLOSE">‖</XMTok>
                     </XMWrap>
                   </XMDual>
                 </XMWrap>
@@ -4558,7 +4558,7 @@
                   <XMDual xml:id="S1.Ex42.m1.13">
                     <XMRef idref="S1.Ex42.m1.5"/>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="OPEN" stretchy="true">|</XMTok>
                       <XMDual xml:id="S1.Ex42.m1.5">
                         <XMApp>
                           <XMTok meaning="matrix"/>
@@ -4583,7 +4583,7 @@
                           </XMRow>
                         </XMArray>
                       </XMDual>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="true">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -4621,7 +4621,7 @@
                       <XMRef idref="S1.Ex42.m1.7"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="OPEN" stretchy="true">|</XMTok>
                       <XMDual xml:id="S1.Ex42.m1.7">
                         <XMApp>
                           <XMTok meaning="matrix"/>
@@ -4646,7 +4646,7 @@
                           </XMRow>
                         </XMArray>
                       </XMDual>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="true">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" name="qquad" role="PUNCT">  </XMTok>
@@ -4656,7 +4656,7 @@
                       <XMRef idref="S1.Ex42.m1.8"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="OPEN" stretchy="true">|</XMTok>
                       <XMArray xml:id="S1.Ex42.m1.8">
                         <XMRow>
                           <XMCell align="center">
@@ -4675,7 +4675,7 @@
                           </XMCell>
                         </XMRow>
                       </XMArray>
-                      <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="true">|</XMTok>
                     </XMWrap>
                   </XMDual>
                 </XMWrap>

--- a/t/digestion/testctr.xml
+++ b/t/digestion/testctr.xml
@@ -70,9 +70,9 @@ Now (Foo,Bar)[25,0] is (25,0)</p>
         <p>Alph [F] = F</p>
       </para>
       <para xml:id="S1.SS2.p6">
-        <p>fnsymbol [<Math mode="inline" tex="\|" text="parallel-to" xml:id="S1.SS2.p6.m1">
+        <p>fnsymbol [<Math mode="inline" tex="\|" text="||" xml:id="S1.SS2.p6.m1">
             <XMath>
-              <XMTok meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+              <XMTok name="||" role="VERTBAR">∥</XMTok>
             </XMath>
           </Math>] = ∥</p>
       </para>
@@ -150,9 +150,9 @@ Now (Foo,Bar)[25,0] is (25,0)</p>
         <p>Alph [F] = F</p>
       </para>
       <para xml:id="S2.SS2.p6">
-        <p>fnsymbol [<Math mode="inline" tex="\|" text="parallel-to" xml:id="S2.SS2.p6.m1">
+        <p>fnsymbol [<Math mode="inline" tex="\|" text="||" xml:id="S2.SS2.p6.m1">
             <XMath>
-              <XMTok meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+              <XMTok name="||" role="VERTBAR">∥</XMTok>
             </XMath>
           </Math>] = ∥</p>
       </para>

--- a/t/fonts/abxtest.xml
+++ b/t/fonts/abxtest.xml
@@ -4481,9 +4481,9 @@
             <td align="left"><text font="typewriter">|</text></td>
           </tr>
           <tr>
-            <td align="left" thead="row"><Math mode="inline" tex="\|" text="parallel-to" xml:id="S0.SS0.SSS0.Px26.p2.m15">
+            <td align="left" thead="row"><Math mode="inline" tex="\|" text="||" xml:id="S0.SS0.SSS0.Px26.p2.m15">
                 <XMath>
-                  <XMTok meaning="parallel-to" name="||" role="VERTBAR">∥</XMTok>
+                  <XMTok name="||" role="VERTBAR">∥</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">\Vert</text></td>

--- a/t/math/declare.xml
+++ b/t/math/declare.xml
@@ -968,7 +968,7 @@
                     <XMRef idref="S6.Ex12.m1.2"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                    <XMTok role="OPEN" stretchy="true">|</XMTok>
                     <XMApp xml:id="S6.Ex12.m1.5">
                       <XMTok role="SUBSCRIPTOP" scriptpos="post2"/>
                       <XMWrap>
@@ -978,7 +978,7 @@
                       </XMWrap>
                       <XMTok font="italic" fontsize="70%" role="UNKNOWN" xml:id="S6.Ex12.m1.2">j</XMTok>
                     </XMApp>
-                    <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="true">|</XMTok>
                   </XMWrap>
                 </XMDual>
                 <XMTok role="PUNCT">;</XMTok>
@@ -989,7 +989,7 @@
                     <XMRef idref="S6.Ex12.m1.4"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                    <XMTok role="OPEN" stretchy="true">|</XMTok>
                     <XMApp xml:id="S6.Ex12.m1.6">
                       <XMTok role="SUBSCRIPTOP" scriptpos="post2"/>
                       <XMWrap>
@@ -1004,7 +1004,7 @@
                       </XMWrap>
                       <XMTok font="italic" fontsize="70%" role="UNKNOWN" xml:id="S6.Ex12.m1.4">j</XMTok>
                     </XMApp>
-                    <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="true">|</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMWrap>

--- a/t/math/sampler.xml
+++ b/t/math/sampler.xml
@@ -1411,7 +1411,7 @@ are not currently tested.</p>
                     </XMApp>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                    <XMTok role="OPEN" stretchy="true">‖</XMTok>
                     <XMArray xml:id="S4.E22.m1.3">
                       <XMRow>
                         <XMCell align="center">
@@ -1436,7 +1436,7 @@ are not currently tested.</p>
                         </XMCell>
                       </XMRow>
                     </XMArray>
-                    <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                    <XMTok role="CLOSE" stretchy="true">‖</XMTok>
                   </XMWrap>
                 </XMDual>
                 <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
@@ -1449,7 +1449,7 @@ are not currently tested.</p>
                     </XMApp>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                    <XMTok role="OPEN" stretchy="true">‖</XMTok>
                     <XMArray xml:id="S4.E22.m1.4">
                       <XMRow>
                         <XMCell align="right">
@@ -1474,7 +1474,7 @@ are not currently tested.</p>
                         </XMCell>
                       </XMRow>
                     </XMArray>
-                    <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                    <XMTok role="CLOSE" stretchy="true">‖</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMWrap>

--- a/t/parse/operators.xml
+++ b/t/parse/operators.xml
@@ -508,9 +508,9 @@
                     <XMRef idref="S3.Ex14.m1.1"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="OPEN" stretchy="false">|</XMTok>
                     <XMTok name="nabla" role="OPERATOR" xml:id="S3.Ex14.m1.1">∇</XMTok>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="false">|</XMTok>
                   </XMWrap>
                 </XMDual>
                 <XMTok font="italic" fontsize="70%" name="alpha" role="UNKNOWN">α</XMTok>

--- a/t/parse/parens.xml
+++ b/t/parse/parens.xml
@@ -545,13 +545,13 @@
                 <XMRef idref="S5.Ex21.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                <XMTok role="OPEN" stretchy="true">|</XMTok>
                 <XMApp xml:id="S5.Ex21.m1.1">
                   <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
                   <XMTok font="italic" role="ID">a</XMTok>
                   <XMTok font="italic" role="ID">b</XMTok>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                <XMTok role="CLOSE" stretchy="true">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -566,13 +566,13 @@
                 <XMRef idref="S5.Ex22.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                <XMTok role="OPEN" stretchy="true">|</XMTok>
                 <XMApp xml:id="S5.Ex22.m1.1">
                   <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
                   <XMTok font="italic" role="ID">a</XMTok>
                   <XMTok font="italic" role="ID">b</XMTok>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                <XMTok role="CLOSE" stretchy="true">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -587,13 +587,13 @@
                 <XMRef idref="S5.Ex23.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="OPEN" stretchy="true">‖</XMTok>
                 <XMApp xml:id="S5.Ex23.m1.1">
                   <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
                   <XMTok font="italic" role="ID">a</XMTok>
                   <XMTok font="italic" role="ID">b</XMTok>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="CLOSE" stretchy="true">‖</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -608,13 +608,13 @@
                 <XMRef idref="S5.Ex24.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="OPEN" stretchy="true">‖</XMTok>
                 <XMApp xml:id="S5.Ex24.m1.1">
                   <XMTok mathstyle="display" meaning="divide" role="FRACOP"/>
                   <XMTok font="italic" role="ID">a</XMTok>
                   <XMTok font="italic" role="ID">b</XMTok>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="true">∥</XMTok>
+                <XMTok role="CLOSE" stretchy="true">‖</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>

--- a/t/parse/qm.xml
+++ b/t/parse/qm.xml
@@ -219,9 +219,9 @@
                 <XMRef idref="S3.p1.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="OPEN" stretchy="false">|</XMTok>
                 <XMTok font="italic" role="UNKNOWN" xml:id="S3.p1.m1.1">a</XMTok>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="CLOSE" stretchy="false">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -236,9 +236,9 @@
                 <XMRef idref="S3.p2.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="OPEN">||</XMTok>
+                <XMTok role="OPEN">‖</XMTok>
                 <XMTok font="italic" role="UNKNOWN" xml:id="S3.p2.m1.1">a</XMTok>
-                <XMTok role="CLOSE">||</XMTok>
+                <XMTok role="CLOSE">‖</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -255,9 +255,9 @@
                   <XMRef idref="S3.p3.m1.1"/>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="OPEN" stretchy="false">|</XMTok>
                   <XMTok font="italic" role="UNKNOWN" xml:id="S3.p3.m1.1">a</XMTok>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="CLOSE" stretchy="false">|</XMTok>
                 </XMWrap>
               </XMDual>
               <XMDual>
@@ -266,9 +266,9 @@
                   <XMRef idref="S3.p3.m1.2"/>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="OPEN" stretchy="false">|</XMTok>
                   <XMTok font="italic" role="UNKNOWN" xml:id="S3.p3.m1.2">b</XMTok>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="CLOSE" stretchy="false">|</XMTok>
                 </XMWrap>
               </XMDual>
             </XMApp>
@@ -284,7 +284,7 @@
                 <XMRef idref="S3.p4.m1.3"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="OPEN" stretchy="false">|</XMTok>
                 <XMApp xml:id="S3.p4.m1.3">
                   <XMTok meaning="minus" role="ADDOP">-</XMTok>
                   <XMDual>
@@ -293,9 +293,9 @@
                       <XMRef idref="S3.p4.m1.1"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="OPEN" stretchy="false">|</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S3.p4.m1.1">a</XMTok>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMDual>
@@ -304,13 +304,13 @@
                       <XMRef idref="S3.p4.m1.2"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="OPEN" stretchy="false">|</XMTok>
                       <XMTok font="italic" role="UNKNOWN" xml:id="S3.p4.m1.2">b</XMTok>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="CLOSE" stretchy="false">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -330,9 +330,9 @@
                     <XMRef idref="S3.p5.m1.1"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="OPEN" stretchy="false">|</XMTok>
                     <XMTok font="italic" role="UNKNOWN" xml:id="S3.p5.m1.1">a</XMTok>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="false">|</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMApp>
@@ -345,9 +345,9 @@
                     <XMRef idref="S3.p5.m1.2"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="OPEN" stretchy="false">|</XMTok>
                     <XMTok font="italic" role="UNKNOWN" xml:id="S3.p5.m1.2">b</XMTok>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="false">|</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMApp>
@@ -360,9 +360,9 @@
                     <XMRef idref="S3.p5.m1.3"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="OPEN" stretchy="false">|</XMTok>
                     <XMTok font="italic" role="UNKNOWN" xml:id="S3.p5.m1.3">c</XMTok>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="false">|</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMApp>
@@ -393,9 +393,9 @@
                     <XMRef idref="S4.p1.m1.2"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="OPEN" stretchy="false">|</XMTok>
                     <XMTok font="italic" role="UNKNOWN" xml:id="S4.p1.m1.2">c</XMTok>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="false">|</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMApp>
@@ -414,9 +414,9 @@
                   <XMRef idref="S4.p2.m1.2"/>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="OPEN" stretchy="false">|</XMTok>
                   <XMTok font="italic" role="UNKNOWN" xml:id="S4.p2.m1.2">a</XMTok>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="CLOSE" stretchy="false">|</XMTok>
                 </XMWrap>
               </XMDual>
               <XMApp>
@@ -427,7 +427,7 @@
                     <XMRef idref="S4.p2.m1.3"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                    <XMTok role="OPEN" stretchy="true">|</XMTok>
                     <XMApp xml:id="S4.p2.m1.3">
                       <XMTok meaning="plus-or-minus" name="pm" role="ADDOP">±</XMTok>
                       <XMTok font="italic" role="UNKNOWN">z</XMTok>
@@ -456,7 +456,7 @@
                         </XMApp>
                       </XMApp>
                     </XMApp>
-                    <XMTok role="VERTBAR" stretchy="true">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="true">|</XMTok>
                   </XMWrap>
                 </XMDual>
               </XMApp>

--- a/t/parse/sets.xml
+++ b/t/parse/sets.xml
@@ -59,7 +59,7 @@
             <XMWrap>
               <XMTok role="OPEN" stretchy="false">{</XMTok>
               <XMTok font="italic" role="ID" xml:id="S0.Ex3.m1.1">a</XMTok>
-              <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+              <XMTok role="MIDDLE" stretchy="false">|</XMTok>
               <XMApp xml:id="S0.Ex3.m1.2">
                 <XMTok meaning="element-of" name="in" role="RELOP">∈</XMTok>
                 <XMTok font="italic" role="ID">a</XMTok>
@@ -87,7 +87,7 @@
               <XMWrap>
                 <XMTok role="OPEN" stretchy="false">{</XMTok>
                 <XMTok font="italic" role="ID" xml:id="S0.Ex4.m1.1">a</XMTok>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="MIDDLE" stretchy="false">|</XMTok>
                 <XMApp xml:id="S0.Ex4.m1.2">
                   <XMTok meaning="element-of" name="in" role="RELOP">∈</XMTok>
                   <XMTok font="italic" role="ID">a</XMTok>
@@ -119,7 +119,7 @@
             <XMWrap>
               <XMTok role="OPEN" stretchy="false">{</XMTok>
               <XMTok font="italic" role="UNKNOWN" xml:id="S0.Ex5.m1.2">x</XMTok>
-              <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+              <XMTok role="MIDDLE" stretchy="false">|</XMTok>
               <XMApp xml:id="S0.Ex5.m1.3">
                 <XMTok meaning="not-element-of" name="not-in" role="RELOP">∉</XMTok>
                 <XMTok font="italic" role="UNKNOWN">x</XMTok>
@@ -132,7 +132,7 @@
                   <XMWrap>
                     <XMTok role="OPEN" stretchy="false">{</XMTok>
                     <XMTok font="italic" role="UNKNOWN" xml:id="S0.Ex5.m1.1">y</XMTok>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="MIDDLE" stretchy="false">|</XMTok>
                     <XMApp xml:id="S0.Ex5.m1.3.1">
                       <XMTok meaning="greater-than" role="RELOP">&gt;</XMTok>
                       <XMTok font="italic" role="UNKNOWN">y</XMTok>

--- a/t/parse/vertbars.xml
+++ b/t/parse/vertbars.xml
@@ -145,9 +145,9 @@
                 <XMRef idref="S2.Ex5.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="OPEN" stretchy="false">|</XMTok>
                 <XMTok font="italic" role="ID" xml:id="S2.Ex5.m1.1">a</XMTok>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="CLOSE" stretchy="false">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -165,13 +165,13 @@
                   <XMRef idref="S2.Ex6.m1.1"/>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="OPEN" stretchy="false">|</XMTok>
                   <XMApp xml:id="S2.Ex6.m1.1">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok font="italic" role="ID">a</XMTok>
                     <XMTok font="italic" role="ID">b</XMTok>
                   </XMApp>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="CLOSE" stretchy="false">|</XMTok>
                 </XMWrap>
               </XMDual>
             </XMApp>
@@ -187,9 +187,9 @@
                 <XMRef idref="S2.Ex7.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="OPEN">||</XMTok>
+                <XMTok role="OPEN">‖</XMTok>
                 <XMTok font="italic" role="ID" xml:id="S2.Ex7.m1.1">a</XMTok>
-                <XMTok role="CLOSE">||</XMTok>
+                <XMTok role="CLOSE">‖</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -206,9 +206,9 @@
                   <XMRef idref="S2.Ex8.m1.1"/>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="OPEN">||</XMTok>
+                  <XMTok role="OPEN">‖</XMTok>
                   <XMTok font="italic" role="UNKNOWN" xml:id="S2.Ex8.m1.1">x</XMTok>
-                  <XMTok role="CLOSE">||</XMTok>
+                  <XMTok role="CLOSE">‖</XMTok>
                 </XMWrap>
               </XMDual>
               <XMTok font="italic" role="ID">a</XMTok>
@@ -218,9 +218,9 @@
                   <XMRef idref="S2.Ex8.m1.2"/>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="OPEN">||</XMTok>
+                  <XMTok role="OPEN">‖</XMTok>
                   <XMTok font="italic" role="UNKNOWN" xml:id="S2.Ex8.m1.2">y</XMTok>
-                  <XMTok role="CLOSE">||</XMTok>
+                  <XMTok role="CLOSE">‖</XMTok>
                 </XMWrap>
               </XMDual>
             </XMApp>
@@ -238,9 +238,9 @@
                   <XMRef idref="S2.Ex9.m1.1"/>
                 </XMApp>
                 <XMWrap>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="OPEN" stretchy="false">|</XMTok>
                   <XMTok font="italic" role="ID" xml:id="S2.Ex9.m1.1">a</XMTok>
-                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                  <XMTok role="CLOSE" stretchy="false">|</XMTok>
                 </XMWrap>
               </XMDual>
               <XMTok fontsize="70%" meaning="infinity" name="infty" role="ID">∞</XMTok>
@@ -257,13 +257,13 @@
                 <XMRef idref="S2.Ex10.m1.1"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="OPEN" stretchy="false">|</XMTok>
                 <XMApp xml:id="S2.Ex10.m1.1">
                   <XMTok meaning="plus" role="ADDOP">+</XMTok>
                   <XMTok font="italic" role="ID">a</XMTok>
                   <XMTok font="italic" role="ID">b</XMTok>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="CLOSE" stretchy="false">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -278,7 +278,7 @@
                 <XMRef idref="S2.Ex11.m1.2"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="OPEN" stretchy="false">|</XMTok>
                 <XMApp xml:id="S2.Ex11.m1.2">
                   <XMTok meaning="minus" role="ADDOP">-</XMTok>
                   <XMTok font="italic" role="ID">a</XMTok>
@@ -288,13 +288,13 @@
                       <XMRef idref="S2.Ex11.m1.1"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="OPEN" stretchy="false">|</XMTok>
                       <XMTok font="italic" role="ID" xml:id="S2.Ex11.m1.1">b</XMTok>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="CLOSE" stretchy="false">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -315,9 +315,9 @@
                     <XMRef idref="S2.Ex12.m1.1"/>
                   </XMApp>
                   <XMWrap>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="OPEN" stretchy="false">|</XMTok>
                     <XMTok font="italic" role="UNKNOWN" xml:id="S2.Ex12.m1.1">x</XMTok>
-                    <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                    <XMTok role="CLOSE" stretchy="false">|</XMTok>
                   </XMWrap>
                 </XMDual>
                 <XMApp>
@@ -362,9 +362,9 @@
                                   <XMRef idref="S2.Ex13.m1.1"/>
                                 </XMApp>
                                 <XMWrap>
-                                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                                  <XMTok role="OPEN" stretchy="false">|</XMTok>
                                   <XMTok font="italic" role="UNKNOWN" xml:id="S2.Ex13.m1.1">t</XMTok>
-                                  <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                                  <XMTok role="CLOSE" stretchy="false">|</XMTok>
                                 </XMWrap>
                               </XMDual>
                             </XMApp>
@@ -408,7 +408,7 @@
                 <XMRef idref="S3.Ex14.m1.3"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="OPEN" stretchy="false">|</XMTok>
                 <XMApp xml:id="S3.Ex14.m1.3">
                   <XMTok meaning="minus" role="ADDOP">-</XMTok>
                   <XMDual>
@@ -417,9 +417,9 @@
                       <XMRef idref="S3.Ex14.m1.1"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="OPEN" stretchy="false">|</XMTok>
                       <XMTok font="italic" role="ID" xml:id="S3.Ex14.m1.1">a</XMTok>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMDual>
@@ -428,13 +428,13 @@
                       <XMRef idref="S3.Ex14.m1.2"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="OPEN" stretchy="false">|</XMTok>
                       <XMTok font="italic" role="ID" xml:id="S3.Ex14.m1.2">b</XMTok>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="CLOSE" stretchy="false">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -449,7 +449,7 @@
                 <XMRef idref="S3.Ex15.m1.2"/>
               </XMApp>
               <XMWrap>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="OPEN" stretchy="false">|</XMTok>
                 <XMApp xml:id="S3.Ex15.m1.2">
                   <XMTok meaning="minus" role="ADDOP">-</XMTok>
                   <XMDual>
@@ -458,14 +458,14 @@
                       <XMRef idref="S3.Ex15.m1.1"/>
                     </XMApp>
                     <XMWrap>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="OPEN" stretchy="false">|</XMTok>
                       <XMTok font="italic" role="ID" xml:id="S3.Ex15.m1.1">a</XMTok>
-                      <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                      <XMTok role="CLOSE" stretchy="false">|</XMTok>
                     </XMWrap>
                   </XMDual>
                   <XMTok font="italic" role="ID">b</XMTok>
                 </XMApp>
-                <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                <XMTok role="CLOSE" stretchy="false">|</XMTok>
               </XMWrap>
             </XMDual>
           </XMath>
@@ -491,9 +491,9 @@
                         <XMRef idref="S3.Ex16.m1.1"/>
                       </XMApp>
                       <XMWrap>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="OPEN" stretchy="false">|</XMTok>
                         <XMTok font="italic" role="ID" xml:id="S3.Ex16.m1.1">a</XMTok>
-                        <XMTok role="VERTBAR" stretchy="false">|</XMTok>
+                        <XMTok role="CLOSE" stretchy="false">|</XMTok>
                       </XMWrap>
                     </XMDual>
                     <XMTok font="italic" role="ID">b</XMTok>

--- a/t/theorem/amstheorem.xml
+++ b/t/theorem/amstheorem.xml
@@ -60,13 +60,13 @@ on the Kobayashi metric.</p>
                           <XMRef idref="ThmAhlforsx1.p1.m1.2"/>
                         </XMApp>
                         <XMWrap>
-                          <XMTok font="upright" role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok font="upright" role="OPEN" stretchy="false">|</XMTok>
                           <XMApp xml:id="ThmAhlforsx1.p1.m1.2">
                             <XMTok meaning="times" role="MULOP">⁢</XMTok>
                             <XMTok role="UNKNOWN">d</XMTok>
                             <XMTok role="UNKNOWN">z</XMTok>
                           </XMApp>
-                          <XMTok font="upright" role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok font="upright" role="CLOSE" stretchy="false">|</XMTok>
                         </XMWrap>
                       </XMDual>
                       <XMTok font="upright" fontsize="70%" meaning="2" role="NUMBER">2</XMTok>
@@ -601,13 +601,13 @@ on the Kobayashi metric.</p>
                           <XMRef idref="ThmAhlforsx2.p1.m1.2"/>
                         </XMApp>
                         <XMWrap>
-                          <XMTok font="upright" role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok font="upright" role="OPEN" stretchy="false">|</XMTok>
                           <XMApp xml:id="ThmAhlforsx2.p1.m1.2">
                             <XMTok meaning="times" role="MULOP">⁢</XMTok>
                             <XMTok role="UNKNOWN">d</XMTok>
                             <XMTok role="UNKNOWN">z</XMTok>
                           </XMApp>
-                          <XMTok font="upright" role="VERTBAR" stretchy="false">|</XMTok>
+                          <XMTok font="upright" role="CLOSE" stretchy="false">|</XMTok>
                         </XMWrap>
                       </XMDual>
                       <XMTok font="upright" fontsize="70%" meaning="2" role="NUMBER">2</XMTok>


### PR DESCRIPTION
This is a simpler alternative to stated goal of #1806.

If we don't put too much stress on the semantics of the divides and parallel-to Unicode codepoints, the main point of the Unicode recommendation referenced in #1806 is about grammar or syntax: use these for fences, those for infix operators.  That distinction is exactly what the math parser has figured out, so it seems appropriate that once the parser has determined that a generic `VERTBAR` actually is an OPEN, CLOSE or whatever, it should at that point change the grammatical role *and* the associated Unicode codepoint.

Rewrite rules seem a bit heavy for this task, but I do think that post-parsing rewrite rules will be an important followup for dealing with the actual semantics of various constructs. They'll probably be slightly easier with this normalization in place?