### PR TITLE
refine regex for \graphicspath argument

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -409,8 +409,11 @@ DefParameterType('DirectoryList', sub {
     my ($gullet)   = @_;
     my $arg_string = ToString($gullet->readArg);
     my @dirs       = ();
-    for my $dir (split(/\s*(?:,|\n+)\s*/, $arg_string)) {
-      while ($dir =~ s/^\{([^\}]*)\}//) {
+    for my $dir (split(/,|\\par|\n+/, $arg_string)) {
+      $dir =~ s/^\s+//;
+      $dir =~ s/\s+$//;
+      next unless $dir;
+      while ($dir =~ s/^\s*\{([^\}]*)\}//) {
         push @dirs, $1 if $1; }
       push @dirs, $dir if $dir; }
     LaTeXML::Core::Array->new(open => T_BEGIN, close => T_END, itemopen => T_BEGIN, itemclose => T_END,


### PR DESCRIPTION
Fixes #2159 

Tested with
```tex
\documentclass{article}
\usepackage{graphicx}
\graphicspath{  {subdir1/}, test/,  {subdir2/}  {subdir3/}

{subdirn/}  }
\begin{document}
\end{document}
```

Result:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?latexml searchpaths="/home/deyan/git/my-LaTeXML,/tmp"?>
<?latexml class="article"?>
<?latexml package="graphicx"?>
<?latexml graphicspath="/tmp/subdir1"?>
<?latexml graphicspath="/tmp/test"?>
<?latexml graphicspath="/tmp/subdir2"?>
<?latexml graphicspath="/tmp/subdir3"?>
<?latexml graphicspath="/tmp/subdirn"?>
<?latexml RelaxNGSchema="LaTeXML"?>
<document xmlns="http://dlmf.nist.gov/LaTeXML">
  <resource src="LaTeXML.css" type="text/css"/>
  <resource src="ltx-article.css" type="text/css"/>
</document>
```