### PR TITLE
Comments welcome

### DIFF
--- a/lib/LaTeXML/Common/XML.pm
+++ b/lib/LaTeXML/Common/XML.pm
@@ -75,7 +75,7 @@ our @EXPORT = (
     decodeFromUTF8  ),
   @XML::LibXML::EXPORT,
   # Possibly (later) export these utility functions
-  qw(&element_nodes &text_in_node &new_node
+  qw(&element_nodes &text_in_node &new_node &element_next &element_prev
     &append_nodes &clear_node &maybe_clone
     &valid_attributes &copy_attributes &rename_attribute &remove_attr
     &get_attr &isTextNode &isElementNode &isChild &isDescendant &isDescendantOrSelf
@@ -96,6 +96,20 @@ sub element_nodes {
 sub text_in_node {
   my ($node) = @_;
   return ($node ? join("\n", map { $_->data } grep { $_->nodeType == XML_TEXT_NODE } $node->childNodes) : ''); }
+
+sub element_next {
+  my ($node) = @_;
+  my $next;
+  while (($next = $node->nextSibling) && ($next->nodeType != XML_ELEMENT_NODE)) {
+    $node = $next; }
+  return $next; }
+
+sub element_prev {
+  my ($node) = @_;
+  my $prev;
+  while (($prev = $node->previousSibling) && ($prev->nodeType != XML_ELEMENT_NODE)) {
+    $node = $prev; }
+  return $prev; }
 
 sub isTextNode {
   my ($node) = @_;

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -196,6 +196,11 @@ sub show_pushback {
 #**********************************************************************
 # Low-level readers: read token, read expanded token
 #**********************************************************************
+# Get the next pending comment token (if any)
+sub getPendingComment {
+  my ($self) = @_;
+  return shift @{ $$self{pending_comments} } }
+
 # Note that every char (token) comes through here (maybe even twice, through args parsing),
 # So, be Fast & Clean!  This method only reads from the current input stream (Mouth).
 our @CATCODE_HOLD = (

--- a/lib/LaTeXML/Core/Parameter.pm
+++ b/lib/LaTeXML/Core/Parameter.pm
@@ -134,7 +134,7 @@ sub digest {
           my ($igullet) = @_;
           $igullet->unread($value);
           my @tokens = ();
-          while (defined(my $token = $igullet->readXToken(1, 1))) {
+          while (defined(my $token = $igullet->getPendingComment || $igullet->readXToken(1, 1))) {
             push(@tokens, $token); }
           $value = Tokens(@tokens);
           $value = $value->neutralize; }); } }

--- a/lib/LaTeXML/Core/Rewrite.pm
+++ b/lib/LaTeXML/Core/Rewrite.pm
@@ -159,7 +159,7 @@ sub applyClause {
     my $n     = $tree;
     for (my $i = 0 ; $n && ($i < $nmatched) ; $i++) {
       push(@nodes, $n);
-      $n = $n->nextSibling; }
+      $n = element_next($n); }
     if ($tree->hasAttribute('_has_wildcards')) {
       setAttributes_wild($document, $pattern, @nodes); }
     else {
@@ -234,7 +234,7 @@ sub markSeen {
   my ($node, $nsibs) = @_;
   for (my $i = 0 ; $node && ($i < $nsibs) ; $i++) {
     markSeen_rec($node);
-    $node = $node->nextSibling; }
+    $node = element_next($node); }
   return; }
 
 sub markSeen_rec {
@@ -273,7 +273,7 @@ sub unmarkWildcards {
 sub nth_sibling {
   my ($node, $n) = @_;
   my $nn = $node;
-  while ($nn && ($n > 1)) { $nn = $nn->nextSibling; $n--; }
+  while ($nn && ($n > 1)) { $nn = element_next($nn); $n--; }
   return $nn; }
 
 sub nth_child {

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2859,45 +2859,38 @@ sub DefLigature {
       %options });
   return; }
 
-my $old_math_ligature_options = {};                                                     # [CONSTANT]
-my $math_ligature_options     = { matcher => 1, role => 1, name => 1, meaning => 1 };   # [CONSTANT]
+my $math_ligature_options = { matcher => 1, role => 1, name => 1, meaning => 1 };    # [CONSTANT]
 
 sub DefMathLigature {
-  if ((scalar(@_) % 2) == 1) {                                                          # Old style!
-    my ($matcher, %options) = @_;
-    Info('deprecated', 'ligature', undef, "Old style arguments to DefMathLigature; please update");
-    CheckOptions("DefMathLigature", $old_math_ligature_options, %options);
-    UnshiftValue('MATH_LIGATURES', { old_style => 1, matcher => $matcher }); }          # Install it...
-  else {                                                                                # new style!
-    my (%options) = @_;
-    my $matcher = $options{matcher};
-    delete $options{matcher};
-    my ($pattern) = grep { !$$math_ligature_options{$_} } keys %options;
-    my $replacement = $pattern && $options{$pattern};
-    delete $options{$pattern} if $replacement;
-    CheckOptions("DefMathLigature", $math_ligature_options, %options);    # Check remaining options
-    if ($matcher && $pattern) {
-      Error('misdefined', 'MathLigature', undef,
-        "DefMathLigature only gets one of matcher or pattern=>replacement keywords");
-      return; }
-    elsif ($pattern) {
-      my @chars    = reverse(split(//, $pattern));
-      my $ntomatch = scalar(@chars);
-      my %attr     = %options;
-      $matcher = sub {
-        my ($document, $node) = @_;
-        foreach my $char (@chars) {
-          return unless
-            ($node
-            && ($document->getModel->getNodeQName($node) eq 'ltx:XMTok')
-            && (($node->textContent || '') eq $char));
-          $node = $node->previousSibling; }
-        return ($ntomatch, $replacement, %attr); }; }
-    elsif (!$matcher) {
-      Error('misdefined', 'MathLigature', undef,
-        "DefMathLigature missing matcher or pattern=>replacement keywords");
-      return; }
-    UnshiftValue('MATH_LIGATURES', { matcher => $matcher }); }    # Install it...
+  my (%options) = @_;
+  my $matcher = $options{matcher};
+  delete $options{matcher};
+  my ($pattern) = grep { !$$math_ligature_options{$_} } keys %options;
+  my $replacement = $pattern && $options{$pattern};
+  delete $options{$pattern} if $replacement;
+  CheckOptions("DefMathLigature", $math_ligature_options, %options);    # Check remaining options
+  if ($matcher && $pattern) {
+    Error('misdefined', 'MathLigature', undef,
+      "DefMathLigature only gets one of matcher or pattern=>replacement keywords");
+    return; }
+  elsif ($pattern) {
+    my @chars    = reverse(split(//, $pattern));
+    my $ntomatch = scalar(@chars);
+    my %attr     = %options;
+    $matcher = sub {
+      my ($document, $node) = @_;
+      foreach my $char (@chars) {
+        return unless
+          ($node
+          && ($document->getModel->getNodeQName($node) eq 'ltx:XMTok')
+          && (($node->textContent || '') eq $char));
+        $node = $node->previousSibling; }
+      return ($ntomatch, $replacement, %attr); }; }
+  elsif (!$matcher) {
+    Error('misdefined', 'MathLigature', undef,
+      "DefMathLigature missing matcher or pattern=>replacement keywords");
+    return; }
+  UnshiftValue('MATH_LIGATURES', { matcher => $matcher });    # Install it...
   return; }
 
 #======================================================================

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -686,7 +686,7 @@ DefConstructor('\@@numbered@section{} Undigested OptionalUndigested Undigested',
       $props{backmatterelement} = LookupMapping('BACKMATTER_ELEMENT', 'ltx:' . $type); }
     $props{title}    = $xtitle;
     $props{toctitle} = $xtoctitle
-      if $xtoctitle && $xtoctitle->unlist && (ToString($xtoctitle) ne ToString($xtitle));
+      if !IsEmpty($xtoctitle) && (ToString($xtoctitle) ne ToString($xtitle));
     return %props; });
 
 # No tags, at all? Consider...
@@ -1520,7 +1520,7 @@ sub RefStepItemCounter {
     $attr{itemsep} = $sep; }
   if (defined $tag) {
     my @props = RefStepID($counter);
-    if ((ref $tag) && !scalar($tag->unlist)) {    # empty tag?
+    if (IsEmpty($tag)) {    # empty tag?
       return (@props); }
     else {
       my $ttag      = (ref $tag              ? $tag                      : T_OTHER($tag));
@@ -3012,8 +3012,8 @@ sub defineNewTheorem {
   $listname =~ s/'/prime/g;
   $listname =~ s/\?/question/g;
   $listname =~ s/\#/hash/g;
-  $otherthmset = $otherthmset       && ToString($otherthmset);
-  $type        = undef unless $type && $type->unlist;
+  $otherthmset = $otherthmset && ToString($otherthmset);
+  $type        = undef if IsEmpty($type);
   $within      = $within ? ToString($within) : undef;
 
   my $counter = $otherthmset || $thmset;
@@ -3058,7 +3058,7 @@ sub defineNewTheorem {
   # if there was one defined, use it, else define a new one.
   my $headformatter = LookupRegister('\thm@headformatter');
   DefMacroI('\format@title@' . $thmset, convertLaTeXArgs(1, 0),
-    ($headformatter->unlist
+    (!IsEmpty($headformatter)
       ? Tokens(
         T_CS('\the'), T_CS('\thm@headfont'),
         $headformatter->unlist,
@@ -4247,7 +4247,7 @@ DefMacro('\cite[] Semiverbatim', sub {
     my ($gullet, $post, $keys) = @_;
     my ($style, $open, $close, $ns)
       = map { LookupValue($_) } qw(CITE_STYLE CITE_OPEN CITE_CLOSE CITE_NOTE_SEPARATOR);
-    $post = undef unless $post && $post->unlist;
+    $post = undef if IsEmpty($post);
     Invocation(T_CS('\@@cite'),
       Tokens(Explode('cite')),
       Tokens($open,

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -4297,26 +4297,6 @@ DefConstructor('\@@eqno{}',
 # This may combine, in the parser, with the following object to generate
 # a prescript.
 
-# Note that this is also being used by alignment.
-sub IsEmpty {
-  my ($box) = @_;
-  my $ref = ref $box;
-  if    (!$box)                            { return 1; }
-  elsif ($ref eq 'LaTeXML::Core::Comment') { return 1; }
-  elsif ($box->getProperty('isEmpty')
-    || $box->getProperty('isSpace')) {    # A space-like thing
-    return 1; }
-  elsif ($ref eq 'LaTeXML::Core::Box') {
-    my $s = $box->getString;
-    return (!defined $s) || ($s =~ /^\s*$/); }
-  elsif ($ref eq 'LaTeXML::Core::List') {
-    return !grep { !IsEmpty($_) } $box->unlist; }
-  elsif ($ref eq 'LaTeXML::Core::Whatsit') {
-    if (($box->getDefinition eq $STATE->lookupDefinition(T_BEGIN))
-      && !grep { !IsEmpty($_) } $box->getBody->unlist) {
-      return 1; } }
-  return 0; }
-
 # Remember a "safe" way to test a script Whatsit.
 # Returns [ (FLOATING|POST) , (SUBSCRIPT|SUPERSCRIPT) ] or nothing
 sub IsScript {
@@ -7295,9 +7275,9 @@ DefConstructor('\lx@superscript OptionalKeyVals:XMath {} InScriptStyle',
     my ($whatsit, $kv, $base, $sup) = @_;
     my $bump = $whatsit->getProperty('bump');
     $bump = 1;    # For now: ALWAYS {} wrap base in the reversion!
-    ($sup && $sup->unlist
-      ? (($bump ? (T_BEGIN, Revert($base), T_END) : Revert($base)), T_SUPER, revertScript($sup))
-      : Revert($base)); },
+    (IsEmpty($sup)
+      ? Revert($base)
+      : (($bump ? (T_BEGIN, Revert($base), T_END) : Revert($base)), T_SUPER, revertScript($sup))); },
   properties => sub {
     my ($stomach, $kv, $base, $script) = @_;
     my $basetype = IsScript($base);
@@ -7317,10 +7297,9 @@ DefConstructor('\lx@subscript OptionalKeyVals:XMath {} InScriptStyle',
     my ($whatsit, $kv, $base, $sub) = @_;
     my $bump = $whatsit->getProperty('bump');
     $bump = 1;    # For now: ALWAYS {} wrap base in the reversion!
-    ($sub && $sub->unlist
-###      ? (T_BEGIN, Revert($base), T_END, T_SUB, revertScript($sub))
-      ? (($bump ? (T_BEGIN, Revert($base), T_END) : Revert($base)), T_SUB, revertScript($sub))
-      : Revert($base)); },
+    (IsEmpty($sub)
+      ? Revert($base)
+      : (($bump ? (T_BEGIN, Revert($base), T_END) : Revert($base)), T_SUB, revertScript($sub))); },
   properties => sub {
     my ($stomach, $kv, $base, $script) = @_;
     my $basetype = IsScript($base);

--- a/lib/LaTeXML/Package/amscd.sty.ltxml
+++ b/lib/LaTeXML/Package/amscd.sty.ltxml
@@ -69,7 +69,7 @@ DefMacroI(T_CS('@.'), undef,
 # Horizontal
 DefMath('\@cd@equals@', "=", role => 'ARROW', stretchy => 'true', reversion => '@=');
 # Vertical
-DefMath('\@cd@bar@', "|", role => 'ARROW', font => { size => 'Big' }, reversion => '@|');
+DefMath('\@cd@bar@',  "|",        role => 'ARROW', font => { size => 'Big' }, reversion => '@|');
 DefMath('\@cd@vert@', "\x{2225}", role => 'ARROW', font => { size => 'Big' }, reversion => '@\vert');
 
 DefRegister('\minaw@' => Dimension('11.111pt'));
@@ -77,10 +77,10 @@ DefRegister('\minaw@' => Dimension('11.111pt'));
 DefConstructor('\cd@stack Undigested {} ScriptStyle ScriptStyle', sub {
     my ($document, $reversion, $op, $over, $under, %props) = @_;
     my $scriptpos = $props{scriptpos};
-    if ($under->unlist) {
+    if (!IsEmpty($under)) {
       $document->openElement('ltx:XMApp', role => 'ARROW');    # Role?
       $document->insertElement('ltx:XMTok', undef, role => 'SUBSCRIPTOP', scriptpos => $scriptpos);
-      if ($over->unlist) {
+      if (!IsEmpty($over)) {
         $document->openElement('ltx:XMApp');                   # Role?
         $document->insertElement('ltx:XMTok', undef, role => 'SUPERSCRIPTOP', scriptpos => $scriptpos);
         $document->insertElement('ltx:XMArg', $op);
@@ -90,8 +90,8 @@ DefConstructor('\cd@stack Undigested {} ScriptStyle ScriptStyle', sub {
         $document->insertElement('ltx:XMArg', $op); }
       $document->insertElement('ltx:XMArg', $under);
       $document->closeElement('ltx:XMApp'); }
-    elsif ($over->unlist) {
-      $document->openElement('ltx:XMApp');                     # Role?
+    elsif (!IsEmpty($over)) {
+      $document->openElement('ltx:XMApp');    # Role?
       $document->insertElement('ltx:XMTok', undef, role => 'SUPERSCRIPTOP', scriptpos => $scriptpos);
       $document->insertElement('ltx:XMArg', $op);
       $document->insertElement('ltx:XMArg', $over);
@@ -107,9 +107,9 @@ DefConstructor('\cd@stack Undigested {} ScriptStyle ScriptStyle', sub {
 DefConstructor('\cd@adjacent Undigested {} ScriptStyle ScriptStyle', sub {
     my ($document, $reversion, $op, $left, $right, %props) = @_;
     $document->openElement('ltx:XMWrap', role => 'ARROW');    # Role?
-    $document->insertElement('ltx:XMArg', $left) if $left->unlist;
+    $document->insertElement('ltx:XMArg', $left) unless IsEmpty($left);
     $document->insertElement('ltx:XMArg', $op);
-    $document->insertElement('ltx:XMArg', $right) if $right->unlist;
+    $document->insertElement('ltx:XMArg', $right) unless IsEmpty($right);
     $document->closeElement('ltx:XMWrap'); },
   reversion => '@#1{#3}#1{#4}#1');
 

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -803,10 +803,10 @@ DefConstructor('\lx@ams@matrix@ RequiredKeyVals:lx@GEN DigestedBody',
     my $nc = ($alignment ? scalar(@{ $$alignment{columnwidths} }) : 0);
     (($nc > 10 ? Invocation(T_CS('\setcounter'), T_OTHER('MaxMatrixCols'), T_OTHER($nc)) : ()),
       ($name ? (T_CS('\begin'), T_BEGIN, Revert($name), T_END) : ()),
-      ($align && $align->unlist ?
-          ($kv->getValue('alignment-required')
-          ? (T_BEGIN, Revert($align), T_END) : (T_OTHER('['), Revert($align), T_OTHER(']')))
-        : ()),
+      (IsEmpty($align)
+        ? ()
+        : ($kv->getValue('alignment-required')
+          ? (T_BEGIN, Revert($align), T_END) : (T_OTHER('['), Revert($align), T_OTHER(']')))),
       Revert($body),
       ($name ? (T_CS('\end'), T_BEGIN, Revert($name), T_END) : ())); }
 );

--- a/lib/LaTeXML/Package/amsppt.sty.ltxml
+++ b/lib/LaTeXML/Package/amsppt.sty.ltxml
@@ -426,7 +426,7 @@ DefMacro('\@fill@bibitem', sub {
 sub ppunbox {
   my ($punct, $pre, $field, $post) = @_;
   my $value = LookupValue('amsbibitem@' . $field);
-  if ($value && $value->unlist) {
+  if (!IsEmpty($value)) {
     return ((defined $punct ? Tokenize($punct)->unlist : ()),
       (defined $pre ? Tokenize($pre)->unlist : (T_SPACE)),
       # Wrap this in text with field as a class or something?

--- a/lib/LaTeXML/Package/amsthm.sty.ltxml
+++ b/lib/LaTeXML/Package/amsthm.sty.ltxml
@@ -75,7 +75,7 @@ DefPrimitive('\newtheoremstyle{}{}{}{}{}{}{}{}{}', sub {
     my ($stomach, $name, $spaceabove, $spacebelow, $bodyfont,
       $indent, $headfont, $headpunct, $spaceafter, $headspec) = @_;
     my $headformatter;
-    if ($headspec->unlist) {    # If spec given, create formatter macro
+    if (!IsEmpty($headspec)) {    # If spec given, create formatter macro
       $headformatter = T_CS('\format@title@theoremstyle@' . ToString($name));
       DefMacroI($headformatter, convertLaTeXArgs(3, 0), $headspec); }
 

--- a/lib/LaTeXML/Package/beamer.cls.ltxml
+++ b/lib/LaTeXML/Package/beamer.cls.ltxml
@@ -1274,7 +1274,7 @@ sub T_END_ENV { Tokens(T_CS('\end'), T_BEGIN, ExplodeText(@_), T_END); }
 # TODO: Might want to move this into $gullet?
 sub readUntilMatch {
   my ($gullet, $match) = @_;
-  return Tokens() if scalar $match->unlist == 0;
+  return Tokens() if IsEmpty($match);
   my ($head, @tail) = $match->unlist;
   my $tail = Tokens(@tail);
   # main loop to collect tokens

--- a/lib/LaTeXML/Package/caption.sty.ltxml
+++ b/lib/LaTeXML/Package/caption.sty.ltxml
@@ -80,11 +80,11 @@ DefMacro('\DeclareCaptionPackage{}',         Tokens());
 
 DefMacro('\bothIfFirst{}{}', sub {
     my ($gullet, $first, $second) = @_;
-    ($first->unlist ? ($first->unlist, $second->unlist) : ()); });
+    (IsEmpty($first) ? () : ($first->unlist, $second->unlist)); });
 
 DefMacro('\bothIfSecond{}{}', sub {
     my ($gullet, $first, $second) = @_;
-    ($second->unlist ? ($first->unlist, $second->unlist) : ()); });
+    (IsEmpty($second) ? () : ($first->unlist, $second->unlist)); });
 
 DefMacro('\AtBeginCaption{}',       Tokens());
 DefMacro('\AtEndCaption{}',         Tokens());

--- a/lib/LaTeXML/Package/cite.sty.ltxml
+++ b/lib/LaTeXML/Package/cite.sty.ltxml
@@ -37,8 +37,8 @@ DefMacro('\citen OptionalMatch:* [][] Semiverbatim', sub {
     my ($style, $open, $close, $ns)
       = map { LookupValue($_) } qw(CITE_STYLE CITE_OPEN CITE_CLOSE CITE_NOTE_SEPARATOR);
     if (!$post) { ($pre, $post) = (undef, $pre); }
-    $pre  = undef unless $pre  && $pre->unlist;
-    $post = undef unless $post && $post->unlist;
+    $pre  = undef if IsEmpty($pre);
+    $post = undef if IsEmpty($post);
     my $author = ($star ? "FullAuthors" : "Authors");
     if ($style eq 'numbers') {
       Invocation(T_CS('\@@cite'),

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -171,18 +171,18 @@ sub lstProcessDisplay {
   # Figure out whether the display is numbered, or has a caption or titles.
   my @caption = ();
   my ($numbered, $labelled, $caption, $x);
-  if (($x = lstGetTokens('caption')) && scalar($x->unlist)) {
+  if (($x = lstGetTokens('caption')) && !IsEmpty($x)) {
     my @t  = $x->unlist;
     my @tc = ();
     if (Equals($t[0], T_OTHER('['))) {
       while (!Equals($t[0], T_OTHER(']'))) { push(@tc, shift(@t)); } }
     $numbered = 1;
     $caption  = Invocation(T_CS('\lstlisting@makecaption'), (@tc ? Tokens(@tc) : undef), Tokens(@t)); }
-  elsif (($x = lstGetTokens('title')) && scalar($x->unlist)) {
+  elsif (($x = lstGetTokens('title')) && !IsEmpty($x)) {
     $caption = Invocation(T_CS('\lstlisting@maketitle'), $x); }
-  elsif (($x = lstGetTokens('toctitle')) && scalar($x->unlist)) {
+  elsif (($x = lstGetTokens('toctitle')) && !IsEmpty($x)) {
     $caption = Invocation(T_CS('\lstlisting@maketoctitle'), $x); }
-  if (($x = lstGetTokens('label')) && scalar($x->unlist)) {
+  if (($x = lstGetTokens('label')) && !IsEmpty($x)) {
     $labelled = 1;
     unshift(@body, Invocation(T_CS('\label'), $x)); }
   if ($caption) {
@@ -694,9 +694,9 @@ sub lstActivateLanguage {
   if ($language) {
     while (1) {
       # Construct the language$dialect that we're trying to find.
-      my $d = ($dialect && $dialect->unlist ? $dialect : LookupValue('LSTDD@' . $language));
+      my $d = (IsEmpty($dialect) ? LookupValue('LSTDD@' . $language) : $dialect);
       $name = 'LST@LANGUAGE@' . $language;
-      if ($d && $d->unlist) {
+      if (!IsEmpty($d)) {
         $d = uc(ToString($d)); $d =~ s/\s+//g;
         $name .= '$' . $d; }
       # language definition is loaded!
@@ -932,7 +932,7 @@ sub lstExtractColor {
   my ($stomach, $cmd) = @_;
   my $color;
   $stomach->bgroup;
-  if ($cmd->unlist) {
+  if (!IsEmpty($cmd)) {
     Digest($cmd);
     $color = LookupValue('font')->getColor; }
   $stomach->egroup;
@@ -1116,12 +1116,12 @@ use Data::Dumper;
 DefPrimitive('\@lstdefinelanguage []{}[]{} SkipSpaces RequiredKeyVals:LST []', sub {
     my ($stomach, $dialect, $language, $base_dialect, $base_language, $keyvals, $aspects) = @_;
     my @base = ();
-    if ($base_language->unlist) {
+    if (!IsEmpty($base_language)) {
       push(@base, T_OTHER('['), $base_dialect->unlist, T_OTHER(']')) if $base_dialect;
       push(@base, $base_language->unlist); }
     $language = uc(ToString($language)); $language =~ s/\s+//g;
     my $name = 'LST@LANGUAGE@' . $language;
-    if ($dialect && $dialect->unlist) {
+    if (!IsEmpty($dialect)) {
       $dialect = uc(ToString($dialect)); $dialect =~ s/\s+//g;
       $name .= '$' . $dialect; }
     $keyvals->setValue('language', Tokens(@base)) if @base;    # Probably don't need to clone, first?

--- a/lib/LaTeXML/Package/llncs.cls.ltxml
+++ b/lib/LaTeXML/Package/llncs.cls.ltxml
@@ -102,7 +102,7 @@ DefMacro('\spnewtheorem OptionalMatch:* {}[]{}[] {}{}', sub {
     my ($stomach, $flag, $thmset, $otherthmset, $type, $reset, $capfont, $bodyfont) = @_;
     $thmset      = ToString($thmset);
     $otherthmset = $otherthmset && ToString($otherthmset);
-    $type        = undef unless $type->unlist;
+    $type        = undef if IsEmpty($type);
     $reset       = $reset ? ToString($reset) : undef;
 
     my $counter = $otherthmset || $thmset;

--- a/lib/LaTeXML/Package/lxRDFa.sty.ltxml
+++ b/lib/LaTeXML/Package/lxRDFa.sty.ltxml
@@ -134,7 +134,7 @@ sub RDFTriple {
     Warn('expected', 'property', $keyvals,
       "Expected 'property' or 'rel' or 'rev' in RDF attributes"); }
   if (!($$attr{content} || $$attr{resource} || $$attr{resourcelabelref} || $$attr{resourceidref}
-      || ($content && scalar($content->unlist)))) {
+      || !IsEmpty(($content)))) {
     Warn('expected', 'resource', $keyvals,
       "Expected 'resource' or 'content' in RDF attributes"); }
   return $attr; }

--- a/lib/LaTeXML/Package/mathtools.sty.ltxml
+++ b/lib/LaTeXML/Package/mathtools.sty.ltxml
@@ -147,27 +147,30 @@ DefConstructor('\lx@@smashoperator{}{} InScriptStyle InScriptStyle',
     my $opw   = $op->getWidth;
     my $width = $opw;
     $align = ToString($align) || 'lr';
-    if ($sub->unlist) {
+    my ($hadsub, $hadsup);
+    if (!IsEmpty($sub)) {
       my $w = $sub->getWidth;
       $whatsit->setProperties(sub => $sub,
         suboffset => $w->multiply(-0.5),
         subwidth  => Dimension(0));
       $sub->setWidth(Dimension(0));
-      $width = $width->larger($w); }
-    if ($sup->unlist) {
+      $width  = $width->larger($w);
+      $hadsub = 1; }
+    if (!IsEmpty($sup)) {
       my $w = $sup->getWidth;
       $whatsit->setProperties(sup => $sup,
         supoffset => $w->multiply(-0.5),
         supwidth  => Dimension(0));
       $sup->setWidth(Dimension(0));
-      $width = $width->larger($w); }
+      $width  = $width->larger($w);
+      $hadsup = 1 }
     my $pad = $width->subtract($opw)->multiply(0.5);
     if ($pad->valueOf > 0) {
       if ($align eq 'l') {
         $whatsit->setProperties(rpadding => $pad); }
       elsif ($align eq 'r') {
         $whatsit->setProperties(lpadding => $pad); } }
-    $whatsit->setProperties(both => (scalar($sub->unlist) && scalar($sup->unlist)),
+    $whatsit->setProperties(both => ($hadsub && $hadsup),
       scriptpos => "mid" . $stomach->getScriptLevel);
     return; },
   reversion => '\smashoperator[#1]{#2_{#3}^{#4}}');    # not exactly, but...

--- a/lib/LaTeXML/Package/natbib.sty.ltxml
+++ b/lib/LaTeXML/Package/natbib.sty.ltxml
@@ -111,8 +111,8 @@ DefMacro('\cite OptionalMatch:* [][] Semiverbatim', sub {
     my ($style, $open, $close, $ns, $ay)
       = map { LookupValue($_) } qw(CITE_STYLE CITE_OPEN CITE_CLOSE CITE_NOTE_SEPARATOR CITE_AY_SEPARATOR);
     if (!$post) { ($pre, $post) = (undef, $pre); }
-    $pre  = undef unless $pre  && $pre->unlist;
-    $post = undef unless $post && $post->unlist;
+    $pre  = undef if IsEmpty($pre);
+    $post = undef if IsEmpty($post);
     my $author = ($star ? "FullAuthors" : "Authors");
     if ($style eq 'numbers') {
       Invocation(T_CS('\@@cite'),
@@ -155,8 +155,8 @@ DefMacro('\citet OptionalMatch:* [][] Semiverbatim', sub {
     my ($style, $open, $close, $ns)
       = map { LookupValue($_) } qw(CITE_STYLE CITE_OPEN CITE_CLOSE CITE_NOTE_SEPARATOR);
     if (!$post) { ($pre, $post) = (undef, $pre); }
-    $pre  = undef unless $pre  && $pre->unlist;
-    $post = undef unless $post && $post->unlist;
+    $pre  = undef if IsEmpty($pre);
+    $post = undef if IsEmpty($post);
     my $author = ($star ? "FullAuthors" : "Authors");
     if ($style eq 'numbers') {
       Invocation(T_CS('\@@cite'),
@@ -196,8 +196,8 @@ DefMacro('\citep OptionalMatch:* [][] Semiverbatim', sub {
       = map { LookupValue($_) } qw(CITE_STYLE CITE_OPEN CITE_CLOSE
       CITE_NOTE_SEPARATOR CITE_AY_SEPARATOR);
     if (!$post) { ($pre, $post) = (undef, $pre); }
-    $pre  = undef unless $pre  && $pre->unlist;
-    $post = undef unless $post && $post->unlist;
+    $pre  = undef if IsEmpty($pre);
+    $post = undef if IsEmpty($post);
     my $author = ($star ? "FullAuthors" : "Authors");
 
     if ($style eq 'numbers') {
@@ -257,8 +257,8 @@ DefMacro('\citeauthor OptionalMatch:* [][] Semiverbatim', sub {
     my ($gullet, $star, $pre, $post, $keys) = @_;
     my $author = ($star ? "FullAuthors" : "Authors");
     if (!$post) { ($pre, $post) = (undef, $pre); }
-    $pre  = undef unless $pre  && $pre->unlist;
-    $post = undef unless $post && $post->unlist;
+    $pre  = undef if IsEmpty($pre);
+    $post = undef if IsEmpty($post);
     my $ns = LookupValue('CITE_NOTE_SEPARATOR');
     Invocation(T_CS('\@@cite'),
       Tokens(Explode('citeauthor')),
@@ -269,8 +269,8 @@ DefMacro('\citeauthor OptionalMatch:* [][] Semiverbatim', sub {
 DefMacro('\citefullauthor [][] Semiverbatim', sub {
     my ($gullet, $pre, $post, $keys) = @_;
     if (!$post) { ($pre, $post) = (undef, $pre); }
-    $pre  = undef unless $pre  && $pre->unlist;
-    $post = undef unless $post && $post->unlist;
+    $pre  = undef if IsEmpty($pre);
+    $post = undef if IsEmpty($post);
     my $ns = LookupValue('CITE_NOTE_SEPARATOR');
     Invocation(T_CS('\@@cite'),
       Tokens(Explode('citefullauthor')),
@@ -281,8 +281,8 @@ DefMacro('\citefullauthor [][] Semiverbatim', sub {
 DefMacro('\citeyear [][] Semiverbatim', sub {
     my ($gullet, $pre, $post, $keys) = @_;
     if (!$post) { ($pre, $post) = (undef, $pre); }
-    $pre  = undef unless $pre  && $pre->unlist;
-    $post = undef unless $post && $post->unlist;
+    $pre  = undef if IsEmpty($pre);
+    $post = undef if IsEmpty($post);
     my $ns = LookupValue('CITE_NOTE_SEPARATOR');
     Invocation(T_CS('\@@cite'),
       Tokens(Explode('citeyear')),
@@ -294,8 +294,8 @@ DefMacro('\citeyearpar [][] Semiverbatim', sub {
     my ($gullet, $pre, $post, $keys) = @_;
     my ($open, $close) = map { LookupValue($_) } qw(CITE_OPEN CITE_CLOSE);
     if (!$post) { ($pre, $post) = (undef, $pre); }
-    $pre  = undef unless $pre  && $pre->unlist;
-    $post = undef unless $post && $post->unlist;
+    $pre  = undef if IsEmpty($pre);
+    $post = undef if IsEmpty($post);
     my $ns = LookupValue('CITE_NOTE_SEPARATOR');
     Invocation(T_CS('\@@cite'),
       Tokens(Explode('citeyearpar')),
@@ -333,8 +333,8 @@ DefMacro('\citetalias [][] Semiverbatim', sub {
     my ($gullet, $pre, $post, $key) = @_;
     my ($open, $close) = map { LookupValue($_) } qw(CITE_OPEN CITE_CLOSE);
     if (!$post) { ($pre, $post) = (undef, $pre); }
-    $pre  = undef unless $pre  && $pre->unlist;
-    $post = undef unless $post && $post->unlist;
+    $pre  = undef if IsEmpty($pre);
+    $post = undef if IsEmpty($post);
     Invocation(T_CS('\@@cite'),
       Tokens(Explode('citealias')),
       Tokens(($pre ? ($pre, T_SPACE) : ()),
@@ -605,7 +605,7 @@ sub NAT_peel_arg {
 DefMacro('\NAT@wrout{}{}{}{} Semiverbatim', sub {
     my ($gullet, $number, $year, $authors, $fullauthors, $key) = @_;
     my ($style, $open, $close) = map { LookupValue($_) } qw(CITE_STYLE CITE_OPEN CITE_CLOSE);
-    $style = 'number' unless $authors->unlist && $year->unlist;
+    $style = 'number' if IsEmpty($authors) || IsEmpty($year);
     if ($style eq 'number') {
       Invocation(T_CS('\NAT@@wrout'), $number, $year, $authors, $fullauthors,
         Tokens($open, $number, $close),

--- a/lib/LaTeXML/Package/physics.sty.ltxml
+++ b/lib/LaTeXML/Package/physics.sty.ltxml
@@ -66,21 +66,18 @@ sub phys_revSize {
 
 sub phys_open {
   my ($size, $delim) = @_;
-  return ($delim && $delim->unlist
-    ? (ref $size ? Tokens($size, $delim) : ($size ? Tokens(T_CS('\left'), $delim) : $delim))
-    : ()); }
+  return (IsEmpty($delim) ? ()
+    : (ref $size ? Tokens($size, $delim) : ($size ? Tokens(T_CS('\left'), $delim) : $delim))); }
 
 sub phys_mid {
   my ($size, $delim) = @_;
-  return ($delim && $delim->unlist
-    ? (ref $size ? Tokens($size, $delim) : ($size ? Tokens(T_CS('\middle'), $delim) : $delim))
-    : ()); }
+  return (IsEmpty($delim) ? ()
+    : (ref $size ? Tokens($size, $delim) : ($size ? Tokens(T_CS('\middle'), $delim) : $delim))); }
 
 sub phys_close {
   my ($size, $delim) = @_;
-  return ($delim && $delim->unlist
-    ? (ref $size ? Tokens($size, $delim) : ($size ? Tokens(T_CS('\right'), $delim) : $delim))
-    : ()); }
+  return (IsEmpty($delim) ? ()
+    : (ref $size ? Tokens($size, $delim) : ($size ? Tokens(T_CS('\right'), $delim) : $delim))); }
 
 # Read a single arg, either TeX delimited {}, or delmited according to hash
 # Error is signaled if $required and no arg found
@@ -148,7 +145,7 @@ DefMacro('\quantity', sub {
 # 1 Required TeX-style arg; Possibly meaning, function and fences provided
 DefMacro('\lx@physics@fenced{}{}{}{}{}', sub {
     my ($gullet, $cs, $semantic, $function, $open, $close) = @_;
-    $semantic = undef unless $semantic->unlist;
+    $semantic = undef if IsEmpty($semantic);
     my $size = phys_readSize($gullet);
     my $arg  = $gullet->readArg();
     return I_dual(
@@ -423,7 +420,7 @@ DefMacro('\lx@physics@deriv{}{}{}', sub {
     else {
       $var = $tmp1; }
     # Check if $expr is EMPTY ??? still an operator!
-    $expr = undef if $expr && !scalar($expr->unlist);
+    $expr = undef if IsEmpty($expr);
     my $cfunc = I_symbol({ meaning => $semantic });
     my $pfunc = I_wrap({ role => 'DIFFOP' }, $diff);
     if ($tmp3) {    # double derivative!
@@ -680,7 +677,7 @@ DefMacro('\antidiagonalmatrix[]{}', sub {
 DefMacro('\lx@physics@mat{}{}{}{}{}', sub {
     my ($gullet, $cs, $semantic, $env, $defopen, $defclose) = @_;
     my $alt = $gullet->readMatch(T_OTHER('*'));
-    $semantic = undef unless $semantic->unlist;
+    $semantic = undef if IsEmpty($semantic);
     my $cfunc = $semantic && I_symbol({ meaning => $semantic });
     $env = ToString($env);
     my ($body, $open, $close) = phys_readArg($gullet, 1, %physics_delimiters);

--- a/lib/LaTeXML/Package/xcolor.sty.ltxml
+++ b/lib/LaTeXML/Package/xcolor.sty.ltxml
@@ -418,7 +418,7 @@ DefPrimitive('\XC@definecolor[]{}[]{}{}', sub {
     # and return a box, so it can be recorded?
     # but we don't want the \XC@ version, and we're not handling the prefix anyway...
     Box(undef, undef, undef,
-      Invocation(T_CS('\definecolor'), ($type && $type->unlist ? $type : undef),
+      Invocation(T_CS('\definecolor'), (IsEmpty($type) ? undef : $type),
         $name, $models, $specs)); });
 
 DefPrimitive('\XC@providecolor[]{}[]{}{}', sub {
@@ -433,7 +433,7 @@ DefPrimitive('\XC@providecolor[]{}[]{}{}', sub {
     AssignValue('xglobal@' => 0);
     Box(undef, undef, undef,
       #      Invocation(T_CS('\XC@providecolor'),$type,$name,$prefix,$models,$specs)); });
-      Invocation(T_CS('\providecolor'), ($type && $type->unlist ? $type : undef),
+      Invocation(T_CS('\providecolor'), (IsEmpty($type) ? undef : $type),
         $name, $models, $specs)); });
 
 # \colorlet[<type>]{<name>}[<num_model>]{<color>}
@@ -715,8 +715,8 @@ DefPrimitive('\rowcolors OptionalMatch:* []{Number}{}{}', sub {
     DefMacroI('\@xcolor@row@after',      undef, $commands);
     DefMacroI('\@xcolor@tabular@before', undef, $commands);
     AssignValue(tabular_row_color_first => $first->valueOf);
-    AssignValue(tabular_row_color_odd   => ($oddcolor->unlist ? ParseXColor(undef, $oddcolor) : undef));
-    AssignValue(tabular_row_color_even => ($evencolor->unlist ? ParseXColor(undef, $evencolor) : undef)); });
+    AssignValue(tabular_row_color_odd => (IsEmpty($oddcolor) ? undef : ParseXColor(undef, $oddcolor)));
+    AssignValue(tabular_row_color_even => (IsEmpty($evencolor) ? undef : ParseXColor(undef, $evencolor))); });
 
 DefConditional('\if@rowcolors', undef);
 RawTeX('\@rowcolorstrue');


### PR DESCRIPTION
This PR deals more consistently with comments, whether Tokens, digested or XML nodes, appearing in places we previously didn't expect them.

The function `IsEmpty` tests whether a tokens or list  is empty, ignoring comments, and is generally preferred over `scalar($x->unlist )`; `element_next($node), element_prev($node)` are usually preferred over `$node->previousSibling`.   Also, avoid splitting xml text nodes with comments, pushing them to the front.

Also, remove an obsolete form of `DefMathLigature`.