### PR TITLE
allow more recursion on invokeToken

### DIFF
--- a/lib/LaTeXML/Core/Definition/Expandable.pm
+++ b/lib/LaTeXML/Core/Definition/Expandable.pm
@@ -55,6 +55,7 @@ sub getExpansion {
 
 # Expand the expandable control sequence. This should be carried out by the Gullet.
 sub invoke {
+  no warnings 'recursion';
   my ($self, $gullet, $onceonly) = @_;
   # shortcut for "trivial" macros; but only if not tracing & profiling!!!!
   my $tracing   = $STATE->lookupValue('TRACINGMACROS');

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -366,6 +366,7 @@ sub readXToken {
       && ($for_evaluation || !$$defn{isProtected})) { # is this the right logic here? don't expand unless di
       local $LaTeXML::CURRENT_TOKEN = $token;
       my $r;
+      no warnings 'recursion';
       my @expansion = map { (($r = ref $_) eq 'LaTeXML::Core::Token' ? $_
           : ($r eq 'LaTeXML::Core::Tokens' ? @$_
             : Error('misdefined', $r, undef, "Expected a Token, got " . Stringify($_),

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -153,8 +153,8 @@ our @CATCODE_ABSORBABLE = (    # [CONSTANT]
   0, 0, 0, 0);
 
 sub invokeToken {
-  my ($self, $token) = @_;
   no warnings 'recursion';
+  my ($self, $token) = @_;
 INVOKE:
   ProgressStep() if ($$self{progress}++ % $DIGESTION_PROGRESS_QUANTUM) == 0;
   push(@{ $$self{token_stack} }, $token);

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -995,6 +995,7 @@ DefPrimitive('\endcsname', sub {
     return; });
 
 DefMacro('\expandafter Token Token', sub {
+    no warnings 'recursion';
     my ($gullet, $tok, $xtok) = @_;
     my $defn;
     if (defined($defn = $STATE->lookupExpandable($xtok))) {

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2010,6 +2010,7 @@ DefParameterType('BoxSpecification', sub {
 # Risky: I think this needs to be digested as a body to work like TeX (?)
 # but parameter think's it's just parsing from gullet...
 sub readBoxContents {
+  no warnings 'recursion';
   my ($gullet, $everybox) = @_;
   my $t;
   while (($t = $gullet->readToken) && !Equals($t, T_BEGIN)) { }    # Skip till { or \bgroup
@@ -2993,6 +2994,7 @@ DefMacroI('\@tabular@end@heading', undef, sub {
 # This is the "normal" case: $ appearing with an alignment that is in text mode.
 # It's just like regular $, except it doesn't look for $$ (no display math).
 DefPrimitiveI('\@dollar@in@textmode', undef, sub {
+    no warnings 'recursion';
     $_[0]->invokeToken(T_CS((LookupValue('IN_MATH') ? '\@@ENDINLINEMATH' : '\@@BEGININLINEMATH'))); });
 
 # This one is for $ appearing within an alignment that's already math.
@@ -4337,6 +4339,7 @@ sub IsScript {
   return; }
 
 sub scriptHandler {
+  no warnings 'recursion';
   my ($stomach, $op) = @_;
   my $gullet = $stomach->getGullet;
   $gullet->skipSpaces;
@@ -4344,6 +4347,7 @@ sub scriptHandler {
   my $style    = $font->getMathstyle;
   my @putback  = ();
   my $nscripts = 0;
+
   if (defined $style) {
     my $cs = '\@@FLOATING' . $op;
     my ($prevscript, $prevspace, $base);


### PR DESCRIPTION
Avoids another deep recursion Fatal in arXiv, useful for some large tikz diagrams.

### Debugging details

<details>

Motivating tikz example screenshot from `arXiv:2210.11132`:

![onenode](https://user-images.githubusercontent.com/348975/206927645-c992af94-cac8-4b60-a9e8-7d5049ba516d.png)

That article recovers from Fatal to Error, in 8 minutes total conversion time.

</details>