### PR TITLE
latexmlc: Only unlink logfile when it is a regular file

### DIFF
--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -117,7 +117,7 @@ if (!$logfile) {
   $opts->set('log', $logfile); }
 # A bit special: Since LaTeXML.pm will always try to append to the log file
 # make sure the file is new before we start.
-unlink($logfile) if (-e $logfile);
+unlink($logfile) if (-f $logfile);
 
 #***************************************************************************
 # Prepare output variables:


### PR DESCRIPTION
As noted in #2069, `latexmlc` and friends were unlinking and re-creating logfiles. This was not a problem in the regular case, however on certain system when `make test` is run with root rights, this caused `/dev/null` to be deleted and re-created as a regular file.

This PR updates the behavior of `latexmlc` to only unlink the logfile if it is a regular file.

Fixes #2069.