### PR TITLE
Improve TeX detection for archive inputs

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -163,6 +163,11 @@ sub unpack_source {
     # if we still have multiples, check if some have a .bbl file
     if (my @with_bbl = grep { my $base = $_; $base =~ s/\.tex$//; -e "$base.bbl"; } @files_by_likelihood) {
       @files_by_likelihood = @with_bbl; }
+# Sometimes in arXiv the decision is made in an unclear manner
+# (example: see 2112.08935 v1, which has equally good main.tex and bare_adv.tex)
+# so, for now, err on the side of preferring one of the extremely common names, when they are available at highest score.
+    if (my @common_name = grep { /(^|\W)(?:main|ms|paper)\.tex$/ } @files_by_likelihood) {
+      @files_by_likelihood = @common_name; }
     # last tie-breaker is lexicographical order
     @files_by_likelihood = sort { $a cmp $b } @files_by_likelihood;
     # set the main source

--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -39,8 +39,8 @@ sub unpack_source {
   # Extract the Perl zip datastructure to the temporary directory
   foreach my $member ($zip_handle->memberNames()) {
     $zip_handle->extractMember($member, catfile($sandbox_directory, $member)); }
-  # Set $source to point to the main TeX file in that directory
-  my @TeX_file_members = map { $_->fileName() } $zip_handle->membersMatching('\.[tT][eE][xX]$');
+  # Set $source to point to the main TeX file in that directory (or .txt, for old arXiv bundles)
+  my @TeX_file_members = map { $_->fileName() } $zip_handle->membersMatching('\.[tT](:?[eE][xX]|[xX][tT])$');
   if (!@TeX_file_members) {    # No .tex file? Try files with no, or unusually long, extensions
     @TeX_file_members = grep { !/\./ || /\.[^.]{4,}$/ } map { $_->fileName() } $zip_handle->members();
   }


### PR DESCRIPTION
Fixes #1882 , fixes [ar5iv#27](https://github.com/dginev/ar5iv/issues/27), fixes [ar5iv#145](https://github.com/dginev/ar5iv/issues/145).

This PR bundles a few improvements for the `--whatsin=archive` mode of conversion, which accepts a ZIP bundle on input. Namely:
 - `.txt` extension is recognized as a possible TeX source
 - two arXiv directives from `00README.XXX` are recognized - `toplevelfile` and `ignore`
 - an extra special case rule is added to tie-break high scoring files, where `main.tex`, `ms.tex` and `paper.tex` will get preferred to any non-standard names (such as the template name `bare_adv.tex`). This has to be done carefully, as a last check of the high-scoring files, to make sure we're choosing legitimate document sources.

