### PR TITLE
use SOURCE_DATE_EPOCH instead of current time

### DIFF
--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -518,7 +518,7 @@ sub assemble_postprocessors {
       if ($icon) {
         $$parameters{ICON} = $icon; }
       if (!defined $timestamp) {
-        $timestamp = localtime(); }
+        $timestamp = defined $ENV{SOURCE_DATE_EPOCH} ? gmtime($ENV{SOURCE_DATE_EPOCH}) : localtime(); }
       if ($timestamp) {
         $$parameters{TIMESTAMP} = "'" . $timestamp . "'"; }
       # Now add in the explicitly given XSLT parameters

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -557,8 +557,8 @@ sub convert_post {
         push(@{ $$parameters{JAVASCRIPT} }, $js); }
       if ($$opts{icon}) {
         $$parameters{ICON} = $$opts{icon}; }
-      if (!defined $$opts{timestamp}) { $$opts{timestamp}       = localtime(); }
-      if ($$opts{timestamp})          { $$parameters{TIMESTAMP} = "'" . $$opts{timestamp} . "'"; }
+      if (!defined $$opts{timestamp}) { $$opts{timestamp} = defined $ENV{SOURCE_DATE_EPOCH} ? gmtime($ENV{SOURCE_DATE_EPOCH}) : localtime(); }
+      if ($$opts{timestamp}) { $$parameters{TIMESTAMP} = "'" . $$opts{timestamp} . "'"; }
       # Now add in the explicitly given XSLT parameters
       foreach my $parm (@{ $$opts{xsltparameters} }) {
         if ($parm =~ /^\s*(\w+)\s*:\s*(.*)$/) {

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1081,7 +1081,7 @@ DefMacro('\tracingall',
 DefMacroI('\tracingnone', undef, Tokens());
 DefMacroI('\hideoutput',  undef, Tokens());
 # This may mess up Daemon state?
-{ my ($sec, $min, $hour, $mday, $mon, $year) = localtime();
+{ my ($sec, $min, $hour, $mday, $mon, $year) = defined $ENV{SOURCE_DATE_EPOCH} ? gmtime($ENV{SOURCE_DATE_EPOCH}) : localtime();
   AssignValue('\day'   => Number($mday),             'global');
   AssignValue('\month' => Number($mon + 1),          'global');
   AssignValue('\year'  => Number(1900 + $year),      'global');

--- a/lib/LaTeXML/Post/Manifest/Epub.pm
+++ b/lib/LaTeXML/Post/Manifest/Epub.pm
@@ -131,7 +131,7 @@ sub initialize {
   $language->appendText($document_language);
   my $modified = $metadata->addNewChild(undef, "meta");
   $modified->setAttribute('property', 'dcterms:modified');
-  my $now_string = strftime "%Y-%m-%dT%H:%M:%SZ", gmtime;    # CCYY-MM-DDThh:mm:ssZ
+  my $now_string = strftime "%Y-%m-%dT%H:%M:%SZ", gmtime($ENV{SOURCE_DATE_EPOCH} // time); # CCYY-MM-DDThh:mm:ssZ
   $modified->appendText($now_string);
   my $identifier = $metadata->addNewChild("http://purl.org/dc/elements/1.1/", "identifier");
   $identifier->setAttribute('id', 'pub-id');

--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -250,6 +250,10 @@ sub get_archive {
     my $current_dir = File::Spec->catdir($directory, $subdir);
     $archive->addTree($current_dir, $subdir, sub { !/$archive_file_exclusion_regex/ }, COMPRESSION_DEFLATED); }
 
+  if (defined $ENV{SOURCE_DATE_EPOCH}) {
+    for my $member ($archive->members()) {
+      $member->setLastModFileDateTimeFromUnix($ENV{SOURCE_DATE_EPOCH}); } }
+
   my $payload;
   if ($whatsout =~ /^archive(::zip)?$/) {
     my $content_handle = IO::String->new($payload);


### PR DESCRIPTION
Quick example implementation of SOURCE_DATE_EPOCH (intended to address #1919). Not sure if it is complete. I just grepped "time" and changed modification times in Util::Pack.

The spec asks that LaTeXML "should" throw an error if SOURCE_DATE_EPOCH is set to an invalid value (i.e. not made of just digits) but I don't know where to do it.

I suppose one could refactor `localtime` into a function in some Util module.