### PR TITLE
patch \bibitem buglet in natbib

### DIFF
--- a/lib/LaTeXML/Package/natbib.sty.ltxml
+++ b/lib/LaTeXML/Package/natbib.sty.ltxml
@@ -537,6 +537,7 @@ DefMacro('\lx@NAT@parselabel{}{}', sub {
       if (Equals(T_CS('\citeauthoryear'), $cs)) {
         # \bibitem[\protect\citeauthoryear{Jones, Baker, and Williams}{Joneset al.}{1990}]{key}
         # \bibitem[\protect\citeauthoryear{Jones et al.}{1990}]{key}...
+        # \bibitem[\protect\citeauthoryear{Jones} {1990}]{key}...
         shift(@tokens);
         ($a1, @tokens) = NAT_peel_arg(@tokens);
         ($a2, @tokens) = NAT_peel_arg(@tokens);
@@ -586,7 +587,7 @@ sub NAT_peel_arg {
   if (!@tokens) {
     return; }
   elsif (@tokens && ($tokens[0]->getCatcode != CC_BEGIN)) {
-    return (pop(@tokens), @tokens); }
+    return (shift(@tokens), @tokens); }
   else {
     my $level = 1;
     shift(@tokens);


### PR DESCRIPTION
Feeling a little proud of spotting this one-liner PR.

There was a Fatal with `arXiv:1104.3156` due to a long chain of malformed ltx:bibitem of the form
```
Error:malformed:ltx:bibitem <ltx:bibitem> isn't allowed in <ltx:p> 
```

Upon inspection, this was due to a peculiar custom parsing algorithm in natbib.sty.ltxml, called `NAT_peel_arg`, which had a fascinating (and hard to hit) bug in using an array `pop` instead of `shift` in one of the recognized cases.

Changing that switches this Fatal to a Warning status.

### Debugging details

minimal TeX to reproduce:
```tex
\documentclass{article}
\usepackage{natbib}

\begin{document}

\begin{thebibliography}{1}
\bibitem[\protect\citeauthoryear{Chabrier} {2003}]{cha03} Test
\bibitem[Cooper et al.(2008)]{coo08} Test2
\end{thebibliography}
\end{document}
```