### PR TITLE
Avoid trailing spaces in vetoed filenames for ZIP inputs

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -106,6 +106,7 @@ sub unpack_source {
         if ($vetoed_file eq 'amstex') {    # TeX Priority
           $Main_TeX_likelihood{$tex_file} = 2; last TEX_FILE_TRAVERSAL; }
         if ($vetoed_file !~ /\./) {
+          $vetoed_file =~ s/\s+$//;        # drop trailing spaces if any;
           $vetoed_file .= '.tex';
         }
         my $base = $tex_file;
@@ -145,8 +146,7 @@ sub unpack_source {
   }
   # Veto files that were e.g. arguments of \input macros
   for my $filename (@vetoed) {
-    delete $Main_TeX_likelihood{$filename};
-  }
+    delete $Main_TeX_likelihood{$filename}; }
   # The highest likelihood (>0) file gets to be the main source.
   my @files_by_likelihood = sort { $Main_TeX_likelihood{$b} <=> $Main_TeX_likelihood{$a} } grep { $Main_TeX_likelihood{$_} > 0 } keys %Main_TeX_likelihood;
   if (@files_by_likelihood) {


### PR DESCRIPTION
Fixes an edge cases reported in [ar5iv#43](https://github.com/dginev/ar5iv/issues/43), which lead to wrongly recognizing a dependent TeX file as the primary article source.

The arXiv "veto" algorithm works well, but there was a need to remove trailing spaces before appending the `.tex` extension.