### PR TITLE
do not create new dates in split documents

### DIFF
--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -842,12 +842,7 @@ sub addDate {
     my @dates;
     #  $fromdoc's document has some, so copy them.
     if ($fromdoc && (@dates = $fromdoc->findnodes('ltx:date', $fromdoc->getDocumentElement))) {
-      $self->addNodes($self->getDocumentElement, @dates); }
-    else {
-      my ($sec, $min, $hour, $mday, $mon, $year) = localtime(time());
-      $self->addNodes($self->getDocumentElement,
-        ['ltx:date', { role => 'creation' },
-          $MonthNames[$mon] . " " . $mday . ", " . (1900 + $year)]); } }
+      $self->addNodes($self->getDocumentElement, @dates); } }
   return; }
 
 #======================================================================


### PR DESCRIPTION
Fix #1654. Assuming the code I removed is really safe to remove. I don't see the use case, so I am guessing it is an historical artefact (maybe `addDate` was originally run on the top document as well?).