### PR TITLE
allow whitespace in \end{comment} line

### DIFF
--- a/lib/LaTeXML/Package/comment.sty.ltxml
+++ b/lib/LaTeXML/Package/comment.sty.ltxml
@@ -29,7 +29,7 @@ sub defineExcluded {
         my ($line);
         my $gullet = $istomach->getGullet;
         $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
-        while (defined($line = $gullet->readRawLine) && ($line ne $endmark)) {
+        while (defined($line = $gullet->readRawLine) && ($line !~ /^\s*\Q$endmark\E\s*$/)) {
           $nlines++; }
         NoteLog("[Skipped $name ($nlines lines)]"); }]);
   return; }


### PR DESCRIPTION
fixes #1819