### PR TITLE
add native support for tikzbricks.sty

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -717,6 +717,7 @@ lib/LaTeXML/Package/titlesec.sty.ltxml
 lib/LaTeXML/Package/titling.sty.ltxml
 lib/LaTeXML/Package/tikz-3dplot.sty.ltxml
 lib/LaTeXML/Package/tikz.sty.ltxml
+lib/LaTeXML/Package/tikzbricks.sty.ltxml
 lib/LaTeXML/Package/times.sty.ltxml
 lib/LaTeXML/Package/tocbibind.sty.ltxml
 lib/LaTeXML/Package/todonotes.sty.ltxml

--- a/lib/LaTeXML/Package/tikzbricks.sty.ltxml
+++ b/lib/LaTeXML/Package/tikzbricks.sty.ltxml
@@ -1,0 +1,24 @@
+# -*- CPERL -*-
+# /=====================================================================\ #
+# |  tikzbricks.sty                                                     | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Deyan Ginev <deyan.ginev@nist.gov>                          #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#**********************************************************************
+
+InputDefinitions('tikzbricks', type => 'sty', noltxml => 1);
+
+#**********************************************************************
+
+1;


### PR DESCRIPTION
Following samcarter's lovely talk about tikzbricks.sty, I discovered latexml can already interpret it raw with good outcomes. For example:

```tex
\documentclass{article}
\usepackage{tikzbricks}
\begin{document}

\begin{wall}
\wallbrick[color=blue]{2}{1}
\wallbrick[color=red]{1}{1}
\addtocounter{brickx}{1}
\wallbrick[color=orange]{1}{1}
\newrow
\addtocounter{brickx}{1}{1}
\wallbrick[color=cyan]{4}{1}
\end{wall}

\end{document}
```

produces:

![image](https://user-images.githubusercontent.com/348975/180609031-6cbaa3c5-6d85-47aa-8707-7ae811f08f09.png)

This PR just lets latexml use the raw definition, seeing that it already knows how to.