### PR TITLE
ignore pagebreak within longtable

### DIFF
--- a/lib/LaTeXML/Package/longtable.sty.ltxml
+++ b/lib/LaTeXML/Package/longtable.sty.ltxml
@@ -24,10 +24,15 @@ DefMacro('\longtable[]{}',
   '\@longtable@bindings{#2}\@@longtable[#1]{#2}\@start@alignment');
 DefMacro('\endlongtable',
   '\@finish@alignment\@end@tabular');
-DefMacro('\csname longtable*\endcsname []{}',
-  '\@longtable@bindings{#2}\@@longtable[#1]{#2}\@start@alignment');
-DefMacro('\csname endlongtable*\endcsname',
-  '\@finish@alignment\@end@tabular');
+# {longtable*} is not defined in longtable.sty
+# and if we're trying to mimic {tabular*},
+# then this needs \endcsname{Dimension}[]{}
+#DefMacro('\csname longtable*\endcsname []{}',
+#  '\@longtable@bindings{#2}\@@longtable[#1]{#2}\@start@alignment');
+#DefMacro('\csname endlongtable*\endcsname',
+#  '\@finish@alignment\@end@tabular');
+
+DefMacro('\@gobble@optional[]', Tokens());
 
 DefConstructor('\@@longtable [] Undigested DigestedBody',
   "<ltx:table xml:id='#id' inlist='lot' labels='#label'>"
@@ -37,7 +42,7 @@ DefConstructor('\@@longtable [] Undigested DigestedBody',
     . "#3"
     . "</ltx:table>",
   reversion    => '\begin{longtable}[#1]{#2}#3\end{longtable}',
-  beforeDigest => sub { $_[0]->bgroup; },
+  beforeDigest => sub { $_[0]->bgroup; Let('\pagebreak', '\@gobble@optional'); },
   afterDigest  => sub {
     my ($stomach, $whatsit) = @_;
     $whatsit->setProperties(%{ LookupValue('LONGTABLE_PROPERTIES') || {} });

--- a/lib/LaTeXML/Package/longtable.sty.ltxml
+++ b/lib/LaTeXML/Package/longtable.sty.ltxml
@@ -24,13 +24,11 @@ DefMacro('\longtable[]{}',
   '\@longtable@bindings{#2}\@@longtable[#1]{#2}\@start@alignment');
 DefMacro('\endlongtable',
   '\@finish@alignment\@end@tabular');
-# {longtable*} is not defined in longtable.sty
-# and if we're trying to mimic {tabular*},
-# then this needs \endcsname{Dimension}[]{}
-#DefMacro('\csname longtable*\endcsname []{}',
-#  '\@longtable@bindings{#2}\@@longtable[#1]{#2}\@start@alignment');
-#DefMacro('\csname endlongtable*\endcsname',
-#  '\@finish@alignment\@end@tabular');
+# {longtable*} is defined in revtex4-1 to be able to span a two column document
+DefMacro('\csname longtable*\endcsname []{}',
+  '\@longtable@bindings{#2}\@@longtable[#1]{#2}\@start@alignment');
+DefMacro('\csname endlongtable*\endcsname',
+  '\@finish@alignment\@end@tabular');
 
 DefMacro('\@gobble@optional[]', Tokens());
 


### PR DESCRIPTION
This ignores `\pagebreak` within `{longtable}`, resolving #2000.  (I have checked that `\pagebreak` still works after the environment ends.)

This also removes the `{longtable*}` environment, which doesn't exist in TeXLive (and if it's supposed to mimic `{tabular*}{width}{colspec}`, then it's missing the `{width}` parameter).