### PR TITLE
stub \Gin@esetsize

### DIFF
--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -21,9 +21,10 @@ use LaTeXML::Util::Image;
 # Provides alternative argument syntax.
 RequirePackage('graphics');
 
-DefMacro('\Gin@ewidth',  '');
-DefMacro('\Gin@eheight', '');
-DefMacro('\Gin@eresize', '');
+DefMacro('\Gin@ewidth',   '');
+DefMacro('\Gin@eheight',  '');
+DefMacro('\Gin@eresize',  '');
+DefMacro('\Gin@esetsize', '');
 #DefKeyVal('Gin', 'width',           'Dimension', '', code=>sub { DefMacro('\Gin@ewidth',$_[1]); });
 DefKeyVal('Gin', 'width',           'GraphixDimension');
 DefKeyVal('Gin', 'height',          'GraphixDimension');


### PR DESCRIPTION
just a stub for `\Gin@esetsize`, that currently causes errors [in CorTeX](https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml/error/undefined?all=true) for 0.16% of arXiv articles (~3000 articles).

I quickly examined `1511.02120`, and I think the macro is invoked as a side-effect from the adjustbox.sty machinery (which we interpret raw), but likely we can't do much more than nod along for now.