### PR TITLE
"implement" cmap.sty

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -425,6 +425,7 @@ lib/LaTeXML/Package/circuitikz.sty.ltxml
 lib/LaTeXML/Package/cite.sty.ltxml
 lib/LaTeXML/Package/citesort.sty.ltxml
 lib/LaTeXML/Package/cleveref.sty.ltxml
+lib/LaTeXML/Package/cmap.sty.ltxml
 lib/LaTeXML/Package/cmbright.sty.ltxml
 lib/LaTeXML/Package/color.sty.ltxml
 lib/LaTeXML/Package/colordvi.sty.ltxml

--- a/lib/LaTeXML/Package/cmap.sty.ltxml
+++ b/lib/LaTeXML/Package/cmap.sty.ltxml
@@ -1,0 +1,24 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  cmap.sty.ltxml                                                     | #
+# | Implementation for latexml                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Tim Prescott <teepeemm@gmail.com>                           #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+DeclareOption('resetfonts', undef);
+ProcessOptions();
+
+# The cmap package makes "search" and "copy-and-paste" functions work properly
+# in pdfs.  There's nothing we need to do.
+
+1;


### PR DESCRIPTION
With `--includestyles`, the package cmap causes a LaTeXML `Warning:latex:(cmap) Package cmap Warning: pdftex not detected - exiting`.  But the purpose of cmap is 'to make the PDF files generated by pdflatex "searchable and copyable"'.  Therefore, the only thing to do is check off any global options and exit successfully.

This is one possible fix for #2035.  It appears that we've already fixed the problem with `\PackageWarningNoLine{}{}` leading to an Error, so that issue is completely resolved.