### PR TITLE
Refix mtext nesting

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -441,11 +441,16 @@ DefMacroI('\today', undef, sub { ExplodeText(today()); });
 
 # Use fonts (w/ special flag) to propogate emphasis as a font change,
 # but preserve it's "emph"-ness.
-DefConstructor('\emph{}',
-  "<ltx:emph _force_font='1'>#1",
-  mode           => 'text', bounded => 1, font => { emph => 1 }, alias => '\emph',
-  afterConstruct => sub { $_[0]->maybeCloseElement('ltx:emph'); },
-  beforeDigest   => sub {
+# Use ltx:emph in text, but use ltx:text within math, since it may collapse within XMText
+# (and minimize html within math, which causes MathJax problems)
+DefConstructor('\emph{}', sub {
+    my ($document, $body, %props) = @_;
+    my $tag = ($document->findnodes('ancestor::ltx:Math', $document->getNode) ? 'ltx:text' : 'ltx:emph');
+    $document->openElement($tag, _force_font => 1, %props);
+    $document->absorb($body);
+    $document->maybeCloseElement($tag); },
+  mode         => 'text', bounded => 1, font => { emph => 1 }, alias => '\emph',
+  beforeDigest => sub {
     DefMacroI('\f@shape', undef,
       (ToString(Tokens(Expand(T_CS('\f@shape')))) eq 'it' ? 'n' : 'it')); });
 Tag('ltx:emph', autoClose => 1);
@@ -5244,7 +5249,7 @@ DefConstructor('\textup@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mod
   beforeDigest => sub { DefMacro('\f@shape', ''); });
 DefConstructor('\textit@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
   bounded      => 1, font => { shape => 'italic' }, alias => '\textit',
-  beforeDigest => sub { DefMacro('\f@shape', 'i'); });
+  beforeDigest => sub { DefMacro('\f@shape', 'it'); });
 DefConstructor('\textsl@math{}', "<ltx:text _noautoclose='1'>#1</ltx:text>", mode => 'text',
   bounded      => 1, font => { shape => 'slanted' }, alias => '\textsl',
   beforeDigest => sub { DefMacro('\f@shape', 'sl'); });

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -492,7 +492,7 @@ sub pmml_internal {
   elsif ($tag eq 'ltx:XMText') {
     my @c = $node->childNodes;
     my $result;
-    if (!$$self{nestmath} && $doc->findnodes('descendant::ltx:Math', $node)) {
+    if (!$$self{nestmath}) {
       $result = pmml_row(map { pmml_text_aux($_) } @c); }
     else {
       $result = ['m:mtext', {}, $self->convertXMTextContent($doc, 1, @c)]; }

--- a/t/daemon/formats/lexmath.xml
+++ b/t/daemon/formats/lexmath.xml
@@ -32,7 +32,7 @@ Also <math id="p4.m3" class="ltx_Math" alttext="\mathit{func}" display="inline">
 
 <tbody><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
 <td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
-<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo>∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mo lspace="0.170em">⁢</mo><mrow><mo rspace="0em">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mtext>zero, <span class="ltx_text ltx_font_italic">yes 0</span></mtext></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo>∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mo lspace="0.170em">⁢</mo><mrow><mo rspace="0em">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mrow><mtext>zero, </mtext><mtext mathvariant="italic">yes 0</mtext></mrow></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
 <td class="ltx_eqn_cell ltx_eqn_center_padright"></td></tr></tbody>
 </table>
 </div>


### PR DESCRIPTION
This is an alternative fix for #1846 to avoid breaking MathJax.  It basically reverts #2009, but defines `\emph` so as to use `ltx:text` when within math, rather than `ltx:emph`.   We can better distill `ltx:text` down to essentials, but `ltx:emph` sticks around and finds its way inside the eventual `m:mtext`.  MathJax can't cope with this. So (arguably) the issue in #1846 is not the `mathvariant` on `m:mtext`, but rather the redundant html `<em>` inside of it.
