### PR TITLE
Make ltx:text->span add class=ltx_inline-block if given a width

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-inline-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-inline-xhtml.xsl
@@ -36,7 +36,9 @@
     <xsl:element name="span" namespace="{$html_ns}">
       <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
-      <xsl:call-template name="add_attributes"/>
+      <xsl:call-template name="add_attributes">
+        <xsl:with-param name="extra_classes" select="f:if(@width,'ltx_inline-block','')"/>
+      </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
         <xsl:with-param name="context" select="$innercontext"/>
       </xsl:apply-templates>


### PR DESCRIPTION
When an `ltx:text` is given a `width` attribute (eg from `\makebox`), when it is converted to html's `span`, the width gets ignored since CSS doesn't allow width on inline elements. 

It would be tempting to have such constructors to create an `ltx:inline-block` instead of an `ltx:text`, but that also has a different content model and so introduces seemingly extraneous `ltx:p` elements, which seem unnatural.

This PR shifts the burden to the XSLT, since it is really CSS that has the "problem": When converting such an `ltx:text` to a `span`, if it has a `@width`, also add the class `ltx_inline-block`.   This seems to solve the immediate problem.

It also reveals a different one: that LaTeXML's sizes, which appear to be accurate within TeX's context, when re-expressed in HTML pts, with different, unknown, fonts, tends to become wrong.  I suspect that we really should be mapping to `rem` (not `em`, since that varies with context).  But `rem` is unnatural outside of a CSS context (it seems to me).  So this will need some experimentation.

It could also be (or not) that `rem` is a better solution to the SVG measurement mismatch?