### PR TITLE
Provision for data-* attributes in HTML5

### DIFF
--- a/lib/LaTeXML/Common/Model.pm
+++ b/lib/LaTeXML/Common/Model.pm
@@ -21,7 +21,8 @@ use LaTeXML::Util::Pathname;
 use base qw(LaTeXML::Common::Object);
 
 #**********************************************************************
-our $LTX_NAMESPACE = "http://dlmf.nist.gov/LaTeXML";    # [CONSTANT]
+our $LTX_NAMESPACE  = "http://dlmf.nist.gov/LaTeXML";                # [CONSTANT]
+our $DATA_NAMESPACE = "http://dlmf.nist.gov/LaTeXML/custom-data";    # [CONSTANT]
 
 sub new {
   my ($class, %options) = @_;

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -500,4 +500,30 @@ sub createDeclarationRewrite {
   return; }
 
 #======================================================================
+
+# simple data-* annotations for a current node.
+DefConstructor('\lxCustomData{}{}', sub {
+    my ($doc, $key, $value) = @_;
+    my $node = $doc->getNode;
+    $node = $node->parentNode if isTextNode($node);
+
+    # if the data namespace isn't registered as global yet - do so.
+    # this is a bit wasteful, but data-* attributes are too rare to assume it declared by default.
+    if (!$$doc{model}->getDocumentNamespacePrefix($LaTeXML::Common::Model::DATA_NAMESPACE, 1, 1)) {
+      $$doc{model}->registerNamespace('data', $LaTeXML::Common::Model::DATA_NAMESPACE);
+      $$doc{model}->registerDocumentNamespace('data', $LaTeXML::Common::Model::DATA_NAMESPACE); }
+    # allow the explicit prefixing in the attribute, as a matter of style. These are identical:
+    #   \lxCustomData{key}{val}
+    #   \lxCustomData{data-key}{val}
+    #   \lxCustomData{data:key}{val}
+    #
+    $key = ToString($key);
+    $key =~ s/^data[:-]//;
+    $key   = "data:$key";
+    $value = ToString($value);
+    $node->setAttributeNS($LaTeXML::Common::Model::DATA_NAMESPACE, $key, $value);
+
+    return; });
+
+#======================================================================
 1;

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-common.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-common.xsl
@@ -15,6 +15,7 @@
     version     = "1.0"
     xmlns:xsl   = "http://www.w3.org/1999/XSL/Transform"
     xmlns:ltx   = "http://dlmf.nist.gov/LaTeXML"
+    xmlns:data   = "http://dlmf.nist.gov/LaTeXML/custom-data"
     xmlns:exsl  = "http://exslt.org/common"
     xmlns:string= "http://exslt.org/strings"
     xmlns:date  = "http://exslt.org/dates-and-times"
@@ -432,6 +433,21 @@
     <xsl:if test="@xml:lang">
       <xsl:apply-templates select="@xml:lang" mode="copy-attribute"/>
     </xsl:if>
+    <xsl:if test="@data:*">
+      <xsl:call-template name="add_custom_data_attributes" />
+    </xsl:if>
+  </xsl:template>
+
+  <!--- Transform custom data attributes from latexml's
+        "data" namespace into HTML's data-* flat scheme
+  -->
+  <xsl:template name="add_custom_data_attributes">
+    <xsl:for-each select="@data:*">
+      <xsl:variable name="data-name">data-<xsl:value-of select="local-name(.)"/></xsl:variable>
+      <xsl:attribute name="{$data-name}">
+        <xsl:value-of select="."/>
+      </xsl:attribute>
+    </xsl:for-each>
   </xsl:template>
 
   <!-- Add a class attribute value to the current html element

--- a/lib/LaTeXML/texmf/latexml.sty
+++ b/lib/LaTeXML/texmf/latexml.sty
@@ -85,6 +85,11 @@
 \providecommand{\lxWithClass}[2]{#2}%
 
 %======================================================================
+% custom data related features
+% Add a data-* attribute to a final (X)HTML document (ignored in latex)
+\providecommand{\lxCustomData}[2]{}%
+
+%======================================================================
 % links
 \def\lxRef#1#2{#2}
 %======================================================================
@@ -168,9 +173,7 @@
 % that `use' it.
 
 % In document scoping, the definition would only be available within
-% the current sectional unit.  I'm not sure the best way to achieve this 
+% the current sectional unit.  I'm not sure the best way to achieve this
 % within latex, itself, but have ideas about latexml...
 % But, perhaps it is only the declarative aspects that are important to
 % latexml...
-
-


### PR DESCRIPTION
This PR contains a first approach that worked for me in providing `data-*` custom data attributes for HTML5. 
It is very much open to discussion and redesign.

* Uses a new `data` namespace prefix for the core LaTeXML XML output
   * (which needs a proper namespace URI, I "imagined" one)
* maps that into the flat `data-*` scheme in (X)HTML5 output formats.
* adds a new `\lxCustomData` macro in latexml.sty to demo the feature.

A (maybe whimsical) example use would be:
```bash
latexmlc --preload=latexml.sty --whatsin=fragment --format=xml \
  'literal:\section{Foo} hello \lxCustomData{mouse}{cookie} \
    \subsection{Bar} \lxCustomData{data-yes}{set} world.'
```

which produces the core processing XML (snipped):
```xml
  <section inlist="toc" xml:id="S1">
    <tags>
      <tag>1</tag>
      <tag role="refnum">1</tag>
      <tag role="typerefnum">§1</tag>
    </tags>
    <title><tag close=" ">1</tag>Foo</title>
    <para xml:id="S1.p1">
      <p xmlns:data="http://dlmf.nist.gov/LaTeXML/custom-data" data:mouse="cookie">hello</p>
    </para>
    <subsection xmlns:data="http://dlmf.nist.gov/LaTeXML/custom-data" data:yes="set"
                inlist="toc" xml:id="S1.SS1">
      <tags>
        <tag>1.1</tag>
        <tag role="refnum">1.1</tag>
        <tag role="typerefnum">§1.1</tag>
      </tags>
      <title><tag close=" ">1.1</tag>Bar</title>
      <para xml:id="S1.SS1.p1">
        <p>world.</p>
      </para>
    </subsection>
  </section>
```

with `--whatsout=fragment --format=html5` we get a desired HTML5 snippet:
```html
<article class="ltx_document">
  <section id="S1" class="ltx_section">
    <h2 class="ltx_title ltx_title_section">
      <span class="ltx_tag ltx_tag_section">1 </span>Foo</h2>

  <div id="S1.p1" class="ltx_para">
    <p class="ltx_p" data-mouse="cookie">hello</p>
  </div>
  <section id="S1.SS1" class="ltx_subsection" data-yes="set">
    <h3 class="ltx_title ltx_title_subsection">
      <span class="ltx_tag ltx_tag_subsection">1.1 </span>Bar</h3>

    <div id="S1.SS1.p1" class="ltx_para">
      <p class="ltx_p">world.</p>
    </div>
  </section>
</section>
</article>
```

For bookkeeping: this relates to an old discussion we've had about attributes in foreign namespaces ( #447 ), and is one namespace-free approach for latexml users that may be fond of the flat HTML5 `data-*` approach.