### PR TITLE
Warn and revert to plain on missing \theoremstyle in amsthm.sty

### DIFF
--- a/lib/LaTeXML/Package/amsthm.sty.ltxml
+++ b/lib/LaTeXML/Package/amsthm.sty.ltxml
@@ -47,9 +47,14 @@ DefMacro('\thm@space@setup', '\thm@preskip=\topsep \thm@postskip=\thm@preskip');
 
 # activate a certain theorem style
 DefPrimitive('\theoremstyle{}', sub {
-    my $style = ToString($_[1]);
+    my $style    = ToString($_[1]);
+    my $style_cs = T_CS('\th@' . $style);
+    if (!IsDefined($style_cs)) {
+      Warn("undefined", "theoremstyle", $_[0], "Unknown theorem style '$style', reverting to 'plain'.");
+      $style    = 'plain';
+      $style_cs = T_CS('\th@plain'); }
     AssignValue('\thm@style' => $style);
-    Digest(T_CS('\th@' . $style));
+    Digest($style_cs);
     return; });
 
 DefMacro('\swapnumbers', sub {


### PR DESCRIPTION
This is a minor patch from an odd-looking error I spotted while debugging 2205.11657, related to amsthm.sty

It turns out, you can invoke/activate a `\theoremstyle{theorem}` for an undefined style name, and pdflatex succeeds error-free, with only mild warning in the log file:

```
Package amsthm Warning: Unknown theoremstyle `theorem' on input line 92.
```

Looking at amsthm.sty, that simply reverts to plain as seen here:
```tex
\newcommand{\theoremstyle}[1]{%
  \@ifundefined{th@#1}{%
    \PackageWarning{amsthm}{Unknown theoremstyle `#1'}%
    \thm@style{plain}%
  }{%
    \thm@style{#1}%
  }%
}
```

So, this PR introduces that mild warning + fallback to plain, hiding the current error for (in this case) an undefined `\th@theorem`.