### PR TITLE
phase out *mathspace mspace values

### DIFF
--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -821,10 +821,10 @@ sub pmml_mo {
   my $islargeop = $role && ($role =~ /^(SUMOP|INTOP)$/);
   my $lpad      = $attr{lpadding}
     || ((ref $item) && $item->getAttribute('lpadding'))
-    || ($role && ($role eq 'MODIFIEROP') && 'mediummathspace');
+    || ($role && ($role eq 'MODIFIEROP') && '0.2222222222222222em');
   my $rpad = $attr{rpadding}
     || ((ref $item) && $item->getAttribute('rpadding'))
-    || ($role && ($role eq 'MODIFIEROP') && 'mediummathspace');
+    || ($role && ($role eq 'MODIFIEROP') && '0.2222222222222222em');
   my $pos = (ref $item && $item->getAttribute('scriptpos')) || 'post';
   return
     pmml_mayberesize($item,
@@ -1595,7 +1595,7 @@ DefMathML('Apply:?:limit-from', sub {
 DefMathML('Apply:?:annotated', sub {
     my ($op, $var, $annotation) = @_;
     return ['m:mrow', {}, pmml($var),
-      ['m:mspace', { width => 'veryverythickmathspace' }],
+      ['m:mspace', { width => '0.3888888888888889em' }],
       pmml($annotation)]; });
 
 DefMathML("Token:?:sum",      undef, sub { return ['m:sum']; });


### PR DESCRIPTION
Fixes #1801 .

Questions to @brucemiller : 
 - Should we use the `em` units MathML Core recommends, instead of `pt`, so that spaces scale along with font-size?
 - Is the PR correct so far?

I can claim the current commit phases out the old values, as a grep for "mathspace" doesn't find any other active code with them. But so far this is the kind of change that someone completely new to latexml would made, since I consider myself mostly novice when it comes to the post-processing unit considerations.

Thanks for any tips!