### PR TITLE
Fix token register

### DIFF
--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -715,7 +715,7 @@ sub readValue {
   elsif ($type eq 'MuGlue')    { return readMuGlue($self); }
   elsif ($type eq 'Tokens')    { return readTokensValue($self); }
   elsif ($type eq 'Token') {
-    my $token = readToken($self);
+    my $token = readNonSpace($self);
     if ($token->defined_as(T_csname)) {
       return readCSName($self); }
     else {

--- a/lib/LaTeXML/Core/Token.pm
+++ b/lib/LaTeXML/Core/Token.pm
@@ -19,7 +19,6 @@ package LaTeXML::Core::Token;
 use strict;
 use warnings;
 use LaTeXML::Global;
-use LaTeXML::Core::State;
 use LaTeXML::Common::Error;
 use LaTeXML::Common::Object;
 use base qw(LaTeXML::Common::Object);


### PR DESCRIPTION
This PR skips spaces before reading the value of (pseudo) registers that take a token as value, such as `\textfont`.

Fixes #2097

Also removes an unneeded circular dependency which broke perl-critic.