### PR TITLE
move spacing from AMSmath to LaTeX

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -2595,7 +2595,26 @@ DefConstructor('\lx@stackrel{}{}',
 #======================================================================-
 # C.7.7 Spacing
 #======================================================================-
-# All this is already in TeX.pool
+# some of this is already in TeX.pool.  the rest was in amsmath, but is now native to LaTeX
+
+DefConstructorI('\thinspace', undef,
+  "?#isMath(<ltx:XMHint name='thinspace' width='#width'/>)(\x{2009})",
+  properties => { isSpace => 1, width => sub { LookupRegister('\thinmuskip'); } });
+DefConstructorI('\negthinspace', undef,
+  "?#isMath(<ltx:XMHint name='negthinspace' width='#width'/>)()",
+  properties => { isSpace => 1, width => sub { LookupRegister('\thinmuskip')->negate; } });
+DefConstructorI('\medspace', undef,
+  "?#isMath(<ltx:XMHint name='medspace' width='#width'/>)()",
+  properties => { isSpace => 1, width => sub { LookupRegister('\medmuskip'); } });
+DefConstructorI('\negmedspace', undef,
+  "?#isMath(<ltx:XMHint name='negmedspace' width='#width'/>)()",
+  properties => { isSpace => 1, width => sub { LookupRegister('\medmuskip')->negate; } });
+DefConstructorI('\thickspace', undef,
+  "?#isMath(<ltx:XMHint name='thickspace' width='#width'/>)(\x{2004})",
+  properties => { isSpace => 1, width => sub { LookupRegister('\thickmuskip'); } });
+DefConstructorI('\negthickspace', undef,
+  "?#isMath(<ltx:XMHint name='negthickspace' width='#width'/>)(\x{2004})",
+  properties => { isSpace => 1, width => sub { LookupRegister('\thickmuskip')->negate; } });
 
 #======================================================================
 # C.7.8 Changing Style

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -843,26 +843,7 @@ DefMacro('\matrix@check{}', Tokens());
 # \! == \negthinspace
 # \negmedspace
 # \negthickspace
-# I think only these are new
-
-DefConstructorI('\thinspace', undef,
-  "?#isMath(<ltx:XMHint name='thinspace' width='#width'/>)(\x{2009})",
-  properties => { isSpace => 1, width => sub { LookupRegister('\thinmuskip'); } });
-DefConstructorI('\negthinspace', undef,
-  "?#isMath(<ltx:XMHint name='negthinspace' width='#width'/>)()",
-  properties => { isSpace => 1, width => sub { LookupRegister('\thinmuskip')->negate; } });
-DefConstructorI('\medspace', undef,
-  "?#isMath(<ltx:XMHint name='medspace' width='#width'/>)()",
-  properties => { isSpace => 1, width => sub { LookupRegister('\medmuskip'); } });
-DefConstructorI('\negmedspace', undef,
-  "?#isMath(<ltx:XMHint name='negmedspace' width='#width'/>)()",
-  properties => { isSpace => 1, width => sub { LookupRegister('\medmuskip')->negate; } });
-DefConstructorI('\thickspace', undef,
-  "?#isMath(<ltx:XMHint name='thickspace' width='#width'/>)(\x{2004})",
-  properties => { isSpace => 1, width => sub { LookupRegister('\thickmuskip'); } });
-DefConstructorI('\negthickspace', undef,
-  "?#isMath(<ltx:XMHint name='negthickspace' width='#width'/>)(\x{2004})",
-  properties => { isSpace => 1, width => sub { LookupRegister('\thickmuskip')->negate; } });
+# these are now native to LaTeX (see section C.7.7 Spacing)
 
 DefConstructor('\mspace{MuDimension}', "<ltx:XMHint name='mspace' width='#1'/>");
 


### PR DESCRIPTION
This fixes #2083.  As noted there, several of the spacing commands have moved from AMSmath into LaTeX.