### PR TITLE
Listings fix

### DIFF
--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -118,25 +118,13 @@ DefMacroI(T_CS('\begin{lstlisting}'), 'OptionalKeyVals:LST', sub {
     lstActivate($keyvals);
     return lstProcessDisplay(lstGetTokens('name'), $text); });
 
-DefParameterType('LstNameVerbatim', sub {
-    my ($gullet) = @_;
-    # Closer to listings approch, but do NOT make - => \textendash! (ends up in file name)
-    AssignCatcode('$', CC_ACTIVE);
-    AssignCatcode('_', CC_ACTIVE);
-    DefMacroI(T_ACTIVE('$'), undef, T_CS('\textdollar'),     scope => 'local');
-    DefMacroI(T_ACTIVE('_'), undef, T_CS('\textunderscore'), scope => 'local');
-    return Tokens(Expand($gullet->readArg)); },
-  semiverbatim => 1,
-  reversion    => sub { (T_BEGIN, Revert($_[0]), T_END); });
-
-DefMacro('\lstinputlisting OptionalKeyVals:LST LstNameVerbatim', sub {
+DefMacro('\lstinputlisting OptionalKeyVals:LST Semiverbatim', sub {
     my ($gullet, $keyvals, $file) = @_;
     my $text = listingsReadRawFile($gullet, $file);
     $STATE->getStomach->bgroup;
     lstActivate($keyvals);
     my $name = lstGetTokens('name');
     $name = $file if IsEmpty($name);
-    AssignValue('LST@toctitle', $name);    # so it shows up in list of..
     return lstProcessDisplay($name, $text); });
 
 NewCounter('lstlisting', 'document', idprefix => 'LST');
@@ -176,9 +164,15 @@ sub lstProcessBlock {
     [@{ LookupValue('LISTINGS_POSTAMBLE') },
       T_END]); }
 
+our %lstFilenameRPL = (
+  '_' => T_CS('\textunderscore'), '$' => T_CS('\textdollar'), '-' => T_CS('\textendash'));
+
 sub lstProcessDisplay {
   my ($name, $text)    = @_;
   my ($body, $trailer) = lstProcessBlock($name, $text);
+  # reencode certain chars, so typewriter-like, but not typewriter font.
+  $name = Tokens(map { $lstFilenameRPL{ ToString($_) } || $_; } $name->unlist) if $name;
+  AssignValue('LST@toctitle', $name);    # so it shows up in list of..
   my @body = @$body;
   # Figure out whether the display is numbered, or has a caption or titles.
   my @caption = ();
@@ -321,7 +315,7 @@ sub listingsReadRawLines {
 
 sub listingsReadRawFile {
   my ($gullet, $file) = @_;
-  my $filename = ToString(Digest($file));
+  my $filename = ToString(Expand($file));
   my $path     = FindFile($filename);
   my $text;
   my $LST_FH;
@@ -874,7 +868,7 @@ DefKeyVal('LST', 'numberstyle',      '');
 DefKeyVal('LST', 'numbersep',        'Dimension');
 DefKeyVal('LST', 'numberblanklines', '', 'true');
 DefKeyVal('LST', 'firstnumber',      '');
-DefKeyVal('LST', 'name',             'LstNameVerbatim');
+DefKeyVal('LST', 'name',             'Semiverbatim');
 NewCounter('lstnumber');
 DefMacro('\thelstnumber', '\arabic{lstnumber}');
 

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -165,13 +165,15 @@ sub lstProcessBlock {
       T_END]); }
 
 our %lstFilenameRPL = (
-  '_' => T_CS('\textunderscore'), '$' => T_CS('\textdollar'), '-' => T_CS('\textendash'));
+  '_' => T_CS('\textunderscore'), '$' => T_CS('\textdollar'),
+  ## '-' => T_CS('\textendash')  # Probably unwise, since it ends up in dataname
+);
 
 sub lstProcessDisplay {
-  my ($name, $text)    = @_;
-  my ($body, $trailer) = lstProcessBlock($name, $text);
+  my ($name, $text) = @_;
   # reencode certain chars, so typewriter-like, but not typewriter font.
   $name = Tokens(map { $lstFilenameRPL{ ToString($_) } || $_; } $name->unlist) if $name;
+  my ($body, $trailer) = lstProcessBlock($name, $text);
   AssignValue('LST@toctitle', $name);    # so it shows up in list of..
   my @body = @$body;
   # Figure out whether the display is numbered, or has a caption or titles.

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -118,16 +118,26 @@ DefMacroI(T_CS('\begin{lstlisting}'), 'OptionalKeyVals:LST', sub {
     lstActivate($keyvals);
     return lstProcessDisplay(lstGetTokens('name'), $text); });
 
-DefMacro('\lstinputlisting OptionalKeyVals:LST Semiverbatim', sub {
+DefParameterType('LstNameVerbatim', sub {
+    my ($gullet) = @_;
+    # Closer to listings approch, but do NOT make - => \textendash! (ends up in file name)
+    AssignCatcode('$', CC_ACTIVE);
+    AssignCatcode('_', CC_ACTIVE);
+    DefMacroI(T_ACTIVE('$'), undef, T_CS('\textdollar'),     scope => 'local');
+    DefMacroI(T_ACTIVE('_'), undef, T_CS('\textunderscore'), scope => 'local');
+    return Tokens(Expand($gullet->readArg)); },
+  semiverbatim => 1,
+  reversion    => sub { (T_BEGIN, Revert($_[0]), T_END); });
+
+DefMacro('\lstinputlisting OptionalKeyVals:LST LstNameVerbatim', sub {
     my ($gullet, $keyvals, $file) = @_;
     my $text = listingsReadRawFile($gullet, $file);
     $STATE->getStomach->bgroup;
     lstActivate($keyvals);
-    my $name;
-    if (($name = lstGetTokens('name')) && !IsEmpty($name)) {
-      $file = $name; }
-    AssignValue('LST@toctitle', $file);    # so it shows up in list of..
-    return lstProcessDisplay($file, $text); });
+    my $name = lstGetTokens('name');
+    $name = $file if IsEmpty($name);
+    AssignValue('LST@toctitle', $name);    # so it shows up in list of..
+    return lstProcessDisplay($name, $text); });
 
 NewCounter('lstlisting', 'document', idprefix => 'LST');
 DefMacro('\ext@lstlisting', 'lol');
@@ -167,7 +177,7 @@ sub lstProcessBlock {
       T_END]); }
 
 sub lstProcessDisplay {
-  my ($name, $text) = @_;
+  my ($name, $text)    = @_;
   my ($body, $trailer) = lstProcessBlock($name, $text);
   my @body = @$body;
   # Figure out whether the display is numbered, or has a caption or titles.
@@ -202,7 +212,7 @@ sub lstProcessDisplay {
     ($numbered || $caption ? (T_CS('\par')) : ()),
     T_BEGIN,
     ($name ? (T_CS('\def'), T_CS('\lstname'), T_BEGIN, $name->unlist, T_END) : ()),
-    ($numbered
+    ($numbered || !IsEmpty($name)
       ? Invocation(T_CS('\@listings'), Tokens(@body))
       : ($caption
         ? Invocation(T_CS('\@@listings'), Tokens(@body))
@@ -311,7 +321,7 @@ sub listingsReadRawLines {
 
 sub listingsReadRawFile {
   my ($gullet, $file) = @_;
-  my $filename = ToString(Expand($file));
+  my $filename = ToString(Digest($file));
   my $path     = FindFile($filename);
   my $text;
   my $LST_FH;
@@ -864,7 +874,7 @@ DefKeyVal('LST', 'numberstyle',      '');
 DefKeyVal('LST', 'numbersep',        'Dimension');
 DefKeyVal('LST', 'numberblanklines', '', 'true');
 DefKeyVal('LST', 'firstnumber',      '');
-DefKeyVal('LST', 'name',             '');
+DefKeyVal('LST', 'name',             'LstNameVerbatim');
 NewCounter('lstnumber');
 DefMacro('\thelstnumber', '\arabic{lstnumber}');
 
@@ -1529,6 +1539,8 @@ DefConstructor('\@lst@startline{}', "<ltx:listingline xml:id='#id'>#1",
 DefConstructor('\@lst@endline',      "</ltx:listingline>");
 DefConstructor('\@lst@linenumber{}', "<ltx:tags><ltx:tag>#1</ltx:tag></ltx:tags>");
 
+DefMacro('\lstnumbertyperefname', 'line');
+
 DefConstructor('\@lst@visible@space', "\x{2423}");
 
 sub lstDoNumber {
@@ -1537,8 +1549,7 @@ sub lstDoNumber {
       || ((($LaTeXML::linenum - 1) % lstGetNumber('stepnumber')) == 0))
     && (lstGetBoolean('numberblanklines') || !$isempty)) {
     AssignValue('LISTINGS_NEEDS_NUMBER' => 0);
-    return Invocation(T_CS('\@lst@linenumber'),
-      Tokens(T_BEGIN, lstGetTokens('numberstyle')->unlist, T_CS('\thelstnumber'), T_END)); }
+    return Invocation(T_CS('\lx@make@tags'), T_OTHER('lstnumber')); }
   else {
     return Invocation(T_CS('\@lst@linenumber'), Tokens()); } }
 

--- a/t/alignment/listing.xml
+++ b/t/alignment/listing.xml
@@ -110,12 +110,18 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_numbers_left ltx_lstlisting" data="c3R1ZmYxCnN0dWZmMgpzdHVmZjM=" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx1"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_identifier">stuff1</text></listingline>
         <listingline xml:id="lstnumberx2"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_identifier">stuff2</text></listingline>
         <listingline xml:id="lstnumberx3"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_identifier">stuff3</text></listingline>
       </listing>
     </para>
@@ -131,12 +137,18 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_C ltx_lst_numbers_left ltx_lstlisting" data="I2RlZmluZSBFWEFNUExFIHdoaWNod2hhdAp4ID0gImZvbyI7CmJyZWFrOw==" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx4"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_directive" font="typewriter">#define</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier" font="slanted">EXAMPLE</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier" font="slanted">whichwhat</text></listingline>
         <listingline xml:id="lstnumberx5"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_identifier" font="slanted">x</text><text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_string">”foo”</text>;</listingline>
         <listingline xml:id="lstnumberx6"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_keyword" font="bold">break</text>;</listingline>
       </listing>
     </para>
@@ -153,12 +165,18 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOwoKV3JpdGUoJ2Nhc2UgaW5zZW5zaXRpdmUnKTsKV3JpdGUoJ2xvbmcgJycgc3RyaW5nJyk7CldyaXRFKCdQYXNjYWwga2V5d29yZHMuJyk7" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx7"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx8"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx9"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
     </para>
@@ -166,25 +184,33 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <p>A numbered listing:</p>
       <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCgliZWdpbgoJCXsgZG8gbm90aGluZyB9CgllbmQ7CgpXcml0ZSgnY2FzZSBpbnNlbnNpdGl2ZScpOwpXcml0ZSgnbG9uZyAnJyBzdHJpbmcnKTsKV3JpdEUoJ1Bhc2NhbCBrZXl3b3Jkcy4nKTs=" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx10"><tags>
-            <tag><text fontsize="50%">1</text></tag>
+            <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space">␣</text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space">␣</text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space">␣</text>0<text class="ltx_lst_space">␣</text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx11"><tags>
             <tag/>
           </tags><text class="ltx_lst_space">␣␣␣␣</text><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx12"><tags>
-            <tag><text fontsize="50%">3</text></tag>
+            <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">␣␣␣␣␣␣␣␣</text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic">␣</text><text font="italic">do<text class="ltx_lst_space">␣</text>nothing<text class="ltx_lst_space">␣</text></text>}</text></listingline>
         <listingline xml:id="lstnumberx13"><tags>
             <tag/>
           </tags><text class="ltx_lst_space">␣␣␣␣</text><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
         <listingline xml:id="lstnumberx14"><tags>
-            <tag><text fontsize="50%">5</text></tag>
+            <tag>5</tag>
+            <tag role="refnum">5</tag>
+            <tag role="typerefnum">line 5</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx15"><tags>
             <tag/>
           </tags><text class="ltx_lst_keyword" font="bold">Write</text>(<text class="ltx_lst_string" color="#FF0000" font="typewriter">’case<text class="ltx_lst_space">␣</text>insensitive’</text>);</listingline>
         <listingline xml:id="lstnumberx16"><tags>
-            <tag><text fontsize="50%">7</text></tag>
+            <tag>7</tag>
+            <tag role="refnum">7</tag>
+            <tag role="typerefnum">line 7</tag>
           </tags><text class="ltx_lst_keyword" font="bold">Write</text>(<text class="ltx_lst_string" color="#FF0000" font="typewriter">’long<text class="ltx_lst_space">␣</text>’’<text class="ltx_lst_space">␣</text>string’</text>);</listingline>
         <listingline xml:id="lstnumberx17"><tags>
             <tag/>
@@ -200,18 +226,28 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOwpXcml0ZSgnY2FzZSBpbnNlbnNpdGl2ZScpOw==" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx18"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx19"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx20"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx21"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
         <listingline xml:id="lstnumberx22"><tags>
             <tag>5</tag>
+            <tag role="refnum">5</tag>
+            <tag role="typerefnum">line 5</tag>
           </tags><text class="ltx_lst_keyword" font="bold">Write</text>(<text class="ltx_lst_string">’case<text class="ltx_lst_space">␣</text>insensitive’</text>);</listingline>
       </listing>
     </float>
@@ -229,15 +265,23 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx23"><tags>
             <tag>100</tag>
+            <tag role="refnum">100</tag>
+            <tag role="typerefnum">line 100</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx24"><tags>
             <tag>101</tag>
+            <tag role="refnum">101</tag>
+            <tag role="typerefnum">line 101</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx25"><tags>
             <tag>102</tag>
+            <tag role="refnum">102</tag>
+            <tag role="typerefnum">line 102</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx26"><tags>
             <tag>103</tag>
+            <tag role="refnum">103</tag>
+            <tag role="typerefnum">line 103</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
     </float>
@@ -253,47 +297,71 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx27"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx28"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx29"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx30"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
     </para>
     <para xml:id="S6.p2">
       <listing class="ltx_lst_language_Pascal ltx_lst_numbers_right ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx31"><tags>
-            <tag><text color="#FF0000">1</text></tag>
+            <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx32"><tags>
-            <tag><text color="#FF0000">2</text></tag>
+            <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx33"><tags>
-            <tag><text color="#FF0000">3</text></tag>
+            <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx34"><tags>
-            <tag><text color="#FF0000">4</text></tag>
+            <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
     </para>
     <para xml:id="S6.p3">
       <listing class="ltx_lst_language_Pascal ltx_lst_numbers_right ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx35"><tags>
-            <tag><text color="#0000FF">1</text></tag>
+            <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx36"><tags>
-            <tag><text color="#0000FF">2</text></tag>
+            <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx37"><tags>
-            <tag><text color="#0000FF">3</text></tag>
+            <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx38"><tags>
-            <tag><text color="#0000FF">4</text></tag>
+            <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
     </para>
@@ -309,15 +377,23 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing backgroundcolor="#FF5EFF" class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain" framecolor="#FF0000" framed="rectangle">
         <listingline xml:id="lstnumberx39"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx40"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx41"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx42"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
     </para>
@@ -325,29 +401,45 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing backgroundcolor="#FFFF00" class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx43"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx44"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx45"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx46"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
       <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain" framed="rectangle">
         <listingline xml:id="lstnumberx47"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx48"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx49"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx50"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
     </para>
@@ -355,15 +447,23 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain" framed="topbottom">
         <listingline xml:id="lstnumberx51"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_keyword" font="bold">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_keyword" font="bold">do</text></listingline>
         <listingline xml:id="lstnumberx52"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">begin</text></listingline>
         <listingline xml:id="lstnumberx53"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_comment">{<text class="ltx_lst_space" font="italic"> </text><text font="italic">do<text class="ltx_lst_space"> </text>nothing<text class="ltx_lst_space"> </text></text>}</text></listingline>
         <listingline xml:id="lstnumberx54"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
     </para>
@@ -378,12 +478,18 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing backgroundcolor="#E6E6E6" class="ltx_lst_language_C ltx_lst_numbers_left ltx_lstlisting" data="I2RlZmluZSBFWEFNUExFIHdoaWNod2hhdAp4ID0gImZvbyI7CmJyZWFrOw==" dataencoding="base64" datamimetype="text/plain" framed="topbottom">
         <listingline xml:id="lstnumberx55"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_directive" font="typewriter">#define</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier" font="slanted">EXAMPLE</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier" font="slanted">whichwhat</text></listingline>
         <listingline xml:id="lstnumberx56"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_identifier" font="slanted">x</text><text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_string">”foo”</text>;</listingline>
         <listingline xml:id="lstnumberx57"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_keyword" font="bold">break</text>;</listingline>
       </listing>
     </float>
@@ -399,6 +505,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_c ltx_lst_numbers_left ltx_lstlisting" data="Ly8gXHVwc2hhcGUgY2FsY3VsYXRlICRhX3tpan0kCmFbaV1bal0gPSBhW2pdW2pdL2FbaV1bal07" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx58"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_comment" color="#00FF00">//calculate <Math mode="inline" tex="a_{ij}" text="a _ (i * j)" xml:id="lstnumberx58.m1">
               <XMath>
                 <XMApp>
@@ -414,6 +522,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             </Math></text></listingline>
         <listingline xml:id="lstnumberx59"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>][<text class="ltx_lst_identifier">j</text>]<text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">j</text>][<text class="ltx_lst_identifier">j</text>]/<text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>][<text class="ltx_lst_identifier">j</text>];</listingline>
       </listing>
     </para>
@@ -421,6 +531,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_c ltx_lst_numbers_left ltx_lstlisting" data="Ly8gXHVwc2hhcGUgY2FsY3VsYXRlICRhX3tpan0kCmFbaV1bal0gPSBhW2pdW2pdL2FbaV1bal07" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx60"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_comment"><text font="italic">//</text>calculate <Math mode="inline" tex="a_{ij}" text="a _ (i * j)" xml:id="lstnumberx60.m1">
               <XMath>
                 <XMApp>
@@ -436,6 +548,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             </Math></text></listingline>
         <listingline xml:id="lstnumberx61"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>][<text class="ltx_lst_identifier">j</text>]<text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">j</text>][<text class="ltx_lst_identifier">j</text>]/<text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>][<text class="ltx_lst_identifier">j</text>];</listingline>
       </listing>
     </para>
@@ -443,6 +557,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_c ltx_lst_numbers_left ltx_lstlisting" data="Ly8gY2FsY3VsYXRlICRhX3tpan0kCiRhX3tpan0KID0gYV97amp9L2F7aWp9JDsKLy8gY2FsY3VsYXRlICRhX3tpan0gPQpcc2luIHgkCmFbaSxqXT1zaW4oeCkKZm9vPSJhIHdvcmQiOwpmb289ImEgJHheMiQgbWF0aCI7" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx62"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_comment" color="#00FF00">//<text class="ltx_lst_space"> </text>calculate<text class="ltx_lst_space"> </text><Math mode="inline" tex="a_{ij}" text="a _ (i * j)" xml:id="lstnumberx62.m1">
               <XMath>
                 <XMApp>
@@ -458,6 +574,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             </Math></text></listingline>
         <listingline xml:id="lstnumberx63"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><Math mode="inline" tex="a_{ij}=a_{jj}/a{ij}" text="a _ (i * j) = (a _ (j * j) / a) * i * j" xml:id="lstnumberx63.m1">
             <XMath>
               <XMApp>
@@ -494,6 +612,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
           </Math>;</listingline>
         <listingline xml:id="lstnumberx64"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_comment" color="#00FF00">//<text class="ltx_lst_space"> </text>calculate<text class="ltx_lst_space"> </text><Math mode="inline" tex="a_{ij}=\sin x" text="a _ (i * j) = sine@(x)" xml:id="lstnumberx64.m1">
               <XMath>
                 <XMApp>
@@ -516,12 +636,18 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             </Math></text></listingline>
         <listingline xml:id="lstnumberx65"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>,<text class="ltx_lst_identifier">j</text>]=<text class="ltx_lst_identifier">sin</text>(<text class="ltx_lst_identifier">x</text>)</listingline>
         <listingline xml:id="lstnumberx66"><tags>
             <tag>5</tag>
+            <tag role="refnum">5</tag>
+            <tag role="typerefnum">line 5</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=<text class="ltx_lst_string">”a<text class="ltx_lst_space">␣</text>word”</text>;</listingline>
         <listingline xml:id="lstnumberx67"><tags>
             <tag>6</tag>
+            <tag role="refnum">6</tag>
+            <tag role="typerefnum">line 6</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=<text class="ltx_lst_string">”a<text class="ltx_lst_space">␣</text><Math mode="inline" tex="x^{2}" text="x ^ 2" xml:id="lstnumberx67.m1">
               <XMath>
                 <XMApp>
@@ -537,6 +663,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_c ltx_lst_numbers_left ltx_lstlisting" data="Ly8gY2FsY3VsYXRlICUkYV97aWp9JCUKYV97aWp9CiA9IGFfe2pqfS9he2lqfTs=" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx68"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_comment" font="italic">//<text class="ltx_lst_space"> </text>calculate<text class="ltx_lst_space"> </text>&lt;<Math mode="inline" tex="a_{ij}" text="a _ (i * j)" xml:id="lstnumberx68.m1">
               <XMath>
                 <XMApp>
@@ -552,9 +680,13 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             </Math>&gt;</text></listingline>
         <listingline xml:id="lstnumberx69"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_identifier">a_</text>{<text class="ltx_lst_identifier">ij</text>}</listingline>
         <listingline xml:id="lstnumberx70"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">a_</text>{<text class="ltx_lst_identifier">jj</text>}/<text class="ltx_lst_identifier">a</text>{<text class="ltx_lst_identifier">ij</text>};</listingline>
       </listing>
     </para>
@@ -562,30 +694,48 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_c ltx_lst_numbers_left ltx_lstlisting" data="Ly8gY2FsY3VsYXRlICRhX3tpan0kCiRhX3tpan0KID0gYV97amp9L2F7aWp9JDsKLy8gY2FsY3VsYXRlICRhX3tpan0gPQpcc2luIHgkCmFbaSxqXT1zaW4oeCkKZm9vPSJhIHdvcmQiOwpmb289ImEgXCJzdHJpbmciOwpmb289ImEgJHheMiQgbWF0aCI7" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx71"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_comment" font="italic">//<text class="ltx_lst_space"> </text>calculate<text class="ltx_lst_space"> </text>$a_{ij}$</text></listingline>
         <listingline xml:id="lstnumberx72"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_identifier">$a_</text>{<text class="ltx_lst_identifier">ij</text>}</listingline>
         <listingline xml:id="lstnumberx73"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">a_</text>{<text class="ltx_lst_identifier">jj</text>}/<text class="ltx_lst_identifier">a</text>{<text class="ltx_lst_identifier">ij</text>}<text class="ltx_lst_identifier">$</text>;</listingline>
         <listingline xml:id="lstnumberx74"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_comment" font="italic">//<text class="ltx_lst_space"> </text>calculate<text class="ltx_lst_space"> </text>$a_{ij}<text class="ltx_lst_space"> </text>=</text></listingline>
         <listingline xml:id="lstnumberx75"><tags>
             <tag>5</tag>
+            <tag role="refnum">5</tag>
+            <tag role="typerefnum">line 5</tag>
           </tags>\<text class="ltx_lst_identifier">sin</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">x$</text></listingline>
         <listingline xml:id="lstnumberx76"><tags>
             <tag>6</tag>
+            <tag role="refnum">6</tag>
+            <tag role="typerefnum">line 6</tag>
           </tags><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>,<text class="ltx_lst_identifier">j</text>]=<text class="ltx_lst_identifier">sin</text>(<text class="ltx_lst_identifier">x</text>)</listingline>
         <listingline xml:id="lstnumberx77"><tags>
             <tag>7</tag>
+            <tag role="refnum">7</tag>
+            <tag role="typerefnum">line 7</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=<text class="ltx_lst_string" font="typewriter">"a<text class="ltx_lst_space">␣</text>word"</text>;</listingline>
         <listingline xml:id="lstnumberx78"><tags>
             <tag>8</tag>
+            <tag role="refnum">8</tag>
+            <tag role="typerefnum">line 8</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=<text class="ltx_lst_string" font="typewriter">"a<text class="ltx_lst_space">␣</text>\"string"</text>;</listingline>
         <listingline xml:id="lstnumberx79"><tags>
             <tag>9</tag>
+            <tag role="refnum">9</tag>
+            <tag role="typerefnum">line 9</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=<text class="ltx_lst_string" font="typewriter">"a<text class="ltx_lst_space">␣</text>$x^2$<text class="ltx_lst_space">␣</text>math"</text>;</listingline>
       </listing>
     </para>
@@ -597,35 +747,53 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <tag role="typerefnum">§9</tag>
     </tags>
     <title><tag close=" ">9</tag>A Perl Listing</title>
-    <float class="ltx_lstlisting" xml:id="LSTx2">
+    <float class="ltx_lstlisting" inlist="lol" xml:id="S9.tab1">
       <toccaption>any.sty.ltxml</toccaption>
       <listing class="ltx_lst_language_perl ltx_lst_numbers_left ltx_lstlisting" data="IyAtKi0gQ1BFUkwgLSotCnBhY2thZ2UgTGFUZVhNTDo6UGFja2FnZTo6UG9vbDsKdXNlIHN0cmljdDsKdXNlIExhVGVYTUw6OlBhY2thZ2U7CgpEZWZDb25zdHJ1Y3RvcignXGNvbnRhaW5lcnt9JywiPGx0eDpzcGVjaWFsPiMxPC9sdHg6c3BlY2lhbD4iKTsKRGVmQ29uc3RydWN0b3IoJ1xmb28nLCI8bHR4Om5vdC1kZWZpbmVkLz4iKTsKCjE7Cg==" dataencoding="base64" datamimetype="text/plain" dataname="any.sty.ltxml">
         <listingline xml:id="lstnumberx80"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_comment" font="italic">#<text class="ltx_lst_space"> </text>-*-<text class="ltx_lst_space"> </text>CPERL<text class="ltx_lst_space"> </text>-*-</text></listingline>
         <listingline xml:id="lstnumberx81"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_keyword" font="bold">package</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">LaTeXML</text>::<text class="ltx_lst_identifier">Package</text>::<text class="ltx_lst_identifier">Pool</text>;</listingline>
         <listingline xml:id="lstnumberx82"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_keyword" font="bold">use</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">strict</text>;</listingline>
         <listingline xml:id="lstnumberx83"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">use</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">LaTeXML</text>::<text class="ltx_lst_identifier">Package</text>;</listingline>
         <listingline xml:id="lstnumberx84"><tags>
             <tag>5</tag>
+            <tag role="refnum">5</tag>
+            <tag role="typerefnum">line 5</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx85"><tags>
             <tag>6</tag>
+            <tag role="refnum">6</tag>
+            <tag role="typerefnum">line 6</tag>
           </tags><text class="ltx_lst_identifier">DefConstructor</text>(<text class="ltx_lst_string">’\container{}’</text>,<text class="ltx_lst_string">”&lt;ltx:special&gt;#1&lt;/ltx:special&gt;”</text>);</listingline>
         <listingline xml:id="lstnumberx86"><tags>
             <tag>7</tag>
+            <tag role="refnum">7</tag>
+            <tag role="typerefnum">line 7</tag>
           </tags><text class="ltx_lst_identifier">DefConstructor</text>(<text class="ltx_lst_string">’\foo’</text>,<text class="ltx_lst_string">”&lt;ltx:not-defined/&gt;”</text>);</listingline>
         <listingline xml:id="lstnumberx87"><tags>
             <tag>8</tag>
+            <tag role="refnum">8</tag>
+            <tag role="typerefnum">line 8</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx88"><tags>
             <tag>9</tag>
+            <tag role="refnum">9</tag>
+            <tag role="typerefnum">line 9</tag>
           </tags>1;</listingline>
       </listing>
     </float>
@@ -637,758 +805,1258 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <tag role="typerefnum">§10</tag>
     </tags>
     <title><tag close=" ">10</tag>A Recursive <text class="ltx_TeX_logo" cssstyle="letter-spacing:-0.2em; margin-right:0.2em">T<text cssstyle="font-variant:small-caps;font-size:120%;" yoffset="-0.2ex">e</text>X</text> listing</title>
-    <float class="ltx_lstlisting" xml:id="LSTx3">
+    <float class="ltx_lstlisting" inlist="lol" xml:id="S10.tab1">
       <toccaption>listing.tex</toccaption>
       <listing class="ltx_lst_language_TeX_LaTeX ltx_lst_numbers_left ltx_lstlisting" data="XGRvY3VtZW50Y2xhc3N7YXJ0aWNsZX0KXHVzZXBhY2thZ2V7bWFrZWlkeH0KXG1ha2VpbmRleApcdXNlcGFja2FnZXtsaXN0aW5nc30KXHVzZXBhY2thZ2VbZHZpcHNuYW1lc117Y29sb3J9ClxiZWdpbntkb2N1bWVudH0KXGxzdHNldHtudW1iZXJzPWxlZnR9ClxzZWN0aW9ue0ludHJvZHVjdGlvbn0KVGhpcyBkb2N1bWVudCBjb250YWlucyB0aGUgZm9sbG93aW5nIGxpc3RpbmdzOgpcbHN0bGlzdG9mbGlzdGluZ3MKClxzZWN0aW9ue0lubGluZSBMaXN0aW5nc30KVmFyaW91cyBkZWxpbWl0ZXJzOiBcbHN0aW5saW5le2Ffd29yZH0sClxsc3RpbmxpbmUhYV93b3JkISwgXGxzdGlubGluZSBBYV93b3JkQSwKXGxzdGlubGluZSZhX3dvcmQmIGFuZCBldmVuIFxsc3RpbmxpbmVeYV93b3JkXiBkb25lLgoKXGRlZlxqdXN0Y29weSMxeyMxfQpJbmRpcmVjdGx5OiBcanVzdGNvcHl7XGxzdGlubGluZXxhX3dvcmR8fTsKYW5kIHdpdGggbWVzc2VkIHVwIGJyYWNlcyBcbHN0aW5saW5le2ZvbyB7IGJhciB9LiUgfQoKewpcbHN0c2V0ewogIG1hdGhlc2NhcGU9dHJ1ZSwKfQpDYXJlZnVsIHdpdGggc3BhY2luZy9tYXRoL21hY3JvczogXGxzdGlubGluZSFmb28oJFxsYW5nbGUgWCBccmFuZ2xlJCkhCn0KXHN1YnNlY3Rpb257U2hvcnRoYW5kc30KTm9ybWFsOiB8QHwgYW5kICR4XnkkClxsc3RNYWtlU2hvcnRJbmxpbmVbbGFuZ3VhZ2U9cGVybCxiYXNpY3N0eWxlPVx0dGZhbWlseV18Clxsc3RNYWtlU2hvcnRJbmxpbmVbbGFuZ3VhZ2U9cGVybCxiYXNpY3N0eWxlPVx0dGZhbWlseV1AClxsc3RNYWtlU2hvcnRJbmxpbmVbbGFuZ3VhZ2U9cGVybCxiYXNpY3N0eWxlPVx0dGZhbWlseV1eCgpMaXN0aW5nMToKfCRmb28tPmJheigvXlxzKi8pIjt8CgpMaXN0aW5nMjoKQCRmb28tPmJheigvXlxzKi8pIjtACgpMaXN0aW5nMzoKXnh5XgpcbHN0RGVsZXRlU2hvcnRJbmxpbmV8Clxsc3REZWxldGVTaG9ydElubGluZUAKXGxzdERlbGV0ZVNob3J0SW5saW5lXgoKTm9ybWFsIGFnYWluOiB8QHwgYW5kICR4XnkkCgpcc2VjdGlvbntBbiB1bnR5cGVkIExpc3Rpbmd9Ck5vIG9wdGlvbnMsIGxhbmd1YWdlLCBldGMKXGJlZ2lue2xzdGxpc3Rpbmd9CnN0dWZmMQpzdHVmZjIKc3R1ZmYzClxlbmR7bHN0bGlzdGluZ30KClxzZWN0aW9ue1NvbWUgQ30KClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT1DLGlkZW50aWZpZXJzdHlsZT1cc2xzaGFwZSxkaXJlY3RpdmVzdHlsZT1cdHRmYW1pbHldCiNkZWZpbmUgRVhBTVBMRSB3aGljaHdoYXQKeCA9ICJmb28iOwpicmVhazsKXGVuZHtsc3RsaXN0aW5nfQoKXHNlY3Rpb257QSBQYXNjYWwgTGlzdGluZ30KQSBsaXN0aW5nIHBvcnRpb246ClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT1QYXNjYWwsZmlyc3RsaW5lPTIsbGFzdGxpbmU9NSxjYXB0aW9uPXt9XQpmb3IgaTo9bWF4aW50IHRvIDAgZG8KYmVnaW4KICB7IGRvIG5vdGhpbmcgfQplbmQ7CgpXcml0ZSgnY2FzZSBpbnNlbnNpdGl2ZScpOwpXcml0ZSgnbG9uZyAnJyBzdHJpbmcnKTsKV3JpdEUoJ1Bhc2NhbCBrZXl3b3Jkcy4nKTsKXGVuZHtsc3RsaXN0aW5nfQoKQSBudW1iZXJlZCBsaXN0aW5nOgpcYmVnaW57bHN0bGlzdGluZ31bbGFuZ3VhZ2U9UGFzY2FsLG51bWJlcnM9bGVmdCwgbnVtYmVyc3R5bGU9XHRpbnksIHN0ZXBudW1iZXI9MixzdHJpbmdzdHlsZT1cY29sb3J7cmVkfVx0dGZhbWlseSxzaG93c3BhY2VzLHRhYnNpemU9NF0KZm9yIGk6PW1heGludCB0byAwIGRvCgliZWdpbgoJCXsgZG8gbm90aGluZyB9CgllbmQ7CgpXcml0ZSgnY2FzZSBpbnNlbnNpdGl2ZScpOwpXcml0ZSgnbG9uZyAnJyBzdHJpbmcnKTsKV3JpdEUoJ1Bhc2NhbCBrZXl3b3Jkcy4nKTsKXGVuZHtsc3RsaXN0aW5nfQoKQSBUaXRsZWQgbGlzdGluZzoKXGJlZ2lue2xzdGxpc3Rpbmd9W2xhbmd1YWdlPVBhc2NhbCx0aXRsZT17QSBiaXQgb2YgUGFzY2FsfV0KZm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOwpXcml0ZSgnY2FzZSBpbnNlbnNpdGl2ZScpOwpcZW5ke2xzdGxpc3Rpbmd9CgoKQSBDYXB0aW9uZWQgbGlzdGluZyAoa25vd24gYXMgTGlzdGluZyBccmVme3Bhc2NhbGxpc3Rpbmd9KSA6ClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT1QYXNjYWwsY2FwdGlvbj1Bbm90aGVyIGJpdCBvZiBQYXNjYWwsIGxhYmVsPXBhc2NhbGxpc3RpbmcsZmlyc3RudW1iZXI9MTAwLG51bWJlcnM9bGVmdF0KZm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOwpcZW5ke2xzdGxpc3Rpbmd9Cgpcc2VjdGlvbntBbiBFbnZpcm9ubWVudH0KXGJlZ2lue2xzdGxpc3Rpbmd9W2xhbmd1YWdlPVBhc2NhbF0KZm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOwpcZW5ke2xzdGxpc3Rpbmd9CgpcbHN0bmV3ZW52aXJvbm1lbnR7Y29sb3JlZH1bMV17XGxzdHNldHtsYW5ndWFnZT1QYXNjYWwsbnVtYmVycz1yaWdodCxudW1iZXJzdHlsZT1cY29sb3J7IzF9fX17fQpcYmVnaW57Y29sb3JlZH17cmVkfQpmb3IgaTo9bWF4aW50IHRvIDAgZG8KYmVnaW4KICB7IGRvIG5vdGhpbmcgfQplbmQ7ClxlbmR7Y29sb3JlZH0KClxiZWdpbntjb2xvcmVkfXtibHVlfQpmb3IgaTo9bWF4aW50IHRvIDAgZG8KYmVnaW4KICB7IGRvIG5vdGhpbmcgfQplbmQ7ClxlbmR7Y29sb3JlZH0KClxzZWN0aW9ue0ZyYW1pbmcgYW5kIHN1Y2h9Clxsc3RzZXR7YmFja2dyb3VuZGNvbG9yPVxjb2xvcltuYW1lZF17Q2FybmF0aW9uUGlua319ClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT1QYXNjYWwsZnJhbWU9c2luZ2xlLHJ1bGVjb2xvcj1cY29sb3J7cmVkfV0KZm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOwpcZW5ke2xzdGxpc3Rpbmd9CgpcYmVnaW57bHN0bGlzdGluZ31bbGFuZ3VhZ2U9UGFzY2FsLGZyYW1lcm91bmQ9dHR0dCxiYWNrZ3JvdW5kY29sb3I9XGNvbG9ye3llbGxvd31dCmZvciBpOj1tYXhpbnQgdG8gMCBkbwpiZWdpbgogIHsgZG8gbm90aGluZyB9CmVuZDsKXGVuZHtsc3RsaXN0aW5nfQpcbHN0c2V0e2JhY2tncm91bmRjb2xvcj19ClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT1QYXNjYWwsZnJhbWU9c2luZ2xlXQpmb3IgaTo9bWF4aW50IHRvIDAgZG8KYmVnaW4KICB7IGRvIG5vdGhpbmcgfQplbmQ7ClxlbmR7bHN0bGlzdGluZ30KClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT1QYXNjYWwsZnJhbWU9bGluZXNdCmZvciBpOj1tYXhpbnQgdG8gMCBkbwpiZWdpbgogIHsgZG8gbm90aGluZyB9CmVuZDsKXGVuZHtsc3RsaXN0aW5nfQoKXGJlZ2lue2xzdGxpc3Rpbmd9W2xhbmd1YWdlPUMsaWRlbnRpZmllcnN0eWxlPVxzbHNoYXBlLGRpcmVjdGl2ZXN0eWxlPVx0dGZhbWlseSwKY2FwdGlvbj1BIEMgbGFuZ3VhZ2UgbGlzdGluZywgZnJhbWU9bGluZXMsYmFja2dyb3VuZGNvbG9yPXtcY29sb3JbY215a117MCwwLDAsMC4xfX1dCiNkZWZpbmUgRVhBTVBMRSB3aGljaHdoYXQKeCA9ICJmb28iOwpicmVhazsKXGVuZHtsc3RsaXN0aW5nfQoKXHNlY3Rpb257TGlzdGluZyB3aXRoIE1hdGh9ClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT1jLHRleGNsLGNvbW1lbnRzdHlsZT1cY29sb3J7Z3JlZW59XQovLyBcdXBzaGFwZSBjYWxjdWxhdGUgJGFfe2lqfSQKYVtpXVtqXSA9IGFbal1bal0vYVtpXVtqXTsKXGVuZHtsc3RsaXN0aW5nfQoKXGJlZ2lue2xzdGxpc3Rpbmd9W3RleGNsLGxhbmd1YWdlPWNdCi8vIFx1cHNoYXBlIGNhbGN1bGF0ZSAkYV97aWp9JAphW2ldW2pdID0gYVtqXVtqXS9hW2ldW2pdOwpcZW5ke2xzdGxpc3Rpbmd9CgpcYmVnaW57bHN0bGlzdGluZ31bbGFuZ3VhZ2U9YyxtYXRoZXNjYXBlLG51bWJlcnM9bGVmdCxjb21tZW50c3R5bGU9XGNvbG9ye2dyZWVufV0KLy8gY2FsY3VsYXRlICRhX3tpan0kCiRhX3tpan0KID0gYV97amp9L2F7aWp9JDsKLy8gY2FsY3VsYXRlICRhX3tpan0gPSAKXHNpbiB4JAphW2ksal09c2luKHgpCmZvbz0iYSB3b3JkIjsKZm9vPSJhICR4XjIkIG1hdGgiOwpcZW5ke2xzdGxpc3Rpbmd9CgpcYmVnaW57bHN0bGlzdGluZ31bbGFuZ3VhZ2U9Yyxlc2NhcGVjaGFyPVwlLGVzY2FwZWJlZ2luPVx0ZXh0bGVzcyxlc2NhcGVlbmQ9XHRleHRncmVhdGVyLG51bWJlcnM9bGVmdF0KLy8gY2FsY3VsYXRlICUkYV97aWp9JCUKYV97aWp9CiA9IGFfe2pqfS9he2lqfTsKXGVuZHtsc3RsaXN0aW5nfQoKXGJlZ2lue2xzdGxpc3Rpbmd9W2xhbmd1YWdlPWMsbnVtYmVycz1sZWZ0LHN0cmluZ3N0eWxlPVx0dGZhbWlseV0KLy8gY2FsY3VsYXRlICRhX3tpan0kCiRhX3tpan0KID0gYV97amp9L2F7aWp9JDsKLy8gY2FsY3VsYXRlICRhX3tpan0gPSAKXHNpbiB4JAphW2ksal09c2luKHgpCmZvbz0iYSB3b3JkIjsKZm9vPSJhIFwic3RyaW5nIjsKZm9vPSJhICR4XjIkIG1hdGgiOwpcZW5ke2xzdGxpc3Rpbmd9Cgpcc2VjdGlvbntBIFBlcmwgTGlzdGluZ30KXGxzdGlucHV0bGlzdGluZ1tsYW5ndWFnZT1wZXJsXXthbnkuc3R5Lmx0eG1sfQoKXHNlY3Rpb257QSBSZWN1cnNpdmUgXFRlWFwgbGlzdGluZ30KXGxzdGlucHV0bGlzdGluZ1tsYW5ndWFnZT17W0xhVGVYXVRlWH1de2xpc3RpbmcudGV4fQoKQSBzaG9ydGVyIGxpc3RpbmcsIHdpdGggY29sb3JlZCBjcyB0aGF0IGluY2x1ZGUgdGhlIHNsYXNoClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT17W0xhVGVYXVRlWH0sdGV4Y3NzdHlsZT0qe1xjb2xvcntibHVlfVxiZnNlcmllc31dCiAgXGlmdHJ1ZSBzb21ldGhpbmcgXGZpClxlbmR7bHN0bGlzdGluZ30KClxzZWN0aW9ue1Rlc3RpbmcgVGFnfQolIEFIQSwgdGFnc3R5bGUgb25seSBpcyBpbiBlZmZlY3Qgd2l0aCBYTUwgKD8pClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT1YTUwsdGFnc3R5bGU9XGJmXQo8ZWxlbWVudCBhdHRyPSd2YWx1ZSc+Y29udGVudDwvZWxlbWVudD4KXGVuZHtsc3RsaXN0aW5nfQpcYmVnaW57bHN0bGlzdGluZ31bbGFuZ3VhZ2U9WE1MLHRhZ3N0eWxlPVxiZix1c2VrZXl3b3Jkc2ludGFnPWZhbHNlXQo8ZWxlbWVudCBhdHRyPSd2YWx1ZSc+Y29udGVudDwvZWxlbWVudD4KXGVuZHtsc3RsaXN0aW5nfQpcYmVnaW57bHN0bGlzdGluZ31bbGFuZ3VhZ2U9WE1MLHRhZ3N0eWxlPVxiZixtYXJrZmlyc3RpbnRhZ10KPGVsZW1lbnQgYXR0cj0ndmFsdWUnPmNvbnRlbnQ8L2VsZW1lbnQ+ClxlbmR7bHN0bGlzdGluZ30KClxzZWN0aW9ue0xpdGVyYXRlIFByb2dyYW1taW5nfQpcYmVnaW57bHN0bGlzdGluZ31bbGFuZ3VhZ2U9Qyxlc2NhcGVjaGFyPUAsbGl0ZXJhdGU9Kns6PX17eyRcZ2V0cyR9fTEgezw9fXt7JFxsZXEkfX0xIHs+PX17eyRcZ2VxJH19MSB7PD59e3skXG5lcSR9fTFdCiAgdmFyIGk6aW50ZWdlcjsKICBpZiAoaTw9MCkgaSA6PSAxO0BcbGFiZWx7bGl0OmF9QAogIGlmIChpPj0wKSBpIDo9IDA7CiAgaWYgKGk8PjApIGkgOj0gMDtAXGxhYmVse2xpdDpifUAKIC8qIEhvd2V2ZXIgbm90IDo9IGhlcmUgKi8KXGVuZHtsc3RsaXN0aW5nfQp3aGVyZSB3ZSBkcmF3IHlvdXIgYXR0ZW50aW9uIHRvIGxpbmVzIFxyZWZ7bGl0OmF9IGFuZCBccmVme2xpdDpifS4KClxzZWN0aW9ue1NjcmV3aW5lc3N9Clxsc3RkZWZpbmVsYW5ndWFnZXtiaW5nb317bW9yZWtleXdvcmRzPXtmb28sYmFyfSxtb3Jla2V5d29yZHM9WzJde2JpbmcsYmFyfX0KJSwKJSBBSEEsIHdvcmRzIGNhbiBvbmx5IGJlIGluIG9uZSBjbGFzcyAoMXN0IG9uZSBkZWNsYXJlZD8pCiUgQlVULCBpbmRleCBpcyBzZXBhcmF0ZSwgYW5kIGNsYXNzbmFtZSBpcyB3aXRob3V0IHRoZSAic3R5bGUiICEhClxiZWdpbntsc3RsaXN0aW5nfVtsYW5ndWFnZT1iaW5nbyxrZXl3b3Jkc3R5bGU9XGJmc2VyaWVzLGtleXdvcmRzdHlsZT17WzJdXGl0c2hhcGV9LGluZGV4PXtbMV1ba2V5d29yZHMyXXtiYXIsYmF6fX1dCmZvbyBiYXIgYmF6IGJpbmcgYm9vYm9vClxlbmR7bHN0bGlzdGluZ30Ke1xiZnNlcmllc1xpdHNoYXBlIGJmaXR9CntcaXRzaGFwZVxiZnNlcmllcyBpdGJmfQpccHJpbnRpbmRleApcZW5ke2RvY3VtZW50fQo=" dataencoding="base64" datamimetype="text/plain" dataname="listing.tex">
         <listingline xml:id="lstnumberx89"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">documentclass</text>{<text class="ltx_lst_identifier">article</text>}</listingline>
         <listingline xml:id="lstnumberx90"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">usepackage</text>{<text class="ltx_lst_identifier">makeidx</text>}</listingline>
         <listingline xml:id="lstnumberx91"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">makeindex</text></listingline>
         <listingline xml:id="lstnumberx92"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">usepackage</text>{<text class="ltx_lst_identifier">listings</text>}</listingline>
         <listingline xml:id="lstnumberx93"><tags>
             <tag>5</tag>
+            <tag role="refnum">5</tag>
+            <tag role="typerefnum">line 5</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">usepackage</text>[<text class="ltx_lst_identifier">dvipsnames</text>]{<text class="ltx_lst_identifier">color</text>}</listingline>
         <listingline xml:id="lstnumberx94"><tags>
             <tag>6</tag>
+            <tag role="refnum">6</tag>
+            <tag role="typerefnum">line 6</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">document</text>}</listingline>
         <listingline xml:id="lstnumberx95"><tags>
             <tag>7</tag>
+            <tag role="refnum">7</tag>
+            <tag role="typerefnum">line 7</tag>
           </tags><text class="ltx_lst_identifier">\lstset</text>{<text class="ltx_lst_identifier">numbers</text>=<text class="ltx_lst_identifier">left</text>}</listingline>
         <listingline xml:id="lstnumberx96"><tags>
             <tag>8</tag>
+            <tag role="refnum">8</tag>
+            <tag role="typerefnum">line 8</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">Introduction</text>}</listingline>
         <listingline xml:id="lstnumberx97"><tags>
             <tag>9</tag>
+            <tag role="refnum">9</tag>
+            <tag role="typerefnum">line 9</tag>
           </tags><text class="ltx_lst_identifier">This</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">document</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">contains</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">the</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">following</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">listings</text>:</listingline>
         <listingline xml:id="lstnumberx98"><tags>
             <tag>10</tag>
+            <tag role="refnum">10</tag>
+            <tag role="typerefnum">line 10</tag>
           </tags><text class="ltx_lst_identifier">\lstlistoflistings</text></listingline>
         <listingline xml:id="lstnumberx99"><tags>
             <tag>11</tag>
+            <tag role="refnum">11</tag>
+            <tag role="typerefnum">line 11</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx100"><tags>
             <tag>12</tag>
+            <tag role="refnum">12</tag>
+            <tag role="typerefnum">line 12</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">Inline</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Listings</text>}</listingline>
         <listingline xml:id="lstnumberx101"><tags>
             <tag>13</tag>
+            <tag role="refnum">13</tag>
+            <tag role="typerefnum">line 13</tag>
           </tags><text class="ltx_lst_identifier">Various</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">delimiters</text>:<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">\lstinline</text>{<text class="ltx_lst_identifier">a</text>_<text class="ltx_lst_identifier">word</text>},</listingline>
         <listingline xml:id="lstnumberx102"><tags>
             <tag>14</tag>
+            <tag role="refnum">14</tag>
+            <tag role="typerefnum">line 14</tag>
           </tags><text class="ltx_lst_identifier">\lstinline</text>!<text class="ltx_lst_identifier">a</text>_<text class="ltx_lst_identifier">word</text>!,<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">\lstinline</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Aa</text>_<text class="ltx_lst_identifier">wordA</text>,</listingline>
         <listingline xml:id="lstnumberx103"><tags>
             <tag>15</tag>
+            <tag role="refnum">15</tag>
+            <tag role="typerefnum">line 15</tag>
           </tags><text class="ltx_lst_identifier">\lstinline</text>&amp;<text class="ltx_lst_identifier">a</text>_<text class="ltx_lst_identifier">word</text>&amp;<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">and</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">even</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">\lstinline</text>^<text class="ltx_lst_identifier">a</text>_<text class="ltx_lst_identifier">word</text>^<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">done</text>.</listingline>
         <listingline xml:id="lstnumberx104"><tags>
             <tag>16</tag>
+            <tag role="refnum">16</tag>
+            <tag role="typerefnum">line 16</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx105"><tags>
             <tag>17</tag>
+            <tag role="refnum">17</tag>
+            <tag role="typerefnum">line 17</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">def</text><text class="ltx_lst_identifier">\justcopy</text>#1{#1}</listingline>
         <listingline xml:id="lstnumberx106"><tags>
             <tag>18</tag>
+            <tag role="refnum">18</tag>
+            <tag role="typerefnum">line 18</tag>
           </tags><text class="ltx_lst_identifier">Indirectly</text>:<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">\justcopy</text>{<text class="ltx_lst_identifier">\lstinline</text>|<text class="ltx_lst_identifier">a</text>_<text class="ltx_lst_identifier">word</text>|};</listingline>
         <listingline xml:id="lstnumberx107"><tags>
             <tag>19</tag>
+            <tag role="refnum">19</tag>
+            <tag role="typerefnum">line 19</tag>
           </tags><text class="ltx_lst_identifier">and</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">with</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">messed</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">up</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">braces</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">\lstinline</text>{<text class="ltx_lst_identifier">foo</text><text class="ltx_lst_space"> </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">bar</text><text class="ltx_lst_space"> </text>}.<text class="ltx_lst_comment" font="italic">%<text class="ltx_lst_space"> </text>}</text></listingline>
         <listingline xml:id="lstnumberx108"><tags>
             <tag>20</tag>
+            <tag role="refnum">20</tag>
+            <tag role="typerefnum">line 20</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx109"><tags>
             <tag>21</tag>
+            <tag role="refnum">21</tag>
+            <tag role="typerefnum">line 21</tag>
           </tags>{</listingline>
         <listingline xml:id="lstnumberx110"><tags>
             <tag>22</tag>
+            <tag role="refnum">22</tag>
+            <tag role="typerefnum">line 22</tag>
           </tags><text class="ltx_lst_identifier">\lstset</text>{</listingline>
         <listingline xml:id="lstnumberx111"><tags>
             <tag>23</tag>
+            <tag role="refnum">23</tag>
+            <tag role="typerefnum">line 23</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_identifier">mathescape</text>=<text class="ltx_lst_identifier">true</text>,</listingline>
         <listingline xml:id="lstnumberx112"><tags>
             <tag>24</tag>
+            <tag role="refnum">24</tag>
+            <tag role="typerefnum">line 24</tag>
           </tags>}</listingline>
         <listingline xml:id="lstnumberx113"><tags>
             <tag>25</tag>
+            <tag role="refnum">25</tag>
+            <tag role="typerefnum">line 25</tag>
           </tags><text class="ltx_lst_identifier">Careful</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">with</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">spacing</text>/<text class="ltx_lst_identifier">math</text>/<text class="ltx_lst_identifier">macros</text>:<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">\lstinline</text>!<text class="ltx_lst_identifier">foo</text>($\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">langle</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">X</text><text class="ltx_lst_space"> </text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">rangle</text>$)!</listingline>
         <listingline xml:id="lstnumberx114"><tags>
             <tag>26</tag>
+            <tag role="refnum">26</tag>
+            <tag role="typerefnum">line 26</tag>
           </tags>}</listingline>
         <listingline xml:id="lstnumberx115"><tags>
             <tag>27</tag>
+            <tag role="refnum">27</tag>
+            <tag role="typerefnum">line 27</tag>
           </tags><text class="ltx_lst_identifier">\subsection</text>{<text class="ltx_lst_identifier">Shorthands</text>}</listingline>
         <listingline xml:id="lstnumberx116"><tags>
             <tag>28</tag>
+            <tag role="refnum">28</tag>
+            <tag role="typerefnum">line 28</tag>
           </tags><text class="ltx_lst_identifier">Normal</text>:<text class="ltx_lst_space"> </text>|<text class="ltx_lst_identifier">@</text>|<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">and</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">x</text>^<text class="ltx_lst_identifier">y</text>$</listingline>
         <listingline xml:id="lstnumberx117"><tags>
             <tag>29</tag>
+            <tag role="refnum">29</tag>
+            <tag role="typerefnum">line 29</tag>
           </tags><text class="ltx_lst_identifier">\lstMakeShortInline</text>[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">perl</text>,<text class="ltx_lst_identifier">basicstyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ttfamily</text>]|</listingline>
         <listingline xml:id="lstnumberx118"><tags>
             <tag>30</tag>
+            <tag role="refnum">30</tag>
+            <tag role="typerefnum">line 30</tag>
           </tags><text class="ltx_lst_identifier">\lstMakeShortInline</text>[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">perl</text>,<text class="ltx_lst_identifier">basicstyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ttfamily</text>]<text class="ltx_lst_identifier">@</text></listingline>
         <listingline xml:id="lstnumberx119"><tags>
             <tag>31</tag>
+            <tag role="refnum">31</tag>
+            <tag role="typerefnum">line 31</tag>
           </tags><text class="ltx_lst_identifier">\lstMakeShortInline</text>[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">perl</text>,<text class="ltx_lst_identifier">basicstyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ttfamily</text>]^</listingline>
         <listingline xml:id="lstnumberx120"><tags>
             <tag>32</tag>
+            <tag role="refnum">32</tag>
+            <tag role="typerefnum">line 32</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx121"><tags>
             <tag>33</tag>
+            <tag role="refnum">33</tag>
+            <tag role="typerefnum">line 33</tag>
           </tags><text class="ltx_lst_identifier">Listing</text>1:</listingline>
         <listingline xml:id="lstnumberx122"><tags>
             <tag>34</tag>
+            <tag role="refnum">34</tag>
+            <tag role="typerefnum">line 34</tag>
           </tags>|$<text class="ltx_lst_identifier">foo</text>-&gt;<text class="ltx_lst_identifier">baz</text>(/^<text class="ltx_lst_identifier">\s</text>*/)”;|</listingline>
         <listingline xml:id="lstnumberx123"><tags>
             <tag>35</tag>
+            <tag role="refnum">35</tag>
+            <tag role="typerefnum">line 35</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx124"><tags>
             <tag>36</tag>
+            <tag role="refnum">36</tag>
+            <tag role="typerefnum">line 36</tag>
           </tags><text class="ltx_lst_identifier">Listing</text>2:</listingline>
         <listingline xml:id="lstnumberx125"><tags>
             <tag>37</tag>
+            <tag role="refnum">37</tag>
+            <tag role="typerefnum">line 37</tag>
           </tags><text class="ltx_lst_identifier">@</text>$<text class="ltx_lst_identifier">foo</text>-&gt;<text class="ltx_lst_identifier">baz</text>(/^<text class="ltx_lst_identifier">\s</text>*/)”;<text class="ltx_lst_identifier">@</text></listingline>
         <listingline xml:id="lstnumberx126"><tags>
             <tag>38</tag>
+            <tag role="refnum">38</tag>
+            <tag role="typerefnum">line 38</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx127"><tags>
             <tag>39</tag>
+            <tag role="refnum">39</tag>
+            <tag role="typerefnum">line 39</tag>
           </tags><text class="ltx_lst_identifier">Listing</text>3:</listingline>
         <listingline xml:id="lstnumberx128"><tags>
             <tag>40</tag>
+            <tag role="refnum">40</tag>
+            <tag role="typerefnum">line 40</tag>
           </tags>^<text class="ltx_lst_identifier">xy</text>^</listingline>
         <listingline xml:id="lstnumberx129"><tags>
             <tag>41</tag>
+            <tag role="refnum">41</tag>
+            <tag role="typerefnum">line 41</tag>
           </tags><text class="ltx_lst_identifier">\lstDeleteShortInline</text>|</listingline>
         <listingline xml:id="lstnumberx130"><tags>
             <tag>42</tag>
+            <tag role="refnum">42</tag>
+            <tag role="typerefnum">line 42</tag>
           </tags><text class="ltx_lst_identifier">\lstDeleteShortInline@</text></listingline>
         <listingline xml:id="lstnumberx131"><tags>
             <tag>43</tag>
+            <tag role="refnum">43</tag>
+            <tag role="typerefnum">line 43</tag>
           </tags><text class="ltx_lst_identifier">\lstDeleteShortInline</text>^</listingline>
         <listingline xml:id="lstnumberx132"><tags>
             <tag>44</tag>
+            <tag role="refnum">44</tag>
+            <tag role="typerefnum">line 44</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx133"><tags>
             <tag>45</tag>
+            <tag role="refnum">45</tag>
+            <tag role="typerefnum">line 45</tag>
           </tags><text class="ltx_lst_identifier">Normal</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">again</text>:<text class="ltx_lst_space"> </text>|<text class="ltx_lst_identifier">@</text>|<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">and</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">x</text>^<text class="ltx_lst_identifier">y</text>$</listingline>
         <listingline xml:id="lstnumberx134"><tags>
             <tag>46</tag>
+            <tag role="refnum">46</tag>
+            <tag role="typerefnum">line 46</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx135"><tags>
             <tag>47</tag>
+            <tag role="refnum">47</tag>
+            <tag role="typerefnum">line 47</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">An</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">untyped</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Listing</text>}</listingline>
         <listingline xml:id="lstnumberx136"><tags>
             <tag>48</tag>
+            <tag role="refnum">48</tag>
+            <tag role="typerefnum">line 48</tag>
           </tags><text class="ltx_lst_identifier">No</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">options</text>,<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">language</text>,<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">etc</text></listingline>
         <listingline xml:id="lstnumberx137"><tags>
             <tag>49</tag>
+            <tag role="refnum">49</tag>
+            <tag role="typerefnum">line 49</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx138"><tags>
             <tag>50</tag>
+            <tag role="refnum">50</tag>
+            <tag role="typerefnum">line 50</tag>
           </tags><text class="ltx_lst_identifier">stuff</text>1</listingline>
         <listingline xml:id="lstnumberx139"><tags>
             <tag>51</tag>
+            <tag role="refnum">51</tag>
+            <tag role="typerefnum">line 51</tag>
           </tags><text class="ltx_lst_identifier">stuff</text>2</listingline>
         <listingline xml:id="lstnumberx140"><tags>
             <tag>52</tag>
+            <tag role="refnum">52</tag>
+            <tag role="typerefnum">line 52</tag>
           </tags><text class="ltx_lst_identifier">stuff</text>3</listingline>
         <listingline xml:id="lstnumberx141"><tags>
             <tag>53</tag>
+            <tag role="refnum">53</tag>
+            <tag role="typerefnum">line 53</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx142"><tags>
             <tag>54</tag>
+            <tag role="refnum">54</tag>
+            <tag role="typerefnum">line 54</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx143"><tags>
             <tag>55</tag>
+            <tag role="refnum">55</tag>
+            <tag role="typerefnum">line 55</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">Some</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">C</text>}</listingline>
         <listingline xml:id="lstnumberx144"><tags>
             <tag>56</tag>
+            <tag role="refnum">56</tag>
+            <tag role="typerefnum">line 56</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx145"><tags>
             <tag>57</tag>
+            <tag role="refnum">57</tag>
+            <tag role="typerefnum">line 57</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">C</text>,<text class="ltx_lst_identifier">identifierstyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">slshape</text>,<text class="ltx_lst_identifier">directivestyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ttfamily</text>]</listingline>
         <listingline xml:id="lstnumberx146"><tags>
             <tag>58</tag>
+            <tag role="refnum">58</tag>
+            <tag role="typerefnum">line 58</tag>
           </tags>#<text class="ltx_lst_identifier">define</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">EXAMPLE</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">whichwhat</text></listingline>
         <listingline xml:id="lstnumberx147"><tags>
             <tag>59</tag>
+            <tag role="refnum">59</tag>
+            <tag role="typerefnum">line 59</tag>
           </tags><text class="ltx_lst_identifier">x</text><text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text>”<text class="ltx_lst_identifier">foo</text>”;</listingline>
         <listingline xml:id="lstnumberx148"><tags>
             <tag>60</tag>
+            <tag role="refnum">60</tag>
+            <tag role="typerefnum">line 60</tag>
           </tags><text class="ltx_lst_identifier">break</text>;</listingline>
         <listingline xml:id="lstnumberx149"><tags>
             <tag>61</tag>
+            <tag role="refnum">61</tag>
+            <tag role="typerefnum">line 61</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx150"><tags>
             <tag>62</tag>
+            <tag role="refnum">62</tag>
+            <tag role="typerefnum">line 62</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx151"><tags>
             <tag>63</tag>
+            <tag role="refnum">63</tag>
+            <tag role="typerefnum">line 63</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Pascal</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Listing</text>}</listingline>
         <listingline xml:id="lstnumberx152"><tags>
             <tag>64</tag>
+            <tag role="refnum">64</tag>
+            <tag role="typerefnum">line 64</tag>
           </tags><text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">listing</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">portion</text>:</listingline>
         <listingline xml:id="lstnumberx153"><tags>
             <tag>65</tag>
+            <tag role="refnum">65</tag>
+            <tag role="typerefnum">line 65</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_identifier">firstline</text>=2,<text class="ltx_lst_identifier">lastline</text>=5,<text class="ltx_lst_identifier">caption</text>={}]</listingline>
         <listingline xml:id="lstnumberx154"><tags>
             <tag>66</tag>
+            <tag role="refnum">66</tag>
+            <tag role="typerefnum">line 66</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx155"><tags>
             <tag>67</tag>
+            <tag role="refnum">67</tag>
+            <tag role="typerefnum">line 67</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx156"><tags>
             <tag>68</tag>
+            <tag role="refnum">68</tag>
+            <tag role="typerefnum">line 68</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx157"><tags>
             <tag>69</tag>
+            <tag role="refnum">69</tag>
+            <tag role="typerefnum">line 69</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx158"><tags>
             <tag>70</tag>
+            <tag role="refnum">70</tag>
+            <tag role="typerefnum">line 70</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx159"><tags>
             <tag>71</tag>
+            <tag role="refnum">71</tag>
+            <tag role="typerefnum">line 71</tag>
           </tags><text class="ltx_lst_identifier">Write</text>(’<text class="ltx_lst_identifier">case</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">insensitive</text>’);</listingline>
         <listingline xml:id="lstnumberx160"><tags>
             <tag>72</tag>
+            <tag role="refnum">72</tag>
+            <tag role="typerefnum">line 72</tag>
           </tags><text class="ltx_lst_identifier">Write</text>(’<text class="ltx_lst_identifier">long</text><text class="ltx_lst_space"> </text>”<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">string</text>’);</listingline>
         <listingline xml:id="lstnumberx161"><tags>
             <tag>73</tag>
+            <tag role="refnum">73</tag>
+            <tag role="typerefnum">line 73</tag>
           </tags><text class="ltx_lst_identifier">WritE</text>(’<text class="ltx_lst_identifier">Pascal</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">keywords</text>.’);</listingline>
         <listingline xml:id="lstnumberx162"><tags>
             <tag>74</tag>
+            <tag role="refnum">74</tag>
+            <tag role="typerefnum">line 74</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx163"><tags>
             <tag>75</tag>
+            <tag role="refnum">75</tag>
+            <tag role="typerefnum">line 75</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx164"><tags>
             <tag>76</tag>
+            <tag role="refnum">76</tag>
+            <tag role="typerefnum">line 76</tag>
           </tags><text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">numbered</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">listing</text>:</listingline>
         <listingline xml:id="lstnumberx165"><tags>
             <tag>77</tag>
+            <tag role="refnum">77</tag>
+            <tag role="typerefnum">line 77</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_identifier">numbers</text>=<text class="ltx_lst_identifier">left</text>,<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">numberstyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">tiny</text>,<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">stepnumber</text>=2,<text class="ltx_lst_identifier">stringstyle</text>=<text class="ltx_lst_identifier">\color</text>{<text class="ltx_lst_identifier">red</text>}\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ttfamily</text>,<text class="ltx_lst_identifier">showspaces</text>,<text class="ltx_lst_identifier">tabsize</text>=4]</listingline>
         <listingline xml:id="lstnumberx166"><tags>
             <tag>78</tag>
+            <tag role="refnum">78</tag>
+            <tag role="typerefnum">line 78</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx167"><tags>
             <tag>79</tag>
+            <tag role="refnum">79</tag>
+            <tag role="typerefnum">line 79</tag>
           </tags><text class="ltx_lst_space">        </text><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx168"><tags>
             <tag>80</tag>
+            <tag role="refnum">80</tag>
+            <tag role="typerefnum">line 80</tag>
           </tags><text class="ltx_lst_space">                </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx169"><tags>
             <tag>81</tag>
+            <tag role="refnum">81</tag>
+            <tag role="typerefnum">line 81</tag>
           </tags><text class="ltx_lst_space">        </text><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx170"><tags>
             <tag>82</tag>
+            <tag role="refnum">82</tag>
+            <tag role="typerefnum">line 82</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx171"><tags>
             <tag>83</tag>
+            <tag role="refnum">83</tag>
+            <tag role="typerefnum">line 83</tag>
           </tags><text class="ltx_lst_identifier">Write</text>(’<text class="ltx_lst_identifier">case</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">insensitive</text>’);</listingline>
         <listingline xml:id="lstnumberx172"><tags>
             <tag>84</tag>
+            <tag role="refnum">84</tag>
+            <tag role="typerefnum">line 84</tag>
           </tags><text class="ltx_lst_identifier">Write</text>(’<text class="ltx_lst_identifier">long</text><text class="ltx_lst_space"> </text>”<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">string</text>’);</listingline>
         <listingline xml:id="lstnumberx173"><tags>
             <tag>85</tag>
+            <tag role="refnum">85</tag>
+            <tag role="typerefnum">line 85</tag>
           </tags><text class="ltx_lst_identifier">WritE</text>(’<text class="ltx_lst_identifier">Pascal</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">keywords</text>.’);</listingline>
         <listingline xml:id="lstnumberx174"><tags>
             <tag>86</tag>
+            <tag role="refnum">86</tag>
+            <tag role="typerefnum">line 86</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx175"><tags>
             <tag>87</tag>
+            <tag role="refnum">87</tag>
+            <tag role="typerefnum">line 87</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx176"><tags>
             <tag>88</tag>
+            <tag role="refnum">88</tag>
+            <tag role="typerefnum">line 88</tag>
           </tags><text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Titled</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">listing</text>:</listingline>
         <listingline xml:id="lstnumberx177"><tags>
             <tag>89</tag>
+            <tag role="refnum">89</tag>
+            <tag role="typerefnum">line 89</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_identifier">title</text>={<text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">bit</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">of</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Pascal</text>}]</listingline>
         <listingline xml:id="lstnumberx178"><tags>
             <tag>90</tag>
+            <tag role="refnum">90</tag>
+            <tag role="typerefnum">line 90</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx179"><tags>
             <tag>91</tag>
+            <tag role="refnum">91</tag>
+            <tag role="typerefnum">line 91</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx180"><tags>
             <tag>92</tag>
+            <tag role="refnum">92</tag>
+            <tag role="typerefnum">line 92</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx181"><tags>
             <tag>93</tag>
+            <tag role="refnum">93</tag>
+            <tag role="typerefnum">line 93</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx182"><tags>
             <tag>94</tag>
+            <tag role="refnum">94</tag>
+            <tag role="typerefnum">line 94</tag>
           </tags><text class="ltx_lst_identifier">Write</text>(’<text class="ltx_lst_identifier">case</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">insensitive</text>’);</listingline>
         <listingline xml:id="lstnumberx183"><tags>
             <tag>95</tag>
+            <tag role="refnum">95</tag>
+            <tag role="typerefnum">line 95</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx184"><tags>
             <tag>96</tag>
+            <tag role="refnum">96</tag>
+            <tag role="typerefnum">line 96</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx185"><tags>
             <tag>97</tag>
+            <tag role="refnum">97</tag>
+            <tag role="typerefnum">line 97</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx186"><tags>
             <tag>98</tag>
+            <tag role="refnum">98</tag>
+            <tag role="typerefnum">line 98</tag>
           </tags><text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Captioned</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">listing</text><text class="ltx_lst_space"> </text>(<text class="ltx_lst_identifier">known</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">as</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Listing</text><text class="ltx_lst_space"> </text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ref</text>{<text class="ltx_lst_identifier">pascallisting</text>})<text class="ltx_lst_space"> </text>:</listingline>
         <listingline xml:id="lstnumberx187"><tags>
             <tag>99</tag>
+            <tag role="refnum">99</tag>
+            <tag role="typerefnum">line 99</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_identifier">caption</text>=<text class="ltx_lst_identifier">Another</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">bit</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">of</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">label</text>=<text class="ltx_lst_identifier">pascallisting</text>,<text class="ltx_lst_identifier">firstnumber</text>=100,<text class="ltx_lst_identifier">numbers</text>=<text class="ltx_lst_identifier">left</text>]</listingline>
         <listingline xml:id="lstnumberx188"><tags>
             <tag>100</tag>
+            <tag role="refnum">100</tag>
+            <tag role="typerefnum">line 100</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx189"><tags>
             <tag>101</tag>
+            <tag role="refnum">101</tag>
+            <tag role="typerefnum">line 101</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx190"><tags>
             <tag>102</tag>
+            <tag role="refnum">102</tag>
+            <tag role="typerefnum">line 102</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx191"><tags>
             <tag>103</tag>
+            <tag role="refnum">103</tag>
+            <tag role="typerefnum">line 103</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx192"><tags>
             <tag>104</tag>
+            <tag role="refnum">104</tag>
+            <tag role="typerefnum">line 104</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx193"><tags>
             <tag>105</tag>
+            <tag role="refnum">105</tag>
+            <tag role="typerefnum">line 105</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx194"><tags>
             <tag>106</tag>
+            <tag role="refnum">106</tag>
+            <tag role="typerefnum">line 106</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">An</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Environment</text>}</listingline>
         <listingline xml:id="lstnumberx195"><tags>
             <tag>107</tag>
+            <tag role="refnum">107</tag>
+            <tag role="typerefnum">line 107</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>]</listingline>
         <listingline xml:id="lstnumberx196"><tags>
             <tag>108</tag>
+            <tag role="refnum">108</tag>
+            <tag role="typerefnum">line 108</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx197"><tags>
             <tag>109</tag>
+            <tag role="refnum">109</tag>
+            <tag role="typerefnum">line 109</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx198"><tags>
             <tag>110</tag>
+            <tag role="refnum">110</tag>
+            <tag role="typerefnum">line 110</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx199"><tags>
             <tag>111</tag>
+            <tag role="refnum">111</tag>
+            <tag role="typerefnum">line 111</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx200"><tags>
             <tag>112</tag>
+            <tag role="refnum">112</tag>
+            <tag role="typerefnum">line 112</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx201"><tags>
             <tag>113</tag>
+            <tag role="refnum">113</tag>
+            <tag role="typerefnum">line 113</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx202"><tags>
             <tag>114</tag>
+            <tag role="refnum">114</tag>
+            <tag role="typerefnum">line 114</tag>
           </tags><text class="ltx_lst_identifier">\lstnewenvironment</text>{<text class="ltx_lst_identifier">colored</text>}[1]{<text class="ltx_lst_identifier">\lstset</text>{<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_identifier">numbers</text>=<text class="ltx_lst_identifier">right</text>,<text class="ltx_lst_identifier">numberstyle</text>=<text class="ltx_lst_identifier">\color</text>{#1}}}{}</listingline>
         <listingline xml:id="lstnumberx203"><tags>
             <tag>115</tag>
+            <tag role="refnum">115</tag>
+            <tag role="typerefnum">line 115</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">colored</text>}{<text class="ltx_lst_identifier">red</text>}</listingline>
         <listingline xml:id="lstnumberx204"><tags>
             <tag>116</tag>
+            <tag role="refnum">116</tag>
+            <tag role="typerefnum">line 116</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx205"><tags>
             <tag>117</tag>
+            <tag role="refnum">117</tag>
+            <tag role="typerefnum">line 117</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx206"><tags>
             <tag>118</tag>
+            <tag role="refnum">118</tag>
+            <tag role="typerefnum">line 118</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx207"><tags>
             <tag>119</tag>
+            <tag role="refnum">119</tag>
+            <tag role="typerefnum">line 119</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx208"><tags>
             <tag>120</tag>
+            <tag role="refnum">120</tag>
+            <tag role="typerefnum">line 120</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">colored</text>}</listingline>
         <listingline xml:id="lstnumberx209"><tags>
             <tag>121</tag>
+            <tag role="refnum">121</tag>
+            <tag role="typerefnum">line 121</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx210"><tags>
             <tag>122</tag>
+            <tag role="refnum">122</tag>
+            <tag role="typerefnum">line 122</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">colored</text>}{<text class="ltx_lst_identifier">blue</text>}</listingline>
         <listingline xml:id="lstnumberx211"><tags>
             <tag>123</tag>
+            <tag role="refnum">123</tag>
+            <tag role="typerefnum">line 123</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx212"><tags>
             <tag>124</tag>
+            <tag role="refnum">124</tag>
+            <tag role="typerefnum">line 124</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx213"><tags>
             <tag>125</tag>
+            <tag role="refnum">125</tag>
+            <tag role="typerefnum">line 125</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx214"><tags>
             <tag>126</tag>
+            <tag role="refnum">126</tag>
+            <tag role="typerefnum">line 126</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx215"><tags>
             <tag>127</tag>
+            <tag role="refnum">127</tag>
+            <tag role="typerefnum">line 127</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">colored</text>}</listingline>
         <listingline xml:id="lstnumberx216"><tags>
             <tag>128</tag>
+            <tag role="refnum">128</tag>
+            <tag role="typerefnum">line 128</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx217"><tags>
             <tag>129</tag>
+            <tag role="refnum">129</tag>
+            <tag role="typerefnum">line 129</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">Framing</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">and</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">such</text>}</listingline>
         <listingline xml:id="lstnumberx218"><tags>
             <tag>130</tag>
+            <tag role="refnum">130</tag>
+            <tag role="typerefnum">line 130</tag>
           </tags><text class="ltx_lst_identifier">\lstset</text>{<text class="ltx_lst_identifier">backgroundcolor</text>=<text class="ltx_lst_identifier">\color</text>[<text class="ltx_lst_identifier">named</text>]{<text class="ltx_lst_identifier">CarnationPink</text>}}</listingline>
         <listingline xml:id="lstnumberx219"><tags>
             <tag>131</tag>
+            <tag role="refnum">131</tag>
+            <tag role="typerefnum">line 131</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_identifier">frame</text>=<text class="ltx_lst_identifier">single</text>,<text class="ltx_lst_identifier">rulecolor</text>=<text class="ltx_lst_identifier">\color</text>{<text class="ltx_lst_identifier">red</text>}]</listingline>
         <listingline xml:id="lstnumberx220"><tags>
             <tag>132</tag>
+            <tag role="refnum">132</tag>
+            <tag role="typerefnum">line 132</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx221"><tags>
             <tag>133</tag>
+            <tag role="refnum">133</tag>
+            <tag role="typerefnum">line 133</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx222"><tags>
             <tag>134</tag>
+            <tag role="refnum">134</tag>
+            <tag role="typerefnum">line 134</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx223"><tags>
             <tag>135</tag>
+            <tag role="refnum">135</tag>
+            <tag role="typerefnum">line 135</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx224"><tags>
             <tag>136</tag>
+            <tag role="refnum">136</tag>
+            <tag role="typerefnum">line 136</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx225"><tags>
             <tag>137</tag>
+            <tag role="refnum">137</tag>
+            <tag role="typerefnum">line 137</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx226"><tags>
             <tag>138</tag>
+            <tag role="refnum">138</tag>
+            <tag role="typerefnum">line 138</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_identifier">frameround</text>=<text class="ltx_lst_identifier">tttt</text>,<text class="ltx_lst_identifier">backgroundcolor</text>=<text class="ltx_lst_identifier">\color</text>{<text class="ltx_lst_identifier">yellow</text>}]</listingline>
         <listingline xml:id="lstnumberx227"><tags>
             <tag>139</tag>
+            <tag role="refnum">139</tag>
+            <tag role="typerefnum">line 139</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx228"><tags>
             <tag>140</tag>
+            <tag role="refnum">140</tag>
+            <tag role="typerefnum">line 140</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx229"><tags>
             <tag>141</tag>
+            <tag role="refnum">141</tag>
+            <tag role="typerefnum">line 141</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx230"><tags>
             <tag>142</tag>
+            <tag role="refnum">142</tag>
+            <tag role="typerefnum">line 142</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx231"><tags>
             <tag>143</tag>
+            <tag role="refnum">143</tag>
+            <tag role="typerefnum">line 143</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx232"><tags>
             <tag>144</tag>
+            <tag role="refnum">144</tag>
+            <tag role="typerefnum">line 144</tag>
           </tags><text class="ltx_lst_identifier">\lstset</text>{<text class="ltx_lst_identifier">backgroundcolor</text>=}</listingline>
         <listingline xml:id="lstnumberx233"><tags>
             <tag>145</tag>
+            <tag role="refnum">145</tag>
+            <tag role="typerefnum">line 145</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_identifier">frame</text>=<text class="ltx_lst_identifier">single</text>]</listingline>
         <listingline xml:id="lstnumberx234"><tags>
             <tag>146</tag>
+            <tag role="refnum">146</tag>
+            <tag role="typerefnum">line 146</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx235"><tags>
             <tag>147</tag>
+            <tag role="refnum">147</tag>
+            <tag role="typerefnum">line 147</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx236"><tags>
             <tag>148</tag>
+            <tag role="refnum">148</tag>
+            <tag role="typerefnum">line 148</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx237"><tags>
             <tag>149</tag>
+            <tag role="refnum">149</tag>
+            <tag role="typerefnum">line 149</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx238"><tags>
             <tag>150</tag>
+            <tag role="refnum">150</tag>
+            <tag role="typerefnum">line 150</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx239"><tags>
             <tag>151</tag>
+            <tag role="refnum">151</tag>
+            <tag role="typerefnum">line 151</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx240"><tags>
             <tag>152</tag>
+            <tag role="refnum">152</tag>
+            <tag role="typerefnum">line 152</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">Pascal</text>,<text class="ltx_lst_identifier">frame</text>=<text class="ltx_lst_identifier">lines</text>]</listingline>
         <listingline xml:id="lstnumberx241"><tags>
             <tag>153</tag>
+            <tag role="refnum">153</tag>
+            <tag role="typerefnum">line 153</tag>
           </tags><text class="ltx_lst_identifier">for</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:=<text class="ltx_lst_identifier">maxint</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text>0<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text></listingline>
         <listingline xml:id="lstnumberx242"><tags>
             <tag>154</tag>
+            <tag role="refnum">154</tag>
+            <tag role="typerefnum">line 154</tag>
           </tags><text class="ltx_lst_identifier">begin</text></listingline>
         <listingline xml:id="lstnumberx243"><tags>
             <tag>155</tag>
+            <tag role="refnum">155</tag>
+            <tag role="typerefnum">line 155</tag>
           </tags><text class="ltx_lst_space">  </text>{<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">do</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">nothing</text><text class="ltx_lst_space"> </text>}</listingline>
         <listingline xml:id="lstnumberx244"><tags>
             <tag>156</tag>
+            <tag role="refnum">156</tag>
+            <tag role="typerefnum">line 156</tag>
           </tags><text class="ltx_lst_identifier">end</text>;</listingline>
         <listingline xml:id="lstnumberx245"><tags>
             <tag>157</tag>
+            <tag role="refnum">157</tag>
+            <tag role="typerefnum">line 157</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx246"><tags>
             <tag>158</tag>
+            <tag role="refnum">158</tag>
+            <tag role="typerefnum">line 158</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx247"><tags>
             <tag>159</tag>
+            <tag role="refnum">159</tag>
+            <tag role="typerefnum">line 159</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">C</text>,<text class="ltx_lst_identifier">identifierstyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">slshape</text>,<text class="ltx_lst_identifier">directivestyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ttfamily</text>,</listingline>
         <listingline xml:id="lstnumberx248"><tags>
             <tag>160</tag>
+            <tag role="refnum">160</tag>
+            <tag role="typerefnum">line 160</tag>
           </tags><text class="ltx_lst_identifier">caption</text>=<text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">C</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">language</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">listing</text>,<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">frame</text>=<text class="ltx_lst_identifier">lines</text>,<text class="ltx_lst_identifier">backgroundcolor</text>={<text class="ltx_lst_identifier">\color</text>[<text class="ltx_lst_identifier">cmyk</text>]{0,0,0,0.1}}]</listingline>
         <listingline xml:id="lstnumberx249"><tags>
             <tag>161</tag>
+            <tag role="refnum">161</tag>
+            <tag role="typerefnum">line 161</tag>
           </tags>#<text class="ltx_lst_identifier">define</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">EXAMPLE</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">whichwhat</text></listingline>
         <listingline xml:id="lstnumberx250"><tags>
             <tag>162</tag>
+            <tag role="refnum">162</tag>
+            <tag role="typerefnum">line 162</tag>
           </tags><text class="ltx_lst_identifier">x</text><text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text>”<text class="ltx_lst_identifier">foo</text>”;</listingline>
         <listingline xml:id="lstnumberx251"><tags>
             <tag>163</tag>
+            <tag role="refnum">163</tag>
+            <tag role="typerefnum">line 163</tag>
           </tags><text class="ltx_lst_identifier">break</text>;</listingline>
         <listingline xml:id="lstnumberx252"><tags>
             <tag>164</tag>
+            <tag role="refnum">164</tag>
+            <tag role="typerefnum">line 164</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx253"><tags>
             <tag>165</tag>
+            <tag role="refnum">165</tag>
+            <tag role="typerefnum">line 165</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx254"><tags>
             <tag>166</tag>
+            <tag role="refnum">166</tag>
+            <tag role="typerefnum">line 166</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">Listing</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">with</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Math</text>}</listingline>
         <listingline xml:id="lstnumberx255"><tags>
             <tag>167</tag>
+            <tag role="refnum">167</tag>
+            <tag role="typerefnum">line 167</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">c</text>,<text class="ltx_lst_identifier">texcl</text>,<text class="ltx_lst_identifier">commentstyle</text>=<text class="ltx_lst_identifier">\color</text>{<text class="ltx_lst_identifier">green</text>}]</listingline>
         <listingline xml:id="lstnumberx256"><tags>
             <tag>168</tag>
+            <tag role="refnum">168</tag>
+            <tag role="typerefnum">line 168</tag>
           </tags>//<text class="ltx_lst_space"> </text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">upshape</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">calculate</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">ij</text>}$</listingline>
         <listingline xml:id="lstnumberx257"><tags>
             <tag>169</tag>
+            <tag role="refnum">169</tag>
+            <tag role="typerefnum">line 169</tag>
           </tags><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>][<text class="ltx_lst_identifier">j</text>]<text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">j</text>][<text class="ltx_lst_identifier">j</text>]/<text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>][<text class="ltx_lst_identifier">j</text>];</listingline>
         <listingline xml:id="lstnumberx258"><tags>
             <tag>170</tag>
+            <tag role="refnum">170</tag>
+            <tag role="typerefnum">line 170</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx259"><tags>
             <tag>171</tag>
+            <tag role="refnum">171</tag>
+            <tag role="typerefnum">line 171</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx260"><tags>
             <tag>172</tag>
+            <tag role="refnum">172</tag>
+            <tag role="typerefnum">line 172</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">texcl</text>,<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">c</text>]</listingline>
         <listingline xml:id="lstnumberx261"><tags>
             <tag>173</tag>
+            <tag role="refnum">173</tag>
+            <tag role="typerefnum">line 173</tag>
           </tags>//<text class="ltx_lst_space"> </text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">upshape</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">calculate</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">ij</text>}$</listingline>
         <listingline xml:id="lstnumberx262"><tags>
             <tag>174</tag>
+            <tag role="refnum">174</tag>
+            <tag role="typerefnum">line 174</tag>
           </tags><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>][<text class="ltx_lst_identifier">j</text>]<text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">j</text>][<text class="ltx_lst_identifier">j</text>]/<text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>][<text class="ltx_lst_identifier">j</text>];</listingline>
         <listingline xml:id="lstnumberx263"><tags>
             <tag>175</tag>
+            <tag role="refnum">175</tag>
+            <tag role="typerefnum">line 175</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx264"><tags>
             <tag>176</tag>
+            <tag role="refnum">176</tag>
+            <tag role="typerefnum">line 176</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx265"><tags>
             <tag>177</tag>
+            <tag role="refnum">177</tag>
+            <tag role="typerefnum">line 177</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">c</text>,<text class="ltx_lst_identifier">mathescape</text>,<text class="ltx_lst_identifier">numbers</text>=<text class="ltx_lst_identifier">left</text>,<text class="ltx_lst_identifier">commentstyle</text>=<text class="ltx_lst_identifier">\color</text>{<text class="ltx_lst_identifier">green</text>}]</listingline>
         <listingline xml:id="lstnumberx266"><tags>
             <tag>178</tag>
+            <tag role="refnum">178</tag>
+            <tag role="typerefnum">line 178</tag>
           </tags>//<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">calculate</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">ij</text>}$</listingline>
         <listingline xml:id="lstnumberx267"><tags>
             <tag>179</tag>
+            <tag role="refnum">179</tag>
+            <tag role="typerefnum">line 179</tag>
           </tags>$<text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">ij</text>}</listingline>
         <listingline xml:id="lstnumberx268"><tags>
             <tag>180</tag>
+            <tag role="refnum">180</tag>
+            <tag role="typerefnum">line 180</tag>
           </tags><text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">jj</text>}/<text class="ltx_lst_identifier">a</text>{<text class="ltx_lst_identifier">ij</text>}$;</listingline>
         <listingline xml:id="lstnumberx269"><tags>
             <tag>181</tag>
+            <tag role="refnum">181</tag>
+            <tag role="typerefnum">line 181</tag>
           </tags>//<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">calculate</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">ij</text>}<text class="ltx_lst_space"> </text>=</listingline>
         <listingline xml:id="lstnumberx270"><tags>
             <tag>182</tag>
+            <tag role="refnum">182</tag>
+            <tag role="typerefnum">line 182</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">sin</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">x</text>$</listingline>
         <listingline xml:id="lstnumberx271"><tags>
             <tag>183</tag>
+            <tag role="refnum">183</tag>
+            <tag role="typerefnum">line 183</tag>
           </tags><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>,<text class="ltx_lst_identifier">j</text>]=<text class="ltx_lst_identifier">sin</text>(<text class="ltx_lst_identifier">x</text>)</listingline>
         <listingline xml:id="lstnumberx272"><tags>
             <tag>184</tag>
+            <tag role="refnum">184</tag>
+            <tag role="typerefnum">line 184</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=”<text class="ltx_lst_identifier">a</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">word</text>”;</listingline>
         <listingline xml:id="lstnumberx273"><tags>
             <tag>185</tag>
+            <tag role="refnum">185</tag>
+            <tag role="typerefnum">line 185</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=”<text class="ltx_lst_identifier">a</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">x</text>^2$<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">math</text>”;</listingline>
         <listingline xml:id="lstnumberx274"><tags>
             <tag>186</tag>
+            <tag role="refnum">186</tag>
+            <tag role="typerefnum">line 186</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx275"><tags>
             <tag>187</tag>
+            <tag role="refnum">187</tag>
+            <tag role="typerefnum">line 187</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx276"><tags>
             <tag>188</tag>
+            <tag role="refnum">188</tag>
+            <tag role="typerefnum">line 188</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">c</text>,<text class="ltx_lst_identifier">escapechar</text>=\<text class="ltx_lst_comment" font="italic">%,escapebegin=\textless,escapeend=\textgreater,numbers=left]</text></listingline>
         <listingline xml:id="lstnumberx277"><tags>
             <tag>189</tag>
+            <tag role="refnum">189</tag>
+            <tag role="typerefnum">line 189</tag>
           </tags>//<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">calculate</text><text class="ltx_lst_space"> </text><text class="ltx_lst_comment" font="italic">%$a_{ij}$%</text></listingline>
         <listingline xml:id="lstnumberx278"><tags>
             <tag>190</tag>
+            <tag role="refnum">190</tag>
+            <tag role="typerefnum">line 190</tag>
           </tags><text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">ij</text>}</listingline>
         <listingline xml:id="lstnumberx279"><tags>
             <tag>191</tag>
+            <tag role="refnum">191</tag>
+            <tag role="typerefnum">line 191</tag>
           </tags><text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">jj</text>}/<text class="ltx_lst_identifier">a</text>{<text class="ltx_lst_identifier">ij</text>};</listingline>
         <listingline xml:id="lstnumberx280"><tags>
             <tag>192</tag>
+            <tag role="refnum">192</tag>
+            <tag role="typerefnum">line 192</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx281"><tags>
             <tag>193</tag>
+            <tag role="refnum">193</tag>
+            <tag role="typerefnum">line 193</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx282"><tags>
             <tag>194</tag>
+            <tag role="refnum">194</tag>
+            <tag role="typerefnum">line 194</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">c</text>,<text class="ltx_lst_identifier">numbers</text>=<text class="ltx_lst_identifier">left</text>,<text class="ltx_lst_identifier">stringstyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ttfamily</text>]</listingline>
         <listingline xml:id="lstnumberx283"><tags>
             <tag>195</tag>
+            <tag role="refnum">195</tag>
+            <tag role="typerefnum">line 195</tag>
           </tags>//<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">calculate</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">ij</text>}$</listingline>
         <listingline xml:id="lstnumberx284"><tags>
             <tag>196</tag>
+            <tag role="refnum">196</tag>
+            <tag role="typerefnum">line 196</tag>
           </tags>$<text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">ij</text>}</listingline>
         <listingline xml:id="lstnumberx285"><tags>
             <tag>197</tag>
+            <tag role="refnum">197</tag>
+            <tag role="typerefnum">line 197</tag>
           </tags><text class="ltx_lst_space"> </text>=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">jj</text>}/<text class="ltx_lst_identifier">a</text>{<text class="ltx_lst_identifier">ij</text>}$;</listingline>
         <listingline xml:id="lstnumberx286"><tags>
             <tag>198</tag>
+            <tag role="refnum">198</tag>
+            <tag role="typerefnum">line 198</tag>
           </tags>//<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">calculate</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">a</text>_{<text class="ltx_lst_identifier">ij</text>}<text class="ltx_lst_space"> </text>=</listingline>
         <listingline xml:id="lstnumberx287"><tags>
             <tag>199</tag>
+            <tag role="refnum">199</tag>
+            <tag role="typerefnum">line 199</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">sin</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">x</text>$</listingline>
         <listingline xml:id="lstnumberx288"><tags>
             <tag>200</tag>
+            <tag role="refnum">200</tag>
+            <tag role="typerefnum">line 200</tag>
           </tags><text class="ltx_lst_identifier">a</text>[<text class="ltx_lst_identifier">i</text>,<text class="ltx_lst_identifier">j</text>]=<text class="ltx_lst_identifier">sin</text>(<text class="ltx_lst_identifier">x</text>)</listingline>
         <listingline xml:id="lstnumberx289"><tags>
             <tag>201</tag>
+            <tag role="refnum">201</tag>
+            <tag role="typerefnum">line 201</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=”<text class="ltx_lst_identifier">a</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">word</text>”;</listingline>
         <listingline xml:id="lstnumberx290"><tags>
             <tag>202</tag>
+            <tag role="refnum">202</tag>
+            <tag role="typerefnum">line 202</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=”<text class="ltx_lst_identifier">a</text><text class="ltx_lst_space"> </text>\”<text class="ltx_lst_identifier">string</text>”;</listingline>
         <listingline xml:id="lstnumberx291"><tags>
             <tag>203</tag>
+            <tag role="refnum">203</tag>
+            <tag role="typerefnum">line 203</tag>
           </tags><text class="ltx_lst_identifier">foo</text>=”<text class="ltx_lst_identifier">a</text><text class="ltx_lst_space"> </text>$<text class="ltx_lst_identifier">x</text>^2$<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">math</text>”;</listingline>
         <listingline xml:id="lstnumberx292"><tags>
             <tag>204</tag>
+            <tag role="refnum">204</tag>
+            <tag role="typerefnum">line 204</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx293"><tags>
             <tag>205</tag>
+            <tag role="refnum">205</tag>
+            <tag role="typerefnum">line 205</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx294"><tags>
             <tag>206</tag>
+            <tag role="refnum">206</tag>
+            <tag role="typerefnum">line 206</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Perl</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Listing</text>}</listingline>
         <listingline xml:id="lstnumberx295"><tags>
             <tag>207</tag>
+            <tag role="refnum">207</tag>
+            <tag role="typerefnum">line 207</tag>
           </tags><text class="ltx_lst_identifier">\lstinputlisting</text>[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">perl</text>]{<text class="ltx_lst_identifier">any</text>.<text class="ltx_lst_identifier">sty</text>.<text class="ltx_lst_identifier">ltxml</text>}</listingline>
         <listingline xml:id="lstnumberx296"><tags>
             <tag>208</tag>
+            <tag role="refnum">208</tag>
+            <tag role="typerefnum">line 208</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx297"><tags>
             <tag>209</tag>
+            <tag role="refnum">209</tag>
+            <tag role="typerefnum">line 209</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Recursive</text><text class="ltx_lst_space"> </text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">TeX</text>\<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">listing</text>}</listingline>
         <listingline xml:id="lstnumberx298"><tags>
             <tag>210</tag>
+            <tag role="refnum">210</tag>
+            <tag role="typerefnum">line 210</tag>
           </tags><text class="ltx_lst_identifier">\lstinputlisting</text>[<text class="ltx_lst_identifier">language</text>={[<text class="ltx_lst_identifier">LaTeX</text>]<text class="ltx_lst_identifier">TeX</text>}]{<text class="ltx_lst_identifier">listing</text>.<text class="ltx_lst_identifier">tex</text>}</listingline>
         <listingline xml:id="lstnumberx299"><tags>
             <tag>211</tag>
+            <tag role="refnum">211</tag>
+            <tag role="typerefnum">line 211</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx300"><tags>
             <tag>212</tag>
+            <tag role="refnum">212</tag>
+            <tag role="typerefnum">line 212</tag>
           </tags><text class="ltx_lst_identifier">A</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">shorter</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">listing</text>,<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">with</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">colored</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">cs</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">that</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">include</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">the</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">slash</text></listingline>
         <listingline xml:id="lstnumberx301"><tags>
             <tag>213</tag>
+            <tag role="refnum">213</tag>
+            <tag role="typerefnum">line 213</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>={[<text class="ltx_lst_identifier">LaTeX</text>]<text class="ltx_lst_identifier">TeX</text>},<text class="ltx_lst_identifier">texcsstyle</text>=*{<text class="ltx_lst_identifier">\color</text>{<text class="ltx_lst_identifier">blue</text>}\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">bfseries</text>}]</listingline>
         <listingline xml:id="lstnumberx302"><tags>
             <tag>214</tag>
+            <tag role="refnum">214</tag>
+            <tag role="typerefnum">line 214</tag>
           </tags><text class="ltx_lst_space">  </text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">iftrue</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">something</text><text class="ltx_lst_space"> </text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">fi</text></listingline>
         <listingline xml:id="lstnumberx303"><tags>
             <tag>215</tag>
+            <tag role="refnum">215</tag>
+            <tag role="typerefnum">line 215</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx304"><tags>
             <tag>216</tag>
+            <tag role="refnum">216</tag>
+            <tag role="typerefnum">line 216</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx305"><tags>
             <tag>217</tag>
+            <tag role="refnum">217</tag>
+            <tag role="typerefnum">line 217</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">Testing</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Tag</text>}</listingline>
         <listingline xml:id="lstnumberx306"><tags>
             <tag>218</tag>
+            <tag role="refnum">218</tag>
+            <tag role="typerefnum">line 218</tag>
           </tags><text class="ltx_lst_comment" font="italic">%<text class="ltx_lst_space"> </text>AHA,<text class="ltx_lst_space"> </text>tagstyle<text class="ltx_lst_space"> </text>only<text class="ltx_lst_space"> </text>is<text class="ltx_lst_space"> </text>in<text class="ltx_lst_space"> </text>effect<text class="ltx_lst_space"> </text>with<text class="ltx_lst_space"> </text>XML<text class="ltx_lst_space"> </text>(?)</text></listingline>
         <listingline xml:id="lstnumberx307"><tags>
             <tag>219</tag>
+            <tag role="refnum">219</tag>
+            <tag role="typerefnum">line 219</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">XML</text>,<text class="ltx_lst_identifier">tagstyle</text>=<text class="ltx_lst_identifier">\bf</text>]</listingline>
         <listingline xml:id="lstnumberx308"><tags>
             <tag>220</tag>
+            <tag role="refnum">220</tag>
+            <tag role="typerefnum">line 220</tag>
           </tags>&lt;<text class="ltx_lst_identifier">element</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">attr</text>=’<text class="ltx_lst_identifier">value</text>’&gt;<text class="ltx_lst_identifier">content</text>&lt;/<text class="ltx_lst_identifier">element</text>&gt;</listingline>
         <listingline xml:id="lstnumberx309"><tags>
             <tag>221</tag>
+            <tag role="refnum">221</tag>
+            <tag role="typerefnum">line 221</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx310"><tags>
             <tag>222</tag>
+            <tag role="refnum">222</tag>
+            <tag role="typerefnum">line 222</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">XML</text>,<text class="ltx_lst_identifier">tagstyle</text>=<text class="ltx_lst_identifier">\bf</text>,<text class="ltx_lst_identifier">usekeywordsintag</text>=<text class="ltx_lst_identifier">false</text>]</listingline>
         <listingline xml:id="lstnumberx311"><tags>
             <tag>223</tag>
+            <tag role="refnum">223</tag>
+            <tag role="typerefnum">line 223</tag>
           </tags>&lt;<text class="ltx_lst_identifier">element</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">attr</text>=’<text class="ltx_lst_identifier">value</text>’&gt;<text class="ltx_lst_identifier">content</text>&lt;/<text class="ltx_lst_identifier">element</text>&gt;</listingline>
         <listingline xml:id="lstnumberx312"><tags>
             <tag>224</tag>
+            <tag role="refnum">224</tag>
+            <tag role="typerefnum">line 224</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx313"><tags>
             <tag>225</tag>
+            <tag role="refnum">225</tag>
+            <tag role="typerefnum">line 225</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">XML</text>,<text class="ltx_lst_identifier">tagstyle</text>=<text class="ltx_lst_identifier">\bf</text>,<text class="ltx_lst_identifier">markfirstintag</text>]</listingline>
         <listingline xml:id="lstnumberx314"><tags>
             <tag>226</tag>
+            <tag role="refnum">226</tag>
+            <tag role="typerefnum">line 226</tag>
           </tags>&lt;<text class="ltx_lst_identifier">element</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">attr</text>=’<text class="ltx_lst_identifier">value</text>’&gt;<text class="ltx_lst_identifier">content</text>&lt;/<text class="ltx_lst_identifier">element</text>&gt;</listingline>
         <listingline xml:id="lstnumberx315"><tags>
             <tag>227</tag>
+            <tag role="refnum">227</tag>
+            <tag role="typerefnum">line 227</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx316"><tags>
             <tag>228</tag>
+            <tag role="refnum">228</tag>
+            <tag role="typerefnum">line 228</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx317"><tags>
             <tag>229</tag>
+            <tag role="refnum">229</tag>
+            <tag role="typerefnum">line 229</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">Literate</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">Programming</text>}</listingline>
         <listingline xml:id="lstnumberx318"><tags>
             <tag>230</tag>
+            <tag role="refnum">230</tag>
+            <tag role="typerefnum">line 230</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">C</text>,<text class="ltx_lst_identifier">escapechar</text>=<text class="ltx_lst_identifier">@</text>,<text class="ltx_lst_identifier">literate</text>=*{:=}{{$\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">gets</text>$}}1<text class="ltx_lst_space"> </text>{&lt;=}{{$\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">leq</text>$}}1<text class="ltx_lst_space"> </text>{&gt;=}{{$\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">geq</text>$}}1<text class="ltx_lst_space"> </text>{&lt;&gt;}{{$\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">neq</text>$}}1]</listingline>
         <listingline xml:id="lstnumberx319"><tags>
             <tag>231</tag>
+            <tag role="refnum">231</tag>
+            <tag role="typerefnum">line 231</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_identifier">var</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:<text class="ltx_lst_identifier">integer</text>;</listingline>
         <listingline xml:id="lstnumberx320"><tags>
             <tag>232</tag>
+            <tag role="refnum">232</tag>
+            <tag role="typerefnum">line 232</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_identifier">if</text><text class="ltx_lst_space"> </text>(<text class="ltx_lst_identifier">i</text>&lt;=0)<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text><text class="ltx_lst_space"> </text>:=<text class="ltx_lst_space"> </text>1;<text class="ltx_lst_identifier">@</text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">label</text>{<text class="ltx_lst_identifier">lit</text>:<text class="ltx_lst_identifier">a</text>}<text class="ltx_lst_identifier">@</text></listingline>
         <listingline xml:id="lstnumberx321"><tags>
             <tag>233</tag>
+            <tag role="refnum">233</tag>
+            <tag role="typerefnum">line 233</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_identifier">if</text><text class="ltx_lst_space"> </text>(<text class="ltx_lst_identifier">i</text>&gt;=0)<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text><text class="ltx_lst_space"> </text>:=<text class="ltx_lst_space"> </text>0;</listingline>
         <listingline xml:id="lstnumberx322"><tags>
             <tag>234</tag>
+            <tag role="refnum">234</tag>
+            <tag role="typerefnum">line 234</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_identifier">if</text><text class="ltx_lst_space"> </text>(<text class="ltx_lst_identifier">i</text>&lt;&gt;0)<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text><text class="ltx_lst_space"> </text>:=<text class="ltx_lst_space"> </text>0;<text class="ltx_lst_identifier">@</text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">label</text>{<text class="ltx_lst_identifier">lit</text>:<text class="ltx_lst_identifier">b</text>}<text class="ltx_lst_identifier">@</text></listingline>
         <listingline xml:id="lstnumberx323"><tags>
             <tag>235</tag>
+            <tag role="refnum">235</tag>
+            <tag role="typerefnum">line 235</tag>
           </tags><text class="ltx_lst_space"> </text>/*<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">However</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">not</text><text class="ltx_lst_space"> </text>:=<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">here</text><text class="ltx_lst_space"> </text>*/</listingline>
         <listingline xml:id="lstnumberx324"><tags>
             <tag>236</tag>
+            <tag role="refnum">236</tag>
+            <tag role="typerefnum">line 236</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx325"><tags>
             <tag>237</tag>
+            <tag role="refnum">237</tag>
+            <tag role="typerefnum">line 237</tag>
           </tags><text class="ltx_lst_identifier">where</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">we</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">draw</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">your</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">attention</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">to</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">lines</text><text class="ltx_lst_space"> </text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ref</text>{<text class="ltx_lst_identifier">lit</text>:<text class="ltx_lst_identifier">a</text>}<text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">and</text><text class="ltx_lst_space"> </text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">ref</text>{<text class="ltx_lst_identifier">lit</text>:<text class="ltx_lst_identifier">b</text>}.</listingline>
         <listingline xml:id="lstnumberx326"><tags>
             <tag>238</tag>
+            <tag role="refnum">238</tag>
+            <tag role="typerefnum">line 238</tag>
           </tags></listingline>
         <listingline xml:id="lstnumberx327"><tags>
             <tag>239</tag>
+            <tag role="refnum">239</tag>
+            <tag role="typerefnum">line 239</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">section</text>{<text class="ltx_lst_identifier">Screwiness</text>}</listingline>
         <listingline xml:id="lstnumberx328"><tags>
             <tag>240</tag>
+            <tag role="refnum">240</tag>
+            <tag role="typerefnum">line 240</tag>
           </tags><text class="ltx_lst_identifier">\lstdefinelanguage</text>{<text class="ltx_lst_identifier">bingo</text>}{<text class="ltx_lst_identifier">morekeywords</text>={<text class="ltx_lst_identifier">foo</text>,<text class="ltx_lst_identifier">bar</text>},<text class="ltx_lst_identifier">morekeywords</text>=[2]{<text class="ltx_lst_identifier">bing</text>,<text class="ltx_lst_identifier">bar</text>}}</listingline>
         <listingline xml:id="lstnumberx329"><tags>
             <tag>241</tag>
+            <tag role="refnum">241</tag>
+            <tag role="typerefnum">line 241</tag>
           </tags><text class="ltx_lst_comment" font="italic">%,</text></listingline>
         <listingline xml:id="lstnumberx330"><tags>
             <tag>242</tag>
+            <tag role="refnum">242</tag>
+            <tag role="typerefnum">line 242</tag>
           </tags><text class="ltx_lst_comment" font="italic">%<text class="ltx_lst_space"> </text>AHA,<text class="ltx_lst_space"> </text>words<text class="ltx_lst_space"> </text>can<text class="ltx_lst_space"> </text>only<text class="ltx_lst_space"> </text>be<text class="ltx_lst_space"> </text>in<text class="ltx_lst_space"> </text>one<text class="ltx_lst_space"> </text>class<text class="ltx_lst_space"> </text>(1st<text class="ltx_lst_space"> </text>one<text class="ltx_lst_space"> </text>declared?)</text></listingline>
         <listingline xml:id="lstnumberx331"><tags>
             <tag>243</tag>
+            <tag role="refnum">243</tag>
+            <tag role="typerefnum">line 243</tag>
           </tags><text class="ltx_lst_comment" font="italic">%<text class="ltx_lst_space"> </text>BUT,<text class="ltx_lst_space"> </text>index<text class="ltx_lst_space"> </text>is<text class="ltx_lst_space"> </text>separate,<text class="ltx_lst_space"> </text>and<text class="ltx_lst_space"> </text>classname<text class="ltx_lst_space"> </text>is<text class="ltx_lst_space"> </text>without<text class="ltx_lst_space"> </text>the<text class="ltx_lst_space"> </text>”style”<text class="ltx_lst_space"> </text>!!</text></listingline>
         <listingline xml:id="lstnumberx332"><tags>
             <tag>244</tag>
+            <tag role="refnum">244</tag>
+            <tag role="typerefnum">line 244</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">begin</text>{<text class="ltx_lst_identifier">lstlisting</text>}[<text class="ltx_lst_identifier">language</text>=<text class="ltx_lst_identifier">bingo</text>,<text class="ltx_lst_identifier">keywordstyle</text>=\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">bfseries</text>,<text class="ltx_lst_identifier">keywordstyle</text>={[2]\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">itshape</text>},<text class="ltx_lst_identifier">index</text>={[1][<text class="ltx_lst_identifier">keywords</text>2]{<text class="ltx_lst_identifier">bar</text>,<text class="ltx_lst_identifier">baz</text>}}]</listingline>
         <listingline xml:id="lstnumberx333"><tags>
             <tag>245</tag>
+            <tag role="refnum">245</tag>
+            <tag role="typerefnum">line 245</tag>
           </tags><text class="ltx_lst_identifier">foo</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">bar</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">baz</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">bing</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">booboo</text></listingline>
         <listingline xml:id="lstnumberx334"><tags>
             <tag>246</tag>
+            <tag role="refnum">246</tag>
+            <tag role="typerefnum">line 246</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">lstlisting</text>}</listingline>
         <listingline xml:id="lstnumberx335"><tags>
             <tag>247</tag>
+            <tag role="refnum">247</tag>
+            <tag role="typerefnum">line 247</tag>
           </tags>{\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">bfseries</text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">itshape</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">bfit</text>}</listingline>
         <listingline xml:id="lstnumberx336"><tags>
             <tag>248</tag>
+            <tag role="refnum">248</tag>
+            <tag role="typerefnum">line 248</tag>
           </tags>{\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">itshape</text>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">bfseries</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">itbf</text>}</listingline>
         <listingline xml:id="lstnumberx337"><tags>
             <tag>249</tag>
+            <tag role="refnum">249</tag>
+            <tag role="typerefnum">line 249</tag>
           </tags><text class="ltx_lst_identifier">\printindex</text></listingline>
         <listingline xml:id="lstnumberx338"><tags>
             <tag>250</tag>
+            <tag role="refnum">250</tag>
+            <tag role="typerefnum">line 250</tag>
           </tags>\<text class="ltx_lst_keyword ltx_lst_texcs" font="bold">end</text>{<text class="ltx_lst_identifier">document</text>}</listingline>
       </listing>
     </float>
@@ -1397,6 +2065,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_TeX_LaTeX ltx_lst_numbers_left ltx_lstlisting" data="ICBcaWZ0cnVlIHNvbWV0aGluZyBcZmk=" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx339"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_texcs" color="#0000FF" font="bold">\iftrue</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">something</text><text class="ltx_lst_space"> </text><text class="ltx_lst_texcs" color="#0000FF" font="bold">\fi</text></listingline>
       </listing>
     </para>
@@ -1412,16 +2082,22 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_XML ltx_lst_numbers_left ltx_lstlisting" data="PGVsZW1lbnQgYXR0cj0ndmFsdWUnPmNvbnRlbnQ8L2VsZW1lbnQ+" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx340"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_tag" font="bold">&lt;element<text class="ltx_lst_space"> </text>attr=<text class="ltx_lst_string">’value’</text>&gt;</text><text class="ltx_lst_identifier">content</text><text class="ltx_lst_tag" font="bold">&lt;/element&gt;</text></listingline>
       </listing>
       <listing class="ltx_lst_language_XML ltx_lst_numbers_left ltx_lstlisting" data="PGVsZW1lbnQgYXR0cj0ndmFsdWUnPmNvbnRlbnQ8L2VsZW1lbnQ+" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx341"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_tag" font="bold">&lt;element<text class="ltx_lst_space"> </text>attr=<text class="ltx_lst_string">’value’</text>&gt;</text><text class="ltx_lst_identifier">content</text><text class="ltx_lst_tag" font="bold">&lt;/element&gt;</text></listingline>
       </listing>
       <listing class="ltx_lst_language_XML ltx_lst_numbers_left ltx_lstlisting" data="PGVsZW1lbnQgYXR0cj0ndmFsdWUnPmNvbnRlbnQ8L2VsZW1lbnQ+" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx342"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_tag" font="bold">&lt;element<text class="ltx_lst_space"> </text>attr=<text class="ltx_lst_string">’value’</text>&gt;</text><text class="ltx_lst_identifier">content</text><text class="ltx_lst_tag" font="bold">&lt;/element&gt;</text></listingline>
       </listing>
     </para>
@@ -1437,9 +2113,13 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_C ltx_lst_numbers_left ltx_lstlisting" data="ICB2YXIgaTppbnRlZ2VyOwogIGlmIChpPD0wKSBpIDo9IDE7QFxsYWJlbHtsaXQ6YX1ACiAgaWYgKGk+PTApIGkgOj0gMDsKICBpZiAoaTw+MCkgaSA6PSAwO0BcbGFiZWx7bGl0OmJ9QAogLyogSG93ZXZlciBub3QgOj0gaGVyZSAqLw==" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx343"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_identifier">var</text><text class="ltx_lst_space"> </text><text class="ltx_lst_identifier">i</text>:<text class="ltx_lst_identifier">integer</text>;</listingline>
         <listingline labels="LABEL:lit:a" xml:id="lstnumberx344"><tags>
             <tag>2</tag>
+            <tag role="refnum">2</tag>
+            <tag role="typerefnum">line 2</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_keyword" font="bold">if</text><text class="ltx_lst_space"> </text>(<text class="ltx_lst_identifier">i</text><text class="ltx_lst_literate"><Math mode="inline" tex="\leq" text="&lt;=" xml:id="lstnumberx344.m1">
               <XMath>
                 <XMTok meaning="less-than-or-equals" name="leq" role="RELOP">≤</XMTok>
@@ -1451,6 +2131,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             </Math></text><text class="ltx_lst_space"> </text>1;</listingline>
         <listingline xml:id="lstnumberx345"><tags>
             <tag>3</tag>
+            <tag role="refnum">3</tag>
+            <tag role="typerefnum">line 3</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_keyword" font="bold">if</text><text class="ltx_lst_space"> </text>(<text class="ltx_lst_identifier">i</text><text class="ltx_lst_literate"><Math mode="inline" tex="\geq" text="&gt;=" xml:id="lstnumberx345.m1">
               <XMath>
                 <XMTok meaning="greater-than-or-equals" name="geq" role="RELOP">≥</XMTok>
@@ -1462,6 +2144,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             </Math></text><text class="ltx_lst_space"> </text>0;</listingline>
         <listingline labels="LABEL:lit:b" xml:id="lstnumberx346"><tags>
             <tag>4</tag>
+            <tag role="refnum">4</tag>
+            <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_space">  </text><text class="ltx_lst_keyword" font="bold">if</text><text class="ltx_lst_space"> </text>(<text class="ltx_lst_identifier">i</text><text class="ltx_lst_literate"><Math mode="inline" tex="\neq" text="not-equals" xml:id="lstnumberx346.m1">
               <XMath>
                 <XMTok meaning="not-equals" name="neq" role="RELOP">≠</XMTok>
@@ -1473,6 +2157,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             </Math></text><text class="ltx_lst_space"> </text>0;</listingline>
         <listingline xml:id="lstnumberx347"><tags>
             <tag>5</tag>
+            <tag role="refnum">5</tag>
+            <tag role="typerefnum">line 5</tag>
           </tags><text class="ltx_lst_space"> </text><text class="ltx_lst_comment" font="italic">/*<text class="ltx_lst_space"> </text>However<text class="ltx_lst_space"> </text>not<text class="ltx_lst_space"> </text>:=<text class="ltx_lst_space"> </text>here<text class="ltx_lst_space"> </text>*/</text></listingline>
       </listing>
       <p>where we draw your attention to lines <ref labelref="LABEL:lit:a"/> and <ref labelref="LABEL:lit:b"/>.</p>
@@ -1489,6 +2175,8 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       <listing class="ltx_lst_language_bingo ltx_lst_numbers_left ltx_lstlisting" data="Zm9vIGJhciBiYXogYmluZyBib29ib28=" dataencoding="base64" datamimetype="text/plain">
         <listingline xml:id="lstnumberx348"><tags>
             <tag>1</tag>
+            <tag role="refnum">1</tag>
+            <tag role="typerefnum">line 1</tag>
           </tags><text class="ltx_lst_keyword" font="bold">foo</text><text class="ltx_lst_space"> </text><indexmark>
             <indexphrase key="bar"><text font="typewriter">bar</text></indexphrase>
           </indexmark><text class="ltx_lst_keyword" font="bold">bar</text><text class="ltx_lst_space"> </text><indexmark>


### PR DESCRIPTION
This PR cherry-picks the best bits of @dginev and @xworld21 patches.  Apologies for all the round-about, but thanks for the patience & ideas.

This PR also adds full numbering tags to the lines in a listing, and gives them a type-name ("line"), so that they can be reasonably referenced (also by index), so hopefully provides the  tools to answer #2007.

Closes #2179, closes #2189, closes #2196, closes #2200.

Fixes #2178
Fixes #2007