### PR TITLE
Allow optional separator for the prefixes in FindFile_fallback

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2046,7 +2046,7 @@ sub FindFile_fallback {
     # if we provide the type, that remains primary.
     $type = $1 unless $type; }
   if ($type) {    # if we know what we're dealing with...
-    my $prefixes_str = '^((?:' . join("|", @find_fallback_prefixes) . ')[-_.])';
+    my $prefixes_str = '^((?:' . join("|", @find_fallback_prefixes) . ')[-_.]?)';
     my $prefixes_rx  = qr/$prefixes_str/i;
     # Note that we also remove numbers glued directly onto the name without a separator.
     my $suffixes_str       = '([._-](?:' . join("|", @find_fallback_suffixes) . '))$';


### PR DESCRIPTION
LaTeXML should now be able to recognize that a load of `myemulateapj.cls` can directly use `emulateapj.cls.ltxml`.

The PR allows the 3 currently registered prefixes - `my`, `rx` and `preprint` - to be glued to the file names.