### PR TITLE
add {algorithm*} env; minor definedness guard

### DIFF
--- a/lib/LaTeXML/Package/algorithm2e.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithm2e.sty.ltxml
@@ -59,36 +59,39 @@ DefMacro('\fnum@algorithm',      '\algorithmcfname\nobreakspace\thealgorithm');
 DefMacro('\fnum@font@algorithm', '\bf');
 DefMacro('\ext@algorithm',       'loa');
 
-DefEnvironment('{algorithm}[]',
-  "<ltx:float xml:id='#id'>"
-    . "#tags"
-    . "<ltx:listing class='ltx_lst_numbers_left'>"
-    . "<ltx:listingline>"
-    . "#body"
-    . "</ltx:listingline>"
-    . "</ltx:listing></ltx:float>",
-  properties   => { layout => 'vertical' },
-  beforeDigest => sub {
-    DigestIf(T_CS('\@ResetCounterIfNeeded'));
-    DigestIf(T_CS('\algocf@linesnumbered'));
-    Let('\par',    '\lx@algo@par');
-    Let('\parbox', '\lx@algo@parbox');
-    Let("\\\\",    '\lx@algo@par');
-    Let('\strut',  '\lx@algo@strut');
-    AssignCatcode("\r" => CC_SPACE);    # NOT CC_EOL, so newlines don't turn to \par!
-                                        #    AssignCatcode("\r" => 13);
-        #    Let(T_ACTIVE("\r"), '\relax');    # More appropriate than \par, I think?
+# {algorithm*}: same as {algorithm}, but used in a two columns text, so just map to original
+for my $env (qw(algorithm algorithm*)) {
+  DefEnvironment("{$env}[]",
+    "<ltx:float xml:id='#id'>"
+      . "#tags"
+      . "<ltx:listing class='ltx_lst_numbers_left'>"
+      . "<ltx:listingline>"
+      . "#body"
+      . "</ltx:listingline>"
+      . "</ltx:listing></ltx:float>",
+    properties   => { layout => 'vertical' },
+    beforeDigest => sub {
+      DigestIf(T_CS('\@ResetCounterIfNeeded'));
+      DigestIf(T_CS('\algocf@linesnumbered'));
+      Let('\par',    '\lx@algo@par');
+      Let('\parbox', '\lx@algo@parbox');
+      Let("\\\\",    '\lx@algo@par');
+      Let('\strut',  '\lx@algo@strut');
+      AssignCatcode("\r" => CC_SPACE);    # NOT CC_EOL, so newlines don't turn to \par!
+                                          #    AssignCatcode("\r" => 13);
+          #    Let(T_ACTIVE("\r"), '\relax');    # More appropriate than \par, I think?
 
-    #    Let('\vtop','\relax');      # ?
-    DefMacro('\;', '\ifmmode\@mathsemicolon\else\@endalgoln\fi');
-    beforeFloat('algorithm');
-  },
-  afterDigest => sub {
-    if (ToString(DigestIf(T_CS('\algocf@style'))) =~ /box/) {
-      $_[1]->setProperty(frame => 'boxed'); }
-    afterFloat($_[1]); },
-  afterConstruct => sub { addFloatFrames($_[0], $_[1]->getProperty('frame')); }
-);
+      #    Let('\vtop','\relax');      # ?
+      DefMacro('\;', '\ifmmode\@mathsemicolon\else\@endalgoln\fi');
+      beforeFloat('algorithm');
+    },
+    afterDigest => sub {
+      if (ToString(DigestIf(T_CS('\algocf@style'))) =~ /box/) {
+        $_[1]->setProperty(frame => 'boxed'); }
+      afterFloat($_[1]); },
+    afterConstruct => sub { addFloatFrames($_[0], $_[1]->getProperty('frame')); }
+  );
+}
 
 DefMacro('\lx@algo@parbox[]{}{}', '#3');
 # NEUTRALIZE most \par's that are built into agorythmic2e

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -730,14 +730,14 @@ sub stylizeContent {
     else {
       $text = ($iselement ? $item->getAttribute('name') || $item->getAttribute('meaning') || $role : '?');
       $color = 'red'; } }
-  elsif ($role eq 'ADDOP' and $text eq '-') {    # MathML Core prefers unicode minus
+  elsif ($role and ($role eq 'ADDOP') and $text eq '-') {    # MathML Core prefers unicode minus
     $text = "\x{2212}"; }
   if ($opacity) {
     $cssstyle = ($cssstyle ? $cssstyle . ';' : '') . "opacity:$opacity"; }
   if ($font && !$variant) {
     Warn('unexpected', $font, undef, "Unrecognized font variant '$font'"); $variant = ''; }
   # Special case for single char identifiers?
-  if (($tag eq 'm:mi') && ($text =~ /^.$/)) {    # Single char in mi? (what about m:ci?)
+  if (($tag eq 'm:mi') && ($text =~ /^.$/)) {                # Single char in mi? (what about m:ci?)
     if    ($variant eq 'italic') { $variant = undef; }         # Defaults to italic
     elsif (!$variant)            { $variant = 'normal'; } }    # must say so explicitly.
 


### PR DESCRIPTION
Fixes an easy Fatal error in arXiv:2112.00827, which was a cascade of errors coming from the `{algorithm*}` environment not being defined in the algorithm2e binding.

Easy, as it is likely harmless to reuse the main `{algorithm}` environment in latexml: the star variant is targeting 2-column layout in PDF.

I also spotted a minor definedness warning in post-processing in this article, adding that in as well.