### PR TITLE
Mark mpadded with relative sizes as explicitly MathML Full

### DIFF
--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -546,11 +546,12 @@ sub pmml_maybe_resize {
       if (!$depth) {
         if ($yoff =~ /^-/) { $depth = $yoff; $depth =~ s/^-/+/; }
         else               { $depth = "-" . $yoff; } } }
-    $$attr{width}   = $width  if $width;
-    $$attr{height}  = $height if $height;
-    $$attr{depth}   = $depth  if $depth;
-    $$attr{lspace}  = $xoff   if $xoff;
-    $$attr{voffset} = $yoff   if $yoff; }
+    $$attr{width}   = $width        if $width;
+    $$attr{height}  = $height       if $height;
+    $$attr{depth}   = $depth        if $depth;
+    $$attr{class}   = "mathml-full" if ($width || $height || $depth);
+    $$attr{lspace}  = $xoff         if $xoff;
+    $$attr{voffset} = $yoff         if $yoff; }
 
   if (my $frame = $node->getAttribute('framed')) {
     my $attr  = $$result[1];


### PR DESCRIPTION
I had an idea for a compromise solution for the mpadded piece of PR #2019 .

Namely, in the cases where we continue to emit an mpadded with relative sizes for width, height or depth, we can also add a class attribute stating "mathml-full".

This way we can leave the decision to the specific deployment how to handle these cases (if at all). I have tested that there is a CSS rule which can avoid the current Chrome "collisions" on relative widths, such as:

```css
mpadded.mathml-full {
  width: initial;
  height: initial;
}
```

which I am happy to add for the possible remaining cases in the millions of yet-to-be-vetted arXiv pages.

Does this sound reasonable? 