### PR TITLE
spurious characters in css file removed

### DIFF
--- a/lib/LaTeXML/resources/CSS/ltx-book.css
+++ b/lib/LaTeXML/resources/CSS/ltx-book.css
@@ -57,7 +57,7 @@
 .ltx_para > .ltx_p:first-child,
 section.ltx_pruned_first > .ltx_title + .ltx_para > .ltx_p,
 section.ltx_indent_first > .ltx_title + .ltx_para > .ltx_p { text-indent:2em; }
-69/* except the initial in a section */
+/* except the initial in a section */
 section > .ltx_title +.ltx_para > .ltx_p,
 section > .ltx_title +.ltx_date +.ltx_para > .ltx_p {text-indent:0em; }
 


### PR DESCRIPTION
Some numbers crept into the ltx-book.css file that shouldn't be there and make validation to fail.