### PR TITLE
Blocks n frames

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3054,8 +3054,7 @@ sub defineNewTheorem {
       my $name = $_[1]->getArg(1);
       Digest('\the\thm@bodyfont\the\thm@styling'
           . '\def\lx@thistheorem{' . ($name ? UnTeX($name) : '') . '}'); },
-    beforeDigestEnd => sub { Digest('\thm@doendmark'); },
-    afterDigest     => sub { Digest('\the\thm@postwork'); },
+    beforeDigestEnd => sub { Digest('\thm@doendmark\the\thm@postwork'); },
     properties      => sub {
       my %ctr = ();
       if ($counter) {

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2200,8 +2200,8 @@ sub insertBlock {
   my ($document, $contents, %blockattr) = @_;
   # Create something like:
   # "<ltx:inline-block vattach='$vattach' height='#height'>#2</ltx:inline-block>"
-  my $model   = $document->getModel;
-  my $context = $document->getElement;    # Where we originally start inserting.
+  my $model    = $document->getModel;
+  my $ocontext = $document->getElement;    # Where we originally start inserting.
 
   my $blocktag  = 'ltx:block';
   my $iblocktag = 'ltx:inline-block';
@@ -2215,14 +2215,15 @@ sub insertBlock {
   # If we're in an inline context, we'll need a ltx:inline-block,  otherwise ltx:block.
   # [Or maybe an ltx:para... when does that happen?]
   my $newblock = undef;
-  my $unwrap   = 0;
   map { ($blockattr{$_} || delete $blockattr{$_}) } keys %blockattr;
   my $hasattr = scalar(keys %blockattr);
-  if ($hasattr || !$document->canContainSomehow($context, 'ltx:p') || $document->canContain($context, '#PCDATA')) {
-    my $tag = ($document->canContain($context, $blocktag)
+  if ($hasattr || !$document->canContainSomehow($ocontext, 'ltx:p') || $document->canContain($ocontext, '#PCDATA')) {
+    my $tag = ($document->canContain($ocontext, $blocktag)
       ? $blocktag
       : $iblocktag);
     $newblock = $document->openElement($tag, '_autoclose' => 1, %blockattr); }
+  my $context = ($newblock ? $newblock->parentNode : $ocontext);
+
   ## I think this option isn't really needed.... try to simplify
   ## elsif ($document->canContainSomehow($context, 'ltx:para')) {
   ## $newblock = $document->openElement('ltx:para', '_autoclose' => 1, %blockattr); }
@@ -2246,32 +2247,32 @@ sub insertBlock {
       push(@newnodes, $document->wrapNodes('ltx:p', @n)); }
     else {
       push(@newnodes, shift(@nodes)); } }
-
   # If we've inserted a wrapper element, close all open elements up to it's parent
   # It may have auto-opened some element to contain it, but leave that open for following material
   # Otherwise, close everything back up to the originally open element (but only if still open!)
   if ($newblock) {
-    $document->closeToNode($newblock->parentNode, 1); }
-  else {
     $document->closeToNode($context, 1); }
-  # Check if the ltx:inline-block container is really needed.
+  else {
+    $document->closeToNode($ocontext, 1); }
+  # Check if the container is really needed.
   if ($newblock) {
-    my @rows  = $newblock->childNodes;
-    my @crows = $rows[0] && $rows[0]->childNodes;
+    my @rows  = element_nodes($newblock);
+    my @crows = $rows[0]  && $rows[0]->childNodes;
+    my $row0  = $rows[0]  && $model->getNodeQName($rows[0]);
+    my $crow0 = $crows[0] && $model->getNodeQName($crows[0]);
     if (scalar(@rows) < 1) {    # Insertion came up empty?
       $document->removeNode($newblock); }    # then remove the new block entirely
-    elsif ((scalar(@rows) == 1)              # Else only 1 item inside...
-      && ($model->getNodeQName($rows[0]) eq 'ltx:p')                # Which is an ltx:p with 1 item
-      && (scalar(@crows) == 1)
-      && $document->canContain($newblock->parentNode, $crows[0])    # if allowed.
+    elsif (scalar(@rows) > 1) {              # Multiple children, probably stock with container
+    }
+    elsif (($row0 =~ /^(?:ltx:p|ltx:para)/)    # Single child is ltx:p or ltx:para?
+      && (scalar(@crows) == 1)                         # with 1 child
+      && $document->canContain($context, $crows[0])    # if allowed.
       && (!$hasattr || !grep { !$document->canHaveAttribute($crows[0], $_) } keys %blockattr)) {
       map { $document->setAttribute($crows[0], $_ => $blockattr{$_}) } keys %blockattr;
       $document->unwrapNodes($rows[0]);
       $document->unwrapNodes($newblock); }
-    elsif ($unwrap ||
-      ((scalar(@rows) == 1)    # Else only 1 item inside, then flatten
-        && $document->canContain($newblock->parentNode, $rows[0])    # if allowed.
-        && (!$hasattr || !grep { !$document->canHaveAttribute($rows[0], $_) } keys %blockattr))) {
+    elsif ($document->canContain($context, $rows[0])    # row[0] allowed.
+      && (!$hasattr || !grep { !$document->canHaveAttribute($rows[0], $_) } keys %blockattr)) {
       map { $document->setAttribute($rows[0], $_ => $blockattr{$_}) } keys %blockattr;
       $document->unwrapNodes($newblock); } }
 

--- a/lib/LaTeXML/Package/framed.sty.ltxml
+++ b/lib/LaTeXML/Package/framed.sty.ltxml
@@ -24,7 +24,7 @@ DefEnvironment('{framed}', sub {
     insertBlock($document, $props{body},
       framed     => 'rectangle',
       framecolor => $props{framecolor},
-      cssstyle   => 'padding-top:' . $props{margin} . 'pt;padding-bottom:' . $props{margin} . 'pt'); },
+      cssstyle   => 'padding:' . $props{margin} . 'pt'); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par'); },
@@ -39,7 +39,7 @@ DefEnvironment('{oframed}', sub {
     insertBlock($document, $props{body},
       framed     => 'rectangle',
       framecolor => $props{framecolor},
-      cssstyle   => 'padding-top:' . $props{margin} . 'pt;padding-bottom:' . $props{margin} . 'pt'); },
+      cssstyle   => 'padding:' . $props{margin} . 'pt'); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par'); },
@@ -56,7 +56,7 @@ DefEnvironment('{shaded}', sub {
     $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
     insertBlock($document, $props{body},
       backgroundcolor => $props{backgroundcolor},
-      cssstyle => 'padding-top:' . $props{margin} . 'pt;padding-bottom:' . $props{margin} . 'pt'); },
+      cssstyle        => 'padding:' . $props{margin} . 'pt'); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par');
@@ -70,7 +70,8 @@ DefEnvironment('{shaded*}', sub {
     $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
     insertBlock($document, $props{body},
       backgroundcolor => $props{backgroundcolor},
-      cssstyle => 'padding-top:' . $props{margin} . 'pt;padding-bottom:' . $props{margin} . 'pt'); },
+      cssstyle        => 'padding:' . $props{margin} . 'pt'); },
+
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par');
@@ -84,7 +85,7 @@ DefEnvironment('{snugshade}', sub {
     $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
     insertBlock($document, $props{body},
       backgroundcolor => $props{backgroundcolor},
-      cssstyle => 'padding-top:' . $props{margin} . 'pt;padding-bottom:' . $props{margin} . 'pt'); },
+      cssstyle        => 'padding:' . $props{margin} . 'pt'); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par');
@@ -93,10 +94,10 @@ DefEnvironment('{snugshade}', sub {
       margin => LookupValue('\fboxsep')->ptValue); });    # Not \FrameSep
 DefEnvironment('{snugshade*}', sub {
     my ($document, %props) = @_;
-    $_[0]->maybeCloseElement('ltx:p');                    # this starts a new vertical block
+    $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
     insertBlock($document, $props{body},
       backgroundcolor => $props{backgroundcolor},
-      cssstyle => 'padding-top:' . $props{margin} . 'pt;padding-bottom:' . $props{margin} . 'pt'); },
+      cssstyle        => 'padding:' . $props{margin} . 'pt'); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par');
@@ -105,7 +106,7 @@ DefEnvironment('{snugshade*}', sub {
       margin => LookupValue('\fboxsep')->ptValue); });
 DefEnvironment('{leftbar}', sub {
     my ($document, %props) = @_;
-    $_[0]->maybeCloseElement('ltx:p');                    # this starts a new vertical block
+    $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
     insertBlock($document, $props{body}, framed => 'left', framecolor => $props{framecolor}); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
@@ -119,7 +120,7 @@ DefEnvironment('{titled-frame} Undigested', sub {
     my ($document, $title, %props) = @_;
     $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
     insertBlock($document, $props{body},
-      framed => 'rectangle', framecolor => $props{framecolor},
+      framed          => 'rectangle', framecolor => $props{framecolor},
       backgroundcolor => $props{backgroundcolor}); },
   beforeDigest => sub {
     Let('\par', '\inner@par');

--- a/lib/LaTeXML/Package/ntheorem.sty.ltxml
+++ b/lib/LaTeXML/Package/ntheorem.sty.ltxml
@@ -39,12 +39,12 @@ foreach my $option (qw(leqno fleqn
   amsmath amsthm hyperref)) {
   DeclareOption($option, undef); }
 
-DeclareOption('standard', sub { });    # ?
-DeclareOption('noconfig', sub { });    # ?
+DeclareOption('standard', sub { AssignValue('thm@usestd' => 1); });    # ?
+DeclareOption('noconfig', sub { });                                    # ?
 
-DeclareOption('framed', sub { });      # ?  [and needs framed.sty to be loaded]
+DeclareOption('framed', sub { });    # ?  [and needs framed.sty to be loaded]
 
-DeclareOption('thmmarks', sub { });    # ?
+DeclareOption('thmmarks', sub { });  # ?
 
 DeclareOption('thref', sub {
     # Redefine \label to take 2nd optional argument, being the type of thing.
@@ -171,7 +171,17 @@ Let('\renewtheorem', '\newtheorem');
 # This needs to tie into framed.sty!!!!
 # Really should execute \theoremframecommand in isolation,
 # then copy the relevant attributes (framing, spacing, color, ...) to the theorem!
-DefMacroI('\lx@addframing', undef, '\@ADDCLASS{ltx_framed}');
+### NEEDS TO integrate with framed.sty better
+### AND in the meantime, this needs a better API
+DefConstructorI('\lx@addframing', undef, sub {
+    my ($doc, %props) = @_;
+    my $node = $doc->getElement;
+    $doc->addClass($node, 'ltx_framed');
+    my $css = $node->getAttribute('cssstyle');
+    my $pad = 'padding:' . $props{margin} . 'pt;';
+    $doc->setAttribute($node, cssstyle => ($css ? $css . ';' . $pad : $pad)); },
+  properties => sub { (framecolor => Black,
+      margin => LookupValue('\FrameSep')->ptValue); });
 
 # Since \theoremframecommand can be defined to be pretty much anything,
 # we don't have a good handle on what colors, etc, it may use.
@@ -202,8 +212,6 @@ DefConstructor('\lx@@snapshot@framing{}', sub {
 
 DefMacro('\newframedtheorem{}[]{}[]',
   '\begingroup'
-    . '\ifx\theoremframecommand\relax'
-    . '\def\theoremframecommand{\fbox}\fi'
     . '\thm@styling{\lx@addframing}'
     . '\newtheorem{#1}[#2]{#3}[#4]'
     . '\endgroup');
@@ -226,6 +234,7 @@ DefPrimitive('\lx@ntheorem@newtheoremstyle{}{}{}{}{}{}', sub {
       '\thm@headstyling' => $headstyle,
       'thm@swap'         => ToString($swap) eq 'S',
       '\thm@numbering'   => $numbering,
+      '\thm@symbol'      => LookupValue('\thm@symbol'),
     );
     DefMacroI(T_CS('\th@' . $name), undef, sub { useTheoremStyle($name); });
     return; });
@@ -243,7 +252,11 @@ RawTeX(<<'EoTeX');
 \lx@ntheorem@newtheoremstyle{emptybreak}{}{}{}{N}{}
 EoTeX
 # Load the other styles from the ntheorem's standard defintions
-InputDefinitions('ntheorem.std');
+
+InputDefinitions('ntheorem.std') if LookupValue('thm@usestd');
+
+# Start off as plain style.
+useTheoremStyle('plain');
 #======================================================================
 # Lists of Theorems.
 

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -303,7 +303,9 @@ dl.ltx_description dl.ltx_description dd { margin-left:3em; }
     display:block;
     position:absolute;bottom:0pt;left:0pt; }
 .ltx_transformed_inner > .ltx_p {text-indent:0em; margin:0; padding:0; }
+
 /* If simulating a table (html5), try to get rowspan to work...sorta? */
+span.ltx_tabular { position:relative; }
 span.ltx_rowspan { position:absolute; top:0; bottom:0; }
 
 /* by default, p doesn't indent */

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-tabular-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-tabular-xhtml.xsl
@@ -149,6 +149,16 @@
               <xsl:text> </xsl:text>
             </xsl:if>
             <xsl:text>ltx_rowspan</xsl:text>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="f:class-pref('ltx_rowspan_',@rowspan)"/>
+          </xsl:if>
+          <xsl:if test="@colspan and $context = 'inline'">
+            <xsl:if test="@thead or @border or @rowspan">
+              <xsl:text> </xsl:text>
+            </xsl:if>
+            <xsl:text>ltx_colspan</xsl:text>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="f:class-pref('ltx_colspan_',@colspan)"/>
           </xsl:if>
         </xsl:with-param>
         <xsl:with-param name="extra_style">
@@ -173,11 +183,14 @@
           </xsl:choose>
         </xsl:with-param>
       </xsl:call-template>
-      <xsl:if test="@colspan">
-        <xsl:attribute name='colspan'><xsl:value-of select='@colspan'/></xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@rowspan">
-        <xsl:attribute name='rowspan'><xsl:value-of select='@rowspan'/></xsl:attribute>
+      <!-- add colspan, rowspan but NOT on fake td elements -->
+      <xsl:if test="$context != 'inline'">
+        <xsl:if test="@colspan">
+          <xsl:attribute name='colspan'><xsl:value-of select='@colspan'/></xsl:attribute>
+        </xsl:if>
+        <xsl:if test="@rowspan">
+          <xsl:attribute name='rowspan'><xsl:value-of select='@rowspan'/></xsl:attribute>
+        </xsl:if>
       </xsl:if>
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$context"/>

--- a/t/graphics/framed.xml
+++ b/t/graphics/framed.xml
@@ -14,21 +14,21 @@
     </tags>
     <title><tag close=" ">1</tag>Basics</title>
     <para xml:id="S1.p1">
-      <p cssstyle="padding-top:12pt;padding-bottom:12pt" framecolor="#000000" framed="rectangle">This is stuff that’s framed.</p>
+      <p cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">This is stuff that’s framed.</p>
     </para>
     <para xml:id="S1.p2">
       <p>Note that the</p>
-      <p cssstyle="padding-top:12pt;padding-bottom:12pt" framecolor="#000000" framed="rectangle">framed</p>
+      <p cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">framed</p>
       <p>stuff is a block!</p>
     </para>
     <para xml:id="S1.p3">
-      <inline-block cssstyle="padding-top:12pt;padding-bottom:12pt" framecolor="#000000" framed="rectangle">
+      <inline-block cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">
         <p>This is stuff that’s framed.</p>
         <p>And it can hold multiple paragraphs.</p>
       </inline-block>
     </para>
     <para xml:id="S1.p4">
-      <p cssstyle="padding-top:12pt;padding-bottom:12pt" framecolor="#000000" framed="rectangle">And even stuff in multiple Paragraphs.</p>
+      <p cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">And even stuff in multiple Paragraphs.</p>
     </para>
     <paragraph inlist="toc" xml:id="S1.SS0.SSS0.Px1">
       <title>Does this work?</title>
@@ -45,24 +45,24 @@
     </tags>
     <title><tag close=" ">2</tag>Variants</title>
     <para xml:id="S2.p1">
-      <p cssstyle="padding-top:12pt;padding-bottom:12pt" framecolor="#000000" framed="rectangle">This is stuff that’s framed, but would stay open at page breaks.
+      <p cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">This is stuff that’s framed, but would stay open at page breaks.
 This doesn’t make so much sense for LaTeXML, so it’s pretty much
 the same.</p>
     </para>
     <para xml:id="S2.p2">
-      <p backgroundcolor="#80BF80" cssstyle="padding-top:12pt;padding-bottom:12pt">This is stuff that’s shaded green;
+      <p backgroundcolor="#80BF80" cssstyle="padding:12pt">This is stuff that’s shaded green;
 should fade into the margin, whatever that means.</p>
     </para>
     <para xml:id="S2.p3">
-      <p backgroundcolor="#80BF80" cssstyle="padding-top:12pt;padding-bottom:12pt">This is stuff that’s shaded green;
+      <p backgroundcolor="#80BF80" cssstyle="padding:12pt">This is stuff that’s shaded green;
 it should end sharply at the margin.</p>
     </para>
     <para xml:id="S2.p4">
-      <p backgroundcolor="#80BF80" cssstyle="padding-top:3pt;padding-bottom:3pt">This is stuff that’s snugly shaded green;
+      <p backgroundcolor="#80BF80" cssstyle="padding:3pt">This is stuff that’s snugly shaded green;
 fading into the margin.</p>
     </para>
     <para xml:id="S2.p5">
-      <p backgroundcolor="#80BF80" cssstyle="padding-top:3pt;padding-bottom:3pt">This is stuff that’s snugly shaded green;
+      <p backgroundcolor="#80BF80" cssstyle="padding:3pt">This is stuff that’s snugly shaded green;
 ending sharply at the margin.</p>
     </para>
     <para xml:id="S2.p6">

--- a/t/theorem/ntheorem.xml
+++ b/t/theorem/ntheorem.xml
@@ -1133,7 +1133,7 @@ the last one gets the endmark:</p>
               <XMath>
                 <XMTok font="upright" name="clubsuit" role="UNKNOWN">♣</XMTok>
               </XMath>
-            </Math></text></p>
+            </Math></text><rule height="1px" width="100%"/></p>
       </para>
     </theorem>
     <theorem class="ltx_theorem_Corollary" inlist="thm theorem:Corollary" xml:id="ThmTheorem2">
@@ -1474,7 +1474,7 @@ The first Kappa-Theorem has been given in <ref labelref="LABEL:kappatheorem1" sh
         <tag role="typerefnum">§1.2</tag>
       </tags>
       <title><tag close=" ">1.2</tag>Framed and Shaded Theorems</title>
-      <theorem class="ltx_framed ltx_theorem_importantTheorem" inlist="thm theorem:importantTheorem" xml:id="ThmTheorem9">
+      <theorem class="ltx_framed ltx_theorem_importantTheorem" cssstyle="padding:12pt;" inlist="thm theorem:importantTheorem" xml:id="ThmTheorem9">
         <tags>
           <tag>Theorem 9</tag>
           <tag role="refnum">9</tag>


### PR DESCRIPTION
Several seemingly related patches regarding frames and blocks, and side issues that cropped up in the process. This places more uniform spacing around frames; more consistent handling of some theorem features.  It makes slight improvements to `insertBlock`, but future work will need to generalize better.  Also slightly improves the validation & styling of rowspan and colspan on tables that are faked with span-soup due to HTML's schema.

Fixes #1704 
Fixes #1706
Fixes #1709
