### PR TITLE
apply CSS to parts in article

### DIFF
--- a/lib/LaTeXML/resources/CSS/ltx-article.css
+++ b/lib/LaTeXML/resources/CSS/ltx-article.css
@@ -17,12 +17,14 @@
    text-align:left; font-size: 100%; font-weight:bold; margin:0.5em 0 0 0; }
 
 .ltx_appendix,
-.ltx_section,   
+.ltx_part,
+.ltx_section,
 .ltx_subsection,
 .ltx_subsubsection { margin-top:1.5em; }
 .ltx_paragraph,
 .ltx_subparagraph   { margin-top:1.0em; }
 
+.ltx_title_part          { font-size:250%; font-weight:bold; margin-bottom:1em; }
 .ltx_title_appendix,
 .ltx_title_section,
 .ltx_title_index,


### PR DESCRIPTION
`\documentclass{article}` defines `\part` (just not `\chapter`).  We currently do not style the resulting html.  This PR applies the same styling to parts in articles that we apply to parts in books.