### PR TITLE
Respect listings-style semiverbatim name/file arguments

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2130,7 +2130,7 @@ sub FindFile_fallback {
 
 sub pathname_is_nasty {
   my ($pathname) = @_;
-  return $pathname =~ /[^\w\-_\+\=\/\\\.~\:\s]/; }
+  return $pathname =~ /[^\w\-_\+\=\/\\\.~\:\s\x{2013}]/; }
 
 sub maybeReportSearchPaths {
   if (LookupValue('SEARCHPATHS_REPORTED')) {

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -118,16 +118,32 @@ DefMacroI(T_CS('\begin{lstlisting}'), 'OptionalKeyVals:LST', sub {
     lstActivate($keyvals);
     return lstProcessDisplay(lstGetTokens('name'), $text); });
 
-DefMacro('\lstinputlisting OptionalKeyVals:LST Semiverbatim', sub {
+# Read a semiverbatim name, neutralizing $, _ and -
+DefParameterType('LstNameVerbatim', sub {
+    my ($gullet) = @_;
+    $gullet->readUntil(T_BEGIN);
+    StartSemiverbatim();
+    AssignCatcode('$', CC_ACTIVE);
+    AssignCatcode('-', CC_ACTIVE);
+    AssignCatcode('_', CC_ACTIVE);
+    DefMacroI(T_ACTIVE('$'), undef, T_CS('\textdollar'),     scope => 'local');
+    DefMacroI(T_ACTIVE('-'), undef, T_CS('\textendash'),     scope => 'local');
+    DefMacroI(T_ACTIVE('_'), undef, T_CS('\textunderscore'), scope => 'local');
+    my $arg = $gullet->readBalanced(1);
+    EndSemiverbatim();
+    return $arg; },
+  reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
+
+DefMacro('\lstinputlisting OptionalKeyVals:LST LstNameVerbatim', sub {
     my ($gullet, $keyvals, $file) = @_;
     my $text = listingsReadRawFile($gullet, $file);
     $STATE->getStomach->bgroup;
     lstActivate($keyvals);
-    my $name;
-    if (($name = lstGetTokens('name')) && !IsEmpty($name)) {
-      $file = $name; }
-    AssignValue('LST@toctitle', $file);    # so it shows up in list of..
-    return lstProcessDisplay($file, $text); });
+    my $name = lstGetTokens('name');
+    if (IsEmpty($name)) {
+      $name = $file; }
+    AssignValue('LST@toctitle', $name);    # so it shows up in list of..
+    return lstProcessDisplay($name, $text); });
 
 NewCounter('lstlisting', 'document', idprefix => 'LST');
 DefMacro('\ext@lstlisting', 'lol');
@@ -167,7 +183,7 @@ sub lstProcessBlock {
       T_END]); }
 
 sub lstProcessDisplay {
-  my ($name, $text) = @_;
+  my ($name, $text)    = @_;
   my ($body, $trailer) = lstProcessBlock($name, $text);
   my @body = @$body;
   # Figure out whether the display is numbered, or has a caption or titles.
@@ -255,7 +271,7 @@ DefConstructor('\@@listings@block {} {} {}',
     my ($stomach, $whatsit) = @_;
     # Could have some options about encoding?
     my $data_key      = 'LISTINGS_DATA_' . ToString($whatsit->getArg(1));
-    my $listings_data = LookupValue($data_key);
+    my $listings_data = LookupValue($data_key) || '';
     if (is_utf8($listings_data)) {
       $listings_data = encode('UTF-8', $listings_data);
     }
@@ -311,7 +327,7 @@ sub listingsReadRawLines {
 
 sub listingsReadRawFile {
   my ($gullet, $file) = @_;
-  my $filename = ToString(Expand($file));
+  my $filename = ToString(Digest($file));
   my $path     = FindFile($filename);
   my $text;
   my $LST_FH;
@@ -864,7 +880,7 @@ DefKeyVal('LST', 'numberstyle',      '');
 DefKeyVal('LST', 'numbersep',        'Dimension');
 DefKeyVal('LST', 'numberblanklines', '', 'true');
 DefKeyVal('LST', 'firstnumber',      '');
-DefKeyVal('LST', 'name',             '');
+DefKeyVal('LST', 'name',             'LstNameVerbatim');
 NewCounter('lstnumber');
 DefMacro('\thelstnumber', '\arabic{lstnumber}');
 


### PR DESCRIPTION
Fixes #2178 .

Successor to the discussion in #2189 .

This PR now matches the original listings behavior of replacing `_`, `-` and `$` with `\textunderscore`, `\textendash` and `\textdollar`.

That keeps the XML values close to the source, as desired, avoiding any font questions.
But it also opens two new edge cases, namely filenames containing a dollar sign, or an endash `–`. The underscore case doesn't have complications, so I won't discuss it.

I modified the example to use a file named `00$–test_context.t`, which continues to fail, as it is probably wise for us to keep treating `$` as a "nasty" character in a filename and back out.

But I decided to allow `00–test_context.t`, even if it is quite strange - one would need to use the simple dash in the TeX source, but the Unicode endash `–` in the actual filename, if they are to match up.