### PR TITLE
Fix #1872: Generate executable pods with prefix

### DIFF
--- a/doc/manual/genpods
+++ b/doc/manual/genpods
@@ -112,7 +112,7 @@ if (!-d $GENDIR) {
 
 foreach my $name (@exes) {
   my $src  = "$SRCDIR/bin/$name";
-  my $dest = "$GENDIR/$name.tex";
+  my $dest = "$GENDIR/exe_$name.tex";
   if ($force || (!-f $dest) || (-M $src < -M $dest)) {
     print "Converting POD for $name to LaTeX\n";
     local $::PODDOC = $name;    # $::PODDOC =~ s/::/_/g;

--- a/doc/manual/genpods
+++ b/doc/manual/genpods
@@ -112,7 +112,7 @@ if (!-d $GENDIR) {
 
 foreach my $name (@exes) {
   my $src  = "$SRCDIR/bin/$name";
-  my $dest = "$GENDIR/exe_$name.tex";
+  my $dest = "$GENDIR/${name}_exe.tex";
   if ($force || (!-f $dest) || (-M $src < -M $dest)) {
     print "Converting POD for $name to LaTeX\n";
     local $::PODDOC = $name;    # $::PODDOC =~ s/::/_/g;

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2173,10 +2173,10 @@ developer.
 %
 % Make verbatim blocks smaller
 \makeatletter\def\verbatim@font{\small\normalfont\ttfamily}\makeatother
-\input{pods/exe_latexml}
-\input{pods/exe_latexmlpost}
-\input{pods/exe_latexmlc}
-\input{pods/exe_latexmlmath}
+\input{pods/latexml_exe}
+\input{pods/latexmlpost_exe}
+\input{pods/latexmlc_exe}
+\input{pods/latexmlmath_exe}
 
 %%%======================================================================
 \chapter[Bindings]{Implemented Bindings}\label{included.bindings}

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2173,10 +2173,10 @@ developer.
 %
 % Make verbatim blocks smaller
 \makeatletter\def\verbatim@font{\small\normalfont\ttfamily}\makeatother
-\input{pods/latexml}
-\input{pods/latexmlpost}
-\input{pods/latexmlc}
-\input{pods/latexmlmath}
+\input{pods/exe_latexml}
+\input{pods/exe_latexmlpost}
+\input{pods/exe_latexmlc}
+\input{pods/exe_latexmlmath}
 
 %%%======================================================================
 \chapter[Bindings]{Implemented Bindings}\label{included.bindings}


### PR DESCRIPTION
As noted in #1872, the `./doc/manual/genpods` generates distinct files `doc/manual/pods/latexml.tex` and `doc/manual/pods/LaTeXML.tex`. These file names clash on case-insensitive filesystems, potentially overwriting one another and preventing a proper generation of the manual.

This PR fixes the issue by generating pods for the executables with a new `exe_` prefix. This commit furthermore adjusts their inclusion in `doc/manual/manual.tex`.