### PR TITLE
transitional state of columnspan + colspan synonym attributes

### DIFF
--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -468,7 +468,7 @@ sub pmml_internal {
         push(@cols, ['m:mtd', { ($a && ($a ne 'center')
                 ? (columnalign => $a, class => 'ltx_align_' . $a) : ()),
               ($c || $cl ? (class      => ($c && $cl ? "$c $cl" : $c || $cl)) : ()),
-              ($cs       ? (columnspan => $cs)                                : ()),
+              ($cs       ? (columnspan => $cs, colspan => $cs)                : ()),
               ($rs       ? (rowspan    => $rs)                                : ()) },
             @cell]); }
       $ncols = $nc if $nc > $ncols;


### PR DESCRIPTION
It is very easy to make the PR, although the outcome looks rather silly.

Tracking https://github.com/w3c/mathml-core/issues/180 , we *could* emit both variants of the `columnspan` attribute, until the newer `colspan` is available cross-browser.

Currently even with `colspan` set, the Chrome 109 rendering will *not* use the attribute, so this PR is likely to only become useful in Q2 of 2023 (or later)