### PR TITLE
allow deeper recursion for tikz diagrams

### DIFF
--- a/lib/LaTeXML/Core/List.pm
+++ b/lib/LaTeXML/Core/List.pm
@@ -63,6 +63,7 @@ sub unlist {
   return @{ $$self{boxes} }; }
 
 sub revert {
+  no warnings 'recursion';
   my ($self) = @_;
   return map { $_->revert } $self->unlist; }
 

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -196,6 +196,7 @@ sub equals {
   return !(@a || @b); }
 
 sub beAbsorbed {
+  no warnings 'recursion';
   my ($self, $document) = @_;
   # Significant time is consumed here, and associated with a specific CS,
   # so we should be profiling as well!

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -2163,6 +2163,7 @@ sub collapseSVGGroup {
 
 DefConstructor('\hbox BoxSpecification HBoxContents', sub {
     # "<ltx:text width='#width' _noautoclose='1'>#2</ltx:text>",
+    no warnings 'recursion';
     my ($document, $spec, $contents, %props) = @_;
     my $model   = $document->getModel;
     my $context = $document->getElement;


### PR DESCRIPTION
I was double-checking if our raw support for `tikz-qtree.sty` has improved (based on [a small example](https://github.com/brucemiller/LaTeXML/issues/341#issuecomment-821877053) from #341 ), and indeed it has!

The only catch was that due to the deeper interpretation, the conversion was running into `Fatal:perl:deep_recursion` fatal errors. I allowed more recursion in 3 locations, which then allowed the conversion to succeed.

Tested with a simple:
```
$ latexmlc test.tex --dest=test.html --includestyles
```

That minimal example tree now renders exactly as in the PDF - with the only exception of having the entire outer frame translated too far down. Tested with today's latexml master at 6143eb15bbbb435bcb0cf67544acac1c55e6b3e2

TeX example:
<details>

```tex
\documentclass{article}
\usepackage{tikz}
\usepackage{tikz-qtree}
\begin{document}

\Tree [.S [.NP [.Det the ] [.N cat ] ]
              [.VP [.V sat ]
                      [.PP [.P on ]
                              [.NP [.Det the ] [.N mat ] ] ] ] ]

\end{document}
```

</details>