### PR TITLE
only run glossary and SI tests in CI

### DIFF
--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -86,13 +86,15 @@ sub check_requirements {
     next unless $reqmts;
     my @required_packages = ();
     my $texlive_min       = 0;
+    my $CI_only           = 0;
     if (!(ref $reqmts)) {
       @required_packages = ($reqmts); }
     elsif (ref $reqmts eq 'ARRAY') {
       @required_packages = @$reqmts; }
     elsif (ref $reqmts eq 'HASH') {
       @required_packages = (ref $$reqmts{packages} eq 'ARRAY' ? @{ $$reqmts{packages} } : $$reqmts{packages});
-      $texlive_min       = $$reqmts{texlive_min} || 0; }
+      $texlive_min       = $$reqmts{texlive_min} || 0;
+      $CI_only           = $$reqmts{CI_only}     || 0; }
     foreach my $reqmt (@required_packages) {
       if (pathname_kpsewhich($reqmt) || pathname_find($reqmt)) { }
       else {
@@ -103,6 +105,11 @@ sub check_requirements {
     # Check if specific texlive versions are required for this test
     if ($texlive_min && (texlive_version() < $texlive_min)) {
       my $message = "Minimal texlive $texlive_min requirement not met for $test";
+      diag("Skip: $message");
+      skip($message, $ntests);
+      return 0; }
+    if ($CI_only && !$ENV{"CI"}) {
+      my $message = "Test $test only runs in continuous integration";
       diag("Skip: $message");
       skip($message, $ntests);
       return 0; } }

--- a/t/50_structure.t
+++ b/t/50_structure.t
@@ -10,4 +10,5 @@ latexml_tests("t/structure",
     csquotes   => 'csquotes.sty',
     glossary   => {
       texlive_min => 2016,
+      CI_only => 1,
       packages    => 'glossaries.sty' } });

--- a/t/80_complex.t
+++ b/t/80_complex.t
@@ -7,4 +7,8 @@ use LaTeXML::Util::Test;
 latexml_tests("t/complex",
   requires => {
     cleveref_minimal => 'cleveref.sty',
-    si               => { packages => 'siunitx.sty', texlive_min => 2015 } });
+    si => {
+      packages => 'siunitx.sty',
+      CI_only=>1,
+      texlive_min => 2015
+    } });


### PR DESCRIPTION
This PR has the quick consensus resolution for getting OS packages to build after the #2044 report.

I added a `CI_only => 1` flag in the known test requirement fields, since we want to skip individual files, rather than the full `50_structure.t` or `80_complex.t` bundles.

Hopefully this looks good.