### PR TITLE
Removes warnings against changing \iflatexml from latexml.sty.ltxml

### DIFF
--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -25,10 +25,6 @@ no warnings 'redefine';    # ????
 #======================================================================
 
 DefConditional('\iflatexml', sub { 1; });
-DefPrimitive('\latexmltrue', sub {
-    Warning('unexpected', '\\latexmltrue', $_[0], "Cannot change \\iflatexml!"); });
-DefPrimitive('\latexmlfalse', sub {
-    Warning('unexpected', '\\latexmlfalse', $_[0], "Cannot change \\iflatexml!"); });
 
 #======================================================================
 # Package Options


### PR DESCRIPTION
This matches the lack of warnings in latexml.sty, as well as allowing you to change the value like most TeX booleans.  The assumption is that a user will know what they're doing if they are changing the booleans.  This resolves #1907 (in the negative).