### PR TITLE
add \setuptodonotes stub

### DIFF
--- a/lib/LaTeXML/Package/todonotes.sty.ltxml
+++ b/lib/LaTeXML/Package/todonotes.sty.ltxml
@@ -37,6 +37,7 @@ DefMacro('\missingfigure[]{}', '[Missing Figure: #2]');
 DefMacro('\todototoc',         '');
 DefMacro('\listoftodos',       '');
 DefMacro('\@todo[]{}',         '');
+DefMacro('\setuptodonotes{}',  '');
 
 DeclareOption('disable', sub {
     DefMacro('\todo{}', '', locked => 1);


### PR DESCRIPTION
Caught my eye in [arXiv:2205.10770](https://ar5iv.labs.arxiv.org/html/2205.10770) which is otherwise without any issues.

Looking at the [todonotes docs](http://tug.ctan.org/macros/latex/contrib/todonotes/todonotes.pdf), we are not emulating the full in-depth features yet, so just adding some harmless scaffolding to keep the conversions clean. 