### PR TITLE
Fix ordering bug in \InputIfFileExists

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4233,8 +4233,10 @@ DefConstructor('\lx@mark@nocite Semiverbatim',
 #======================================================================
 Let('\@@input', '\input');    # Save TeX's version.
                               # LaTeX's \input is a bit different...
+# Input, now
+DefPrimitive('\ltx@input {}', sub { Input(Expand($_[1])); });
 DefMacroI('\input', undef, '\@ifnextchar\bgroup\@iinput\@@input');
-DefPrimitive('\@iinput {}', sub { Input(Expand($_[1])); });
+Let('\@iinput', '\ltx@input');
 DefMacro('\@input{}',  '\IfFileExists{#1}{\@@input\@filef@und}{\typeout{No file #1.}}');
 DefMacro('\@input@{}', '\InputIfFileExists{#1}{}{\typeout{No file #1.}}');
 
@@ -5972,7 +5974,7 @@ DefMacro('\InputIfFileExists{}{}{}', sub {
     if (FindFile($file_string)) {
       DefMacro('\@filef@und', '"' . $file_string . '" ');
       return Tokens($if, T_CS('\@addtofilelist'), T_BEGIN, $file, T_END,
-        T_CS('\@iinput'), T_BEGIN, $file, T_END); }
+        T_CS('\ltx@input'), T_BEGIN, $file, T_END); }
     else { return ($else->unlist); } });
 
 #======================================================================

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -5967,11 +5967,12 @@ DefMacro('\IfFileExists{}{}{}', sub {
 
 DefMacro('\InputIfFileExists{}{}{}', sub {
     my ($gullet, $file, $if, $else) = @_;
-    my $file_string = ToString(Expand($file));
+    $file = Expand($file);
+    my $file_string = ToString($file);
     if (FindFile($file_string)) {
       DefMacro('\@filef@und', '"' . $file_string . '" ');
-      Input($file_string);
-      return ($if->unlist); }
+      return Tokens($if, T_CS('\@addtofilelist'), T_BEGIN, $file, T_END,
+        T_CS('\@iinput'), T_BEGIN, $file, T_END); }
     else { return ($else->unlist); } });
 
 #======================================================================

--- a/t/80_complex.t
+++ b/t/80_complex.t
@@ -6,5 +6,5 @@ use LaTeXML::Util::Test;
 
 latexml_tests("t/complex",
   requires => {
-     cleveref_minimal => 'cleveref.sty',
-     si => 'siunitx.sty' });
+    cleveref_minimal => 'cleveref.sty',
+    si               => { packages => 'siunitx.sty', texlive_min => 2015 } });


### PR DESCRIPTION
The "if" clause should appear *before* the file is input!  This fixes the 2020 babel greek regression.