### PR TITLE
attempt to guard the \@captype for \subcaption

### DIFF
--- a/lib/LaTeXML/Package/subcaption.sty.ltxml
+++ b/lib/LaTeXML/Package/subcaption.sty.ltxml
@@ -44,8 +44,16 @@ DefMacro('\format@title@font@subtable',  '\format@title@font@table');
 # So it should become a sub<float>, inheriting whatever style from outer float;
 # But, ltx:caption will float up outside the minipage (not allowed there)!
 # Probably should convert the minipage to a float, or wrap it, if we could?
-DefMacro('\subcaption OptionalMatch:* []{}',
-  '{\edef\@captype{sub\@captype}\caption[#2]{#3}}');
+DefMacro('\subcaption OptionalMatch:* []{}', sub {
+    my ($gullet, $star, $opt, $caption) = @_;
+    # TODO: this is a temporary kludge to avoid sub-sub mistakes.
+    if (IsDefined('\@captype')) {
+      my $ctype = ToString(Expand(T_CS('\@captype')));
+      if ($ctype && $ctype !~ /^sub/) {    # avoid subsubfigure, etc.
+        DefMacro('\@captype', "sub$ctype", scope => 'local'); } }
+    return (T_CS('\caption'),
+      $opt ? (T_OTHER('['), $opt, T_OTHER(']')) : (), T_BEGIN, $caption, T_END);
+});
 
 #======================================================================
 # Let these float, since subfigures tend to get wrapped with weird positioning.


### PR DESCRIPTION
This issue intersects an ar5iv report and my current deeper dive into figures/subfigures/minipages.

A minimal example was available at [ar5iv#31](https://github.com/dginev/ar5iv/issues/31#issuecomment-1700154030), excerpted here:

```tex
\documentclass{article}
\usepackage{graphicx}
\usepackage{subcaption}
\begin{document}
\begin{figure}
   \centering
   \begin{subfigure}[t]{0.49\textwidth}
       \centering
       \includegraphics[width=0.74\textwidth]{example-image-a}
       \subcaption{} \label{fig:a}
   \end{subfigure}
   \caption{Test}
\end{figure}
\end{document}
```

It appears that our latexml use of `beforeFloat('subfigure',...` combined with the unconditional `\subcaption` code of `\edef\@captype{sub\@captype}` leads to setting an incorrect captype of `subsubfigure`, which leads to errors.

Reading the comments of subcaption.sty.ltxml, and the raw code of subcaption.sty/caption.sty/caption3.sty, I see that we are still "scratching the surface" of the complexity of those packages, in particular the custom behavior related to minipages.

I am not sure I can offer a PR that does justice to the subcaption.sty code, but I could at least come up with a guard that only ever adds a single "sub" level to the `\@captype` macro. It's definitely a simple patch resolving a specific kind of error - so if the PR isn't merged, that's perfectly fine.

But I wanted to raise the issue, while it was fresh in front of me. Feedback welcome!