### PR TITLE
Hotfix for infinite loop in enumitem ref

### DIFF
--- a/lib/LaTeXML/Package/enumitem.sty.ltxml
+++ b/lib/LaTeXML/Package/enumitem.sty.ltxml
@@ -102,6 +102,11 @@ sub beginEnumItemize {
   }
   if (my $label = $$hash{ref}) {
     my $llabel = replace_star($label, T_OTHER($usecounter));
+    # This is a Hotfix.
+    # DG: what is the correct general implementation here?
+    # if $llabel contains "\the$usecounter", expand it, to avoid the inf. loop.
+    if (ToString($llabel) =~ "\Q\\the$usecounter\E") {
+      $llabel = Expand($llabel); }
     DefMacroI('\the' . $usecounter, undef, $llabel); }
   if (my $font = $$hash{font} || $$hash{format}) {
     DefMacroI('\fnum@font@' . $usecounter, undef, $font); }


### PR DESCRIPTION
Fixes #1966 . But only "the symptom".

For a general upgrade:

Maybe we ought to refactor/revisit the enumitem "ref" capability (and I need to learn more about it in general) to see if we can sidestep the quick-and-dirty internal use of `\theenumi` in latexml.

I see that the raw sty file uses a delayed expansion trick via `\enit@delayedkeys`, which may be something to emulate. But it is all so roundabout compared to the current binding code that I'd rather not touch it on a short notice - so just preventing an infinite loop in this PR.