### PR TITLE
respect colorlinks in \hypersetup

### DIFF
--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -110,6 +110,8 @@ DefKeyVal('Hyp', 'baseurl', 'Semiverbatim');
 
 sub hyperref_setoption {
   my ($key, $value) = @_;
+  if ($key eq 'colorlinks' and ToString($value) eq 'true') {
+    RequirePackage('color'); }
   AssignMapping('Hyperref_options', $key, $value);
   if ($key eq 'baseurl') {
     AssignValue(BASE_URL => ToString($value)); }


### PR DESCRIPTION
Fixes #2125 

We had provisions to recognize `\usepackage[colorlinks]{hyperref}`, but no provision to recognize the option when passed in through `\hypersetup`.