### PR TITLE
Don't complicate mtext if no nested math

### DIFF
--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -492,7 +492,7 @@ sub pmml_internal {
   elsif ($tag eq 'ltx:XMText') {
     my @c = $node->childNodes;
     my $result;
-    if (!$$self{nestmath}) {
+    if (!$$self{nestmath} && $doc->findnodes('descendant::ltx:Math', $node)) {
       $result = pmml_row(map { pmml_text_aux($_) } @c); }
     else {
       $result = ['m:mtext', {}, $self->convertXMTextContent($doc, 1, @c)]; }

--- a/t/daemon/formats/lexmath.xml
+++ b/t/daemon/formats/lexmath.xml
@@ -32,7 +32,7 @@ Also <math id="p4.m3" class="ltx_Math" alttext="\mathit{func}" display="inline">
 
 <tbody><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
 <td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
-<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo>∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mo lspace="0.170em">⁢</mo><mrow><mo rspace="0em">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mrow><mtext>zero, </mtext><mtext mathvariant="italic">yes 0</mtext></mrow></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo>∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mo lspace="0.170em">⁢</mo><mrow><mo rspace="0em">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mtext>zero, <span class="ltx_text ltx_font_italic">yes 0</span></mtext></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
 <td class="ltx_eqn_cell ltx_eqn_center_padright"></td></tr></tbody>
 </table>
 </div>


### PR DESCRIPTION
As it says; was unnecessarily scanning the children of `XMText`, resulting in multiple `mtext`.

Fixes #1846