### PR TITLE
Patch: attribute typo in "invisible" flag

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2378,7 +2378,7 @@ DefConstructor('\vrule RuleSpecification',
         || ((defined $h) && (defined $w) && ($h > 3 * $w))) {
         $whatsit->setProperty(isVerticalRule => 1) } }    # Marked as rule within alignment
     elsif ((defined $w) && ($w == 0)) {
-      $whatsit->setProperty(invishible => 1); }
+      $whatsit->setProperty(invisible => 1); }
     if (my $color = LookupValue('font')->getColor) {
       if ($color ne 'black') {
         $whatsit->setProperty(color => $color); } }


### PR DESCRIPTION
As it says. Spotted while auditing the alignment code (and small enough to fix fast).