### PR TITLE
stub in fixed font macros as \relax

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2786,8 +2786,8 @@ DefPrimitive('\DeclareMathSymbol DefToken SkipSpaces DefToken {}{Number}', sub {
     DefMathI($cs, undef, $glyph, role => $role);
     return; });
 
-DefPrimitive('\DeclareFixedFont{}{}{}{}{}{}', undef);
-DefPrimitive('\DeclareErrorFont{}{}{}{}{}',   undef);
+DefPrimitive('\DeclareFixedFont{}{}{}{}{}{}', sub { DefMacroI($_[1], undef, T_CS('\relax')); return; });
+DefPrimitive('\DeclareErrorFont{}{}{}{}{}', sub { DefMacroI($_[1], undef, T_CS('\relax')); return; });
 
 DefMacroI('\cdp@list', undef, '\@empty');
 Let('\cdp@elt', '\relax');


### PR DESCRIPTION
Fixes [ar5iv#89](https://github.com/dginev/ar5iv/issues/89)

We currently don't implement the font specifics behind `\DeclareFixedFont` and `\DeclareErrorFont`, but we should at least stub in the implied macros to avoid needless errors.

Elevates the article in question from Error to Warning (just math parsing).