### PR TITLE
Indentation

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -663,7 +663,8 @@ DefConstructor('\@@numbered@section{} Undigested OptionalUndigested Undigested',
         Warn("malformed", "ltx:$type", "Tried to open an unknown tag ltx:$type for numbered section"); } }
     $document->openElement($tagname,
       'xml:id' => CleanID($id),
-      inlist   => ToString($inlist));
+      inlist   => ToString($inlist),
+      (LookupValue('INDENT_FIRST') ? (class => 'ltx_nofirstchild') : ()));
     if (my $tags = $props{tags}) {
       $document->absorb($tags); }
     $document->insertElement('ltx:title',    $props{title});
@@ -700,7 +701,8 @@ DefConstructor('\@@unnumbered@section{} Undigested OptionalUndigested Undigested
         Warn("malformed", "ltx:$type", "Tried to open an unknown tag ltx:$type for unnumbered section"); } }
     $document->openElement($tagname,
       'xml:id' => CleanID($id),
-      inlist   => ToString($inlist));
+      inlist   => ToString($inlist),
+      (LookupValue('INDENT_FIRST') ? (class => 'ltx_nofirstchild') : ()));
     $document->insertElement('ltx:title',    $props{title});
     $document->insertElement('ltx:toctitle', $props{toctitle}) if $props{toctitle}; },
   properties => sub {

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -3501,7 +3501,10 @@ DefConstructorI('\indent', undef, sub {
       $node->setAttribute(class => "ltx_indent"); }
     elsif ($document->canContainSomehow($node, "ltx:para")) {
       # Used in a position where a paragraph can be started, start
-      $document->openElement("ltx:para", class => "ltx_indent"); }
+      # However, perversely ignore indent on 1st para after sectioning titles
+      my $prev     = $node->lastChild;
+      my $noindent = $prev && ($document->getNodeQName($prev) =~ /^ltx:(?:toc)?title$/);
+      $document->openElement("ltx:para", ($noindent ? () : (class => "ltx_indent"))); }
     # Otherwise ignore.
     return; });
 DefConstructorI('\noindent', undef, sub {
@@ -3578,6 +3581,9 @@ sub pruneEmpty {
   # In some cases we could have e.g. a \noindent followed by a {table},
   # in which case we end up with an empty ltx:para which we can prune.
   if (!scalar($node->childNodes)) {
+    my $prev = $node->previousSibling;
+    if (!$prev || ($document->getNodeQName($prev) ne 'ltx:para')) {    # If $node WAS the 1st child
+      $document->addClass($node->parentNode, 'ltx_nofirstchild'); }
     $node->unlinkNode; }
   return; }
 

--- a/lib/LaTeXML/Package/indentfirst.sty.ltxml
+++ b/lib/LaTeXML/Package/indentfirst.sty.ltxml
@@ -15,9 +15,5 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
-#**********************************************************************
-# Is mostly a no-op, since we aren't (correctly) dealing with
-# modifiable indentation (but should)
-#**********************************************************************
-
+AssignValue('INDENT_FIRST' => 1);
 1;

--- a/lib/LaTeXML/resources/CSS/ltx-article.css
+++ b/lib/LaTeXML/resources/CSS/ltx-article.css
@@ -51,8 +51,9 @@
 .ltx_table .ltx_caption,
 .ltx_figure .ltx_caption { text-align:justify; }
 
-/* first p in para gets indented */
-.ltx_para > .ltx_p:first-child { text-indent:2em; }
+/* first p in para gets indented; , even 1st in section if marked "no" first child */
+.ltx_para > .ltx_p:first-child,
+section.ltx_nofirstchild > .ltx_title + .ltx_para > .ltx_p { text-indent:2em; }
 /* except the initial in a section */
 section > .ltx_title +.ltx_para > .ltx_p,
 section > .ltx_title +.ltx_date +.ltx_para > .ltx_p {text-indent:0em; }

--- a/lib/LaTeXML/resources/CSS/ltx-book.css
+++ b/lib/LaTeXML/resources/CSS/ltx-book.css
@@ -53,8 +53,9 @@
 .ltx_table .ltx_caption,
 .ltx_figure .ltx_caption { text-align:justify; }
 
-/* first p in para gets indented */
-.ltx_para > .ltx_p:first-child { text-indent:2em; }
+/* first p in para gets indented; , even 1st in section if marked "no" first child */
+.ltx_para > .ltx_p:first-child,
+section.ltx_nofirstchild > .ltx_title + .ltx_para > .ltx_p { text-indent:2em; }
 /* except the initial in a section */
 section > .ltx_title +.ltx_para > .ltx_p,
 section > .ltx_title +.ltx_date +.ltx_para > .ltx_p {text-indent:0em; }

--- a/lib/LaTeXML/resources/CSS/ltx-report.css
+++ b/lib/LaTeXML/resources/CSS/ltx-report.css
@@ -53,8 +53,9 @@
 .ltx_table .ltx_caption,
 .ltx_figure .ltx_caption { text-align:justify; }
 
-/* first p in para gets indented */
-.ltx_para > .ltx_p:first-child { text-indent:2em; }
+/* first p in para gets indented; , even 1st in section if marked "no" first child */
+.ltx_para > .ltx_p:first-child,
+section.ltx_nofirstchild > .ltx_title + .ltx_para > .ltx_p { text-indent:2em; }
 /* except the initial in a section */
 section > .ltx_title +.ltx_para > .ltx_p,
 section > .ltx_title +.ltx_date +.ltx_para > .ltx_p {text-indent:0em; }

--- a/t/structure/autoref.xml
+++ b/t/structure/autoref.xml
@@ -36,7 +36,7 @@
         </subsubsection>
       </subsection>
     </section>
-    <section labels="LABEL:otherlabel" xml:id="Ch1.Sx1">
+    <section class="ltx_nofirstchild" labels="LABEL:otherlabel" xml:id="Ch1.Sx1">
       <title>Other Section Name</title>
       <figure inlist="lof" labels="LABEL:figurelabel" placement="h" xml:id="Ch1.F1">
         <tags>


### PR DESCRIPTION
This PR fixes several inconsistencies with LaTeX with respect to the indentation (or lack thereof) of the 1st paragraph within sections.  It is a little clunky and indirect; but I was trying to avoid ending up with all paragraphs explicitly marked as whether indented or not.  That would possibly be more accurate, but would probably require more code, testcase churn and be harder to customize the CSS?

Fixes #1928 