### PR TITLE
Not a function

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -5906,10 +5906,10 @@ DefMathI('\angle', undef, "\x{2220}");
 
 # NOTE: This is probably the wrong role.
 # Also, should probably carry info about Binding for OpenMath
-DefMathI('\forall',    undef, "\x{2200}", role => 'BIGOP',    meaning => 'for-all');
-DefMathI('\exists',    undef, "\x{2203}", role => 'BIGOP',    meaning => 'exists');
-DefMathI('\neg',       undef, UTF(0xAC),  role => 'OPERATOR', meaning => 'not');
-DefMathI('\lnot',      undef, UTF(0xAC),  role => 'OPERATOR', meaning => 'not');
+DefMathI('\forall',    undef, "\x{2200}", role => 'BIGOP', meaning => 'for-all');
+DefMathI('\exists',    undef, "\x{2203}", role => 'BIGOP', meaning => 'exists');
+DefMathI('\neg',       undef, UTF(0xAC),  role => 'BIGOP', meaning => 'not');
+DefMathI('\lnot',      undef, UTF(0xAC),  role => 'BIGOP', meaning => 'not');
 DefMathI('\flat',      undef, "\x{266D}");
 DefMathI('\natural',   undef, "\x{266E}");
 DefMathI('\sharp',     undef, "\x{266F}");

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -5908,8 +5908,8 @@ DefMathI('\angle', undef, "\x{2220}");
 # Also, should probably carry info about Binding for OpenMath
 DefMathI('\forall',    undef, "\x{2200}", role => 'BIGOP',    meaning => 'for-all');
 DefMathI('\exists',    undef, "\x{2203}", role => 'BIGOP',    meaning => 'exists');
-DefMathI('\neg',       undef, UTF(0xAC),  role => 'FUNCTION', meaning => 'not');
-DefMathI('\lnot',      undef, UTF(0xAC),  role => 'FUNCTION', meaning => 'not');
+DefMathI('\neg',       undef, UTF(0xAC),  role => 'OPERATOR', meaning => 'not');
+DefMathI('\lnot',      undef, UTF(0xAC),  role => 'OPERATOR', meaning => 'not');
 DefMathI('\flat',      undef, "\x{266D}");
 DefMathI('\natural',   undef, "\x{266E}");
 DefMathI('\sharp',     undef, "\x{266F}");

--- a/t/encoding/ansinew.xml
+++ b/t/encoding/ansinew.xml
@@ -92,7 +92,7 @@
             <td align="center">«</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td/>

--- a/t/encoding/ansinew.xml
+++ b/t/encoding/ansinew.xml
@@ -92,7 +92,7 @@
             <td align="center">«</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td/>

--- a/t/encoding/applemac.xml
+++ b/t/encoding/applemac.xml
@@ -166,7 +166,7 @@
             <td align="center">¡</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m13">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center"><Math mode="inline" tex="\surd" text="square-root" xml:id="S1.p1.m14">

--- a/t/encoding/applemac.xml
+++ b/t/encoding/applemac.xml
@@ -166,7 +166,7 @@
             <td align="center">¡</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m13">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center"><Math mode="inline" tex="\surd" text="square-root" xml:id="S1.p1.m14">

--- a/t/encoding/cp1250.xml
+++ b/t/encoding/cp1250.xml
@@ -92,7 +92,7 @@
             <td align="center">«</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td/>

--- a/t/encoding/cp1250.xml
+++ b/t/encoding/cp1250.xml
@@ -92,7 +92,7 @@
             <td align="center">«</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td/>

--- a/t/encoding/cp1252.xml
+++ b/t/encoding/cp1252.xml
@@ -92,7 +92,7 @@
             <td align="center">«</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td/>

--- a/t/encoding/cp1252.xml
+++ b/t/encoding/cp1252.xml
@@ -92,7 +92,7 @@
             <td align="center">«</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td/>

--- a/t/encoding/cp437.xml
+++ b/t/encoding/cp437.xml
@@ -88,7 +88,7 @@
             <td/>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/cp437.xml
+++ b/t/encoding/cp437.xml
@@ -88,7 +88,7 @@
             <td/>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/cp437de.xml
+++ b/t/encoding/cp437de.xml
@@ -88,7 +88,7 @@
             <td/>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/cp437de.xml
+++ b/t/encoding/cp437de.xml
@@ -88,7 +88,7 @@
             <td/>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/cp850.xml
+++ b/t/encoding/cp850.xml
@@ -94,7 +94,7 @@
             <td align="center">®</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m2">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/cp850.xml
+++ b/t/encoding/cp850.xml
@@ -94,7 +94,7 @@
             <td align="center">®</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m2">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/cp858.xml
+++ b/t/encoding/cp858.xml
@@ -94,7 +94,7 @@
             <td align="center">®</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m2">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/cp858.xml
+++ b/t/encoding/cp858.xml
@@ -94,7 +94,7 @@
             <td align="center">®</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m2">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/cp865.xml
+++ b/t/encoding/cp865.xml
@@ -88,7 +88,7 @@
             <td/>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/cp865.xml
+++ b/t/encoding/cp865.xml
@@ -88,7 +88,7 @@
             <td/>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="center">½</td>

--- a/t/encoding/latin1.xml
+++ b/t/encoding/latin1.xml
@@ -54,7 +54,7 @@
             <td align="center" border="t">«</td>
             <td align="center" border="t"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td border="t"/>

--- a/t/encoding/latin1.xml
+++ b/t/encoding/latin1.xml
@@ -54,7 +54,7 @@
             <td align="center" border="t">«</td>
             <td align="center" border="t"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td border="t"/>

--- a/t/encoding/latin5.xml
+++ b/t/encoding/latin5.xml
@@ -54,7 +54,7 @@
             <td align="center" border="t">«</td>
             <td align="center" border="t"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td border="t"/>

--- a/t/encoding/latin5.xml
+++ b/t/encoding/latin5.xml
@@ -54,7 +54,7 @@
             <td align="center" border="t">«</td>
             <td align="center" border="t"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td border="t"/>

--- a/t/encoding/latin9.xml
+++ b/t/encoding/latin9.xml
@@ -244,7 +244,7 @@
             <td align="center">«</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td/>

--- a/t/encoding/latin9.xml
+++ b/t/encoding/latin9.xml
@@ -244,7 +244,7 @@
             <td align="center">«</td>
             <td align="center"><Math mode="inline" tex="\lnot" text="not" xml:id="S1.p1.m1">
                 <XMath>
-                  <XMTok meaning="not" name="lnot" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="lnot" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td/>

--- a/t/fonts/abxtest.xml
+++ b/t/fonts/abxtest.xml
@@ -638,7 +638,7 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="\neg" text="not" xml:id="S0.SS0.SSS0.Px6.p2.m1">
                 <XMath>
-                  <XMTok meaning="not" name="neg" role="OPERATOR">¬</XMTok>
+                  <XMTok meaning="not" name="neg" role="BIGOP">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">\neg</text></td>

--- a/t/fonts/abxtest.xml
+++ b/t/fonts/abxtest.xml
@@ -638,7 +638,7 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="\neg" text="not" xml:id="S0.SS0.SSS0.Px6.p2.m1">
                 <XMath>
-                  <XMTok meaning="not" name="neg" role="FUNCTION">¬</XMTok>
+                  <XMTok meaning="not" name="neg" role="OPERATOR">¬</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">\neg</text></td>

--- a/t/parse/array_math.xml
+++ b/t/parse/array_math.xml
@@ -237,7 +237,7 @@
   </para>
   <para xml:id="p7">
     <equation xml:id="S0.Ex7">
-      <Math mode="display" tex="\arcsin\pi+\neg a=\{\begin{array}[]{cc}a&amp;b\\&#10;c&amp;d\end{array}" text="inverse-sine@(pi) + not * a = cases@(Array[[a, b], [c, d]])" xml:id="S0.Ex7.m1">
+      <Math mode="display" tex="\arcsin\pi+\neg a=\{\begin{array}[]{cc}a&amp;b\\&#10;c&amp;d\end{array}" text="inverse-sine@(pi) + not@(a) = cases@(Array[[a, b], [c, d]])" xml:id="S0.Ex7.m1">
         <XMath>
           <XMApp>
             <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -248,8 +248,7 @@
                 <XMTok font="italic" name="pi" role="UNKNOWN">π</XMTok>
               </XMApp>
               <XMApp>
-                <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                <XMTok meaning="not" name="neg" role="FUNCTION">¬</XMTok>
+                <XMTok meaning="not" name="neg" role="OPERATOR">¬</XMTok>
                 <XMTok font="italic" role="UNKNOWN">a</XMTok>
               </XMApp>
             </XMApp>

--- a/t/parse/array_math.xml
+++ b/t/parse/array_math.xml
@@ -248,7 +248,7 @@
                 <XMTok font="italic" name="pi" role="UNKNOWN">π</XMTok>
               </XMApp>
               <XMApp>
-                <XMTok meaning="not" name="neg" role="OPERATOR">¬</XMTok>
+                <XMTok meaning="not" name="neg" role="BIGOP">¬</XMTok>
                 <XMTok font="italic" role="UNKNOWN">a</XMTok>
               </XMApp>
             </XMApp>


### PR DESCRIPTION
make `\lnot` and `\neg` be OPERATOR rather than FUNCTION, which leads to better parsing & MathML.

Fixes #2163