### PR TITLE
Fix unparsed

### DIFF
--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -560,11 +560,8 @@ sub parse_kludge {
     my $kludge = $$pair[0];
     push(@replacements, (ref $kludge eq 'ARRAY') && ($$kludge[0] eq 'ltx:XMWrap')
       ? @$kludge[2 .. $#$kludge] : ($kludge)); }
-  # mark as unparsed
-  foreach my $replacement (@replacements) {
-    p_setAttribute($replacement, '_unparsed', '1'); }
-
   $document->appendTree($mathnode, @replacements);
+  p_setAttribute($mathnode, '_unparsed', '1');    # But mark as unparsed
   return; }
 
 sub parse_kludgeScripts_rec {

--- a/t/complex/physics.xml
+++ b/t/complex/physics.xml
@@ -337,7 +337,7 @@
       </para>
       <para xml:id="S1.SS1.p3">
         <equation xml:id="S1.Ex5">
-          <Math class="ltx_math_unparsed" mode="display" tex="\evaluated{x}_{0}^{\infty}\qquad\evaluated(x|_{0}^{\infty}\qquad\evaluated[x|_%&#10;{0}^{\infty}\qquad\evaluated[\sum_{X=0}^{N}|_{0}^{\infty}\qquad\evaluated*[%&#10;\sum_{X=0}^{N}|_{0}^{\infty}" text="list@(evaluated-at@(x, 0, infinity), evaluated-at@(x, 0, infinity), evaluated-at@(x, 0, infinity), evaluated-at@((sum _ (X = 0)) ^ N, 0, infinity), evaluated-at@((sum _ (X = 0)) ^ N, 0, infinity))" xml:id="S1.Ex5.m1">
+          <Math mode="display" tex="\evaluated{x}_{0}^{\infty}\qquad\evaluated(x|_{0}^{\infty}\qquad\evaluated[x|_%&#10;{0}^{\infty}\qquad\evaluated[\sum_{X=0}^{N}|_{0}^{\infty}\qquad\evaluated*[%&#10;\sum_{X=0}^{N}|_{0}^{\infty}" text="list@(evaluated-at@(x, 0, infinity), evaluated-at@(x, 0, infinity), evaluated-at@(x, 0, infinity), evaluated-at@((sum _ (X = 0)) ^ N, 0, infinity), evaluated-at@((sum _ (X = 0)) ^ N, 0, infinity))" xml:id="S1.Ex5.m1">
             <XMath>
               <XMDual>
                 <XMApp>
@@ -3280,7 +3280,7 @@
           </Math>
         </equation>
         <equation xml:id="S1.Ex31">
-          <Math class="ltx_math_unparsed" mode="display" tex="\bra{\phi}\outerproduct{\psi}{\xi}.\mbox{\quad as opposed to\quad}\bra{\phi}%&#10;\ket{\psi}\bra{\xi}" text="formulae@(bra@(phi) * outer-product@(psi, xi), [ as opposed to ] * inner-product@(phi, psi) * bra@(xi))" xml:id="S1.Ex31.m1">
+          <Math mode="display" tex="\bra{\phi}\outerproduct{\psi}{\xi}.\mbox{\quad as opposed to\quad}\bra{\phi}%&#10;\ket{\psi}\bra{\xi}" text="formulae@(bra@(phi) * outer-product@(psi, xi), [ as opposed to ] * inner-product@(phi, psi) * bra@(xi))" xml:id="S1.Ex31.m1">
             <XMath>
               <XMDual>
                 <XMApp>
@@ -3630,7 +3630,7 @@
           </Math>
         </equation>
         <equation xml:id="S1.Ex35">
-          <Math class="ltx_math_unparsed" mode="display" tex="\innerproduct{a}{b}\qquad\outerproduct{a}{b}\qquad\outerproduct{a}{a}\qquad%&#10;\outerproduct{a}{X^{Y}}\qquad\outerproduct*{a}{X^{Y}}\qquad\outerproduct{a}{b}" text="list@(inner-product@(a, b), outer-product@(a, b), outer-product@(a, a), outer-product@(a, X ^ Y), outer-product@(a, X ^ Y), outer-product@(a, b))" xml:id="S1.Ex35.m1">
+          <Math mode="display" tex="\innerproduct{a}{b}\qquad\outerproduct{a}{b}\qquad\outerproduct{a}{a}\qquad%&#10;\outerproduct{a}{X^{Y}}\qquad\outerproduct*{a}{X^{Y}}\qquad\outerproduct{a}{b}" text="list@(inner-product@(a, b), outer-product@(a, b), outer-product@(a, a), outer-product@(a, X ^ Y), outer-product@(a, X ^ Y), outer-product@(a, b))" xml:id="S1.Ex35.m1">
             <XMath>
               <XMDual>
                 <XMApp>
@@ -3764,7 +3764,7 @@
           </Math>
         </equation>
         <equation xml:id="S1.Ex36">
-          <Math class="ltx_math_unparsed" mode="display" tex="\outerproduct{a}{b}\qquad\expectationvalue{A}\qquad\expectationvalue{A}{\Psi}%&#10;\qquad\expectationvalue{A}{\Psi}\qquad\expectationvalue{\frac{X}{Y}}{\Psi}%&#10;\qquad\expectationvalue*{\frac{X}{Y}}{X^{Y}}\qquad\expectationvalue{\frac{X}{Y%&#10;}}{\Psi}" text="list@(outer-product@(a, b), expectation-value@(A), expectation-value@(A, Psi, Psi), expectation-value@(A, Psi, Psi), expectation-value@(X / Y, Psi, Psi), expectation-value@(X / Y, X ^ Y, X ^ Y), expectation-value@(X / Y, Psi, Psi))" xml:id="S1.Ex36.m1">
+          <Math mode="display" tex="\outerproduct{a}{b}\qquad\expectationvalue{A}\qquad\expectationvalue{A}{\Psi}%&#10;\qquad\expectationvalue{A}{\Psi}\qquad\expectationvalue{\frac{X}{Y}}{\Psi}%&#10;\qquad\expectationvalue*{\frac{X}{Y}}{X^{Y}}\qquad\expectationvalue{\frac{X}{Y%&#10;}}{\Psi}" text="list@(outer-product@(a, b), expectation-value@(A), expectation-value@(A, Psi, Psi), expectation-value@(A, Psi, Psi), expectation-value@(X / Y, Psi, Psi), expectation-value@(X / Y, X ^ Y, X ^ Y), expectation-value@(X / Y, Psi, Psi))" xml:id="S1.Ex36.m1">
             <XMath>
               <XMDual>
                 <XMApp>


### PR DESCRIPTION
I knew there was something peculiar there! When parsing the contents of an `XMWrap` fails, we don't need to add an extra wrapper, but can simply mark the container (the `XMWrap`) as unparsed; but *not* mark the children, since they are often quite legitimate and referred to by the content branch of an `XMDual`.