### PR TITLE
Default the html language to "en"

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -87,9 +87,14 @@
     <xsl:element name="html" namespace="{$html_ns}">
       <xsl:apply-templates select="." mode="begin"/>
       <xsl:call-template name="add_RDFa_prefix"/>
-      <xsl:if test="*/@xml:lang">
-        <xsl:apply-templates select="*/@xml:lang" mode="copy-attribute"/>
-      </xsl:if>
+      <xsl:choose>
+        <xsl:when test="*/@xml:lang">
+          <xsl:apply-templates select="*/@xml:lang" mode="copy-attribute"/>
+        </xsl:when>
+        <xsl:otherwise><!-- the default language is English -->
+          <xsl:attribute name="lang">en</xsl:attribute>
+        </xsl:otherwise>
+      </xsl:choose>
       <xsl:apply-templates select="." mode="head"/>
       <xsl:apply-templates select="." mode="body"/>
       <xsl:apply-templates select="." mode="end"/>

--- a/t/daemon/formats/citation.xml
+++ b/t/daemon/formats/citation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1 plus MathML 2.0//EN" "http://www.w3.org/Math/DTD/mathml2/xhtml-math11-f.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
 <meta http-equiv="content-type" content="application/xhtml+xml; charset=UTF-8"/>
 <title>References</title>

--- a/t/daemon/formats/citationraw.xml
+++ b/t/daemon/formats/citationraw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1 plus MathML 2.0//EN" "http://www.w3.org/Math/DTD/mathml2/xhtml-math11-f.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
 <meta http-equiv="content-type" content="application/xhtml+xml; charset=UTF-8"/>
 <title>References</title>

--- a/t/daemon/formats/mixedmath.xml
+++ b/t/daemon/formats/mixedmath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1 plus MathML 2.0//EN" "http://www.w3.org/Math/DTD/mathml2/xhtml-math11-f.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
 <meta http-equiv="content-type" content="application/xhtml+xml; charset=UTF-8"/>
 <title>Untitled Document</title>

--- a/t/moderncv/cs_cv.html
+++ b/t/moderncv/cs_cv.html
@@ -139,7 +139,7 @@ nostrud exercitation ullamco laboris (nisi ut aliquip).</p>
 <p class="ltx_p">10/2014 – 11/2017</p>
 </div>
 <div class="ltx_block ltx_cv_item_content">
-<p class="ltx_p">Maker and Doer at Company Inc, Place 
+<p class="ltx_p">Maker and Doer at Company Inc, Place
 <br class="ltx_break">Homepage: <a href="https://www.example.com/" title="" class="ltx_ref ltx_url ltx_font_typewriter">https://www.example.com/</a></p>
 </div>
 </div>
@@ -148,7 +148,7 @@ nostrud exercitation ullamco laboris (nisi ut aliquip).</p>
 <p class="ltx_p">06/2007 – 09/2014</p>
 </div>
 <div class="ltx_block ltx_cv_item_content">
-<p class="ltx_p">Research assistant at the Assisted research group, Some University. Projects included A, B, C, D and E. 
+<p class="ltx_p">Research assistant at the Assisted research group, Some University. Projects included A, B, C, D and E.
 <br class="ltx_break">Homepage: <a href="http://www.example.com/" title="" class="ltx_ref ltx_url ltx_font_typewriter">http://www.example.com/</a></p>
 </div>
 </div>
@@ -167,7 +167,7 @@ nostrud exercitation ullamco laboris (nisi ut aliquip).</p>
 <p class="ltx_p">07/2009 – 09/2009</p>
 </div>
 <div class="ltx_block ltx_cv_item_content">
-<p class="ltx_p">Researcher at the Dept. of Foo Bar, Baz University. 
+<p class="ltx_p">Researcher at the Dept. of Foo Bar, Baz University.
 <br class="ltx_break">Homepage: <a href="http://www.example.com/" title="" class="ltx_ref ltx_url ltx_font_typewriter">http://www.example.com/</a></p>
 </div>
 </div>
@@ -176,7 +176,7 @@ nostrud exercitation ullamco laboris (nisi ut aliquip).</p>
 <p class="ltx_p">06/2008 – 08/2008</p>
 </div>
 <div class="ltx_block ltx_cv_item_content">
-<p class="ltx_p">Summer intern at the Great group, ABRV City. 
+<p class="ltx_p">Summer intern at the Great group, ABRV City.
 <br class="ltx_break">Homepage: <a href="http://www.example.com" title="" class="ltx_ref ltx_url ltx_font_typewriter">http://www.example.com</a></p>
 </div>
 </div>


### PR DESCRIPTION
Fixes #1626 .

- I defaulted to "en", since it is allowed, and we have no real reason to assume US over UK/AU.
- Only in XSLT, so that the default only impacts (X)HTML formats, where we know there is benefit.