### PR TITLE
declare Windows specific dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -74,6 +74,11 @@ WriteMakefile(NAME => 'LaTeXML',
     'Time::HiRes'       => 0,
     'URI'               => 0,
     'version'           => 0,
+    # Windows terminal handling (see Common::Error)
+    ($^O eq 'MSWin32'
+      ? ('Win32::Console' => 0,
+        'Win32::Console::ANSI' => 0)
+      : ()),
     # If we have an "old" version of XML::LibXML,
     # we also need XPathContext.
     # But we can't determine that additional dependence

--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -19,6 +19,13 @@ use LaTeXML::Core::Token qw(T_CS);
 use Time::HiRes;
 use Term::ANSIColor qw(colored colorstrip);
 
+my $IS_WINDOWS;
+
+BEGIN {
+  $IS_WINDOWS = $^O eq 'MSWin32';
+  require Win32::Console if $IS_WINDOWS;
+}
+
 use base qw(Exporter);
 our @EXPORT = (
   qw(&SetVerbosity),
@@ -71,7 +78,7 @@ sub UseSTDERR {
     *STDERR->autoflush();
 
     # Win32 console handling
-    if ($IS_TERMINAL && eval { require Win32::Console; }) {
+    if ($IS_WINDOWS && $IS_TERMINAL) {
       # set utf-8 codepage
       # CP_UTF8 = 65001
       Win32::Console::OutputCP(65001);


### PR DESCRIPTION
This PR fixes something ugly I did pre-0.8.6 to make LaTeXML work in Windows consoles, which is to try importing `Win32::Console` rather than properly checking the platform, declaring the `Win32::Console` dependency in the Makefile, etc.

To declare the PR done, I want to make it behave properly under `$^O eq 'cygwin'`, but my Windows machine is taking its time. In the meanwhile, I sense an impending release, so please let me know if there is something obviously wrong here!