### PR TITLE
also detect .ltx source files in ZIP input

### DIFF
--- a/lib/LaTeXML/Util/Pack.pm
+++ b/lib/LaTeXML/Util/Pack.pm
@@ -63,7 +63,7 @@ sub unpack_source {
 
   # I.2. Without an explicit directive,
   #      heuristically determine the input (borrowed from arXiv::FileGuess)
-  my @TeX_file_members = map { $_->fileName() } $zip_handle->membersMatching('\.[tT](:?[eE][xX]|[xX][tT])$');
+  my @TeX_file_members = map { $_->fileName() } $zip_handle->membersMatching('\.(?:[tT](:?[eE][xX]|[xX][tT])|ltx|LTX)$');
   if (!@TeX_file_members) {    # No .tex file? Try files with no, or unusually long, extensions
     @TeX_file_members = grep { !/\./ || /\.[^.]{4,}$/ } map { $_->fileName() } $zip_handle->members();
   }


### PR DESCRIPTION
An easy problem with an easy fix I stumbled on for [arXiv:2303.15130](https://arxiv.org/abs/2303.15130), which uses a `.ltx` format for its main TeX source.

Currently latexml's ZIP input only checks the extensions `.tex` and `.txt`. This PR also adds the `.ltx` variant, which recognizes that paper's source.