### PR TITLE
Fixes comments, and comment.sty

### DIFF
--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -679,7 +679,8 @@ sub insertComment {
   chomp($text);
   $text =~ s/\-\-+/__/g;
   my $comment;
-  my $prev     = $$self{node}->lastChild;
+  my $node     = getElement($self);
+  my $prev     = $node && $node->lastChild;
   my $prevtype = $prev && $prev->nodeType;
   if ($$self{node}->nodeType == XML_DOCUMENT_NODE) {
     push(@{ $$self{pending} }, $comment = $$self{document}->createComment(' ' . $text . ' ')); }
@@ -688,11 +689,11 @@ sub insertComment {
     $comment->setData($comment->data . "\n     " . $text . ' '); }
   elsif ($prevtype && ($prevtype == XML_TEXT_NODE)) {    # Put comment BEFORE text node
     if (($comment = $prev->previousSibling) && ($comment->nodeType == XML_COMMENT_NODE)) {
-      $comment = $$self{node}->appendChild($$self{document}->createComment(' ' . $text . ' ')); }
+      $comment = $node->appendChild($$self{document}->createComment(' ' . $text . ' ')); }
     else {
-      $comment = $$self{node}->insertBefore($$self{document}->createComment(' ' . $text . ' '), $prev); } }
+      $comment = $node->insertBefore($$self{document}->createComment(' ' . $text . ' '), $prev); } }
   else {
-    $comment = $$self{node}->appendChild($$self{document}->createComment(' ' . $text . ' ')); }
+    $comment = $node->appendChild($$self{document}->createComment(' ' . $text . ' ')); }
   return $comment; }
 
 # Insert a ProcessingInstruction of the form <?op attr=value ...?>

--- a/lib/LaTeXML/Package/comment.sty.ltxml
+++ b/lib/LaTeXML/Package/comment.sty.ltxml
@@ -22,16 +22,14 @@ sub defineExcluded {
   my ($stomach, $name) = @_;
   $name = ToString($name);
   my $endmark = '\end{' . $name . '}';
-  DefConstructorI(T_CS("\\begin{$name}"), undef, '', reversion => '',
-    afterDigest => [sub {
-        my ($istomach, $whatsit) = @_;
-        my $nlines = 0;
-        my ($line);
-        my $gullet = $istomach->getGullet;
-        $gullet->readRawLine;    # IGNORE 1st line (after the \begin{$name} !!!
-        while (defined($line = $gullet->readRawLine) && ($line !~ /^\s*\Q$endmark\E\s*$/)) {
-          $nlines++; }
-        NoteLog("[Skipped $name ($nlines lines)]"); }]);
+  DefMacroI(T_CS("\\begin{$name}"), undef, sub {
+      my ($gullet) = @_;
+      my $line     = $gullet->readRawLine;    # skip rest of 1st line (after the \begin{$name} !!!
+      my @stuff    = ();
+      push(@stuff, $line) if $line;
+      while (defined($line = $gullet->readRawLine) && ($line !~ /^\s*\Q$endmark\E\s*$/)) {
+        push(@stuff, $line); }
+      return Tokens(T_COMMENT(join("\n", @stuff))); });
   return; }
 
 sub defineIncluded {


### PR DESCRIPTION
This PR fixes how comments are inserted into the XML, and enhances `comment.sty` to preserve the comments in the output.

Fixes #2087