### PR TITLE
Tikz matrices don't need to be pruned (they aren't real tables)

### DIFF
--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -923,7 +923,7 @@ sub tikzAlignmentBindings {
     openColumn     => sub { openTikzAlignmentCol($coltype, @_); },
     closeColumn    => sub { closeTikzAlignmentElement($container, @_); },
     isMath         => $ismath,
-    properties     => {%properties});
+    properties     => { preserve_structure => 1, %properties });
   AssignValue(Alignment => $alignment);
   Let(T_MATH, ($ismath ? '\@dollar@in@mathmode' : '\@dollar@in@textmode'));
   return; }


### PR DESCRIPTION
Like xy, these matrices end up as a bunch of explicitly positioned fragments, so pruning empty cells only leads to spacing errors.

Fixes #794