### PR TITLE
align rules to baseline

### DIFF
--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -377,6 +377,8 @@ span.ltx_rowspan { position:absolute; top:0; bottom:0; }
 .ltx_framed_leftright { border-left-style:solid; border-left-width:1px;
                         border-right-style:solid; border-right-width:1px; }
 
+.ltx_rule { vertical-align: bottom; height: 0.4pt; width: 0.4pt; }
+
 /*======================================================================
  Misc */
 /* .ltx_verbatim*/


### PR DESCRIPTION
This aligns rules to the baseline, resolving #1995.  It also provides default dimensions (otherwise, vrules end up with a width of text-indent).  Some other notes:
* hrule should be in vertical mode but isn't.  (I think that's the correct terminology: TeX put the hrule on its own line and subsequent text on another line; LaTeXML put everything on the same line.)
* I don't appear to have html.sty, so I'm not sure what html.sty.ltxml is trying to emulate.
* TeX.pool.ltxml claims that hrule and vrule can appear [as rules within an alignment/table](https://github.com/brucemiller/LaTeXML/blob/c3aea809d9b677b8237103f9166dfb43328e5d0f/lib/LaTeXML/Package/TeX.pool.ltxml#L2353).  I was unable to see this behavior in LaTeXML: all tabular rules were rendered via a ltx:td/@ltx:border attribute, not a ltx:rule element.  Did I overlook some construction that would have resulted in ltx:rule?

The tex code I was using to test this out:

```tex
\documentclass{article}
\usepackage[lined]{algorithm2e}
\usepackage{xcolor}
\usepackage{latexml}
\iflatexml\usepackage{html}\fi
\begin{document}
A\rule{1cm}{.4pt}A
B\vrule height 1cm\relax B

C\hrule width 5cm\relax C

D\boxframe{5cm}{.1pt}{1cm}D

\begin{algorithm}[H]
  \If{understand}{go to next section\;}
\end{algorithm}

\iflatexml
E\htmlrule E
F\htmlrule*F
G\HTMLrule G
H\HTMLrule*H
\fi

\end{document}
```