### PR TITLE
move away from using MathML <none>

### DIFF
--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -307,7 +307,7 @@ sub pmml_scriptsize {
   my ($script) = @_;
   local $LaTeXML::MathML::STYLE = $style_script_step{$LaTeXML::MathML::STYLE};
   local $LaTeXML::MathML::SIZE  = $stylesize{$LaTeXML::MathML::STYLE};
-  return ($script ? pmml($script) : ['m:none']); }
+  return ($script ? pmml($script) : ['m:mrow']); }
 
 sub pmml {
   my ($node) = @_;
@@ -1256,10 +1256,12 @@ DefMathML("Token:UNDERACCENT:?", \&pmml_mo, undef);
 DefMathML("Token:NUMBER:?", \&pmml_mn, sub {
     my $n = $_[0]->textContent;
     return ['m:cn', { type => ($n =~ /^[+-]?\d+$/ ? 'integer' : 'float') }, $n]; });
-DefMathML("Token:?:absent", sub { return ['m:mi', {}] });    # Not m:none!
-    # Hints normally would have disappeared during parsing
-    # (turned into punctuation or padding?)
-    # but if they survive (unparsed?) turn them into space
+
+DefMathML("Token:?:absent", sub { return ['m:mi', {}] });
+
+# Hints normally would have disappeared during parsing
+# (turned into punctuation or padding?)
+# but if they survive (unparsed?) turn them into space
 DefMathML('Hint:?:?', sub {
     my ($node) = @_;
     if (my $w = $node->getAttribute('width')) {

--- a/lib/LaTeXML/Post/MathML/Linebreaker.pm
+++ b/lib/LaTeXML/Post/MathML/Linebreaker.pm
@@ -1016,12 +1016,12 @@ sub asScripts {
 sub layout_msub {
   my ($node, $target, $level, $demerits) = @_;
   my ($base, $sub) = nodeChildren($node);
-  return asScripts($node, $target, $level, $demerits, 0, $base, $sub, ['m:none']); }
+  return asScripts($node, $target, $level, $demerits, 0, $base, $sub, ['m:mrow']); }
 
 sub layout_msup {
   my ($node, $target, $level, $demerits) = @_;
   my ($base, $sup) = nodeChildren($node);
-  return asScripts($node, $target, $level, $demerits, 0, $base, ['m:none'], $sup); }
+  return asScripts($node, $target, $level, $demerits, 0, $base, ['m:mrow'], $sup); }
 
 sub layout_msubsup {
   my ($node, $target, $level, $demerits) = @_;
@@ -1031,12 +1031,12 @@ sub layout_msubsup {
 sub layout_munder {
   my ($node, $target, $level, $demerits) = @_;
   my ($base, $sub) = nodeChildren($node);
-  return asScripts($node, $target, $level, $demerits, 1, $base, $sub, ['m:none']); }
+  return asScripts($node, $target, $level, $demerits, 1, $base, $sub, ['m:mrow']); }
 
 sub layout_mover {
   my ($node, $target, $level, $demerits) = @_;
   my ($base, $sup) = nodeChildren($node);
-  return asScripts($node, $target, $level, $demerits, 1, $base, ['m:none'], $sup); }
+  return asScripts($node, $target, $level, $demerits, 1, $base, ['m:mrow'], $sup); }
 
 sub layout_munderover {
   my ($node, $target, $level, $demerits) = @_;

--- a/t/math/sampler.tex
+++ b/t/math/sampler.tex
@@ -107,19 +107,19 @@ and \mml{mstyle}:
 \begin{equation}
  \frac{a}{b},\qquad
  \tfrac{a}{b},\qquad
- \dfrac{a}{b} 
+ \dfrac{a}{b}
 \end{equation}
-\begin{equation} 
- \binom{a}{b} 
+\begin{equation}
+ \binom{a}{b}
  \genfrac{}{}{0.0ex}{}{a}{b},\qquad
  \genfrac{}{}{0.01ex}{}{a}{b},\qquad
  \genfrac{}{}{0.1ex}{}{a}{b},\qquad
  \genfrac{}{}{1ex}{}{a}{b}
 \end{equation}
-\begin{equation} 
+\begin{equation}
  \genfrac{(}{)}{}{}{a}{b},\qquad
  \genfrac{(}{)}{}{}{a^2}{b^2},\qquad
- \genfrac{(}{)}{}{}{\int_a^b f(x)dx}{\int_a^b g(x)dx} 
+ \genfrac{(}{)}{}{}{\int_a^b f(x)dx}{\int_a^b g(x)dx}
 \end{equation}
 
 Roots \mml{msqrt} and \mml{mroot}, as well as enclosures \mml{menclose}:
@@ -130,7 +130,7 @@ Roots \mml{msqrt} and \mml{mroot}, as well as enclosures \mml{menclose}:
  \sqrt[3]{x},\qquad
  \root 3 \of {x},\qquad
  \boxed{x^2},\qquad
- \not{?} 
+ \not{?}
 \end{equation}
 
 % m:mstyle, @displaystyle, @scriptlevel
@@ -157,7 +157,7 @@ used only for errors: \mml{merror}.
 \section{Script and Limit Schemata}
 A variety of sub- and super-scripts (\mml{msub}, \mml{msup}, \mml{msubsup}),
 under- and over-scripts (\mml{munder}, \mml{mover}, \mml{munderover}),
-some as accents, and pre-scripts (\mml{multiscripts}, \mml{mprescripts}, \mml{none}).
+some as accents, and pre-scripts (\mml{multiscripts}, \mml{mprescripts}).
 % m:sub, m:sup, m:subsup
 
 \begin{equation}
@@ -167,7 +167,7 @@ some as accents, and pre-scripts (\mml{multiscripts}, \mml{mprescripts}, \mml{no
  a_{b},\qquad
  a_{b_{c}},\qquad
  a_{b_{c_ {d}}},\qquad
- a^{b}_{c} 
+ a^{b}_{c}
 \end{equation}
 
 % m:under, m:over, m:underover

--- a/t/math/sampler.xml
+++ b/t/math/sampler.xml
@@ -903,7 +903,7 @@ used only for errors: <text font="typewriter">m:merror</text>.</p>
     <para xml:id="S3.p1">
       <p>A variety of sub- and super-scripts (<text font="typewriter">m:msub</text>, <text font="typewriter">m:msup</text>, <text font="typewriter">m:msubsup</text>),
 under- and over-scripts (<text font="typewriter">m:munder</text>, <text font="typewriter">m:mover</text>, <text font="typewriter">m:munderover</text>),
-some as accents, and pre-scripts (<text font="typewriter">m:multiscripts</text>, <text font="typewriter">m:mprescripts</text>, <text font="typewriter">m:none</text>).</p>
+some as accents, and pre-scripts (<text font="typewriter">m:multiscripts</text>, <text font="typewriter">m:mprescripts</text>).</p>
     </para>
     <para xml:id="S3.p2">
       <equation xml:id="S3.E17">


### PR DESCRIPTION
This PR introduces the changes implied by [removing `<none>` in MathML Core](https://github.com/w3c/mathml-core/issues/173), by simply switching latexml's use of that element for an empty `<mrow>`.

---

### Open Question:

LaTeXML seemingly also has an interesting choice in the "gray zone" of the MathML spec, by using an empty `<mi></mi>` element for slots where it expected tokens, but they were "absent":
```perl
DefMathML("Token:?:absent", sub { return ['m:mi', {}] });
```

These _could_ also be transitioned to empty mrow elements, especially since they get used in the base child slot of `mmultiscripts`. As an example: `${}_a^b {}_c^d$`, produces:
```xml
  <mmultiscripts>
    <mi/>
    <mi>c</mi>
    <mi>d</mi>
    <mprescripts/>
    <mi>a</mi>
    <mi>b</mi>
  </mmultiscripts>
```

where the recommendation used to be a use of `<none/>` and is now transitioning to a use of `<mrow/>` instead.