### PR TITLE
Citationkey case

### DIFF
--- a/lib/LaTeXML/Post/CrossRef.pm
+++ b/lib/LaTeXML/Post/CrossRef.pm
@@ -514,9 +514,8 @@ sub make_bibcite {
   my @lists   = split(/\s+/, $bibref->getAttribute('inlist') || 'bibliography');
   foreach my $key (@keys) {
     my ($bentry, $id, $entry);
-    # NOTE: bibkeys are downcased when we look them up!
     foreach my $list (@lists) {            # Find the first of the lists that contains this bibkey
-      $bentry = $$self{db}->lookup("BIBLABEL:" . $list . ':' . lc($key));
+      $bentry = $$self{db}->lookup("BIBLABEL:" . $list . ':' . $key);
       last if $bentry; }
     if ($bentry
       && ($id    = $bentry->getValue('id'))

--- a/lib/LaTeXML/Post/Scan.pm
+++ b/lib/LaTeXML/Post/Scan.pm
@@ -380,7 +380,6 @@ sub bibref_handler {
       my @lists = (($l ? split(/\s+/, $l) : ()), 'bibliography');
       foreach my $bibkey (split(',', $keys)) {
         if ($bibkey) {
-          $bibkey = lc($bibkey);         # NOW we downcase!
           foreach my $list (@lists) {    # Records a *reference* to a bibkey! (for each list)
             my $entry = $$self{db}->register("BIBLABEL:$list:$bibkey");
             $entry->noteAssociation(referrers => $parent_id); } } } } }
@@ -460,10 +459,7 @@ sub bibitem_handler {
   my ($self, $doc, $node, $tag, $parent_id) = @_;
   my $id = $node->getAttribute('xml:id');
   if ($id) {
-    # NOTE: We didn't downcase the key when we created the bib file
-    # BUT, we're going to index it in the ObjectDB by the downcased name!!!
     my $key = $node->getAttribute('key');
-    $key = lc($key) if $key;
     my $bib = $doc->findnode('ancestor-or-self::ltx:bibliography', $node);
     # Probably should only be one list, but just in case?
     my @lists = split(/\s+/, ($bib && $bib->getAttribute('lists')) || 'bibliography');


### PR DESCRIPTION
Try to emulate BibTeX's (curious) behavior: It uses case-insensitive lookup to find entries in the bib file, but then uses the key with the case as cited for the aux file, since LaTeX's labels & cites are case-sensitive.

fixes #1674