### PR TITLE
only run t/83_expl3.t in CI mode

### DIFF
--- a/t/170_grammar_coverage.t
+++ b/t/170_grammar_coverage.t
@@ -13,7 +13,7 @@ use Data::Dumper;
 local $Data::Dumper::Sortkeys = 1;
 
 if (!$ENV{"CI"}) {
-  plan skip_all => "Only checked in continuous integration. (enable via: CI=true make test)";
+  plan skip_all => "Only checked in continuous integration. (set environment var CI=true and rerun tests)";
   done_testing();
   exit;
 }

--- a/t/170_grammar_coverage.t
+++ b/t/170_grammar_coverage.t
@@ -13,7 +13,7 @@ use Data::Dumper;
 local $Data::Dumper::Sortkeys = 1;
 
 if (!$ENV{"CI"}) {
-  plan skip_all => "Only checked in continuous integration. (set environment var CI=true and rerun tests)";
+  plan skip_all => "Only checked in continuous integration. (use make test CI=true)";
   done_testing();
   exit;
 }

--- a/t/170_grammar_coverage.t
+++ b/t/170_grammar_coverage.t
@@ -13,7 +13,7 @@ use Data::Dumper;
 local $Data::Dumper::Sortkeys = 1;
 
 if (!$ENV{"CI"}) {
-  plan skip_all => "Only checked in continuous integration.";
+  plan skip_all => "Only checked in continuous integration. (enable via: CI=true make test)";
   done_testing();
   exit;
 }

--- a/t/83_expl3.t
+++ b/t/83_expl3.t
@@ -7,7 +7,7 @@ use warnings;
 use LaTeXML::Util::Test;
 
 if (!$ENV{"CI"}) {
-  plan skip_all => "Only checked in continuous integration. (enable via: CI=true make test)";
+  plan skip_all => "Only checked in continuous integration. (set environment var CI=true and rerun tests)";
   done_testing();
   exit;
 }

--- a/t/83_expl3.t
+++ b/t/83_expl3.t
@@ -4,6 +4,12 @@
 #**********************************************************************
 use LaTeXML::Util::Test;
 
+if (!$ENV{"CI"}) {
+  plan skip_all => "Only checked in continuous integration.";
+  done_testing();
+  exit;
+}
+
 latexml_tests("t/expl3",
   requires => {
     tilde_tricks => {

--- a/t/83_expl3.t
+++ b/t/83_expl3.t
@@ -7,7 +7,7 @@ use warnings;
 use LaTeXML::Util::Test;
 
 if (!$ENV{"CI"}) {
-  plan skip_all => "Only checked in continuous integration. (set environment var CI=true and rerun tests)";
+  plan skip_all => "Only checked in continuous integration. (use make test CI=true)";
   done_testing();
   exit;
 }

--- a/t/83_expl3.t
+++ b/t/83_expl3.t
@@ -2,10 +2,12 @@
 #**********************************************************************
 # Test cases for LaTeXML
 #**********************************************************************
+use strict;
+use warnings;
 use LaTeXML::Util::Test;
 
 if (!$ENV{"CI"}) {
-  plan skip_all => "Only checked in continuous integration.";
+  plan skip_all => "Only checked in continuous integration. (enable via: CI=true make test)";
   done_testing();
   exit;
 }

--- a/t/97_manifest.t
+++ b/t/97_manifest.t
@@ -8,7 +8,7 @@ if ($ENV{"CI"}) {
   ok(!@$missing, "MANIFEST contains outdated files: \n\t".join("\n\t", @$missing));
   ok(!@$extra, "Files missing from MANIFEST: \n\t".join("\n\t", @$extra));
 } else {
-  plan skip_all => "Only checked in continuous integration.";
+  plan skip_all => "Only checked in continuous integration. (enable via: CI=true make test)";
 }
 
 done_testing();

--- a/t/97_manifest.t
+++ b/t/97_manifest.t
@@ -8,7 +8,7 @@ if ($ENV{"CI"}) {
   ok(!@$missing, "MANIFEST contains outdated files: \n\t".join("\n\t", @$missing));
   ok(!@$extra, "Files missing from MANIFEST: \n\t".join("\n\t", @$extra));
 } else {
-  plan skip_all => "Only checked in continuous integration. (enable via: CI=true make test)";
+  plan skip_all => "Only checked in continuous integration. (set environment var CI=true and rerun tests)";
 }
 
 done_testing();

--- a/t/97_manifest.t
+++ b/t/97_manifest.t
@@ -8,7 +8,7 @@ if ($ENV{"CI"}) {
   ok(!@$missing, "MANIFEST contains outdated files: \n\t".join("\n\t", @$missing));
   ok(!@$extra, "Files missing from MANIFEST: \n\t".join("\n\t", @$extra));
 } else {
-  plan skip_all => "Only checked in continuous integration. (set environment var CI=true and rerun tests)";
+  plan skip_all => "Only checked in continuous integration. (use make test CI=true)";
 }
 
 done_testing();


### PR DESCRIPTION
My patch in #1969 results in a more correct latexml interpretation of expl3, but it *also* results in a slower interpretation.

1. The `t/83_expl3.t` tests now take 7 minutes on my local PC, which has a decent CPU. 
    - In comparison, the second slowest test is `t/80_complex.t` which takes 3.5 minutes .

2. Separately, the expl3 test was a reason for raising a flag in the Debian "AutoPKG test suite", where the latexml package builds failed due to expl3 no longer loading error-free in interpretation.

3. I think it is a great goal to stay compatible with LaTeX 3, to keep that test, and to **always** run it in CI.

4. But at the same time I think regressions in our processing of LaTeX 3 should not be a reason for the latexml package builds to fail. Similarly to tikz, which may regress and we currently won't notice. Requiring every latexml user that builds from source to wait the extra time on every `make test` is considered too high a burden for tikz, and I think should now also be too high a burden for expl3.

I would be very happy to return the test to "always on" if we can get it back down to 3 minutes in runtime. Just my opinion, but I think the suggested change offers us a good trade-off.

So this PR switches the test to CI-only.