### PR TITLE
allow deep recursion in adjustBoxColor_rec; add \tikz@align@temp

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1935,6 +1935,7 @@ sub adjustBoxColor {
   return; }
 
 sub adjustBoxColor_rec {
+  no warnings 'recursion';
   my ($color, $adjusted, @boxes) = @_;
   foreach my $box (@boxes) {
     next unless defined $box;

--- a/lib/LaTeXML/Package/tikz.sty.ltxml
+++ b/lib/LaTeXML/Package/tikz.sty.ltxml
@@ -47,4 +47,6 @@ DefPrimitive('\use@@tikzlibrary{}', sub {
     } }
     return; });
 
+Let('\tikz@align@temp', '\relax');
+
 1;


### PR DESCRIPTION
Improves arXiv:2010.15940 from (deep recursion) Fatal to Warning status.

- simply allow for deep recursion in `adjustBoxColor_rec`
- start with a `\tikz@align@temp` that is defensively initialized to `\relax`

**Debugging details:**
<details>

Here is a Firefox screenshot of the responsible tikz diagram that had the recursion, after it succeeds in getting generated with the PR changes:

<img src="https://user-images.githubusercontent.com/348975/206768701-d9630829-5061-4405-b40f-2eb1c53d705e.png" width="600">

It still needs some upgrades to the sizing/measuring logic, but I think it is a rather good reasonable output compared to a Fatal error.

</details>
