### PR TITLE
Fix profiling

### DIFF
--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -278,6 +278,9 @@ sub convert {
           return $rescued; }); } }
   $$runtime{status}      = $latexml->getStatusMessage;
   $$runtime{status_code} = $latexml->getStatusCode;
+
+  $latexml->showProfile();    # Show profile (if any)
+
   # 2.2 Bookkeeping in case in-eval perl die() deaths occurred
   if ($eval_report) {
     $$runtime{status} .= "\n" . $eval_report . "\n";
@@ -701,6 +704,7 @@ sub new_latexml {
 
   # TODO: Do again, need to do this in a GOOD way as well:
   $latexml->digestFile($_, noinitialize => 1) foreach (@str_pre);
+
   return $latexml;
 }
 

--- a/lib/LaTeXML/Core/Definition.pm
+++ b/lib/LaTeXML/Core/Definition.pm
@@ -16,6 +16,7 @@ use LaTeXML::Global;
 use LaTeXML::Common::Object;
 use LaTeXML::Core::Token;
 use LaTeXML::Core::Parameters;
+use LaTeXML::Common::Error;
 use Time::HiRes;
 use base qw(LaTeXML::Common::Object);
 # Make these present, but do not import.
@@ -172,7 +173,7 @@ sub stopProfiling {
   while (@{$stack}) {
     my ($top, $topmode, $t0, $entry) = @{ $$stack[-1] };
     if ((($top ne $name) || ($topmode ne $mode)) && ($topmode ne 'expand')) {
-      return if $mode eq 'expand';                         # No error (yet) if this is a macro end marker.
+      return if $mode eq 'expand';    # No error (yet) if this is a macro end marker.
       Debug("PROFILE Error: ending $mode of $name but stack holds "
           . join(',', map { $$_[0] . '(' . $$_[1] . ')' } @$stack) . ", $top ($topmode)");
       return; }
@@ -192,7 +193,7 @@ sub stopProfiling {
     unless $mode eq 'expand';
   return; }
 
-our $MAX_PROFILE_ENTRIES = 30;                 # [CONSTANT]
+our $MAX_PROFILE_ENTRIES = 30;    # [CONSTANT]
 
 # Print out profiling information, if any was collected
 sub showProfile {
@@ -216,10 +217,9 @@ sub showProfile {
     Debug("Deepest :\n   "
         . join(', ', map { $_ . ':' . $$profile{$_}[1] } @deepest));
     Debug("Most expensive inclusive:\n   "
-        . join(', ', map { $_ . ':' . sprintf("%.2fs", $$profile{$_}[2]) } @inclusive));
+        . join(', ', map { $_ . ':' . sprintf("%.2fs/%d", $$profile{$_}[2], $$profile{$_}[0]) } @inclusive));
     Debug("Most expensive exclusive:\n   "
-        . join(', ', map { $_ . ':' . sprintf("%.2fs", $$profile{$_}[3]) } @exclusive));
-
+        . join(', ', map { $_ . ':' . sprintf("%.2fs/%d", $$profile{$_}[3], $$profile{$_}[0]) } @exclusive));
     my $stack = $STATE->lookupValue('runtime_stack');
     if (@$stack) {
       Debug("The following were never marked as done:\n  "

--- a/lib/LaTeXML/Core/Definition/Expandable.pm
+++ b/lib/LaTeXML/Core/Definition/Expandable.pm
@@ -20,7 +20,7 @@ use LaTeXML::Core::Token;
 use LaTeXML::Core::Tokens;
 use LaTeXML::Core::Parameters;
 use LaTeXML::Package qw(TokenizeInternal);
-use base qw(LaTeXML::Core::Definition);
+use base             qw(LaTeXML::Core::Definition);
 
 sub new {
   my ($class, $cs, $parameters, $expansion, %traits) = @_;
@@ -66,16 +66,15 @@ sub invoke {
   my $result;
   my $parms = $$self{parameters};
 
+  LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
   if ($iscode) {
     # Harder to emulate \tracingmacros here.
     my @args = ($parms ? $parms->readArguments($gullet, $self) : ());
-    LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     $result = Tokens(&$expansion($gullet, @args));
     if ($tracing || $LaTeXML::DEBUG{tracing}) {    # More involved...
       Debug($self->tracingCSName . ' ==> ' . tracetoString($result));
       Debug($self->tracingArgs(@args)) if @args; } }
   elsif (!$$self{parameters}) {                    # Trivial macro
-    LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     Debug($self->tracingCSName . ' ->' . tracetoString($expansion))
       if $tracing || $LaTeXML::DEBUG{tracing};
     # For trivial expansion, make sure we don't get \cs or \relax\cs direct recursion!
@@ -99,7 +98,6 @@ sub invoke {
     if ($tracing || $LaTeXML::DEBUG{tracing}) {    # More involved...
       Debug($self->tracingCSName . ' ->' . tracetoString($expansion));
       Debug($self->tracingArgs(@targs)) if @args; }
-    LaTeXML::Core::Definition::startProfiling($profiled, 'expand') if $profiled;
     $result = $expansion->substituteParameters(@targs); }
   # Getting exclusive requires dubious Gullet support!
   $result = Tokens($result, T_MARKER($profiled)) if $profiled;

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -489,7 +489,7 @@ sub readBalanced {
     elsif ($cc == CC_BEGIN) {
       $level++;
       push(@tokens, $token); }
-    elsif ($cc == CC_MARKER) {
+    elsif ($cc == CC_MARKER) {    # Really should already have been handled by read(X)Token
       LaTeXML::Core::Definition::stopProfiling($token, 'expand'); } }
   if ($level > 0) {
  # TODO: The current implementation has a limitation where if the balancing end is in a different mouth,
@@ -562,10 +562,15 @@ sub readUntil {
     while (($token = shift(@{ $$self{pushback} }) || $$self{mouth}->readToken())
       && (($$token[1] != CC_SMUGGLE_THE) || ($token = $$token[2]))
       && !$token->equals($want)) {
-      push(@tokens, $token);
-      if ($$token[1] == CC_BEGIN) {    # And if it's a BEGIN, copy till balanced END
+      my $cc = $$token[1];
+      if ($cc == CC_MARKER) {    # would have been handled by readToken, but we're bypassing
+        $self->handleMarker($token); }
+      elsif ($$token[1] == CC_BEGIN) {    # And if it's a BEGIN, copy till balanced END
+        push(@tokens, $token);
         $nbraces++;
-        push(@tokens, $self->readBalanced, T_END); } } }
+        push(@tokens, $self->readBalanced, T_END); }
+      else {
+        push(@tokens, $token); } } }
   else {
 
     my @ring = ();


### PR DESCRIPTION
This PR gets the profiling option (to `latexml.sty`) working again.

@dginev I've added a call to `LaTeXML.pm` so that `latexmlc` also provides reports, but I'm not sure I added in the ideal place.