### PR TITLE
Careful about CS that have already been tokenized in \lstinline

### DIFF
--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -284,6 +284,10 @@ sub listingsReadRawString {
         else         { $inmath = 1; $STATE = $SAVESTATE; } }
       if ($inmath && $token->equals(T_BEGIN)) {
         push(@tokens, T_BEGIN, $gullet->readBalanced->unlist, T_END); }
+      elsif (!$inmath && ($token->getCatcode == CC_CS)) {    # Dumb down CS if already seen by Gullet
+        my $name = $token->getString;
+        $name =~ s/^\\//;
+        push(@tokens, T_OTHER($name)); }
       else {
         push(@tokens, $token); } }
     while (@tokens && $tokens[-1]->getCatcode == CC_SPACE) {    # Remove trailing space


### PR DESCRIPTION
This PR dumbs down CS given to `\lstinline` that have already been tokenized by Gullet, eg within a `\caption'

fixes #1377 
(sorry for the delay!)
