### PR TITLE
make csquotes commands inline

### DIFF
--- a/lib/LaTeXML/Package/csquotes.sty.ltxml
+++ b/lib/LaTeXML/Package/csquotes.sty.ltxml
@@ -129,10 +129,10 @@ RawTeX(<<'EoTeX');
   \fi}
 EoTeX
 
-DefConstructor('\ltxml@oqmark@open', '<ltx:text class="ltx_quote ltx_outerquote" _noautoclose="1">');
+DefConstructor('\ltxml@oqmark@open', '<ltx:text class="ltx_inline-quote ltx_outerquote" _noautoclose="1">');
 DefConstructor('\ltxml@oqmark@close', '</ltx:text>');
 
-DefConstructor('\ltxml@iqmark@open', '<ltx:text class="ltx_quote ltx_innerquote" _noautoclose="1">');
+DefConstructor('\ltxml@iqmark@open', '<ltx:text class="ltx_inline-quote ltx_innerquote" _noautoclose="1">');
 DefConstructor('\ltxml@iqmark@close', '</ltx:text>');
 
 ###########################################################################
@@ -236,10 +236,10 @@ DefMacro('\ltxml@mkblockquote@open', '\begingroup\ltxml@mkblockquote@open@i');
 DefPrimitive('\ltxml@mkblockquote@open@i', sub {
     DefEnvironment('{quote}', '<ltx:quote class="ltx_blockquote">#body</ltx:quote>',
       beforeDigest => sub { Let('\\\\', '\@block@cr'); Let('\par', '\@block@cr') },
-      mode => 'text'); });
+      mode         => 'text'); });
 DefMacro('\ltxml@mkblockquote@close', '\endgroup');
 
-DefConstructor('\ltxml@mkblockquote@aopen',  '<ltx:text class="ltx_quote" _noautoclose="1">');
+DefConstructor('\ltxml@mkblockquote@aopen', '<ltx:text class="ltx_inline-quote" _noautoclose="1">');
 DefConstructor('\ltxml@mkblockquote@aclose', '</ltx:text>');
 
 ###########################################################################
@@ -267,11 +267,11 @@ DefMacro('\ltxml@blockenvironment@open', '\begingroup\ltxml@blockenvironment@ope
 DefPrimitive('\ltxml@blockenvironment@open@i', sub {
     DefEnvironment('{quote}', '<ltx:quote class="ltx_displayquote">#body</ltx:quote>',
       beforeDigest => sub { Let('\\\\', '\@block@cr'); Let('\par', '\@block@cr') },
-      mode => 'text'); });
+      mode         => 'text'); });
 DefMacro('\ltxml@blockenvironment@close', '\endgroup');
 
 DefMacro('\ltxml@mkbegdispquote{}{}', '\ltxml@mkbegdispquote@aopen\mkbegdispquote{#1}{#2}');
-DefConstructor('\ltxml@mkbegdispquote@aopen', '<ltx:text class="ltx_quote" _noautoclose="1">');
+DefConstructor('\ltxml@mkbegdispquote@aopen', '<ltx:text class="ltx_inline-quote" _noautoclose="1">');
 
 DefMacro('\ltxml@mkenddispquote{}{}', '\mkenddispquote{#1}{#2}\ltxml@mkenddispquote@aclose');
 DefConstructor('\ltxml@mkenddispquote@aclose', '</ltx:text>');

--- a/t/babel/csquotes.xml
+++ b/t/babel/csquotes.xml
@@ -23,8 +23,8 @@
       </tags>
       <title><tag close=" ">1.1</tag>french</title>
       <para xml:id="S1.SS1.p1">
-        <p><text class="ltx_quote ltx_outerquote">«  Citation extérieure  »</text>
-<text class="ltx_quote ltx_outerquote">«  Extérieure <text class="ltx_quote ltx_innerquote">“intérieur”</text> extérieure  »</text></p>
+        <p><text class="ltx_inline-quote ltx_outerquote">«  Citation extérieure  »</text>
+<text class="ltx_inline-quote ltx_outerquote">«  Extérieure <text class="ltx_inline-quote ltx_innerquote">“intérieur”</text> extérieure  »</text></p>
       </para>
     </subsection>
     <subsection inlist="toc" xml:id="S1.SS2" xml:lang="de">
@@ -35,8 +35,8 @@
       </tags>
       <title><tag close=" ">1.2</tag>german</title>
       <para xml:id="S1.SS2.p1">
-        <p><text class="ltx_quote ltx_outerquote">„Äußeres Zitat“</text>
-<text class="ltx_quote ltx_outerquote">„Äußeres <text class="ltx_quote ltx_innerquote">‚inneres‘</text> Äußeres“</text></p>
+        <p><text class="ltx_inline-quote ltx_outerquote">„Äußeres Zitat“</text>
+<text class="ltx_inline-quote ltx_outerquote">„Äußeres <text class="ltx_inline-quote ltx_innerquote">‚inneres‘</text> Äußeres“</text></p>
       </para>
     </subsection>
     <subsection inlist="toc" xml:id="S1.SS3">
@@ -47,8 +47,8 @@
       </tags>
       <title><tag close=" ">1.3</tag>english</title>
       <para xml:id="S1.SS3.p1">
-        <p><text class="ltx_quote ltx_outerquote">“Outer Quote”</text>
-<text class="ltx_quote ltx_outerquote">“Outer <text class="ltx_quote ltx_innerquote">‘Inner’</text> Outer”</text></p>
+        <p><text class="ltx_inline-quote ltx_outerquote">“Outer Quote”</text>
+<text class="ltx_inline-quote ltx_outerquote">“Outer <text class="ltx_inline-quote ltx_innerquote">‘Inner’</text> Outer”</text></p>
       </para>
     </subsection>
   </section>
@@ -67,13 +67,13 @@
       </tags>
       <title><tag close=" ">2.1</tag>french</title>
       <para xml:id="S2.SS1.p1">
-        <p><text class="ltx_quote ltx_outerquote" xml:lang="fr">«  Citation extérieure  »</text>
+        <p><text class="ltx_inline-quote ltx_outerquote" xml:lang="fr">«  Citation extérieure  »</text>
 
-<text class="ltx_quote ltx_outerquote" xml:lang="fr">«  Extérieure 
-<text class="ltx_quote ltx_innerquote">“intérieur”</text> extérieure  »</text>
+<text class="ltx_inline-quote ltx_outerquote" xml:lang="fr">«  Extérieure
+<text class="ltx_inline-quote ltx_innerquote">“intérieur”</text> extérieure  »</text>
 
-<text class="ltx_quote ltx_outerquote" xml:lang="fr">«  Extérieure 
-<text class="ltx_quote ltx_innerquote">“intérieur”</text> extérieure  »</text></p>
+<text class="ltx_inline-quote ltx_outerquote" xml:lang="fr">«  Extérieure
+<text class="ltx_inline-quote ltx_innerquote">“intérieur”</text> extérieure  »</text></p>
       </para>
     </subsection>
     <subsection inlist="toc" xml:id="S2.SS2">
@@ -84,9 +84,9 @@
       </tags>
       <title><tag close=" ">2.2</tag>german</title>
       <para xml:id="S2.SS2.p1">
-        <p><text class="ltx_quote ltx_outerquote" xml:lang="de">„Äußeres Zitat“</text>
-<text class="ltx_quote ltx_outerquote" xml:lang="de">„Äußeres <text class="ltx_quote ltx_innerquote">‚inneres‘</text> Äußeres“</text>
-<text class="ltx_quote ltx_outerquote" xml:lang="de">„Äußeres <text class="ltx_quote ltx_innerquote">‚inneres‘</text> Äußeres“</text></p>
+        <p><text class="ltx_inline-quote ltx_outerquote" xml:lang="de">„Äußeres Zitat“</text>
+<text class="ltx_inline-quote ltx_outerquote" xml:lang="de">„Äußeres <text class="ltx_inline-quote ltx_innerquote">‚inneres‘</text> Äußeres“</text>
+<text class="ltx_inline-quote ltx_outerquote" xml:lang="de">„Äußeres <text class="ltx_inline-quote ltx_innerquote">‚inneres‘</text> Äußeres“</text></p>
       </para>
     </subsection>
   </section>
@@ -105,7 +105,7 @@
       </tags>
       <title><tag close=" ">3.1</tag>french</title>
       <para xml:id="S3.SS1.p1">
-        <p><text class="ltx_textquote"><text class="ltx_quote ltx_outerquote">«  du texte ici  »</text><text class="ltx_citation"> (Citation)</text></text></p>
+        <p><text class="ltx_textquote"><text class="ltx_inline-quote ltx_outerquote">«  du texte ici  »</text><text class="ltx_citation"> (Citation)</text></text></p>
       </para>
     </subsection>
     <subsection inlist="toc" xml:id="S3.SS2" xml:lang="de">
@@ -116,7 +116,7 @@
       </tags>
       <title><tag close=" ">3.2</tag>german</title>
       <para xml:id="S3.SS2.p1">
-        <p><text class="ltx_textquote"><text class="ltx_quote ltx_outerquote">„etwas Text hier“</text><text class="ltx_citation"> (Zitat)</text></text></p>
+        <p><text class="ltx_textquote"><text class="ltx_inline-quote ltx_outerquote">„etwas Text hier“</text><text class="ltx_citation"> (Zitat)</text></text></p>
       </para>
     </subsection>
     <subsection inlist="toc" xml:id="S3.SS3">
@@ -127,7 +127,7 @@
       </tags>
       <title><tag close=" ">3.3</tag>english</title>
       <para xml:id="S3.SS3.p1">
-        <p><text class="ltx_textquote"><text class="ltx_quote ltx_outerquote">“some text here”</text><text class="ltx_citation"> (Citation)</text></text></p>
+        <p><text class="ltx_textquote"><text class="ltx_inline-quote ltx_outerquote">“some text here”</text><text class="ltx_citation"> (Citation)</text></text></p>
       </para>
     </subsection>
   </section>
@@ -139,8 +139,8 @@
     </tags>
     <title><tag close=" ">4</tag>textquote in foreign Language</title>
     <para xml:id="S4.p1">
-      <p><text class="ltx_textquote" xml:lang="fr"><text class="ltx_quote ltx_outerquote">«  du texte ici  »</text><text class="ltx_citation" xml:lang="en"> (Citation)</text></text>
-<text class="ltx_textquote" xml:lang="de"><text class="ltx_quote ltx_outerquote">„etwas Text hier“</text><text class="ltx_citation" xml:lang="en"> (Zitat)</text></text></p>
+      <p><text class="ltx_textquote" xml:lang="fr"><text class="ltx_inline-quote ltx_outerquote">«  du texte ici  »</text><text class="ltx_citation" xml:lang="en"> (Citation)</text></text>
+<text class="ltx_textquote" xml:lang="de"><text class="ltx_inline-quote ltx_outerquote">„etwas Text hier“</text><text class="ltx_citation" xml:lang="en"> (Zitat)</text></text></p>
     </para>
   </section>
   <section inlist="toc" xml:id="S5">
@@ -159,7 +159,7 @@
       <title><tag close=" ">5.1</tag>french</title>
       <para xml:id="S5.SS1.p1">
         <quote class="ltx_displayquote">
-          <p><text class="ltx_quote">du texte ici
+          <p><text class="ltx_inline-quote">du texte ici
 <text class="ltx_citation"> (Citation)</text></text></p>
         </quote>
       </para>
@@ -173,7 +173,7 @@
       <title><tag close=" ">5.2</tag>german</title>
       <para xml:id="S5.SS2.p1">
         <quote class="ltx_displayquote">
-          <p><text class="ltx_quote">etwas Text hier
+          <p><text class="ltx_inline-quote">etwas Text hier
 <text class="ltx_citation"> (Zitat)</text></text></p>
         </quote>
       </para>
@@ -187,7 +187,7 @@
       <title><tag close=" ">5.3</tag>english</title>
       <para xml:id="S5.SS3.p1">
         <quote class="ltx_displayquote">
-          <p><text class="ltx_quote">some text here
+          <p><text class="ltx_inline-quote">some text here
 <text class="ltx_citation"> (Citation)</text></text></p>
         </quote>
       </para>
@@ -202,13 +202,13 @@
     <title><tag close=" ">6</tag>displayquote in foreign Language</title>
     <para xml:id="S6.p1">
       <quote class="ltx_displayquote">
-        <p><text class="ltx_quote" xml:lang="fr">du texte ici
+        <p><text class="ltx_inline-quote" xml:lang="fr">du texte ici
 <text class="ltx_citation" xml:lang="en"> (Citation)</text></text></p>
       </quote>
     </para>
     <para xml:id="S6.p2">
       <quote class="ltx_displayquote">
-        <p><text class="ltx_quote" xml:lang="de">etwas Text hier
+        <p><text class="ltx_inline-quote" xml:lang="de">etwas Text hier
 <text class="ltx_citation" xml:lang="en"> (Zitat)</text></text></p>
       </quote>
     </para>

--- a/t/structure/csquotes.xml
+++ b/t/structure/csquotes.xml
@@ -14,15 +14,15 @@
     </tags>
     <title><tag close=" ">1</tag>Active Quotes</title>
     <para xml:id="S1.p1">
-      <p><text class="ltx_quote ltx_outerquote">“Outer quote”</text></p>
+      <p><text class="ltx_inline-quote ltx_outerquote">“Outer quote”</text></p>
     </para>
     <para xml:id="S1.p2">
-      <p><text class="ltx_quote ltx_outerquote">“Outer <text class="ltx_quote ltx_innerquote">‘Inner’</text> Outer”</text></p>
+      <p><text class="ltx_inline-quote ltx_outerquote">“Outer <text class="ltx_inline-quote ltx_innerquote">‘Inner’</text> Outer”</text></p>
     </para>
     <para xml:id="S1.p3">
       <p>Some text before the quotation.</p>
       <quote class="ltx_blockquote">
-        <p><text class="ltx_quote">A long quotation latex would show indented.
+        <p><text class="ltx_inline-quote">A long quotation latex would show indented.
 A long quotation latex would show indented.
 A long quotation latex would show indented.
 A long quotation latex would show indented.
@@ -50,13 +50,13 @@ A long quotation latex would show indented.
     </tags>
     <title><tag close=" ">2</tag>enquote macro</title>
     <para xml:id="S2.p1">
-      <p><text class="ltx_quote ltx_outerquote">“Outer Quote”</text></p>
+      <p><text class="ltx_inline-quote ltx_outerquote">“Outer Quote”</text></p>
     </para>
     <para xml:id="S2.p2">
-      <p><text class="ltx_quote ltx_outerquote">“Outer <text class="ltx_quote ltx_innerquote">‘Inner’</text> Outer”</text></p>
+      <p><text class="ltx_inline-quote ltx_outerquote">“Outer <text class="ltx_inline-quote ltx_innerquote">‘Inner’</text> Outer”</text></p>
     </para>
     <para xml:id="S2.p3">
-      <p><text class="ltx_quote ltx_outerquote">“Outer <text class="ltx_quote ltx_innerquote">‘Inner’</text> Outer”</text></p>
+      <p><text class="ltx_inline-quote ltx_outerquote">“Outer <text class="ltx_inline-quote ltx_innerquote">‘Inner’</text> Outer”</text></p>
     </para>
   </section>
   <section inlist="toc" xml:id="S3">
@@ -67,7 +67,7 @@ A long quotation latex would show indented.
     </tags>
     <title><tag close=" ">3</tag>Textquote</title>
     <para xml:id="S3.p1">
-      <p><text class="ltx_textquote"><text class="ltx_quote ltx_outerquote">“This is a short quotation typeset with a text quotation
+      <p><text class="ltx_textquote"><text class="ltx_inline-quote ltx_outerquote">“This is a short quotation typeset with a text quotation
 command. It would be presented in inline style even if it were longer than
 three lines.”</text><text class="ltx_citation"> (Citation)</text></text></p>
     </para>
@@ -82,7 +82,7 @@ three lines.”</text><text class="ltx_citation"> (Citation)</text></text></p>
     <para xml:id="S4.p1">
       <p>Some text before the quotation.</p>
       <quote class="ltx_displayquote">
-        <p><text class="ltx_quote">A short quotation shown intended.
+        <p><text class="ltx_inline-quote">A short quotation shown intended.
 <text class="ltx_citation"> (Citation)</text></text></p>
       </quote>
       <p>Some text after the quotation.</p>
@@ -90,7 +90,7 @@ three lines.”</text><text class="ltx_citation"> (Citation)</text></text></p>
     <para xml:id="S4.p2">
       <p>Some text before the quotation.</p>
       <quote class="ltx_displayquote">
-        <p><text class="ltx_quote">A long quotation latex would show indented.
+        <p><text class="ltx_inline-quote">A long quotation latex would show indented.
 A long quotation latex would show indented.
 A long quotation latex would show indented.
 A long quotation latex would show indented.
@@ -115,14 +115,14 @@ A long quotation latex would show indented.
     <para xml:id="S5.p1">
       <p>Some text before the quotation.</p>
       <quote class="ltx_blockquote">
-        <p><text class="ltx_quote">A short quotation latex would embed. </text><text class="ltx_citation"> (Citation)</text></p>
+        <p><text class="ltx_inline-quote">A short quotation latex would embed. </text><text class="ltx_citation"> (Citation)</text></p>
       </quote>
       <p>Some text after the quotation.</p>
     </para>
     <para xml:id="S5.p2">
       <p>Some text before the quotation.</p>
       <quote class="ltx_blockquote">
-        <p><text class="ltx_quote">A long quotation latex would show indented.
+        <p><text class="ltx_inline-quote">A long quotation latex would show indented.
 A long quotation latex would show indented.
 A long quotation latex would show indented.
 A long quotation latex would show indented.


### PR DESCRIPTION
Fix #1930.

My theory is that the current meaning of `ltx_quote` (the class for `<ltx:quote>`) is not the same as it was in 2013. Since inline quotes in the sense of csquotes have little to do with `<ltx:quote>`, I changed the class name to `ltx_csquote`. I hope that doesn't break anything else.