### PR TITLE
Epub toc

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -441,6 +441,8 @@ sub convert_post {
     if (my $dbdir = pathname_directory($dbfile)) {
       pathname_mkdir($dbdir); } }
   my $DB = LaTeXML::Util::ObjectDB->new(dbfile => $dbfile, %PostOPS);
+  if ($format eq 'epub') {    # epub requires a TOC
+    $self->check_TOC($DOCUMENT); }
   ### Advanced Processors:
   if ($$opts{split}) {
     require LaTeXML::Post::Split;
@@ -646,6 +648,19 @@ sub convert_post {
   if ($$opts{destination} && $$opts{local} && ($$opts{whatsout} eq 'document')) {
     undef $postdoc; }
   return $postdoc; }
+
+# This is *very* unmodular, but introducing a pre-Epub postprocessor
+# seems rather heavy at this stage?
+# Add a full TOC, to be used for navigation, but *not* displayed.
+sub check_TOC {
+  my ($self, $document) = @_;
+  if (!$document->findnode('//ltx:TOC[@lists="toc"]')) {
+    my @s = (qw(ltx:part ltx:chapter ltx:section ltx:subsection ltx:subsubsection
+        ltx:paragraph ltx:subparagraph ltx:appendix ltx:index ltx:bibliography));
+    $document->prependNodes($document->getDocumentElement,
+      ['ltx:TOC', { lists => 'toc', select => join(' | ', @s),
+          class => 'ltx_nodisplay' }]); }
+  return; }
 
 sub new_latexml {
   my ($opts) = @_;

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -448,7 +448,7 @@ sub convert_post {
         db => $DB, %PostOPS)); }
   my $scanner = ($$opts{scan} || $DB) && (LaTeXML::Post::Scan->new(
       db       => $DB,
-      labelids => $$opts{splitnaming} && ($$opts{splitnaming} =~ /^label/),
+      labelids => ($$opts{splitnaming} && ($$opts{splitnaming} =~ /^label/) ? 1 : 0),
       %PostOPS));
   push(@procs, $scanner) if $$opts{scan};
   if (!($$opts{prescan})) {

--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -242,8 +242,9 @@ sub get_archive {
       or (print STDERR "Fatal:I/O:$pathname File $pathname is not readable.");
     my $file_contents = <$FH>;
     close($FH);
-    # Compress all files
-    $archive->addString($file_contents, $file,)->desiredCompressionMethod(COMPRESSION_DEFLATED); }
+    # Compress all files except mimetype
+    my $compression = ($file eq 'mimetype' ? COMPRESSION_STORED : COMPRESSION_DEFLATED);
+    $archive->addString($file_contents, $file,)->desiredCompressionMethod($compression); }
 
   foreach my $subdir (sort @subdirs) {
     my $current_dir = File::Spec->catdir($directory, $subdir);

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -403,6 +403,7 @@ span.ltx_rowspan { position:absolute; top:0; bottom:0; }
 .ltx_rdf          { display:none; }
 .ltx_missing      { color:red;}
 .ltx_nounicode    { color:red; }
+.ltx_nodisplay    { display:none; }
 /*======================================================================
  SVG (pgf/tikz ?) basics */
 

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
@@ -13,9 +13,11 @@
 \=========================================================ooo==U==ooo=/
 -->
 <xsl:stylesheet
-    version   = "1.0"
-    xmlns:xsl = "http://www.w3.org/1999/XSL/Transform"
-    xmlns:ltx = "http://dlmf.nist.gov/LaTeXML"
+    version     = "1.0"
+    xmlns:xsl   = "http://www.w3.org/1999/XSL/Transform"
+    xmlns:ltx   = "http://dlmf.nist.gov/LaTeXML"
+    xmlns:f     = "http://dlmf.nist.gov/LaTeXML/functions"
+    xmlns:epub  = "http://www.idpf.org/2007/ops"
     exclude-result-prefixes="ltx">
 
   <!-- Include all LaTeXML to xhtml modules -->
@@ -50,5 +52,30 @@
   <!-- Linking to a text/plain data URL is invalid in EPUB3,
        so just skip over it -->
   <xsl:template match="ltx:listing[@data]" mode="begin"/>
+
+  <xsl:template match="ltx:TOC">
+    <xsl:param name="context"/>
+    <xsl:if test="ltx:toclist/descendant::ltx:tocentry">
+      <xsl:text>&#x0A;</xsl:text>
+      <xsl:element name="nav" namespace="{$html_ns}">
+        <xsl:attribute name="epub:type">toc</xsl:attribute>
+        <xsl:call-template name='add_attributes'>
+          <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
+        </xsl:call-template>
+        <xsl:if test="ltx:title">
+          <xsl:element name="h6" namespace="{$html_ns}">
+            <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+            <xsl:attribute name="class">ltx_title ltx_title_contents</xsl:attribute>
+            <xsl:apply-templates select="ltx:title/node()">
+              <xsl:with-param name="context" select="$innercontext"/>
+            </xsl:apply-templates>
+          </xsl:element>
+        </xsl:if>
+        <xsl:apply-templates>
+          <xsl:with-param name="context" select="$context"/>
+        </xsl:apply-templates>
+      </xsl:element>
+    </xsl:if>
+  </xsl:template>
 
 </xsl:stylesheet>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
@@ -78,4 +78,8 @@
     </xsl:if>
   </xsl:template>
 
+  <!-- And, probably ePub pages do not need headers or footers -->
+  <xsl:template match="/" mode="header"/>
+  <xsl:template match="/" mode="footer"/>
+
 </xsl:stylesheet>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -574,7 +574,7 @@
   <!-- explicitly requested TOC -->
   <xsl:template match="ltx:TOC[@format='short']">
     <xsl:param name="context"/>
-    <xsl:element name="nav" namespace="{$html_ns}">
+    <xsl:element name="{f:if($USE_HTML5,'nav','div')}" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
         <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
       </xsl:call-template>
@@ -586,7 +586,7 @@
 
   <xsl:template match="ltx:TOC[@format='veryshort']">
     <xsl:param name="context"/>
-    <xsl:element name="nav" namespace="{$html_ns}">
+    <xsl:element name="{f:if($USE_HTML5,'nav','div')}" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
         <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
       </xsl:call-template>
@@ -598,7 +598,7 @@
 
   <xsl:template match="ltx:TOC[@format='normal2']">
     <xsl:param name="context"/>
-    <xsl:element name="nav" namespace="{$html_ns}">
+    <xsl:element name="{f:if($USE_HTML5,'nav','div')}" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
         <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
       </xsl:call-template>
@@ -612,7 +612,7 @@
     <xsl:param name="context"/>
     <xsl:if test="ltx:toclist/descendant::ltx:tocentry">
       <xsl:text>&#x0A;</xsl:text>
-      <xsl:element name="nav" namespace="{$html_ns}">
+      <xsl:element name="{f:if($USE_HTML5,'nav','div')}" namespace="{$html_ns}">
         <xsl:call-template name='add_attributes'>
           <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
         </xsl:call-template>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -574,7 +574,7 @@
   <!-- explicitly requested TOC -->
   <xsl:template match="ltx:TOC[@format='short']">
     <xsl:param name="context"/>
-    <xsl:element name="div" namespace="{$html_ns}">
+    <xsl:element name="nav" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
         <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
       </xsl:call-template>
@@ -586,7 +586,7 @@
 
   <xsl:template match="ltx:TOC[@format='veryshort']">
     <xsl:param name="context"/>
-    <xsl:element name="div" namespace="{$html_ns}">
+    <xsl:element name="nav" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
         <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
       </xsl:call-template>
@@ -598,7 +598,7 @@
 
   <xsl:template match="ltx:TOC[@format='normal2']">
     <xsl:param name="context"/>
-    <xsl:element name="div" namespace="{$html_ns}">
+    <xsl:element name="nav" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
         <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
       </xsl:call-template>
@@ -612,7 +612,7 @@
     <xsl:param name="context"/>
     <xsl:if test="ltx:toclist/descendant::ltx:tocentry">
       <xsl:text>&#x0A;</xsl:text>
-      <xsl:element name="div" namespace="{$html_ns}">
+      <xsl:element name="nav" namespace="{$html_ns}">
         <xsl:call-template name='add_attributes'>
           <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
         </xsl:call-template>
@@ -663,7 +663,7 @@
   <xsl:template match="ltx:toclist">
     <xsl:param name="context"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="ul" namespace="{$html_ns}">
+    <xsl:element name="ol" namespace="{$html_ns}">
       <xsl:call-template name='add_id'/>
       <xsl:call-template name='add_attributes'/>
       <xsl:apply-templates>

--- a/t/931_epub.t
+++ b/t/931_epub.t
@@ -35,9 +35,9 @@ ok(!-z $epub_filename, 'epub file has content');
 
 my $zip_file = Archive::Zip->new();
 is($zip_file->read($epub_filename), AZ_OK, 'epub file successfully loads as Archive::Zip object');
-is($zip_file->numberOfMembers, 10, "correct number of files were present in final ePub");
+is($zip_file->numberOfMembers, 9, "correct number of files were present in final ePub");
 my $names = join(", ",sort($zip_file->memberNames));
-ok($names =~ /^META-INF\/, META-INF\/container\.xml, OPS\/, OPS\/931_test\.log, OPS\/931_test....\.xhtml, OPS\/LaTeXML-epub\.css, OPS\/LaTeXML\.css, OPS\/content\.opf, OPS\/nav\.xhtml, mimetype$/, "correct files were present in final ePub: $names");
+ok($names =~ /^META-INF\/, META-INF\/container\.xml, OPS\/, OPS\/931_test\.log, OPS\/931_test....\.xhtml, OPS\/LaTeXML-epub\.css, OPS\/LaTeXML\.css, OPS\/content\.opf, mimetype$/, "correct files were present in final ePub: $names");
 
 my $log_member = $zip_file->memberNamed("OPS/$log_filename");
 ok($log_member, "log file was written to epub");


### PR DESCRIPTION
This PR uses the table of contents as generated by `\tableofcontents` as the navigation document for an ePub. (along with the necessary XSLT tweaks to make it a legitimate nav doc). 

In its current form, it requires that you put a `\tableofcontents` in your main document, but perhaps this should be inserted automatically, when missing and an ePub is being created?

Also, in the example epub of #1643, the header & footer navigation is omitted, which is perhaps desirable within an ePub reader?  Should there be anything at all in epub page headers & footers? or just omit the relative links? or what?

Would appreciate feedback from @xworld21 

This is intended to eventually be alternative for, and
Closes #1643;
Closes #1644;
