### PR TITLE
Img alt

### DIFF
--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -47,10 +47,16 @@ DefMacro('\includegraphics OptionalMatch:* []',
   '\@ifnextchar[{\@includegraphics#1[#2]}{\@includegraphicx#1[#2]}', scope => 'global');
 
 DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbatim',
-  "<ltx:graphics graphic='#path' candidates='#candidates' description='#alt' options='#options'/>",
-  alias      => '\includegraphics',
-  sizer      => \&image_graphicx_sizer,
-  scope      => 'global',
+  "<ltx:graphics graphic='#path' candidates='#candidates' options='#options'/>",
+  alias          => '\includegraphics',
+  sizer          => \&image_graphicx_sizer,
+  scope          => 'global',
+  afterConstruct => sub {
+    my ($document, $whatsit) = @_;
+    my $alt = $whatsit->getProperty('alt');
+    # Trickery to set @description EVEN IF empty string (constructor shorthand omits it)
+    if (defined $alt) {
+      $document->getNode->lastChild->setAttribute(description => ToString($alt)); } },
   properties => sub {
     my ($stomach, $starred, $kv, $graphic) = @_;
     my $options = graphicX_options($starred, $kv);

--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -32,6 +32,7 @@ DefKeyVal('Gin', 'keepaspectratio', '', 'true');
 DefKeyVal('Gin', 'clip',            '', 'true');
 DefKeyVal('Gin', 'scale',           '');
 DefKeyVal('Gin', 'angle',           '');
+DefKeyVal('Gin', 'alt',             '');
 # NOTE: graphicx defines @angle to actually carry out the rotation (on \box\z@) w/\Gin@erotate
 # rather than to simply record the angle for later use. (also origin redefines)
 # This is used by adjustbox.
@@ -46,7 +47,7 @@ DefMacro('\includegraphics OptionalMatch:* []',
   '\@ifnextchar[{\@includegraphics#1[#2]}{\@includegraphicx#1[#2]}', scope => 'global');
 
 DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbatim',
-  "<ltx:graphics graphic='#path' candidates='#candidates' options='#options'/>",
+  "<ltx:graphics graphic='#path' candidates='#candidates' description='#alt' options='#options'/>",
   alias      => '\includegraphics',
   sizer      => \&image_graphicx_sizer,
   scope      => 'global',
@@ -54,9 +55,11 @@ DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbat
     my ($stomach, $starred, $kv, $graphic) = @_;
     my $options = graphicX_options($starred, $kv);
     my ($path, @candidates) = image_candidates(ToString($graphic));
+    my $alt = $kv && $kv->getValue('alt');
     (path => $path,
       candidates => join(',', @candidates),
-      options    => $options); },
+      ($alt ? (alt => $alt) : ()),
+      options => $options); },
   mode => 'text');    # Hopefully only to affect reading of arguments
 
 #**********************************************************************

--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -58,7 +58,7 @@ DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbat
     my $alt = $kv && $kv->getValue('alt');
     (path => $path,
       candidates => join(',', @candidates),
-      ($alt ? (alt => $alt) : ()),
+      (defined $alt ? (alt => $alt) : ()),
       options => $options); },
   mode => 'text');    # Hopefully only to affect reading of arguments
 

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
@@ -171,12 +171,11 @@
           </xsl:attribute>
         </xsl:when>
         <xsl:when test="ancestor::ltx:figure/ltx:caption">
-          <xsl:attribute name='alt'>
-            <xsl:value-of select="ancestor::ltx:figure/ltx:caption/text()"/>
-          </xsl:attribute>
+          <xsl:attribute name='alt'><xsl:text>Refer to caption</xsl:text></xsl:attribute>
+          <!-- Possibly aria-describedby, providing the caption has an id ??? -->
         </xsl:when>
         <xsl:otherwise>
-          <xsl:attribute name='alt'></xsl:attribute> <!--required; what else? -->
+          <xsl:attribute name='alt'><xsl:text>[Uncaptioned image]</xsl:text></xsl:attribute>
         </xsl:otherwise>
       </xsl:choose>
       <xsl:apply-templates select="." mode="begin">
@@ -198,7 +197,7 @@
           <xsl:value-of select="@description"/>
         </xsl:when>
         <xsl:when test="ancestor::ltx:figure/ltx:caption">
-            <xsl:value-of select="ancestor::ltx:figure/ltx:caption/text()"/>
+          <xsl:attribute name='alt'><xsl:text>Refer to caption</xsl:text></xsl:attribute>
         </xsl:when>
         <xsl:otherwise/>
       </xsl:choose>


### PR DESCRIPTION
This PR adds support for the new `\includegraphics` keyword `alt` for the author to provide descriptive text for images.  It also simplifies the alt tag generation on html images, avoiding the redundant copying of caption (when present), saying "Refer to caption" instead. Images with no description or caption get "[Uncaptioned image]".

Fixes #1452
Fixes #1922 

Relates also to #1627, eventually...
depending on if you two (@dginev @xworld21 ) can come to agreement on if there is a proper working aria solution.
I'm kinda reluctant to add ids to `ltx:caption`; it seems unnatural, and will cause lot's of test case churn.  But if it's necessary and actually works, we can do that.