### PR TITLE
recognize \graphicspath{{dir1/}{dir2/}}

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -391,8 +391,13 @@ DefParameterType('TeXFileName', sub {
 
 # A LaTeX style directory List
 DefParameterType('DirectoryList', sub {
-    my ($gullet) = @_;
-    my @dirs = map { (/^\{(.*)\}$/ ? $1 : $_); } split(/\s*(?:,|\n+)\s*/, ToString($gullet->readArg));
+    my ($gullet)   = @_;
+    my $arg_string = ToString($gullet->readArg);
+    my @dirs       = ();
+    for my $dir (split(/\s*(?:,|\n+)\s*/, $arg_string)) {
+      while ($dir =~ s/^\{([^\}]*)\}//) {
+        push @dirs, $1 if $1; }
+      push @dirs, $dir if $dir; }
     LaTeXML::Core::Array->new(open => T_BEGIN, close => T_END, itemopen => T_BEGIN, itemclose => T_END,
       type   => LaTeXML::Package::parseParameters(ToString("Semiverbatim"), "CommaList")->[0],
       values => [@dirs]); });


### PR DESCRIPTION
A [social report](https://twitter.com/isomorphisms/status/1556444329811578881) spotted a particular lack of images in arxiv-vanity that also affects ar5iv, namely caused by:

```tex
\graphicspath{{figs/}{anc/}}
```

which our convenient `DirectoryList` parameter type wasn't parsing correctly. I added another level of indirection for the unbracing, and this should now work. The article in question is [1801.04486](https://ar5iv.labs.arxiv.org/html/1801.04486), in particular Figure 1.