### PR TITLE
$ctr is never used in \@startsection

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,8 +61,8 @@ jobs:
         # GitHub's CI environment comes with a preinstalled version of Strawberry Perl.
         # So first uninstall that one, then pick the version we want.
         run: |
-          cuninst -y strawberryperl
-          cinst -y strawberryperl --version ${{ matrix.perl }}
+          choco uninstall -y strawberryperl
+          choco install -y strawberryperl --version ${{ matrix.perl }}
 
       # ====================
       # Setup MiKTeX
@@ -89,7 +89,7 @@ jobs:
       - name: Install & Configure MiKTeX
         if: matrix.miktex != 'none'
         run: |
-          cinst -y miktex --version ${{ matrix.miktex }} --params '"/Set:complete /RepoPath:""C:\miktex-repo"" /Mirror:https://mirrors.rit.edu/CTAN/systems/win32/miktex/tm/packages/"'
+          choco install -y miktex --version ${{ matrix.miktex }} --params '"/Set:complete /RepoPath:""C:\miktex-repo"" /Mirror:https://mirrors.rit.edu/CTAN/systems/win32/miktex/tm/packages/"'
           echo "C:\Program Files\MiKTeX/miktex/bin/x64/" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
           Invoke-WebRequest -Uri "https://github.com/tkw1536/execsilent/releases/download/v0.0.2/execsilent-windows-amd64.exe" -OutFile C:\execsilent.exe

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -632,7 +632,6 @@ DefMacro('\@startsection{}{}{}{}{}{} OptionalMatch:*', sub {
       else {                    # otherwise, just unset the flag?
         $STATE->assignValue('IN_MATH' => 0, 'global'); } }
     ### Main logic
-    my $ctr = LookupValue('counter_for_' . ToString($type)) || ToString($type);
     $level = ToString($level);
     if ($flag) {                # No number, not in TOC
       (T_CS('\par'), T_CS('\@startsection@hook'), T_CS('\\@@unnumbered@section'),


### PR DESCRIPTION
A little compiler birdie told me that a `$ctr` very similar to the one we have in `\@startsection` is never used.

I double-checked and indeed, some wasted compute cycles can be eliminated. Enjoy!