### PR TITLE
Minor boilerplate / latex.ltx fixes

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -530,10 +530,12 @@ DefConstructor('\lx@notetext[]{}[]{}',
     (role => $type . 'text', makeNoteTags($type, $_[1], $_[3] || Digest(T_CS('\the' . $type)))); },
   reversion => '');
 
-DefMacro('\footnote',      '\lx@note{footnote}');
-DefMacro('\footnotemark',  '\lx@notemark{footnote}');
-DefMacro('\footnotetext',  '\lx@notetext{footnote}');
-DefMacro('\@footnotetext', '\lx@notetext{footnote}');
+DefMacro('\footnote',      '\lx@note{footnote}',     locked => 1);
+DefMacro('\footnotemark',  '\lx@notemark{footnote}', locked => 1);
+DefMacro('\footnotetext',  '\lx@notetext{footnote}', locked => 1);
+DefMacro('\@footnotetext', '\lx@notetext{footnote}', locked => 1);
+# we don't implement the internals directly, so lock them to the latexml variant
+Let('\@thefnmark', '\lx@notemark{footnote}', locked => 1);
 
 Tag('ltx:note', afterClose => \&relocateFootnote);
 
@@ -831,13 +833,16 @@ DefRegister('\mathindent'    => Dimension(0));
 
 DefMacroI('\@clsextension', undef, 'cls');
 DefMacroI('\@pkgextension', undef, 'sty');
-Let('\@currext',          '\@empty');
-Let('\@currname',         '\@empty');
-Let('\@classoptionslist', '\relax');
-# Note that there are variables used in Package.pmfor these,
+Let('\@currext',              '\@empty');
+Let('\@currname',             '\@empty');
+Let('\@classoptionslist',     '\relax');
+Let('\@raw@classoptionslist', '\relax');
+
+# Note that there are variables used in Package.pm for these,
 # but they are NOT tied to these macros. Do they need to be?
-DefMacroI('\@declaredoptions', undef, undef);
-DefMacroI('\@curroptions',     undef, undef);
+DefMacroI('\@declaredoptions',  undef, Tokens());
+DefMacroI('\@curroptions',      undef, undef);
+DefMacroI('\@unusedoptionlist', undef, Tokens());
 
 DefConstructor('\usepackage OptionalSemiverbatim Semiverbatim []',
   "<?latexml package='#2' ?#1(options='#1')?>",
@@ -5545,6 +5550,7 @@ sub make_message {
     map { ToString(Expand($_, T_CS('\@spaces'), T_CS('\@spaces'))) } @args);
   $type    =~ s/(?:\\\@?spaces?)+/ /g;
   $message =~ s/(?:\\\@?spaces?)+/ /g;
+  $message =~ s/\\MessageBreak/\n/g;
   $stomach->egroup;
   return ('latex', $type, $stomach, $message); }
 
@@ -5837,6 +5843,12 @@ RawTeX(<<'EOTeX');
        \expandafter\@fornoop \else
       #4\relax\expandafter\@tforloop\fi#2\@@#3{#4}}
 \long\def\@break@tfor#1\@@#2#3{\fi\fi}
+\def\@removeelement#1#2#3{%
+  \def\reserved@a##1,#1,##2\reserved@a{##1,##2\reserved@b}%
+  \def\reserved@b##1,\reserved@b##2\reserved@b{%
+    \ifx,##1\@empty\else##1\fi}%
+  \edef#3{%
+    \expandafter\reserved@b\reserved@a,#2,\reserved@b,#1,\reserved@a}}
 \def\remove@to@nnil#1\@nnil{}
 \def\remove@angles#1>{\set@simple@size@args}
 \def\remove@star#1*{#1}

--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -371,14 +371,24 @@ map { DefMacroI(T_CS('\\' . $_ . 'autorefname'), undef, '\itemautorefname'); }
 
 # I wonder if this is good enough for our context?
 # \pdfstringdef{macroname}{texstring}
-DefMacro('\pdfstring{Token}{}', '\def#1{#2}');
+DefMacro('\pdfstringdef{Token}{}', '\def#1{#2}');
+# Hopefully noop is sufficient for PDF-specific uses?
+DefMacro('\pdfstringdefDisableCommands', '');
+DefMacro('\pdfbookmark[]{}{}',      '');
+DefMacro('\currentpdfbookmark{}{}', '');
+DefMacro('\subpdfbookmark{}{}',     '');
+DefMacro('\belowpdfbookmark{}{}',   '');
 
-DefMacro('\pdfstringdefDisableCommands', '');    # Hopefully noop is sufficient?
 #======================================================================
 # 4.1 Replacement macros
 
 # \texorpdfstring{TeXString}{PDFstring}
 DefMacro('\texorpdfstring{}{}', '#1');
+
+if (!IsDefined(T_CS("\\pdfstringdefPreHook"))) {
+  Let('\pdfstringdefPreHook', '\@empty'); }
+if (!IsDefined(T_CS("\\pdfstringdefPostHook"))) {
+  Let('\pdfstringdefPostHook', '\@gobble'); }
 
 #======================================================================
 # 4.2 Utility macros

--- a/lib/LaTeXML/texmf/latexml.sty
+++ b/lib/LaTeXML/texmf/latexml.sty
@@ -168,9 +168,7 @@
 % that `use' it.
 
 % In document scoping, the definition would only be available within
-% the current sectional unit.  I'm not sure the best way to achieve this 
+% the current sectional unit.  I'm not sure the best way to achieve this
 % within latex, itself, but have ideas about latexml...
 % But, perhaps it is only the declarative aspects that are important to
 % latexml...
-
-


### PR DESCRIPTION
I was quickly surveying mdframed.sty articles, and got side-tracked into adding some minor boilerplate that removes spurious PDF-related errors from arXiv:1306.2973

Mostly no-ops, list is:
 - add `\@thefnmark` and lock the footnote macros, as they will almost certainly produce broken markup upon redefinition.
 - add a handful of latex.ltx internal macros that may get exercised during raw interpretation, but have no real effect in latexml processing (PDF-related)
 - add `\@removeelement` with its real definition from latex.ltx
 - fix a typo of the macro `\pdfstringdef` which was written `\pdfstring` in hyperref
 - add stubs for the PDF bookmark macros in hyperref
 - sanitized `\MessageBreak` into a newline when it made its way into our custom generic messaging subroutine
 - even more minor: my editor ended up trimming some spaces in latexml.sty, which ended up here

Besides tweaking these minor bits, I could also state that `scrbook.cls`, `mdframed.sty` and `datetime.sty` will indeed need real bindings written in Perl - but of course we already knew that. The arXiv article in question exercises all three.