### PR TITLE
Use optional argument to pagebreak

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4540,11 +4540,16 @@ DefMacro('\sloppypar',    '\par\sloppy');
 DefMacro('\endsloppypar', '\par');
 DefMacroI('\nobreakdashes', undef, T_OTHER('-'));
 
-DefMacro('\showhyphens{}', '#1');     # ?
+DefMacro('\showhyphens{}', '#1');    # ?
     #======================================================================
     # C.12.2 Page Breaking
     #======================================================================
-DefMacro('\pagebreak[]', '\vadjust{\clearpage}');
+DefMacro('\pagebreak[Default:4]', sub {
+    my ($gullet, $arg) = @_;
+    $arg = $arg->toString;
+    if ($arg <= 2) {
+      return; }
+    return Invocation(T_CS('\vadjust'), T_CS('\clearpage')); });
 DefPrimitive('\nopagebreak[]', undef);
 DefPrimitiveI('\columnbreak', undef, undef);    # latex? or multicol?
 DefPrimitive('\enlargethispage OptionalMatch:* {}', undef);


### PR DESCRIPTION
Examines the optional argument to `\pagebreak[]`, and outputs the XML only when the argument is 3 or 4.  (The alternative would be to end up with vertical spacing equal to `(argument/2)em`, but this would require more complicated XML and also changing the CSS, not to mention still needing to decide whether to break the page in epub.)

Fixes #1802.