### PR TITLE
prune single XMTok math to text, if PUNCT or PERIOD

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -3843,9 +3843,12 @@ Tag('ltx:Math', afterClose => \&cleanup_Math);
 sub cleanup_Math {
   my ($document, $mathnode) = @_;
   # If the Math ONLY contains XMath/XMText, it apparently isn't math at all!?!
+  # Single token PUNCTs can also be taken out of math.
   if (!$document->findnodes('ltx:XMath/ltx:*'
-        . '[local-name() != "XMText"'
-        . ' and local-name() != "XMHint"]', $mathnode)) {
+        . '[local-name() != "XMText" and local-name() != "XMHint" '
+        . 'and not('
+        . 'local-name() = "XMTok" and (@role="PUNCT" or @role="PERIOD") '
+        . 'and not(preceding-sibling::*) and not(following-sibling::*) )]', $mathnode)) {
     # So unwrap down to the contents of the XMText's.
     my @texts = ();
     foreach my $xmnode (map { $_->childNodes } $mathnode->childNodes) {
@@ -3860,17 +3863,6 @@ sub cleanup_Math {
           else {
             $document->addClass($child, 'ltx_markedasmath');
             push(@texts, $child); } } } }
-    # and replace the whole Math with the pieces
-    $document->replaceTree([undef, undef, @texts], $mathnode); }
-  # Single token PUNCTs can be taken out of math.
-  elsif (my $xmtok = $document->findnode('ltx:XMath[count(./*) = 1]/ltx:XMTok[@role="PUNCT" or @role="PERIOD"]', $mathnode)) {
-    my @texts = ();
-    for my $child ($xmtok->childNodes) {
-      if ($child->nodeType != XML_ELEMENT_NODE) {    # Make sure we've got an element
-        push(@texts, ['ltx:text', { class => 'ltx_markedasmath' }, $child]); }
-      else {
-        $document->addClass($child, 'ltx_markedasmath');
-        push(@texts, $child); } }
     # and replace the whole Math with the pieces
     $document->replaceTree([undef, undef, @texts], $mathnode); }
   else {    # Cleanup any remaining XMTexts

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -3862,6 +3862,17 @@ sub cleanup_Math {
             push(@texts, $child); } } } }
     # and replace the whole Math with the pieces
     $document->replaceTree([undef, undef, @texts], $mathnode); }
+  # Single token PUNCTs can be taken out of math.
+  elsif (my $xmtok = $document->findnode('ltx:XMath[count(./*) = 1]/ltx:XMTok[@role="PUNCT" or @role="PERIOD"]', $mathnode)) {
+    my @texts = ();
+    for my $child ($xmtok->childNodes) {
+      if ($child->nodeType != XML_ELEMENT_NODE) {    # Make sure we've got an element
+        push(@texts, ['ltx:text', { class => 'ltx_markedasmath' }, $child]); }
+      else {
+        $document->addClass($child, 'ltx_markedasmath');
+        push(@texts, $child); } }
+    # and replace the whole Math with the pieces
+    $document->replaceTree([undef, undef, @texts], $mathnode); }
   else {    # Cleanup any remaining XMTexts
     cleanup_XMText_outer($document, $mathnode); }
   return; }


### PR DESCRIPTION
This is a discussion starter PR (but maybe already useful?)

I was quickly trying to tackle a timeout from arXiv, using [arXiv:math/0601709](https://arxiv.org/abs/math/0601709), [ar5iv log](https://ar5iv.labs.arxiv.org/log/math/0601709).

It turns out that document has 2162 uses of `$,$` to control comma spacing, which creates - as expected - 2162 math elements with a single comma in them.

I think the markup is cleaner if these kinds of "typesetting abuse" uses of math modes start to gradually get teased away back into text mode. And since latexml is "filled to the brim with heuristics", might as well keep adding more of those.

Not necessarily the best strategy, but I quite like that we now have the `cleanup_Math` subroutine to host such considerations.