### PR TITLE
Fix #2113

### DIFF
--- a/lib/LaTeXML/Post/MakeBibliography.pm
+++ b/lib/LaTeXML/Post/MakeBibliography.pm
@@ -782,7 +782,7 @@ sub do_links {
     [[['ltx:bib-name[@role="author"]', '', '', 'author', \&do_authors, ''],
       ['ltx:bib-name[@role="editor"]',      '', '', 'editor', \&do_editorsA,          ''],
       ['ltx:bib-date[@role="publication"]', '', '', 'year',   \&do_year,              ''],
-      ['ltx:title',                         '', '', 'title',  \&do_any,               ''],
+      ['ltx:bib-title',                         '', '', 'title',  \&do_any,               ''],
       ['ltx:bib-type',                      '', '', 'type',   \&do_any,               ''],
       ['! ltx:bib-type',                    '', '', 'type',   sub { ('(Website)'); }, '']],
     [['ltx:bib-organization', ', ', ' ', 'publisher', \&do_any, ''],


### PR DESCRIPTION
As noted in #2113 there is a possible typo in `MakeBibliography.pm` naming an attribute `ltx:title` as opposed to `ltx:bib-title`. This PR fixes the typo.

Note: I am unsure if this part of the code is covered by any of the existing test cases, this one should probably be tested  manually. 