### PR TITLE
add missing stub for \bstctlcite

### DIFF
--- a/lib/LaTeXML/Package/IEEEtran.cls.ltxml
+++ b/lib/LaTeXML/Package/IEEEtran.cls.ltxml
@@ -415,6 +415,12 @@ Let('\biographynophoto',    '\IEEEbiographynophoto');
 Let('\endbiography',        '\endIEEEbiography');
 Let('\endbiographynophoto', '\endIEEEbiographynophoto');
 
+# The \bstctlcite command
+#    which is used to invoke a BibTeX style control bibliography entry that can alter the formatting of .bst files that support it (such as IEEEtran.bst).
+# see docs at http://www.michaelshell.org/tex/ieeetran/tools/
+# TODO: Maybe once we can emulate ".bst" files natively this comes into play?
+DefMacro('\bstctlcite[]{}', Tokens());
+
 #======================================================================
 
 1;


### PR DESCRIPTION
Minor, adds a missing macro that gets arXiv:1801.03552 from Error to a Warning status.

Maybe one day we can do more here, but it appears to hinge on raw `.bst` interpretation.