### PR TITLE
weaken numeric test to pass with more ImageMagick versions

### DIFF
--- a/t/003_unit_imagemagick.t
+++ b/t/003_unit_imagemagick.t
@@ -16,12 +16,12 @@ else {
   my $conversion_ok = 0;
   if (image_type($pdf_image) eq "portable document format") {
     my ($loaded_image, $w, $h) = image_graphicx_complex($pdf_image, []);
-    if (ref $loaded_image eq "Image::Magick" and $w == 221 and $h == 242) {
+    if (ref $loaded_image eq "Image::Magick" and $w > 0 and $h > 0) {
       image_write($loaded_image,$png_target);
       if (-f $png_target) {
-        # if we *can* convert, make sure it's the expected PNG size
-        is(-s $png_target, 2557,
-          "PDF to PNG conversion did not produce an image of the expected size");
+        # if we *can* convert, make sure the PNG has some size
+        ok((-s $png_target) > 0,
+          "PDF to PNG conversion did not produce an image of non-zero size");
         unlink($png_target) if -f $png_target;
         $conversion_ok = 1; } } }
   if (!$conversion_ok) {


### PR DESCRIPTION
Quick follow-up to #2195, meant to pass on *any* working version of ImageMagick (by making weaker numeric assumptions)