### PR TITLE
glossaries.sty possible reliance on LaTeX 3

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -586,6 +586,7 @@ lib/LaTeXML/Package/mathptm.sty.ltxml
 lib/LaTeXML/Package/mathptmx.sty.ltxml
 lib/LaTeXML/Package/mathrsfs.sty.ltxml
 lib/LaTeXML/Package/mathtools.sty.ltxml
+lib/LaTeXML/Package/mfirstuc.sty.ltxml
 lib/LaTeXML/Package/microtype.sty.ltxml
 lib/LaTeXML/Package/minimal.cls.ltxml
 lib/LaTeXML/Package/mleftright.sty.ltxml

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -6238,6 +6238,8 @@ DefMacro('\DeclareDefaultHookRule{}{}{}', '');
 DefMacro('\ClearHookRule{}{}{}',          '');
 DefMacro('\IfHookEmptyTF{}{}{}',          '#3');
 DefMacro('\IfHookExistsTF{}{}{}',         '#3');
+DefMacro('\MakeTextLowercase',            '\lowercase');
+DefMacro('\MakeTextUppercase',            '\uppercase');
 
 DefConditional('\if@includeinrelease');
 Let('\@kernel@after@enddocument',               '\@empty');

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -7126,6 +7126,14 @@ foreach my $ltxtrigger (qw(documentclass
   typeout begin listfiles nofiles)) {
   DefAutoload($ltxtrigger, 'LaTeX.pool.ltxml'); }
 
+foreach my $ltx3trigger (qw(ExplSyntaxOn
+  ProvidesExplClass ProvidesExplPackage)) {
+  # DG: note that these auto-loads are not perfect --
+  #     if they are triggered with a raw .sty file for example,
+  #     the expl3 support will "expire" at the end of the current scope,
+  #     and e.g. \ExplSyntaxOn will once again be undefined.
+  DefAutoload($ltx3trigger, 'expl3.pool.ltxml'); }
+
 # Seemingly good candidates to trigger AmSTeX ??
 foreach my $amstrigger (qw(BlackBoxes NoBlackBoxes
   TagsAsMath TagsAsText TagsOnLeft TagsOnRight CenteredTagsOnSplits TopOrBottomTagsOnSplits

--- a/lib/LaTeXML/Package/mfirstuc.sty.ltxml
+++ b/lib/LaTeXML/Package/mfirstuc.sty.ltxml
@@ -1,0 +1,21 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  mfirstuc                                                         | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+LoadPool('expl3');
+InputDefinitions('mfirstuc', type => 'sty', noltxml => 1);
+
+1;

--- a/lib/LaTeXML/Package/revtex4_support.sty.ltxml
+++ b/lib/LaTeXML/Package/revtex4_support.sty.ltxml
@@ -269,9 +269,9 @@ DefEnvironment('{turnpage}', '#body');
 # XX.  Extra stuff
 #======================================================================
 
-Let('\MakeTextLowercase', '\lowercase');
-Let('\MakeTextUppercase', '\uppercase');
-DefMacro('\NoCaseChange', '');
+DefMacro('\MakeTextLowercase', '\lowercase');
+DefMacro('\MakeTextUppercase', '\uppercase');
+DefMacro('\NoCaseChange',      '');
 
 # Macro & Control stuff.
 #  Are these really intended for authors to use?


### PR DESCRIPTION
Fixes #1985 .

There are other possible approaches. This one tries to preserve the performance we have on pre-2022 texlives, trying to only load expl3 when needed.

Although I had to resort to explicitly loading expl3 in a new binding for mfirstuc.sty, as the several nested levels of loads appeared to make it impossible for the autoload to be visibile.

So overall, not really happy with this PR, but it keeps the test passing.