### PR TITLE
preserve xhtml:attrs in XSLT

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-common.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-common.xsl
@@ -413,6 +413,11 @@
           <xsl:value-of select="."/>
         </xsl:attribute>
       </xsl:when>
+      <xsl:when test="namespace-uri() = 'http://www.w3.org/1999/xhtml'">
+        <xsl:attribute name="{local-name()}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:when>
       <xsl:when test="$prefix = 'data'">
         <xsl:attribute name="{concat('data-',local-name())}">
           <xsl:value-of select="."/>


### PR DESCRIPTION
This is a PR-shaped question to @brucemiller, while brainstorming on #2165 .

It is generally quite simple to write a small binding that deposits ARIA attributes for latexml, except that those attributes are not declared in the schema, and aren't allowed to pass through in the XSLT post-processing.

We could allow each and every one of the list of ARIA attributes in the `ltx` namespace, but - in purely pragmatic terms - such a requirement limits experimentation for lay binding authors a bit. I myself find it somewhat uncomfortable to be buffered through the latexml schema, before being able to experiment with emitting the ultimate HTML markup. Going back to enhance the schema after a stable HTML markup pattern emerges feels slightly more natural to exploratory coding.

The PR contains the first quick upgrade while wearing my HTML hat - allow any `xhtml:attribute` to pass through the XSLT as a plain `attribute` in the final (X)HTML, in the same conditional check that currently emits `data-` attributes as a fallback.

This allowed to write the binding:
```perl
DefEnvironment("{namedblock}{}{}", "<ltx:block xhtml:aria-label='#1' xhtml:aria-description='#2'>#body</ltx:block>");
```
author:
```tex
\begin{namedblock}{sample-value}{describe it}
  Hello World!
\end{namedblock}
```
and emit to HTML5:
```html
<div class="ltx_block" aria-description="describe it" aria-label="sample-value">
<p class="ltx_p">Hello World!</p>
</div>
```

More generally, passing arbitrary `xhtml:names` along allows direct experimentation with (X)HTML attributes of any variety, bypassing that aspect of latexml's schema.

---

In addition, maybe in a next PR (or next commit), if one was to be Principled in the XML sense, we'd follow the [WAI-ARIA host languages](https://www.w3.org/TR/wai-aria-1.0/host_languages#host_general_attrs) instructions and declare an `aria` namespace at the official URI `http://www.w3.org/ns/wai-aria`. Then I'd need a dedicated XSLT rule that maps `aria:` namespaced values into `aria-` values in HTML5, as we do for `data-`.

I believe this simplest PR can be useful for general quick experimentation, and I can bring along the namespaced aria approach in addition to that.

How much of that aligns with your perspective here @brucemiller ?