### PR TITLE
floating marginpar

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3558,12 +3558,16 @@ DefMacro('\@dblfloatplacement', '');
 # C.9.2 Marginal Notes
 #======================================================================
 
-AssignValue(marginparclass => undef);
+DefConditional('\if@reversemargin');
+Let('\reversemarginpar', '\@reversemargintrue');
+Let('\normalmarginpar',  '\@reversemarginfalse');
 DefConstructor('\marginpar[]{}',
-  "<ltx:note role='margin' class='#class'><ltx:inline-para>#2</ltx:inline-para></ltx:note>",
-  properties => sub { (class => LookupValue('marginparclass')); });
-DefPrimitiveI('\reversemarginpar', undef, sub { AssignValue(marginparclass => 'ltx_marginpar_reverse'); });
-DefPrimitiveI('\normalmarginpar', undef, sub { AssignValue(marginparclass => undef); });
+  "<ltx:note role='margin' class='#class'><ltx:inline-para>#content</ltx:inline-para></ltx:note>",
+  properties => sub {
+    my $isReversed = IfCondition('\if@reversemargin');
+    my $class      = $isReversed             ? 'ltx_marginpar_reverse' : 'ltx_marginpar_normal';
+    my $content    = ($isReversed and $_[1]) ? $_[1]->toString         : $_[2]->toString;
+    return (class => $class, content => $content); });
 DefRegister('\marginparpush', Dimension(0));
 
 #**********************************************************************

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3562,12 +3562,9 @@ DefConditional('\if@reversemargin');
 Let('\reversemarginpar', '\@reversemargintrue');
 Let('\normalmarginpar',  '\@reversemarginfalse');
 DefConstructor('\marginpar[]{}',
-  "<ltx:note role='margin' class='#class'><ltx:inline-para>#content</ltx:inline-para></ltx:note>",
-  properties => sub {
-    my $isReversed = IfCondition('\if@reversemargin');
-    my $class      = 'ltx_marginpar_' . ($isReversed ? 'reverse' : 'normal');
-    my $content    = ($isReversed and $_[1]) ? $_[1] : $_[2];
-    return (class => $class, content => $content); });
+"?#1(<ltx:note role='margin' class='ltx_marginpar_left'><ltx:inline-para>#1</ltx:inline-para></ltx:note>"
+    . "?#2(<ltx:note role='margin' class='ltx_marginpar_right'><ltx:inline-para>#2</ltx:inline-para></ltx:note>))"
+    . "(<ltx:note role='margin' class='ltx_marginpar'><ltx:inline-para>#2</ltx:inline-para></ltx:note>)");
 DefRegister('\marginparpush', Dimension(0));
 
 #**********************************************************************
@@ -4708,11 +4705,11 @@ DefConstructor('\@framebox[Dimension][]{}',
     $stomach->beginMode('text');
     AssignValue(FRAME_IN_MATH => $wasmath); },
   properties => sub {
-    my $sep= LookupRegister('\fboxsep')->toAttribute;
+    my $sep = LookupRegister('\fboxsep')->toAttribute;
     (($_[2] ? (align => $makebox_alignment{ ToString($_[2]) }) : ()),
       framecolor => LookupValue('font')->getColor,
-     ($sep ne '3.0pt' ? (cssstyle   => 'padding:' . $sep):()),
-      ($_[1] ? (width => $_[1]) : ())); },
+      ($sep ne '3.0pt' ? (cssstyle => 'padding:' . $sep) : ()),
+      ($_[1]           ? (width    => $_[1])             : ())); },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my $wasmath = LookupValue('FRAME_IN_MATH');

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3565,8 +3565,8 @@ DefConstructor('\marginpar[]{}',
   "<ltx:note role='margin' class='#class'><ltx:inline-para>#content</ltx:inline-para></ltx:note>",
   properties => sub {
     my $isReversed = IfCondition('\if@reversemargin');
-    my $class      = $isReversed             ? 'ltx_marginpar_reverse' : 'ltx_marginpar_normal';
-    my $content    = ($isReversed and $_[1]) ? $_[1]->toString         : $_[2]->toString;
+    my $class      = 'ltx_marginpar_' . ($isReversed ? 'reverse' : 'normal');
+    my $content    = ($isReversed and $_[1]) ? $_[1] : $_[2];
     return (class => $class, content => $content); });
 DefRegister('\marginparpush', Dimension(0));
 

--- a/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
@@ -2,10 +2,13 @@
   (more sophisticated layout probably requires xslt) */
 .ltx_note.ltx_role_margin .ltx_note_mark { display:none; }
 .ltx_note.ltx_role_margin .ltx_note_type { display:none; }
+.ltx_note.ltx_role_margin {
+    margin-right: -15%; width:15%;
+    float: right; clear: right; }
 .ltx_note.ltx_role_margin .ltx_note_content {
     display:block;
-    position:absolute; left:83%; width:15%;
+    position:relative; right:-15%;
     background-color: transparent; border:0pt; }
 
 /* Narrower, to make room for marginpar */
-.ltx_page_main { width:80%; }
+.ltx_page_main { width:75%; }

--- a/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
@@ -2,13 +2,23 @@
   (more sophisticated layout probably requires xslt) */
 .ltx_note.ltx_role_margin .ltx_note_mark { display:none; }
 .ltx_note.ltx_role_margin .ltx_note_type { display:none; }
-.ltx_note.ltx_role_margin {
-    margin-right: -15%; width:15%;
-    float: right; clear: right; }
+.ltx_note.ltx_role_margin { width:15%; }
 .ltx_note.ltx_role_margin .ltx_note_content {
-    display:block;
-    position:relative; right:-15%;
-    background-color: transparent; border:0pt; }
+    display:block; position:relative;
+    background-color:transparent; border:0pt; }
+.ltx_note.ltx_role_margin.ltx_marginpar_reverse {
+    margin-left:-15%; float:left; clear:left; }
+.ltx_note.ltx_role_margin.ltx_marginpar_normal {
+    margin-right:-15%; float:right; clear:right; }
+.ltx_note.ltx_role_margin.ltx_marginpar_reverse .ltx_note_content { left:-15%; }
+.ltx_note.ltx_role_margin.ltx_marginpar_normal .ltx_note_content { right:-15%; }
 
-/* Narrower, to make room for marginpar */
-.ltx_page_main { width:75%; }
+/* Narrower, to make room for marginpar.
+ * We don't want to change .ltx_page_main, because navbar chnages that and
+ * these would interfere. */
+.ltx_page_main.ltx_has_marginpar_reverse .ltx_page_content {
+    left:15%; position:relative; }
+.ltx_page_main.ltx_has_marginpar_normal .ltx_page_content,
+.ltx_page_main.ltx_has_marginpar_reverse .ltx_page_content { width:85%; }
+.ltx_page_main.ltx_has_marginpar_normal.ltx_has_marginpar_reverse .ltx_page_content {
+    width:70%; }

--- a/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
@@ -6,21 +6,19 @@
 .ltx_note.ltx_role_margin .ltx_note_content {
     display:block; position:relative;
     background-color:transparent; border:0pt; }
-.ltx_note.ltx_role_margin.ltx_marginpar_reverse {
-    margin-left:-15%; float:left; clear:left; }
-.ltx_note.ltx_role_margin.ltx_marginpar_normal {
-    margin-right:-15%; float:right; clear:right; }
-.ltx_note.ltx_role_margin.ltx_marginpar_reverse .ltx_note_content { left:-15%; }
-.ltx_note.ltx_role_margin.ltx_marginpar_normal .ltx_note_content { right:-15%; }
 
 /* Narrower, to make room for marginpar.
  * We don't want to change .ltx_page_main, because navbar changes that and
- * these would interfere. */
-.ltx_page_main:has(.ltx_marginpar_reverse) .ltx_page_content {
-    left:15%; position:relative; }
-/* if there's either one */
-.ltx_page_main:has(.ltx_marginpar_normal,.ltx_marginpar_reverse) .ltx_page_content {
-    width:85%; }
-/* if there's both */
-.ltx_page_main:has(.ltx_marginpar_normal):has(.ltx_marginpar_reverse) .ltx_page_content {
-    width:70%; }
+ * this would interfere. */
+.ltx_page_main .ltx_page_content { width:85%; }
+
+.ltx_note.ltx_role_margin.ltx_marginpar,
+.ltx_note.ltx_role_margin.ltx_marginpar_right {
+    margin-right:-15%; float:right; clear:right; }
+.ltx_note.ltx_role_margin.ltx_marginpar .ltx_note_content,
+.ltx_note.ltx_role_margin.ltx_marginpar_right .ltx_note_content { right:-15%; }
+.ltx_note.ltx_role_margin.ltx_marginpar_left { display:none; }
+
+/* For left marginpar:
+ * swap all occurences of 'left' and 'right' and add
+ * .ltx_page_main .ltx_page_content { left:15%; position:relative; } */

--- a/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML-marginpar.css
@@ -14,11 +14,13 @@
 .ltx_note.ltx_role_margin.ltx_marginpar_normal .ltx_note_content { right:-15%; }
 
 /* Narrower, to make room for marginpar.
- * We don't want to change .ltx_page_main, because navbar chnages that and
+ * We don't want to change .ltx_page_main, because navbar changes that and
  * these would interfere. */
-.ltx_page_main.ltx_has_marginpar_reverse .ltx_page_content {
+.ltx_page_main:has(.ltx_marginpar_reverse) .ltx_page_content {
     left:15%; position:relative; }
-.ltx_page_main.ltx_has_marginpar_normal .ltx_page_content,
-.ltx_page_main.ltx_has_marginpar_reverse .ltx_page_content { width:85%; }
-.ltx_page_main.ltx_has_marginpar_normal.ltx_has_marginpar_reverse .ltx_page_content {
+/* if there's either one */
+.ltx_page_main:has(.ltx_marginpar_normal,.ltx_marginpar_reverse) .ltx_page_content {
+    width:85%; }
+/* if there's both */
+.ltx_page_main:has(.ltx_marginpar_normal):has(.ltx_marginpar_reverse) .ltx_page_content {
     width:70%; }

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -401,6 +401,7 @@ span.ltx_framed       { display:inline-block; text-indent:0; } /* avoid padding/
 .ltx_note:hover .ltx_note_content,
 .ltx_note .ltx_note_content:hover {
    display:block; position:absolute; z-index:10; }
+.ltx_note.ltx_marginpar_left { display:none; }
 
 .ltx_ERROR        { color:red; }
 .ltx_rdf          { display:none; }

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -403,13 +403,7 @@
   <xsl:template match="/" mode="body-main">
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
-      <xsl:attribute name="class">
-          <xsl:text>ltx_page_main</xsl:text>
-          <xsl:if test="//ltx:note[@role='margin'][@class='ltx_marginpar_reverse']"
-              > ltx_has_marginpar_reverse</xsl:if>
-          <xsl:if test="//ltx:note[@role='margin'][@class='ltx_marginpar_normal']"
-              > ltx_has_marginpar_normal</xsl:if>
-      </xsl:attribute>
+      <xsl:attribute name="class">ltx_page_main</xsl:attribute>
       <xsl:apply-templates select="." mode="body-main-begin"/>
       <xsl:apply-templates select="." mode="header"/>
       <xsl:apply-templates select="." mode="body-content"/>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -403,7 +403,13 @@
   <xsl:template match="/" mode="body-main">
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
-      <xsl:attribute name="class">ltx_page_main</xsl:attribute>
+      <xsl:attribute name="class">
+          <xsl:text>ltx_page_main</xsl:text>
+          <xsl:if test="//ltx:note[@role='margin'][@class='ltx_marginpar_reverse']"
+              > ltx_has_marginpar_reverse</xsl:if>
+          <xsl:if test="//ltx:note[@role='margin'][@class='ltx_marginpar_normal']"
+              > ltx_has_marginpar_normal</xsl:if>
+      </xsl:attribute>
       <xsl:apply-templates select="." mode="body-main-begin"/>
       <xsl:apply-templates select="." mode="header"/>
       <xsl:apply-templates select="." mode="body-content"/>


### PR DESCRIPTION
This allows marginpars to float (in the CSS sense), so that they display in order instead of overlapping, fixing #2041.  LaTeXML-marginpar.css doesn't appear to mesh well with LaTeXML-navbar-left.css (for example `.ltx_page_main { width }` is determined by which is loaded last), so I've not tried to resolve that.  On the other hand, if someone is loading both, then they will probably want their own css file anyway.

The tex code I was using to test this out:

```tex
\documentclass{article}
\usepackage{latexml}
\begin{lxNavbar}
\lxContextTOC
\end{lxNavbar}
\begin{document}
\section{Section Title}
A small amount of text.\marginpar{first}\marginpar{second second second second}
A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text. A large amount of text.
A large amount of text.\marginpar{third}\marginpar{fourth}
A small amount of text.
\end{document}
```
