### PR TITLE
Aligned numbers

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2273,7 +2273,8 @@ Tag('ltx:Math', afterOpen => sub { GenerateID(@_, 'm'); });
 # They provide an environment to wrap around equations,
 # which hijack the equation counter to sub-number within the group.
 DefConstructor('\lx@equationgroup@subnumbering@begin',
-  "<ltx:equationgroup xml:id='#id'>",
+  "<ltx:equationgroup xml:id='#id'>"
+    . "#tags",
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my %eqn   = RefStepCounter('equation');

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -6761,7 +6761,9 @@ DefPrimitive('\lx@gen@matrix@bindings RequiredKeyVals:lx@GEN', sub {
           : (repeated => [{@colspec}]))),
       'math',
       (keys %attributes ? (attributes => {%attributes}) : ()));    # });
-    Let("\\\\", '\@alignment@newline');
+    Let("\\\\",         '\@alignment@newline');
+    Let('\@row@before', '\@empty');    # Disable special row treatment (eg. numbering) unless requested
+    Let('\@row@after',  '\@empty');
 });
 
 DefPrimitive('\lx@end@gen@matrix', sub { $_[0]->egroup; });

--- a/t/ams/amsdisplay.xml
+++ b/t/ams/amsdisplay.xml
@@ -843,6 +843,10 @@
   <para xml:id="p2">
     <p>Sub-numbered equations</p>
     <equationgroup xml:id="S0.E14">
+      <tags>
+        <tag>(14)</tag>
+        <tag role="refnum">14</tag>
+      </tags>
       <equation xml:id="S0.E14.1">
         <tags>
           <tag>(14a)</tag>
@@ -886,6 +890,10 @@
   <para xml:id="p3">
     <p>Subnumbered, but some unnumbered (before/after) or tagged explicitly (before/after)</p>
     <equationgroup xml:id="S0.E15">
+      <tags>
+        <tag>(15)</tag>
+        <tag role="refnum">15</tag>
+      </tags>
       <equation xml:id="S0.E15.1">
         <tags>
           <tag>(15a)</tag>


### PR DESCRIPTION
This PR fixes a couple of numbering issues with nested alignments and subequations.

Fixes #2055
Fixes #2105 
Fixes #2042
Fixes #2142 

(Actually, I'm not sure if it fixed #2142, or if it was already fixed; in any case it seems correct now)