### PR TITLE
Deluxetable alt

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -159,8 +159,13 @@ sub UTF {
 
 sub coerceCS {
   my ($cs) = @_;
-  $cs = T_CS($cs)           unless ref $cs;
-  $cs = T_CS(ToString($cs)) unless ref $cs eq 'LaTeXML::Core::Token';
+  if ((ref $cs) && (ref $cs ne 'LaTeXML::Core::Token')) {
+    $cs = ToString($cs); }
+  if    (ref $cs) { }
+  elsif ($cs =~ s/^\\csname\s+(.*)\\endcsname//) {
+    $cs = T_CS('\\' . $1); }
+  else {
+    $cs = T_CS($cs); }
   return $cs; }
 
 sub parsePrototype {

--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -326,8 +326,8 @@ DefMacro('\figcaption OptionalSemiverbatim', sub {
 #======================================================================
 # 2.15 Tables
 RequirePackage('deluxetable');
-Let(T_CS('\begin{planotable}'), T_CS('\begin{deluxetable}'));
-Let(T_CS('\end{planotable}'),   T_CS('\end{deluxetable}'));
+Let(T_CS('\planotable'),    T_CS('\deluxetable'));
+Let(T_CS('\endplanotable'), T_CS('\enddeluxetable'));
 
 DefConditional('\ifcolnumberson');
 DefConditional('\ifdeluxedecimals');
@@ -371,10 +371,10 @@ DefColumnType('h', sub {
       before => Tokens(T_BEGIN,            T_CS('\eatone')),
       after  => Tokens(T_CS('\endeatone'), T_END));
     return; });
-Let(T_CS('\begin{splitdeluxetable}'),  T_CS('\begin{deluxetable}'));
-Let(T_CS('\end{splitdeluxetable}'),    T_CS('\end{deluxetable}'));
-Let(T_CS('\begin{splitdeluxetable*}'), T_CS('\begin{deluxetable*}'));
-Let(T_CS('\end{splitdeluxetable*}'),   T_CS('\end{deluxetable*}'));
+Let(T_CS('\splitdeluxetable'),     T_CS('\deluxetable'));
+Let(T_CS('\endsplitdeluxetable'),  T_CS('\enddeluxetable'));
+Let(T_CS('\splitdeluxetable*'),    T_CS('\deluxetable*'));
+Let(T_CS('\endsplitdeluxetable*'), T_CS('\enddeluxetable*'));
 
 DefColumnType('B', sub {    # TODO: fake for now, should break table eventually
     $LaTeXML::BUILD_TEMPLATE->addColumn(

--- a/lib/LaTeXML/Package/deluxetable.sty.ltxml
+++ b/lib/LaTeXML/Package/deluxetable.sty.ltxml
@@ -30,13 +30,12 @@ use LaTeXML::Package;
 
 DefMacro('\dummytable', '\refstepcounter{table}');
 
-DefMacroI(T_CS('\begin{deluxetable}'), "{}",
+DefMacroI('\deluxetable', '{}',
   '\set@deluxetable@template{#1}\def\@deluxetable@header{}\begin{table}');
-DefMacroI(T_CS('\end{deluxetable}'), undef, '\spew@tblnotes\end{table}');
-
-DefMacroI(T_CS('\begin{deluxetable*}'), "{}",
+DefMacro('\enddeluxetable', '\spew@tblnotes\end{table}');
+DefMacroI('\csname deluxetable*\endcsname', '{}',
   '\set@deluxetable@template{#1}\def\@deluxetable@header{}\begin{table}');
-DefMacroI(T_CS('\end{deluxetable*}'), undef, '\spew@tblnotes\end{table}');
+DefMacro('\csname enddeluxetable*\endcsname', '\spew@tblnotes\end{table}');
 
 DefMacro('\set@deluxetable@template AlignmentTemplate', sub {
     AssignValue('@deluxetable@template', $_[1]); });
@@ -142,12 +141,13 @@ DefMacro('\dlap{}', '#1');
 # MISSING, but any usage here would fail, anyway...
 # \appdef, \appgdef, \prepdef
 
-AtBeginDocument('\let\tblnote@list\@empty
+AtBeginDocument(<<'EoTeX');
+\let\tblnote@list\@empty
 \let\pt@caption\@empty 
 \let\pt@head\@empty 
 \let\pt@tail\@empty 
 \pt@width\textwidth 
-\def\pt@headfrac{.1}');
-
+\def\pt@headfrac{.1}
+EoTeX
 #======================================================================
 1;

--- a/lib/LaTeXML/Package/emulateapj.sty.ltxml
+++ b/lib/LaTeXML/Package/emulateapj.sty.ltxml
@@ -29,8 +29,6 @@ RequirePackage('aastex', withoptions => 1);
 RequirePackage('epsf');
 # ... Well, almost...
 DefMacroI('\LongTables', undef, '');
-Let('\begin{deluxetable*}', '\begin{deluxetable}');
-Let('\end{deluxetable*}',   '\end{deluxetable}');
 
 Let('\BeginEnvironment', '\begin');
 Let('\EndEnvironment',   '\end');


### PR DESCRIPTION
Rude to usurp #1823, but expedient since by the time I'd sorted out all the false clues, it was basically done.

Once `coerceCS` (used by `DefMacroI` etc) properly recognized the `\csname...\endcsname` idiom, it's less mysterious to just define `\deluxetable` and `\enddeluxetable` (and all the variants), rather than go through the `\begin{deluxetable}` route and then try to patch on top of that.

I didn't do anything about `flushrt`; not sure what that was.

And, I'm assuming you have ar5iv sty.ltxml bindings for   aasms4 aaspp4 aas2pp4 aj_pt4 apjpt4 astro ? Many of the documents referenced in #1823 start off `\documentsyle[aasms4]{article}`  (they work fine if you change article to aastex). I assume the bindings are just like aasms.sty.ltxml.  We can include them in distribution if you like, though they're kinda piddly.
