### PR TITLE
set URI to destination for postprocessed documents

### DIFF
--- a/lib/LaTeXML/Post.pm
+++ b/lib/LaTeXML/Post.pm
@@ -664,6 +664,7 @@ use DB_File;
 use Unicode::Normalize;
 use LaTeXML::Post;    # to import error handling...
 use LaTeXML::Common::Error;
+use URI::file;
 use base qw(LaTeXML::Common::Object);
 our $NSURI = "http://dlmf.nist.gov/LaTeXML";
 our $XPATH = LaTeXML::Common::XML::XPath->new(ltx => $NSURI);
@@ -855,6 +856,8 @@ sub setDocument_internal {
     $self->addNodes($node, @children); }
   else {
     Fatal('unexpected', $root, undef, "Dont know how to use '$root' as document element"); }
+  # set URI to destination
+  $$self{document}->setURI(URI::file->new($self->getDestination));
   return $self; }
 
 our @MonthNames = (qw( January February March April May June


### PR DESCRIPTION
Fixes #2093 by setting the URI of postprocessing documents to their destination. This guarantees that calling e.g. `document(@imagesrc)` resolves relative URLs correctly, i.e., relative to the destination directory.