### PR TITLE
Switch mpadded with relative widths for mspace

### DIFF
--- a/t/daemon/formats/lexmath.xml
+++ b/t/daemon/formats/lexmath.xml
@@ -32,7 +32,7 @@ Also <math id="p4.m3" class="ltx_Math" alttext="\mathit{func}" display="inline">
 
 <tbody><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
 <td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
-<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo largeop="true" symmetric="true">∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mpadded width="+1.7pt"><mi>x</mi></mpadded><mo>⁢</mo><mrow><mo rspace="0pt">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mrow><mtext>zero, </mtext><mtext mathvariant="italic">yes 0</mtext></mrow></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo largeop="true" symmetric="true">∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mspace width="1.7pt"></mspace><mo>⁢</mo><mrow><mo rspace="0pt">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mrow><mtext>zero, </mtext><mtext mathvariant="italic">yes 0</mtext></mrow></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
 <td class="ltx_eqn_cell ltx_eqn_center_padright"></td></tr></tbody>
 </table>
 </div>


### PR DESCRIPTION
A simple fix for #1804 . Maybe too simple?

A basic test document is:

<details>

```tex
\documentclass{article}
\usepackage{amsmath}
\begin{document}

\[ a \quad b \, c \: d \; e \! f \  g \qquad h \]

\bigskip

\begin{align*}
f(x) &= x^2\! +3x\! +2 \\
f(x) &= x^2+3x+2 \\
f(x) &= x^2\, +3x\, +2 \\
f(x) &= x^2\: +3x\: +2 \\
f(x) &= x^2\; +3x\; +2 \\
f(x) &= x^2\ +3x\ +2 \\
f(x) &= x^2\quad +3x\quad +2 \\
f(x) &= x^2\qquad +3x\qquad +2
\end{align*}

\bigskip

% From arXiv:1910.06709
\begin{displaymath}
  -\frac{B}{2A} \pm \sqrt{\frac{B^2}{4A^2} - \frac{C}{A}}
  \ = \
  -\frac{B}{2A} \pm \sqrt{\frac{B^2 - 4AC}{4A^2}}
  \ = \
  \frac{-B \pm \sqrt{B^2 - 4AC}}{2A}.
\end{displaymath}

\end{document}
```

</details>

For best effect in Chrome (with the MathML Core flag enabled), one needs a math-capable font set explicitly, e.g. via
```
latexmlc test.tex --dest=test.html --nodefaultresources \
  --css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.7.4/css/ar5iv.min.css
```

which will try to use STIX Two Math.

I am certain that @brucemiller will have a better overview than me here, but hopefully this is a workable start.