### PR TITLE
Serialization encoding fixes for LaTeXML.pm

### DIFF
--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -87,7 +87,7 @@ my $deststat;
 $deststat = (stat($opts->get('destination')))[9] if $opts->get('destination');
 $deststat = 0 unless defined $deststat;
 
-push @$keyvals, ['path', $cdir];    #add current path, to ensure never empty
+push @$keyvals,                ['path', $cdir];    #add current path, to ensure never empty
 push @{ $opts->get('paths') }, $cdir;
 
 if (!$source) { die "Input was empty.\n"; }
@@ -192,8 +192,7 @@ if ($result) {
     print $output_handle $result;
     close $output_handle;
   } else {
-    binmode(STDOUT, ":encoding(UTF-8)");
-    print STDOUT "\n", $result, "\n"; } }
+    print "\n", $result, "\n"; } }
 
 # == End of Program ==
 # cleanup STDERR e.g. in case of fatals

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -338,21 +338,13 @@ sub convert {
       delete $$opts{destination}; } }
 
 # 5 Output -- if not using Post::Writer, which never considers this serialization logic
+#
 # 5.1 Serialize the XML/HTML result (or just return the Perl object, if requested)
 # GOAL: $serialized must contain a utf8-encoded string at the return.
-# NOTES: This is difficult, because we can be serializing different objects, with different serialization logic
-# 1. Byte strings: LaTeXML's Document::serialize_aux, and XML::LibXML::Document's toString and toStringHTML
-#    which have NOT been encoded into utf-8, so we need an explicit encode before printing/returning
-# 2. Unreliable: the fragment case, which uses XML::LibXML::Element (and hence Node's) toString method,
-#    is sometimes already encoded as UTF-8. In fact, the documentation claims it is by default:
-# https://metacpan.org/pod/distribution/XML-LibXML/lib/XML/LibXML/Node.pod#toString
-# Digging to the bottom of the code, we reach:
-# https://metacpan.org/source/SHLOMIF/XML-LibXML-2.0200/LibXML.xs#L5212
-# which *will* set the utf8 flag iff the "HAVE_UTF8" flag was set on the system which compiled libxml
-# that's pretty terrifying in fact, since we can't rely that libxml returns the same encoding cross-platform for its default behavior!
-# 3. Reliable: Always explicitly request the document encoding to be used in serializing a Node
-#     by passing a second true flag into toString(1,1) to ensure that the encoding is handled explicitly at the libxml2 level
-# 4. Other: returning a DOM object programmatically, or a non-XML representation (archives), has no serialization component, result is returned as-is
+#
+# This logic can be fragile, especially due to external components changing behavior between versions.
+# but also due to having a variety of serialization routes based on Core vs Post, whatsout, destination...
+#
   undef $serialized;
   my $ref_result = ref($result) || '';
   if ($$opts{format} eq 'dom') {    # No serialize needed in DOM output case
@@ -361,15 +353,14 @@ sub convert {
     if ($$opts{format} =~ /^jats|x(ht)?ml$/) {
       if ($ref_result =~ /Document$/) {
         $serialized = $result->toString(1);
-        $serialized = Encode::encode('UTF-8', $serialized) if $serialized;
+        if ($serialized and $ref_result eq 'LaTeXML::Core::Document') {
+          $serialized = Encode::encode('UTF-8', $serialized); }
       } else {    # fragment case
         $serialized = $result->toString(1, 1);
     } }
     elsif ($$opts{format} =~ /^html/) {
       if (ref($result) =~ /^LaTeXML::(Post::)?Document$/) {
-        # Needs explicit encode call, toStringHTML returns Perl byte strings
-        $serialized = $result->getDocument->toStringHTML;
-        $serialized = Encode::encode('UTF-8', $serialized) if $serialized; }
+        $serialized = $result->getDocument->toStringHTML; }
       else {      # fragment case
         local $XML::LibXML::setTagCompression = 1;
         $serialized = $result->toString(1, 1); } } }

--- a/lib/LaTeXML/Post/Writer.pm
+++ b/lib/LaTeXML/Post/Writer.pm
@@ -22,14 +22,14 @@ use Encode;
 sub new {
   my ($class, %options) = @_;
   my $self = $class->SUPER::new(%options);
-  $$self{format} = ($options{format} || 'xml');
+  $$self{format}       = ($options{format} || 'xml');
   $$self{omit_doctype} = 1 if $options{omit_doctype};
   $$self{is_html}      = 1 if $options{is_html};
   return $self; }
 
 sub toProcess {
   my ($self, $doc) = @_;
-  return $$doc{document}; }			# Presumably can print anything?
+  return $$doc{document}; }    # Presumably can print anything?
 
 sub process {
   my ($self, $doc, $root) = @_;
@@ -43,9 +43,9 @@ sub process {
   # Note that this will NOT RE-format a document read in from xml,
   # (providing no_blanks is false; which it should be, since it is dangerous.
   #  it can also remove significant spaces between elements!)
-  my $serialized = ($xmldoc->documentElement  # Is some sort of DOM?
-		    ? ($$self{is_html} ? $xmldoc->toStringHTML : $xmldoc->toString(1))
-		    : $xmldoc->textContent);
+  my $serialized = ($xmldoc->documentElement    # Is some sort of DOM?
+    ? ($$self{is_html} ? $xmldoc->toStringHTML : $xmldoc->toString(1))
+    : $xmldoc->textContent);
   # NOTE that we are serializing the XML::LibXML::Document whose toString
   # has ALREADY encoded (in this case to utf8), so NO encode is needed!
   if (my $destination = $doc->getDestination) {
@@ -64,4 +64,3 @@ sub process {
 
 # ================================================================================
 1;
-


### PR DESCRIPTION
Fixes #1800 .

I hope. It seems to be correct for all variations I tried, but that testing is limited to my `perl v5.34.0`, `libxml version 20913`, using the latest latexml.

The pieces that continue to feel solid are:
 - Any standard run with a provided destination will rely on Writer.pm, which has been robust in terms of encodings for a very long while.
 - The fragment/math serialization routes which rely on `->toString(1,1)` are also quite robust in providing a properly encoded UTF-8 string.
 - The other output cases are the ones I keep juggling code until I get the incantation right, especially for printing to STDOUT.

I double-checked that the Mojolicious web editor also continues to work correctly with the PR changes, so maybe they are closer to the correct setup (or even - completely correct?).

Definitely worth a review. I removed a range of possibly outdated/inaccurate comments that I had added in the past, to return to a clean slate.