### PR TITLE
Address texlive 10.2022 regressions

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -363,6 +363,9 @@ DefParameterType('Register', sub {
       [$defn, ($$defn{parameters} ? $$defn{parameters}->readArguments($gullet) : ())]; }
     else {
       if ($token && ($token->getCatcode == CC_CS)) {
+        if ($token->getString eq '\font') {
+          # \font is a bit of a register-like exception
+          return [$defn]; }
         Error('expected', '<register>', $gullet,
           "A <register> was supposed to be here", "Got " . Stringify($token),
           "Defining it now.");
@@ -1017,6 +1020,8 @@ DefMacro('\the Register', sub {
     my $type = $defn->isRegister;
     if (!$type) {
       my $cs = ToString($defn->getCS);
+      if ($cs eq '\font') {    # what to do here?
+        return T_CS('\tenrm'); }
       Error('unexpected', "\\the$cs", $gullet, "You can't use $cs after \\the"); return (); }
     my $value = $defn->valueOf(@args);
     ## In all cases, these should be OTHER, except for space. (!?)

--- a/lib/LaTeXML/Package/babel_support.sty.ltxml
+++ b/lib/LaTeXML/Package/babel_support.sty.ltxml
@@ -149,7 +149,6 @@ EoTeX
 DefPrimitive('\ltx@bbl@select@language{}', sub {
     my ($stomach, $language) = @_;
     $language = ToString(Expand($language));
-    NoteSTDERR("SELECTING LANGUAGE $language !");
     my $iso = $$bbl_language_map{$language};
     MergeFont(language => $iso) if $iso;
     return; });

--- a/lib/LaTeXML/Package/csquotes.sty.ltxml
+++ b/lib/LaTeXML/Package/csquotes.sty.ltxml
@@ -27,11 +27,11 @@ InputDefinitions('csquotes', type => 'sty', noltxml => 1);
 ###########################################################################
 # Compatibility fixes
 
+# the unicode check does not work properly in LaTeXML
+# furthermore, package version <= 2018/04/06 v1.3b contain
+# a known bug, but might still be around.
+# therfore we skip the check here.
 RawTeX(<<'EoTeX');
-% the unicode check does not work properly in LaTeXML
-% furthermore, package version <= 2018/04/06 v1.3b contain
-% a known bug, but might still be around. 
-% therfore we skip the check here. 
 \def\csq@ifutfchar#1{%
   \ifundef\@inpenc@undefined
     {\@secondoftwo}
@@ -225,11 +225,11 @@ RawTeX(<<'EoTeX');
        {\unexpanded{\csq@switchlang{#3{#4}}}}}}%
   #1\csq@tempa#8#2%
   \end{\csq@blockenvironment}\ltxml@mkblockquote@close}
-
-% Because detection of word length does not work properly in LaTeXML
-% always use a proper block-quote environment
-\let\csq@bquote@ii\csq@bquote@iii
 EoTeX
+
+# Because detection of word length does not work properly in LaTeXML
+# always use a proper block-quote environment
+Let('\csq@bquote@ii', '\csq@bquote@iii');
 
 # update the 'quote' environment to be <ltx:quote class="ltx_blockquote">
 DefMacro('\ltxml@mkblockquote@open', '\begingroup\ltxml@mkblockquote@open@i');

--- a/lib/LaTeXML/Package/eTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/eTeX.pool.ltxml
@@ -44,7 +44,17 @@ DefMacro('\readline Number SkipKeyword:to SkipSpaces Token', sub {
     my ($gullet, $port, $token) = @_;
     $port = ToString($port);
     if (my $mouth = LookupValue('input_file:' . $port)) {
-      DefMacroI($token, undef, Tokens(Explode(($mouth->readRawLine || '') . "\r"))); }
+      my $line_string = ($mouth->readRawLine || '');
+      # DG: Can't we do this \endlinechar check in readRawLine ?!
+      # DG:  and can't we make it *faster* ?
+      if (my $eol = $STATE->lookupDefinition(T_CS('\endlinechar'))) {
+        my $eol   = $eol->valueOf()->valueOf;
+        my $eolch = (($eol > 0) && ($eol <= 255) ? chr($eol) : undef);
+        if ($eolch) {
+          $line_string .= $eolch; } }
+      else {
+        $line_string .= "\r"; }
+      DefMacroI($token, undef, Tokens(Explode($line_string))); }
     return; });
 
 DefMacro('\scantokens GeneralText', sub {


### PR DESCRIPTION
Fixes #1963 .

After the usual wild goose chases, I identified two causes for the test suite failing with the latest texlive 10.2022.
 1. We were missing support for `\the\font`, which I added via 
    - a special case in the `Register` parameter type
    - a special case in `\the`.
    - For now the PR returns a stub font CS, namely `\tenrm`
 2. The more sinister error was in the depths of expl3, namely loading of data `.txt` files, and in particular `SpecialCasing.txt` and `GraphemeBreakProperty.txt`
    - the fix here boiled down to respecting `\endlinechar` in the `\readline` reader in eTeX.
       - though that seems to slow down expl3 loading even further - maybe there is a faster way?


The font side is obvious, so I'll just add a bit of detail on the expl3 side:
After a multi-hour debugging session, I could reduce the exact cause to the empty lines in the 
data files, such as:
```
FB06; FB06; 0053 0074; 0053 0054; # LATIN SMALL LIGATURE ST

0587; 0587; 0535 0582; 0535 0552; # ARMENIAN SMALL LIGATURE ECH YIWN
```

Which in turn lead to finding the bit of code doing the reading, which relied on *both* `\endlinechar` and `\readline` and realizing we don't implement that correctly yet:
```tex
\cs_new_protected:Npn \__ior_str_get:NN #1#2
  {
    \exp_args:Nno \use:n
      {
        \int_set:Nn \tex_endlinechar:D { -1 }
        \tex_readline:D #1 to #2
        \int_set:Nn \tex_endlinechar:D
      }   { \int_use:N \tex_endlinechar:D }
  }
```

Curious to see if this PR passes CI on all texlives, but if it does - I think we can survive through yet another texlive update.