### PR TITLE
providecommand for lxRequireResource

### DIFF
--- a/lib/LaTeXML/texmf/latexml.sty
+++ b/lib/LaTeXML/texmf/latexml.sty
@@ -89,16 +89,18 @@
 \def\lxRef#1#2{#2}
 %======================================================================
 % Resources
+\providecommand{\lxRequireResource}[2][]{}
 
 %======================================================================
 % Page customization
+\def\lxKeywords#1{}
+
 \RequirePackage{comment}
 \def\lxContextTOC{}%
 \excludecomment{lxNavbar}
 \excludecomment{lxHeader}
 \excludecomment{lxFooter}
 
-\def\lxKeywords#1{}
 %======================================================================
 % Table beautification.
 % Low-level support to mark column and row headers.


### PR DESCRIPTION
lxRequireResource is defined in latexml.sty.ltxml, but not latexml.sty.  This defines it to do nothing.

Since I was editing the file, I also moved lxKeyWords to come before lxContextTOC, in order to match the order in latexml.sty.ltxml.