### PR TITLE
Guard against anonymous node names in math postprocessing

### DIFF
--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -947,7 +947,7 @@ sub checkDestination {
 
 sub stringify {
   my ($self) = @_;
-  return 'Post::Document[' . $self->siteRelativeDestination . ']'; }
+  return 'Post::Document[' . ($self->siteRelativeDestination || '') . ']'; }
 
 sub getLocator {
   my ($self) = @_;
@@ -1084,7 +1084,10 @@ sub addNodes {
   foreach my $child (@data) {
     if (ref $child eq 'ARRAY') {
       my ($tag, $attributes, @children) = @$child;
-      if ($tag eq '_Fragment_') {
+      if (!$tag) {
+        # don't add anonymous nodes? or?
+        next; }
+      elsif ($tag eq '_Fragment_') {
         my $indent;    # Derive indentation from indentation of $node
         if (my $pre = $node->previousSibling) {
           if (($pre->nodeType == XML_TEXT_NODE) && (($pre = $pre->textContent) =~ /^\s*$/)) {

--- a/lib/LaTeXML/Post/MathML/Presentation.pm
+++ b/lib/LaTeXML/Post/MathML/Presentation.pm
@@ -72,18 +72,18 @@ sub associateNodeHook {
   my ($self, $node, $sourcenode) = @_;
   # TODO: Shouldn't we have a single getQName shared for the entire latexml codebase
   #  in LaTeXML::Common or LaTeXML::Util ?
-  my $name = LaTeXML::Post::MathML::getQName($node);
-  if ($name =~ /^m:(?:mi|mo|mn)$/) {
-    if (my $href = $sourcenode->getAttribute('href')) {
-      if (ref $node eq 'ARRAY') {
-        $$node[1]{href} = $href; }
-      else {
-        $node->setAttribute('href', $href); } }
-    if (my $title = $sourcenode->getAttribute('title')) {
-      if (ref $node eq 'ARRAY') {
-        $$node[1]{title} = $title; }
-      else {
-        $node->setAttribute('title', $title); } } }
+  if (my $name = LaTeXML::Post::MathML::getQName($node)) {
+    if ($name =~ /^m:(?:mi|mo|mn)$/) {
+      if (my $href = $sourcenode->getAttribute('href')) {
+        if (ref $node eq 'ARRAY') {
+          $$node[1]{href} = $href; }
+        else {
+          $node->setAttribute('href', $href); } }
+      if (my $title = $sourcenode->getAttribute('title')) {
+        if (ref $node eq 'ARRAY') {
+          $$node[1]{title} = $title; }
+        else {
+          $node->setAttribute('title', $title); } } } }
   return; }
 
 #================================================================================


### PR DESCRIPTION
There are certain cases in arXiv where we get a barrage of warnings due to math nodes with `undef` names.

As one example, I believe empty XMHint elements can get constructed in some tabular contexts (just holding a `role` attribute) in the XMath processing. Which then (sometimes?) get mapped into nodes with `undef` names in post-processing. I think. I haven't fully dug down to the bottom of the cause for the nodes. But they are present in `arXiv:hep-ph9607289`, and I could imagine other strange TeX contraptions to induce them as well.

So, this PR cleans up what are about 112 warnings in that article, by defensively expecting `undef` in node name checks, at least in the code locations where I saw warnings being raised.

### Debugging details

In `arXiv:hep-ph9607289` there was an unreasonable number of warnings stemming from nodes with `undef` names (in the latexml "array-ref triple" data structure formulation).

A minimal example isolating that is:
```tex
\def\GeV{{\rm GeV}}
\def\lsim{\mathrel{\mathpalette\versim<}}
\catcode`@=11
\def\versim#1#2{\lower0.2ex\vbox{\baselineskip\z@skip\lineskip\z@skip
       \lineskiplimit\z@\ialign{$\m@th#1\hfil##$\crcr#2\crcr\sim\crcr}}}

(2~$\GeV\lsim Q_0\lsim4$~GeV)

\end
```

That 1996 construct actually runs through pdftex and typesets a neat-looking formula. What happens to it in latexml is a much bigger topic, one that we may (or may not) want to examine in the mid-term future. The currently generated MathML is not ideal, but at least "reminds of" the expected outcome.