### PR TITLE
allow to globally toggle line-breaking of UnTeX

### DIFF
--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -59,6 +59,10 @@ DeclareOption('rawclasses',     sub { AssignValue('INCLUDE_CLASSES' => 1,       
 DeclareOption('localrawclasses', sub { AssignValue('INCLUDE_CLASSES' => 'searchpaths', 'global'); });
 DeclareOption('norawclasses',    sub { AssignValue('INCLUDE_CLASSES' => 0, 'global'); });
 
+# Avoid extra line-breaks in UnTeX
+DeclareOption('breakuntex',   sub { AssignValue('SUPPRESS_UNTEX_LINEBREAKS' => 0, 'global'); });
+DeclareOption('nobreakuntex', sub { AssignValue('SUPPRESS_UNTEX_LINEBREAKS' => 1, 'global'); });
+
 DefConstructor('\lx@save@parameter{}{}', sub {
     $_[0]->insertPI('latexml', ToString($_[1]) => $_[2]); });
 DefKeyVal('LTXML', 'dpi', 'Number', '', code => sub {


### PR DESCRIPTION
Fixes #1393 .

This PR keeps the current behavior of latexml as-is, but it exposes a new global toggle through latexml.sty, which can set/unset the line-breaking **default** of the `UnTeX` helper subroutine. That can still be overridden using the optional second argument of `UnTeX`.

The expected use case (which I will test in the next ar5iv run) is to disable the line-breaks globally, via:

```bash
latexmlc  --preload=[nobreakuntex]latexml.sty \
  'literal:$111111111+2222222222+333333333+444444444+555555555+
            66666666+777777777+888888888+99999999$'
```

which will generate the tex attribute:
```
tex="111111111+2222222222+333333333+444444444+555555555+66666666+777777777+888888888+99999999"
```

in contrast the default would generate an extra line-break via `%\n`, as in:
```
tex="111111111+2222222222+333333333+444444444+555555555+66666666+777777777+88888888%&#10;8+99999999"
```

which is identical to the explicit `--preload=[breakuntex]latexml.sty`.

I have not allowed customizing the line length for the breaks, which is currently always 78, but I switched it to an `our` declaration, just in case. If accessing a variable length through State is also desired change, I can update the PR.