### PR TITLE
jheppub.sty : Handle \notoc and fix \arxivnumber

### DIFF
--- a/lib/LaTeXML/Package/jheppub.sty.ltxml
+++ b/lib/LaTeXML/Package/jheppub.sty.ltxml
@@ -46,7 +46,9 @@ DefMacro('\emailAdd Semiverbatim', '\@add@to@frontmatter{ltx:creator}{\@@@email{
 DefMacro('\keywordname', '\textbf{Keywords}');
 DefMacro('\keywords{}',  '\@add@frontmatter{ltx:keywords}[name={\keywordname}]{#1}');
 
-DefMacro('\artxivnumber{}', '\@add@frontmatter{ltx:note}[role=arxiv]{#1}');
+DefMacro('\arxivnumber{}', '\@add@frontmatter{ltx:note}[role=arxiv]{#1}');
+
+DefMacro('\notoc', '');
 
 DefMacro('\toccontinuoustrue', '');
 


### PR DESCRIPTION
`\notoc` is missing. It should be handled as an empty macro, since TOC is not created at all, for now.

`\artxivnumber{}` seems to be a typo of `\arxivnumber{}`

Reference:
https://jhep.sissa.it/jhep/help/JHEP/TeXclass/DOCS/JHEP-author-manual.pdf