### PR TITLE
Add "notoday" option for latexml.sty

### DIFF
--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -59,6 +59,9 @@ DeclareOption('rawclasses',     sub { AssignValue('INCLUDE_CLASSES' => 1,       
 DeclareOption('localrawclasses', sub { AssignValue('INCLUDE_CLASSES' => 'searchpaths', 'global'); });
 DeclareOption('norawclasses',    sub { AssignValue('INCLUDE_CLASSES' => 0, 'global'); });
 
+# No \today, useful when re-converting older archival articles
+DeclareOption('notoday', sub { DefMacro('\today', '\relax', locked => 1, scope => 'global'); });
+
 DefConstructor('\lx@save@parameter{}{}', sub {
     $_[0]->insertPI('latexml', ToString($_[1]) => $_[2]); });
 DefKeyVal('LTXML', 'dpi', 'Number', '', code => sub {


### PR DESCRIPTION
This PR adds a small option to latexml.sty, which allows to request disabling the `\today` macro.

This is motivated entirely by arXiv, where certain papers use the `\date{\today}` LaTeX idiom, which is only ever reasonable at the date when the article was originally submitted. 

Since we currently don't have a convenient handle on that submission metadata, a second-best workaround is to hide the date entirely in such cases, which I find simplest by disabling the `\today` macro in any arXiv conversion job.

It's opt-in only, and I expect only the arXiv builds will be using this in the near future.