### PR TITLE
generate global toc for \tableofcontents

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -658,8 +658,8 @@ sub check_TOC {
     my @s = (qw(ltx:part ltx:chapter ltx:section ltx:subsection ltx:subsubsection
         ltx:paragraph ltx:subparagraph ltx:appendix ltx:index ltx:bibliography));
     $document->prependNodes($document->getDocumentElement,
-      ['ltx:TOC', { lists => 'toc', select => join(' | ', @s),
-          class => 'ltx_nodisplay' }]); }
+      ['ltx:TOC', { lists => 'toc', scope => 'global',
+          select => join(' | ', @s), class => 'ltx_nodisplay' }]); }
   return; }
 
 sub new_latexml {

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -765,7 +765,7 @@ DefMacroI('\\@@appendix', undef, '\@startsection{appendix}{0}{}{}{}{}');
 # Insert stubs that will be filled in during post processing.
 DefMacroI('\contentsname', undef, 'Contents');
 DefConstructorI('\tableofcontents', undef,
-  "<ltx:TOC lists='toc' select='#select'><ltx:title>#name</ltx:title></ltx:TOC>",
+  "<ltx:TOC lists='toc' scope='global' select='#select'><ltx:title>#name</ltx:title></ltx:TOC>",
   properties => sub {
     my $td = CounterValue('tocdepth')->valueOf + 1;
     my @s  = (qw(ltx:part ltx:chapter ltx:section ltx:subsection ltx:subsubsection

--- a/t/structure/book.xml
+++ b/t/structure/book.xml
@@ -12,7 +12,7 @@
     <personname>Someone Else</personname>
   </creator>
   <date role="creation">December 31, 1999</date>
-  <TOC lists="toc" select="ltx:part | ltx:chapter | ltx:section | ltx:subsection | ltx:appendix | ltx:index | ltx:bibliography">
+  <TOC lists="toc" scope="global" select="ltx:part | ltx:chapter | ltx:section | ltx:subsection | ltx:appendix | ltx:index | ltx:bibliography">
     <title>Contents</title>
   </TOC>
   <TOC lists="lof" scope="global">


### PR DESCRIPTION
Simple fix for #1606. I think `scope='global'` is safe here – `\tableofcontents` is supposed to generate a TOC for the entire document after all, just like for the list of figures, tables, etc.