### PR TITLE
detect raw PDF inclusion documents and mark them as invalid inputs

### DIFF
--- a/lib/LaTeXML/Package/pdfpages.sty.ltxml
+++ b/lib/LaTeXML/Package/pdfpages.sty.ltxml
@@ -25,11 +25,24 @@ use LaTeXML::Package;
 DefConstructor('\includepdf OptionalKeyVals{}',
   "<ltx:resource src='#src' type='application/pdf'/>"
     . "See #pages<ltx:ref href='#src'>#src</ltx:ref>",
+  beforeDigest => sub {
+    # arXiv care: if a document consists of only a single \includepdf inclusion
+    # detect that, and flag it as *invalid*, as we never had the original TeX source.
+    AtEndDocument('\ltx@detect@raw@pdf'); },
   properties => sub {
     my $pages = GetKeyVal($_[1], 'pages');
     (src => $_[2],
       pages => ($pages ? "pages " . ToString($pages) . " of " : undef)); });
 
 #================================================================================
+
+DefConstructor('\ltx@detect@raw@pdf', sub {
+    my ($document)  = @_;
+    my $docroot     = $document->findnode('ltx:document');
+    my @doc_content = grep { $document->getNodeQName($_) ne 'ltx:resource' } element_nodes($docroot);
+    if (scalar(@doc_content) <= 1) {
+      Fatal("invalid", "PDF", $_[0], "Only a raw PDF inclusion was detected, this is not a latexml-compatible source."); }
+    return;
+});
 
 1;


### PR DESCRIPTION
This PR marks another class of arXiv inputs as invalid, following a user report from today at [ar5iv#376](https://github.com/dginev/ar5iv/issues/376).

There is a range of special case documents that are erroneously included in the arXiv source bundles, which precompile a local PDF and re-include it via `\includepdf` to satisfy the arXiv submission requirement.

I think it is an honest "invalid" marker that a document which only has a single use of that macro isn't meant for latexml conversion. Suggestions welcome if there is a better test than the one I tried - I simply checked at the end of the document construction whether we have more than one content node under `ltx:document`, when `\includepdf` has been used.
