### PR TITLE
avoid literal primes in \newtheorem listname

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2979,7 +2979,7 @@ sub defineNewTheorem {
   my ($stomach, $flag, $thmset, $otherthmset, $type, $within) = @_;
   $thmset = ToString($thmset);
   my $classname = CleanClassName($thmset);
-  my $listname  = "theorem:$thmset"; $listname =~ s/\s//g;
+  my $listname  = "theorem:$thmset"; $listname =~ s/\s//g; $listname =~ s/'/prime/g;
   $otherthmset = $otherthmset       && ToString($otherthmset);
   $type        = undef unless $type && $type->unlist;
   $within      = $within ? ToString($within) : undef;


### PR DESCRIPTION
A bit of a rare error from arXiv:0911.5369, which uses a prime character in some theorem names, as in :

```tex
\newtheorem*{theoremA'}{Theorem A'}

\begin{theoremA'} \label{aprime}
%...
\end{theoremA'}
```

currently latexml uses that in a nested constructor replacement string, leading to the error:
```
Complilation of constructor '\begin{theoremC'}' failed at finalpreprint.tex; 
line 19 col 11 - line 19 col 11 
<ltx:theorem xml:id='#id' inlist='thm theorem:theoremC'' 
class='ltx_theorem_theoremC'>#tags<ltx:title font='#titlefont' 
...
```

I think the simplest patch is to guard `$listname` from the literal prime character, though a more general patch may be ensuring that it is an NCName by using `CleanClassName`, e.g. the simple 
```perl
my $listname  = "theorem:$classname";
```

Unsure if `$listname` has any other considerations attached to it, so opening with the minimal fix and can update to another patch if preferred.