### PR TITLE
Change marginpar position from fixed to absolute

### DIFF
--- a/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
@@ -4,7 +4,7 @@
 .ltx_note.ltx_role_margin .ltx_note_type { display:none; }
 .ltx_note.ltx_role_margin .ltx_note_content {
     display:block;
-    position:fixed; left:83%; width:15%;
+    position:absolute; left:83%; width:15%;
     background-color: transparent; border:0pt; }
 
 /* Narrower, to make room for marginpar */


### PR DESCRIPTION
In LaTeXML-marginpar.css, a margin note's content should be positioned with `absolute`, so that it can scroll with its anchor point.