### PR TITLE
Add a couple of revtex internals

### DIFF
--- a/lib/LaTeXML/Package/revtex4_support.sty.ltxml
+++ b/lib/LaTeXML/Package/revtex4_support.sty.ltxml
@@ -419,6 +419,12 @@ DefMacroI('\ds@tighten',   undef, '\@tightenlinestrue');
 DefMacroI('\ds@floats',    undef, '\@floatstrue');
 DefMacroI('\ds@eqsecnum',  undef, '\global\secnumberstrue');
 
+DefMacro('\replace@command{}{}',     '\global\let#1#2 #1');
+DefMacro('\replace@environment{}{}', '\glet@environment{#1}{#2}\@nameuse{#1}');
+DefMacro('\glet@environment{}{}', '\global\expandafter\let'
+    . '\csname#1\expandafter\endcsname\csname#2\endcsname'
+    . '\global\expandafter\let'
+    . '\csname end#1\expandafter\endcsname\csname end#2\endcsname');
 #======================================================================
 
 1;


### PR DESCRIPTION
I spotted that `\replace@command` is used in arXiv:1112.1218, and its lack was currently causing a (circumstantial) infinite loop in that document conversion.

Looks harmless enough to provide in the revtex support binding, hence this PR.
The document in question converts successfully, with only two minor errors remaining (missing support for `\sanitize@url` and `\@email`)