### PR TITLE
Tracing optimization

### DIFF
--- a/lib/LaTeXML/Core/Definition/Conditional.pm
+++ b/lib/LaTeXML/Core/Definition/Conditional.pm
@@ -169,7 +169,7 @@ sub invoke_else {
     Debug('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
         . " [for " . ToString($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid}
         . " skipping to " . ToString($t) . "]")
-      if ($STATE->lookupValue('TRACING') || 0) & 2;
+      if ($STATE->lookupValue('TRACING') || 0) & TRACE_COMMANDS;
     return; } }
 
 sub invoke_fi {
@@ -187,7 +187,7 @@ sub invoke_fi {
     $STATE->shiftValue('if_stack');    # Done with this frame
     Debug('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
         . " [for " . Stringify($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid} . "]")
-      if ($STATE->lookupValue('TRACING') || 0) & 2;
+      if ($STATE->lookupValue('TRACING') || 0) & TRACE_COMMANDS;
     return; } }
 
 sub equals {

--- a/lib/LaTeXML/Core/Definition/Conditional.pm
+++ b/lib/LaTeXML/Core/Definition/Conditional.pm
@@ -66,7 +66,7 @@ sub invoke_conditional {
   my $parms = $$self{parameters};
   my @args  = ($parms ? $parms->readArguments($gullet) : ());
   $$LaTeXML::IFFRAME{parsing} = 0;    # Now, we're done parsing the Test clause.
-  my $tracing = ($STATE->lookupValue('TRACING') || 0) & 2;
+  my $tracing = ($STATE->lookupValue('TRACING') || 0) & TRACE_COMMANDS;
   if ($tracing) {
     Debug('{' . $self->tracingCSName . "} [#$ifid]");
     Debug($self->tracingArgs(@args)) if @args; }

--- a/lib/LaTeXML/Core/Definition/Conditional.pm
+++ b/lib/LaTeXML/Core/Definition/Conditional.pm
@@ -66,7 +66,7 @@ sub invoke_conditional {
   my $parms = $$self{parameters};
   my @args  = ($parms ? $parms->readArguments($gullet) : ());
   $$LaTeXML::IFFRAME{parsing} = 0;    # Now, we're done parsing the Test clause.
-  my $tracing = $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
+  my $tracing = ($STATE->lookupValue('TRACING') || 0) & 2;
   if ($tracing) {
     Debug('{' . $self->tracingCSName . "} [#$ifid]");
     Debug($self->tracingArgs(@args)) if @args; }
@@ -169,7 +169,7 @@ sub invoke_else {
     Debug('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
         . " [for " . ToString($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid}
         . " skipping to " . ToString($t) . "]")
-      if $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
+      if ($STATE->lookupValue('TRACING') || 0) & 2;
     return; } }
 
 sub invoke_fi {
@@ -187,7 +187,7 @@ sub invoke_fi {
     $STATE->shiftValue('if_stack');    # Done with this frame
     Debug('{' . ToString($LaTeXML::CURRENT_TOKEN) . '}'
         . " [for " . Stringify($$LaTeXML::IFFRAME{token}) . " #" . $$LaTeXML::IFFRAME{ifid} . "]")
-      if $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
+      if ($STATE->lookupValue('TRACING') || 0) & 2;
     return; } }
 
 sub equals {

--- a/lib/LaTeXML/Core/Definition/Constructor.pm
+++ b/lib/LaTeXML/Core/Definition/Constructor.pm
@@ -77,8 +77,8 @@ sub invoke {
   my ($self, $stomach) = @_;
   # Call any `Before' code.
   my $_tracing = $STATE->lookupValue('TRACING') || 0;
-  my $tracing  = ($_tracing & 2);
-  my $profiled = ($_tracing & 4) && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
+  my $tracing  = ($_tracing & TRACE_COMMANDS);
+  my $profiled = ($_tracing & TRACE_PROFILE) && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
 
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
 

--- a/lib/LaTeXML/Core/Definition/Constructor.pm
+++ b/lib/LaTeXML/Core/Definition/Constructor.pm
@@ -76,8 +76,10 @@ sub getNumArgs {
 sub invoke {
   my ($self, $stomach) = @_;
   # Call any `Before' code.
-  my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
-  my $tracing  = $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
+  my $_tracing = $STATE->lookupValue('TRACING') || 0;
+  my $tracing  = ($_tracing & 2);
+  my $profiled = ($_tracing & 4) && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
+
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
 
   my @pre = $self->executeBeforeDigest($stomach);

--- a/lib/LaTeXML/Core/Definition/Primitive.pm
+++ b/lib/LaTeXML/Core/Definition/Primitive.pm
@@ -52,8 +52,8 @@ sub executeAfterDigest {
 sub invoke {
   my ($self, $stomach) = @_;
   my $_tracing = $STATE->lookupValue('TRACING') || 0;
-  my $tracing  = ($_tracing & 2);                                              # tracing commands
-  my $profiled = ($_tracing & 4) && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
+  my $tracing  = ($_tracing & TRACE_COMMANDS);
+  my $profiled = ($_tracing & TRACE_PROFILE) && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
 
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
   Debug('{' . $self->tracingCSName . '}')                        if $tracing;

--- a/lib/LaTeXML/Core/Definition/Primitive.pm
+++ b/lib/LaTeXML/Core/Definition/Primitive.pm
@@ -51,8 +51,10 @@ sub executeAfterDigest {
 # Digest the primitive; this should occur in the stomach.
 sub invoke {
   my ($self, $stomach) = @_;
-  my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
-  my $tracing  = $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
+  my $_tracing = $STATE->lookupValue('TRACING') || 0;
+  my $tracing  = ($_tracing & 2);                                              # tracing commands
+  my $profiled = ($_tracing & 4) && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
+
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
   Debug('{' . $self->tracingCSName . '}')                        if $tracing;
   my @result = ($self->executeBeforeDigest($stomach));

--- a/lib/LaTeXML/Core/Definition/Register.pm
+++ b/lib/LaTeXML/Core/Definition/Register.pm
@@ -57,7 +57,7 @@ sub valueOf {
 
 sub setValue {
   my ($self, $value, $scope, @args) = @_;
-  my $tracing = (($STATE->lookupValue('TRACING') || 0) & 2);    # tracing commands
+  my $tracing = (($STATE->lookupValue('TRACING') || 0) & TRACE_COMMANDS);
   if ($tracing) {
     my $scope  = $STATE->getPrefix('global') ? 'globally ' : '';
     my $csname = ToString($$self{cs});
@@ -97,7 +97,7 @@ sub addValue {
 sub invoke {
   my ($self, $stomach) = @_;
   my $_tracing = $STATE->lookupValue('TRACING') || 0;
-  my $profiled = ($_tracing & 4) && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
+  my $profiled = ($_tracing & TRACE_PROFILE) && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
 
   my $gullet = $stomach->getGullet;

--- a/lib/LaTeXML/Core/Definition/Register.pm
+++ b/lib/LaTeXML/Core/Definition/Register.pm
@@ -57,7 +57,7 @@ sub valueOf {
 
 sub setValue {
   my ($self, $value, $scope, @args) = @_;
-  my $tracing = $STATE->lookupValue('TRACINGCOMMANDS') || $LaTeXML::DEBUG{tracing};
+  my $tracing = (($STATE->lookupValue('TRACING') || 0) & 2);    # tracing commands
   if ($tracing) {
     my $scope  = $STATE->getPrefix('global') ? 'globally ' : '';
     my $csname = ToString($$self{cs});
@@ -96,7 +96,8 @@ sub addValue {
 # (other than afterassign)
 sub invoke {
   my ($self, $stomach) = @_;
-  my $profiled = $STATE->lookupValue('PROFILING') && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
+  my $_tracing = $STATE->lookupValue('TRACING') || 0;
+  my $profiled = ($_tracing & 4) && ($LaTeXML::CURRENT_TOKEN || $$self{cs});
   LaTeXML::Core::Definition::startProfiling($profiled, 'digest') if $profiled;
 
   my $gullet = $stomach->getGullet;

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -210,7 +210,7 @@ sub beAbsorbed {
         "Whatsit absorb limit of $LaTeXML::ABSORB_LIMIT exceeded, infinite loop?"); } }
 
   my $defn     = $self->getDefinition;
-  my $profiled = (($STATE->lookupValue('TRACING') || 0) & 4) && $defn->getCS;
+  my $profiled = (($STATE->lookupValue('TRACING') || 0) & TRACE_PROFILE) && $defn->getCS;
   LaTeXML::Core::Definition::startProfiling($profiled, 'absorb') if $profiled;
   my @result = $defn->doAbsorbtion($document, $self);
   LaTeXML::Core::Definition::stopProfiling($profiled, 'absorb') if $profiled;

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -210,7 +210,7 @@ sub beAbsorbed {
         "Whatsit absorb limit of $LaTeXML::ABSORB_LIMIT exceeded, infinite loop?"); } }
 
   my $defn     = $self->getDefinition;
-  my $profiled = $STATE->lookupValue('PROFILING') && $defn->getCS;
+  my $profiled = (($STATE->lookupValue('TRACING') || 0) & 4) && $defn->getCS;
   LaTeXML::Core::Definition::startProfiling($profiled, 'absorb') if $profiled;
   my @result = $defn->doAbsorbtion($document, $self);
   LaTeXML::Core::Definition::stopProfiling($profiled, 'absorb') if $profiled;

--- a/lib/LaTeXML/Global.pm
+++ b/lib/LaTeXML/Global.pm
@@ -24,11 +24,17 @@ use strict;
 use warnings;
 use base qw(Exporter);
 our @EXPORT = (    # Global STATE; This gets bound by LaTeXML.pm
-  qw( *STATE),
+  qw( *STATE
+    TRACE_MACROS TRACE_COMMANDS TRACE_ALL TRACE_PROFILE
+  ),
 );
 
 #local $LaTeXML::STATE;
 
+use constant TRACE_MACROS   => 0x1;
+use constant TRACE_COMMANDS => 0x2;
+use constant TRACE_ALL      => 0x3;    # MACROS | COMMANDS
+use constant TRACE_PROFILE  => 0x4;
 #**********************************************************************
 1;
 

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1073,13 +1073,13 @@ DefMacro('\the Register', sub {
 # Integer registers; TeXBook p. 272-273
 
 DefRegister('\tracingmacros', Number(0),
-  getter => sub { Number((LookupValue('TRACING') || 0) & 1); },
+  getter => sub { Number((LookupValue('TRACING') || 0) & TRACE_MACROS); },
   setter => sub { my $p = (LookupValue('TRACING') || 0);
-    AssignValue(TRACING => ($_[0]->valueOf ? $p | 1 : $p & ~1)); });
+    AssignValue(TRACING => ($_[0]->valueOf ? $p | TRACE_MACROS : $p & ~TRACE_MACROS)); });
 DefRegister('\tracingcommands', Number(0),
-  getter => sub { Number((LookupValue('TRACING') || 0) & 2); },
+  getter => sub { Number((LookupValue('TRACING') || 0) & TRACE_COMMANDS); },
   setter => sub { my $p = (LookupValue('TRACING') || 0);
-    AssignValue(TRACING => ($_[0]->valueOf ? $p | 2 : $p & ~2)); });
+    AssignValue(TRACING => ($_[0]->valueOf ? $p | TRACE_COMMANDS : $p & ~TRACE_COMMANDS)); });
 {
   my %iparms = (
     pretolerance         => 100,   tolerance           => 200, hbadness => 1000, vbadness => 1000,

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1073,12 +1073,13 @@ DefMacro('\the Register', sub {
 # Integer registers; TeXBook p. 272-273
 
 DefRegister('\tracingmacros', Number(0),
-  getter => sub { Number(LookupValue('TRACINGMACROS') || 0); },
-  setter => sub { AssignValue(TRACINGMACROS => $_[0]->valueOf, $_[1]); });
+  getter => sub { Number((LookupValue('TRACING') || 0) & 1); },
+  setter => sub { my $p = (LookupValue('TRACING') || 0);
+    AssignValue(TRACING => ($_[0]->valueOf ? $p | 1 : $p & ~1)); });
 DefRegister('\tracingcommands', Number(0),
-  getter => sub { Number(LookupValue('TRACINGCOMMANDS')); },
-  setter => sub { AssignValue(TRACINGCOMMANDS => $_[0]->valueOf, $_[1]); });
-
+  getter => sub { Number((LookupValue('TRACING') || 0) & 2); },
+  setter => sub { my $p = (LookupValue('TRACING') || 0);
+    AssignValue(TRACING => ($_[0]->valueOf ? $p | 2 : $p & ~2)); });
 {
   my %iparms = (
     pretolerance         => 100,   tolerance           => 200, hbadness => 1000, vbadness => 1000,

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -34,10 +34,14 @@ DeclareOption('noids', sub { AssignValue('GENERATE_IDS' => 0, 'global'); });
 DeclareOption('comments',   sub { AssignValue('INCLUDE_COMMENTS' => 1, 'global'); });
 DeclareOption('nocomments', sub { AssignValue('INCLUDE_COMMENTS' => 0, 'global'); });
 
-DeclareOption('tracing',     sub { AssignValue(TRACING => (LookupValue('TRACING') || 0) | 3); });
-DeclareOption('notracing',   sub { AssignValue(TRACING => (LookupValue('TRACING') || 0) & ~3); });
-DeclareOption('profiling',   sub { AssignValue(TRACING => (LookupValue('TRACING') || 0) | 4); });
-DeclareOption('noprofiling', sub { AssignValue(TRACING => (LookupValue('TRACING') || 0) & ~4); });
+DeclareOption('tracing', sub {
+    AssignValue(TRACING => (LookupValue('TRACING') || 0) | TRACE_ALL); });
+DeclareOption('notracing', sub {
+    AssignValue(TRACING => (LookupValue('TRACING') || 0) & ~TRACE_ALL); });
+DeclareOption('profiling', sub {
+    AssignValue(TRACING => (LookupValue('TRACING') || 0) | TRACE_PROFILE); });
+DeclareOption('noprofiling', sub {
+    AssignValue(TRACING => (LookupValue('TRACING') || 0) & ~TRACE_PROFILE); });
 
 DeclareOption('mathparserspeculate',   sub { AssignValue('MATHPARSER_SPECULATE' => 1, 'global'); });
 DeclareOption('nomathparserspeculate', sub { AssignValue('MATHPARSER_SPECULATE' => 0, 'global'); });

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -34,8 +34,10 @@ DeclareOption('noids', sub { AssignValue('GENERATE_IDS' => 0, 'global'); });
 DeclareOption('comments',   sub { AssignValue('INCLUDE_COMMENTS' => 1, 'global'); });
 DeclareOption('nocomments', sub { AssignValue('INCLUDE_COMMENTS' => 0, 'global'); });
 
-DeclareOption('profiling',   sub { AssignValue('PROFILING' => 1, 'global'); });
-DeclareOption('noprofiling', sub { AssignValue('PROFILING' => 0, 'global'); });
+DeclareOption('tracing',     sub { AssignValue(TRACING => (LookupValue('TRACING') || 0) | 3); });
+DeclareOption('notracing',   sub { AssignValue(TRACING => (LookupValue('TRACING') || 0) & ~3); });
+DeclareOption('profiling',   sub { AssignValue(TRACING => (LookupValue('TRACING') || 0) | 4); });
+DeclareOption('noprofiling', sub { AssignValue(TRACING => (LookupValue('TRACING') || 0) & ~4); });
 
 DeclareOption('mathparserspeculate',   sub { AssignValue('MATHPARSER_SPECULATE' => 1, 'global'); });
 DeclareOption('nomathparserspeculate', sub { AssignValue('MATHPARSER_SPECULATE' => 0, 'global'); });

--- a/lib/LaTeXML/texmf/latexml.sty
+++ b/lib/LaTeXML/texmf/latexml.sty
@@ -18,6 +18,8 @@
 \DeclareOption{noids}{}
 \DeclareOption{comments}{}
 \DeclareOption{nocomments}{}
+\DeclareOption{tracing}{\tracingall}
+\DeclareOption{notracing}{\tracingnone}
 \DeclareOption{profiling}{}
 \DeclareOption{noprofiling}{}
 \DeclareOption{mathparserspeculate}{}


### PR DESCRIPTION
This combines the tracing and profiling flags into a single bitmask, which reduces the number of lookups required (and we're usually not tracing or profiling).  This is a performance boost since it is happening frequently and at lower level.

Yes, magic numbers; but context should make them clear & the hassle (in Perl) of faking constants isn't worth it.