### PR TITLE
Non urls

### DIFF
--- a/lib/LaTeXML/Package/cleveref.sty.ltxml
+++ b/lib/LaTeXML/Package/cleveref.sty.ltxml
@@ -45,10 +45,11 @@ sub splitLabels {
   return split(/\s*,\s*/, ToString($labels)); }
 
 sub crefMulti {
-  my ($labels, $showtype, $capitalized) = @_;
+  my ($starred, $labels, $showtype, $capitalized) = @_;
   my @labels = splitLabels($labels);
   if (scalar(@labels) < 2) {
     return Invocation(T_CS('\lx@cref'),
+      $starred,
       T_OTHER($showtype
         ? ($capitalized
           ? "creftypecap~refnum"
@@ -57,6 +58,7 @@ sub crefMulti {
       $labels[0]); }
   else {
     my @tokens = (Invocation(T_CS('\lx@cref'),
+        $starred,
         T_OTHER($showtype
           ? ($capitalized
             ? "creftypepluralcap~refnum"
@@ -65,37 +67,37 @@ sub crefMulti {
         shift(@labels)));
     if (scalar(@labels == 1)) {
       push(@tokens, T_CS('\crefpairconjunction'),
-        Invocation(T_CS('\lx@cref'), T_OTHER('refnum'), $labels[0])); }
+        Invocation(T_CS('\lx@cref'), $starred, T_OTHER('refnum'), $labels[0])); }
     else {
       while (scalar(@labels) > 1) {
         push(@tokens, T_CS('\crefmiddleconjunction'),
-          Invocation(T_CS('\lx@cref'), T_OTHER('refnum'), shift(@labels))); }
+          Invocation(T_CS('\lx@cref'), $starred, T_OTHER('refnum'), shift(@labels))); }
       push(@tokens, T_CS('\creflastconjunction'),
-        Invocation(T_CS('\lx@cref'), T_OTHER('refnum'), shift(@labels))); }
+        Invocation(T_CS('\lx@cref'), $starred, T_OTHER('refnum'), shift(@labels))); }
     return @tokens; } }
 # Since we're not grouping by type, we're ignoring \crefpairgroupconjunction, etc
 
-DefConstructor('\lx@cref {} Semiverbatim',
-  "<ltx:ref labelref='#label' show='#1' _force_font='true'/>",
-  properties => sub { (label => CleanLabel($_[2])); });
+DefConstructor('\lx@cref OptionalMatch:* {} Semiverbatim',
+  "<ltx:ref labelref='#label' show='#2' ?#1(class='ltx_nolink')() _force_font='true'/>",
+  properties => sub { (label => CleanLabel($_[3])); });
 
-DefMacro('\cref OptionalMatch:* Semiverbatim', sub { crefMulti($_[2], 1, 0); });
-DefMacro('\Cref OptionalMatch:* Semiverbatim', sub { crefMulti($_[2], 1, 1); });
+DefMacro('\cref OptionalMatch:* Semiverbatim', sub { crefMulti($_[1], $_[2], 1, 0); });
+DefMacro('\Cref OptionalMatch:* Semiverbatim', sub { crefMulti($_[1], $_[2], 1, 1); });
 
 DefMacro('\crefrange OptionalMatch:* Semiverbatim Semiverbatim',
-  '\lx@cref{creftypeplural~refnum}{#2}\crefrangeconjunction\ref{#3}');
+  '\lx@cref#1{creftypeplural~refnum}{#2}\crefrangeconjunction\ref{#3}');
 DefMacro('\Crefrange OptionalMatch:* Semiverbatim Semiverbatim',
-  '\lx@cref{creftypepluralcap~refnum}{#2}\crefrangeconjunction\ref{#3}');
+  '\lx@cref#1{creftypepluralcap~refnum}{#2}\crefrangeconjunction\ref{#3}');
 
 # Make page refs same as regular?
-DefMacro('\cpageref OptionalMatch:* Semiverbatim', sub { crefMulti($_[2], 1, 0); });
-DefMacro('\Cpageref OptionalMatch:* Semiverbatim', sub { crefMulti($_[2], 1, 1); });
+DefMacro('\cpageref OptionalMatch:* Semiverbatim', sub { crefMulti($_[1], $_[2], 1, 0); });
+DefMacro('\Cpageref OptionalMatch:* Semiverbatim', sub { crefMulti($_[1], $_[2], 1, 1); });
 
 # More likely with page ranges that the types are different?
 DefMacro('\cpagerefrange OptionalMatch:* Semiverbatim Semiverbatim',
-  '\lx@cref{creftype~refnum}{#2}\crefrangeconjunction\lx@cref{creftype~refnum}{#3}');
+  '\lx@cref#1{creftype~refnum}{#2}\crefrangeconjunction\lx@cref#1{creftype~refnum}{#3}');
 DefMacro('\Cpagerefrange OptionalMatch:* Semiverbatim Semiverbatim',
-  '\lx@cref{creftypecap~refnum}{#2}\crefrangeconjunction\lx@ref{creftype~refnum{#3}');
+  '\lx@cref#1{creftypecap~refnum}{#2}\crefrangeconjunction\lx@cref#1{creftype~refnum{#3}');
 
 DefMacro('\namecref Semiverbatim',    '\lx@cref{creftype}{#1}');
 DefMacro('\nameCref Semiverbatim',    '\lx@cref{creftypecap}{#1}');
@@ -104,8 +106,8 @@ DefMacro('\nameCrefs Semiverbatim',   '\lx@cref{creftypepluralcap}{#1}');
 DefMacro('\lcnamecref Semiverbatim',  '\lx@cref{creftype}{#1}');
 DefMacro('\lcnamecrefs Semiverbatim', '\lx@cref{creftypeplural}{#1}');
 
-DefMacro('\labelcref Semiverbatim',     sub { crefMulti($_[1], 0, 0); });
-DefMacro('\labelcpageref Semiverbatim', sub { crefMulti($_[1], 0, 0); });
+DefMacro('\labelcref Semiverbatim',     sub { crefMulti(undef, $_[1], 0, 0); });
+DefMacro('\labelcpageref Semiverbatim', sub { crefMulti(undef, $_[1], 0, 0); });
 
 # No, this isn't quite the same thing...
 DefPrimitive('\crefalias {}{}', sub {

--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -153,12 +153,12 @@ DefRegister('\pdfcompresslevel', Number(0));
 # Additional User Macros
 
 # \href{url}{text}
-DefMacro('\href HyperVerbatim {}', '\@@Url\href{}{}{#1}{#2}');
+DefMacro('\href HyperVerbatim {}', '\lx@hyper@url@\href{}{}{#1}{#2}');
 
-# \url{url} from url.sty... well sorta
+# Redefine \url{url} from url.sty...
 # It's slightly different in that it expands the argument
 # Redefine \@url to sanitize the argument less
-DefMacro('\@Url Token', sub {
+DefMacro('\lx@hyper@url Token', sub {
     my ($gullet, $cmd) = @_;
     my ($open, $close, $url);
     $open = $gullet->readToken;
@@ -174,14 +174,26 @@ DefMacro('\@Url Token', sub {
     my @toks = grep { $_->getCatcode != CC_SPACE; } $url->unlist;
     # Identical with url's \@Url except, let CS's through!
     @toks = map { (($_->getCatcode == CC_CS) ? $_ : T_OTHER(ToString($_))) } @toks;
-    (Invocation(T_CS('\@@Url'),
+    (Invocation(T_CS('\lx@hyper@url@'),
         T_OTHER(ToString($cmd)), Tokens($open), Tokens($close),
         Tokens(@toks),
         Tokens(T_CS('\UrlFont'), T_CS('\UrlLeft'), @toks, T_CS('\UrlRight')))->unlist,
       T_CS('\endgroup')); });
 
+# RE-define from url w
+DefMacro('\url', '\begingroup\lx@hyper@url\url', locked => 1);
+
+DefConstructor('\lx@hyper@url@ Undigested {}{} Semiverbatim {}',
+  "?#isMath(<ltx:XMWrap class='#class' href='#href'>#5</ltx:XMWrap>)"    # Allow this to work in Math!
+    . " (<ltx:ref href='#href' class='#class'>#5</ltx:ref>)",
+  properties => sub { (href => ComposeURL(LookupValue('BASE_URL'), $_[4]),
+      class => sub { my $c = ToString($_[1]); $c =~ s/^\\//; 'ltx_' . $c; }); },
+  sizer     => '#5',
+  reversion => '#1#2#4#3');
+
 # \nolinkurl{url}
-DefConstructor('\nolinkurl Semiverbatim', '#1');
+DefConstructor('\nolinkurl Semiverbatim',
+  "<ltx:ref href='#1' class='ltx_nolink' >#1</ltx:ref>");
 
 # \hyperbaseurl{url}
 DefPrimitive('\hyperbaseurl Semiverbatim', sub { AssignValue(BASE_URL => ToString($_[1])); });

--- a/lib/LaTeXML/Package/url.sty.ltxml
+++ b/lib/LaTeXML/Package/url.sty.ltxml
@@ -38,13 +38,13 @@ Let('\UrlRight', '\@empty');
 
 # \DeclareUrlCommand\cmd{settings}
 # Have this expand into \@Url w/ the declared cmd as arg, so it gets reflected in XML.
-DefMacro('\DeclareUrlCommand{}{}', '\def#1{\begingroup #2\@Url#1}');
+DefMacro('\DeclareUrlCommand{}{}', '\def#1{\begingroup #2\lx@url@url#1}');
 
 # This is an extended version of \Url that takes an extra token as 1st arg.
 # That token is the cs that invoked it, so that it can be reflected in the generated XML,
 # as well as used to generate the reversion.
 # In any case, we read the verbatim arg, and build a Whatsit for @@Url
-DefMacro('\@Url Token', sub {
+DefMacro('\lx@url@url Token', sub {
     my ($gullet, $cmd) = @_;
     my ($open, $close, $url);
     StartSemiverbatim('%');
@@ -58,7 +58,7 @@ DefMacro('\@Url Token', sub {
     EndSemiverbatim();
     my @toks = grep { $_->getCatcode != CC_SPACE; } (ref $url ? $url->unlist : ());
     @toks = map { T_OTHER(ToString($_)) } @toks;
-    (Invocation(T_CS('\@@Url'),
+    (Invocation(T_CS('\lx@url@url@nolink'),
         T_OTHER(ToString($cmd)), Tokens($open), Tokens($close),
         Tokens(@toks),
         Tokens(T_CS('\UrlFont'), T_CS('\UrlLeft'), @toks, T_CS('\UrlRight')))->unlist,
@@ -68,20 +68,21 @@ DefMacro('\@Url Token', sub {
 DefMacro('\Url', sub {
     my ($gullet) = @_;
     $gullet->unread(T_OTHER('\Url'));
-    (T_CS('\@Url')); });
+    (T_CS('\lx@url@url')); });
 
 # \@@Url cmd {open}{close}{url}{formattedurl}
-DefConstructor('\@@Url Undigested {}{} Semiverbatim {}',
-  "?#isMath(<ltx:XMWrap href='#href'>#5</ltx:XMWrap>)"    # Allow this to work in Math!
-    . " (<ltx:ref href='#href' class='#class'>#5</ltx:ref>)",
+#DefConstructor('\@@Url Undigested {}{} Semiverbatim {}',
+DefConstructor('\lx@url@url@nolink Undigested {}{} Semiverbatim {}',
+  "?#isMath(<ltx:XMWrap class='ltx_nolink #class' href='#href'>#5</ltx:XMWrap>)" # Allow this to work in Math!
+    . " (<ltx:ref href='#href' class='ltx_nolink #class'>#5</ltx:ref>)",
   properties => sub { (href => ComposeURL(LookupValue('BASE_URL'), $_[4]),
       class => sub { my $c = ToString($_[1]); $c =~ s/^\\//; 'ltx_' . $c; }); },
   sizer     => '#5',
   reversion => '#1#2#4#3');
 
 # These are the expansions of \DeclareUrlCommand
-DefMacro('\path', '\begingroup\urlstyle{tt}\@Url\path');
-DefMacro('\url', '\begingroup\@Url\url', locked => 1);
+DefMacro('\path', '\begingroup\urlstyle{tt}\lx@url@url\path');
+DefMacro('\url', '\begingroup\lx@url@url\url', locked => 1);
 
 # \urldef{newcmd}\cmd{arg}
 # Kinda tricky, since we need to get the expansion of \cmd as the value of \newcmd

--- a/t/expansion/urls.xml
+++ b/t/expansion/urls.xml
@@ -22,7 +22,7 @@
               <tag role="typerefnum">1st item</tag>
             </tags>
             <para xml:id="S1.I1.i1.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/wordword">https://example.com/wordword</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/wordword">https://example.com/wordword</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I1.i2">
@@ -31,7 +31,7 @@
               <tag role="typerefnum">2nd item</tag>
             </tags>
             <para xml:id="S1.I1.i2.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/~User">https://example.com/~User</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/~User">https://example.com/~User</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I1.i3">
@@ -40,7 +40,7 @@
               <tag role="typerefnum">3rd item</tag>
             </tags>
             <para xml:id="S1.I1.i3.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/someplace#id">https://example.com/someplace#id</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/someplace#id">https://example.com/someplace#id</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I1.i4">
@@ -49,7 +49,7 @@
               <tag role="typerefnum">4th item</tag>
             </tags>
             <para xml:id="S1.I1.i4.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/user@password">https://example.com/user@password</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/user@password">https://example.com/user@password</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I1.i5">
@@ -58,7 +58,7 @@
               <tag role="typerefnum">5th item</tag>
             </tags>
             <para xml:id="S1.I1.i5.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/user&amp;param">https://example.com/user&amp;param</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/user&amp;param">https://example.com/user&amp;param</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I1.i6">
@@ -67,7 +67,7 @@
               <tag role="typerefnum">6th item</tag>
             </tags>
             <para xml:id="S1.I1.i6.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/with_underscore">https://example.com/with_underscore</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/with_underscore">https://example.com/with_underscore</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I1.i7">
@@ -76,7 +76,7 @@
               <tag role="typerefnum">7th item</tag>
             </tags>
             <para xml:id="S1.I1.i7.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/with^caret">https://example.com/with^caret</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/with^caret">https://example.com/with^caret</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I1.i8">
@@ -85,7 +85,7 @@
               <tag role="typerefnum">8th item</tag>
             </tags>
             <para xml:id="S1.I1.i8.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/with$dollar">https://example.com/with$dollar</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/with$dollar">https://example.com/with$dollar</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I1.i9">
@@ -94,7 +94,7 @@
               <tag role="typerefnum">9th item</tag>
             </tags>
             <para xml:id="S1.I1.i9.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/encoded%code">https://example.com/encoded%code</ref>.</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/encoded%code">https://example.com/encoded%code</ref>.</p>
             </para>
           </item>
         </itemize>
@@ -110,7 +110,7 @@
               <tag role="typerefnum">1st item</tag>
             </tags>
             <para xml:id="S1.I2.i1.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/someplace\#id">https://example.com/someplace\#id</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/someplace\#id">https://example.com/someplace\#id</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I2.i2">
@@ -119,7 +119,7 @@
               <tag role="typerefnum">2nd item</tag>
             </tags>
             <para xml:id="S1.I2.i2.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/with.{}braces">https://example.com/with.{}braces</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/with.{}braces">https://example.com/with.{}braces</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I2.i3">
@@ -128,7 +128,7 @@
               <tag role="typerefnum">3rd item</tag>
             </tags>
             <para xml:id="S1.I2.i3.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/withslash\&amp;ampersand">https://example.com/withslash\&amp;ampersand</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/withslash\&amp;ampersand">https://example.com/withslash\&amp;ampersand</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I2.i4">
@@ -137,7 +137,7 @@
               <tag role="typerefnum">4th item</tag>
             </tags>
             <para xml:id="S1.I2.i4.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/withslash\_underscore">https://example.com/withslash\_underscore</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/withslash\_underscore">https://example.com/withslash\_underscore</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I2.i5">
@@ -146,7 +146,7 @@
               <tag role="typerefnum">5th item</tag>
             </tags>
             <para xml:id="S1.I2.i5.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/withslash\^caret">https://example.com/withslash\^caret</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/withslash\^caret">https://example.com/withslash\^caret</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I2.i6">
@@ -155,7 +155,7 @@
               <tag role="typerefnum">6th item</tag>
             </tags>
             <para xml:id="S1.I2.i6.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/withslash\$dollar">https://example.com/withslash\$dollar</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/withslash\$dollar">https://example.com/withslash\$dollar</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I2.i7">
@@ -164,7 +164,7 @@
               <tag role="typerefnum">7th item</tag>
             </tags>
             <para xml:id="S1.I2.i7.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/withslash\%percent">https://example.com/withslash\%percent</ref>;</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/withslash\%percent">https://example.com/withslash\%percent</ref>;</p>
             </para>
           </item>
           <item xml:id="S1.I2.i8">
@@ -173,7 +173,7 @@
               <tag role="typerefnum">8th item</tag>
             </tags>
             <para xml:id="S1.I2.i8.p1">
-              <p><ref class="ltx_url" font="typewriter" href="https://example.com/unexpandedmacro.\macro">https://example.com/unexpandedmacro.\macro</ref>.</p>
+              <p><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/unexpandedmacro.\macro">https://example.com/unexpandedmacro.\macro</ref>.</p>
             </para>
           </item>
         </itemize>
@@ -185,42 +185,42 @@
           <tag>1</tag>
           <tag role="refnum">1</tag>
           <tag role="typerefnum">footnote 1</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/wordword">https://example.com/wordword</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/wordword">https://example.com/wordword</ref></note>
       <note mark="2" role="footnote" xml:id="footnote2"><tags>
           <tag>2</tag>
           <tag role="refnum">2</tag>
           <tag role="typerefnum">footnote 2</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/~User">https://example.com/~User</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/~User">https://example.com/~User</ref></note>
       <note mark="3" role="footnote" xml:id="footnote3"><tags>
           <tag>3</tag>
           <tag role="refnum">3</tag>
           <tag role="typerefnum">footnote 3</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/someplace#id">https://example.com/someplace#id</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/someplace#id">https://example.com/someplace#id</ref></note>
       <note mark="4" role="footnote" xml:id="footnote4"><tags>
           <tag>4</tag>
           <tag role="refnum">4</tag>
           <tag role="typerefnum">footnote 4</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/user@password">https://example.com/user@password</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/user@password">https://example.com/user@password</ref></note>
       <note mark="5" role="footnote" xml:id="footnote5"><tags>
           <tag>5</tag>
           <tag role="refnum">5</tag>
           <tag role="typerefnum">footnote 5</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/user&amp;param">https://example.com/user&amp;param</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/user&amp;param">https://example.com/user&amp;param</ref></note>
       <note mark="6" role="footnote" xml:id="footnote6"><tags>
           <tag>6</tag>
           <tag role="refnum">6</tag>
           <tag role="typerefnum">footnote 6</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/with_underscore">https://example.com/with_underscore</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/with_underscore">https://example.com/with_underscore</ref></note>
       <note mark="7" role="footnote" xml:id="footnote7"><tags>
           <tag>7</tag>
           <tag role="refnum">7</tag>
           <tag role="typerefnum">footnote 7</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/with^caret">https://example.com/with^caret</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/with^caret">https://example.com/with^caret</ref></note>
       <note mark="8" role="footnote" xml:id="footnote8"><tags>
           <tag>8</tag>
           <tag role="refnum">8</tag>
           <tag role="typerefnum">footnote 8</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/with$dollar">https://example.com/with$dollar</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/with$dollar">https://example.com/with$dollar</ref></note>
     </paragraph>
     <paragraph inlist="toc" xml:id="S1.SS0.SSS0.Px4">
       <title>Probably unexpected URLs in footnotes</title>
@@ -228,12 +228,12 @@
           <tag>9</tag>
           <tag role="refnum">9</tag>
           <tag role="typerefnum">footnote 9</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/lostpercent">https://example.com/lostpercent</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/lostpercent">https://example.com/lostpercent</ref></note>
       <note mark="10" role="footnote" xml:id="footnote10"><tags>
           <tag>10</tag>
           <tag role="refnum">10</tag>
           <tag role="typerefnum">footnote 10</tag>
-        </tags><ref class="ltx_url" font="typewriter" href="https://example.com/slash\%percent">https://example.com/slash\%percent</ref></note>
+        </tags><ref class="ltx_nolink ltx_url" font="typewriter" href="https://example.com/slash\%percent">https://example.com/slash\%percent</ref></note>
     </paragraph>
   </section>
 </document>

--- a/t/tokenize/percent.xml
+++ b/t/tokenize/percent.xml
@@ -17,17 +17,17 @@
 In section <ref labelref="LABEL:foobar"/></p>
     </para>
     <para xml:id="S1.p2">
-      <p><ref class="ltx_url" font="typewriter" href="http://foo.com/dont%00ignorethis">http://foo.com/dont%00ignorethis</ref>
+      <p><ref class="ltx_nolink ltx_url" font="typewriter" href="http://foo.com/dont%00ignorethis">http://foo.com/dont%00ignorethis</ref>
 and
-<ref class="ltx_url" font="typewriter" href="http://foo.com/dont%00ignorethis">http://foo.com/dont%00ignorethis</ref>
+<ref class="ltx_nolink ltx_url" font="typewriter" href="http://foo.com/dont%00ignorethis">http://foo.com/dont%00ignorethis</ref>
 However
-<ref class="ltx_url" font="typewriter" href="http://foo.com/dont">http://foo.com/dont</ref> ignore this either</p>
+<ref class="ltx_nolink ltx_url" font="typewriter" href="http://foo.com/dont">http://foo.com/dont</ref> ignore this either</p>
     </para>
     <para xml:id="S1.p3">
-      <p>Consider <verbatim font="typewriter">http://\host/page</verbatim> versus <ref class="ltx_url" font="typewriter" href="http://\host/page">http://\host/page</ref>.</p>
+      <p>Consider <verbatim font="typewriter">http://\host/page</verbatim> versus <ref class="ltx_nolink ltx_url" font="typewriter" href="http://\host/page">http://\host/page</ref>.</p>
     </para>
     <para xml:id="S1.p4">
-      <p>Consider <verbatim font="typewriter">a_b</verbatim> versus <ref class="ltx_url" font="typewriter" href="a_b">a_b</ref>.</p>
+      <p>Consider <verbatim font="typewriter">a_b</verbatim> versus <ref class="ltx_nolink ltx_url" font="typewriter" href="a_b">a_b</ref>.</p>
     </para>
     <para xml:id="S1.p5">
       <p>When delimited, extra braces are allowed by verb, but not url.

--- a/t/tokenize/url.xml
+++ b/t/tokenize/url.xml
@@ -13,10 +13,10 @@
     </tags>
     <title><tag close=" ">1</tag>Basic URLS</title>
     <para xml:id="S1.p1">
-      <p>Basic url: <ref class="ltx_url" font="typewriter" href="http://example.com/~user">http://example.com/~user</ref> or <ref class="ltx_url" font="typewriter" href="http://example.com/~user">http://example.com/~user</ref>.</p>
+      <p>Basic url: <ref class="ltx_nolink ltx_url" font="typewriter" href="http://example.com/~user">http://example.com/~user</ref> or <ref class="ltx_nolink ltx_url" font="typewriter" href="http://example.com/~user">http://example.com/~user</ref>.</p>
     </para>
     <para xml:id="S1.p2">
-      <p>Path url: <ref class="ltx_path" font="typewriter" href="/foo/bar/baz">/foo/bar/baz</ref> or <ref class="ltx_path" font="typewriter" href="/foo/bar/baz">/foo/bar/baz</ref></p>
+      <p>Path url: <ref class="ltx_nolink ltx_path" font="typewriter" href="/foo/bar/baz">/foo/bar/baz</ref> or <ref class="ltx_nolink ltx_path" font="typewriter" href="/foo/bar/baz">/foo/bar/baz</ref></p>
     </para>
   </section>
   <section inlist="toc" xml:id="S2">
@@ -28,16 +28,16 @@
     <title><tag close=" ">2</tag>Verbatimness</title>
     <para xml:id="S2.p1">
       <p>Special characters neutralized:
-<ref class="ltx_url" font="typewriter" href="http://example.com/foo_bar">http://example.com/foo_bar</ref>,
-<ref class="ltx_url" font="typewriter" href="http://example.com/foo#bar">http://example.com/foo#bar</ref>,
-<ref class="ltx_url" font="typewriter" href="http://example.com/foo&amp;bar">http://example.com/foo&amp;bar</ref>.</p>
+<ref class="ltx_nolink ltx_url" font="typewriter" href="http://example.com/foo_bar">http://example.com/foo_bar</ref>,
+<ref class="ltx_nolink ltx_url" font="typewriter" href="http://example.com/foo#bar">http://example.com/foo#bar</ref>,
+<ref class="ltx_nolink ltx_url" font="typewriter" href="http://example.com/foo&amp;bar">http://example.com/foo&amp;bar</ref>.</p>
     </para>
     <para xml:id="S2.p2">
       <p>And even though <verbatim font="typewriter">\baz</verbatim> gives index.html;
-<ref class="ltx_path" font="typewriter" href="C:\foo\bar\baz">C:\foo\bar\baz</ref></p>
+<ref class="ltx_nolink ltx_path" font="typewriter" href="C:\foo\bar\baz">C:\foo\bar\baz</ref></p>
     </para>
     <para xml:id="S2.p3">
-      <p>OTOH, you get this: <ref class="ltx_url" font="typewriter" href="http://example.com/~user">http://example.com/\~{}user</ref></p>
+      <p>OTOH, you get this: <ref class="ltx_nolink ltx_url" font="typewriter" href="http://example.com/~user">http://example.com/\~{}user</ref></p>
     </para>
   </section>
   <section inlist="toc" xml:id="S3">
@@ -48,7 +48,7 @@
     </tags>
     <title><tag close=" ">3</tag>Styles</title>
     <para xml:id="S3.p1">
-      <p>Email: <ref class="ltx_email" font="sansserif" href="myself%node@gateway.net">myself%node@gateway.net</ref> or <ref class="ltx_email" font="sansserif" href="myself%node@gateway.net">myself%node@gateway.net</ref>.</p>
+      <p>Email: <ref class="ltx_nolink ltx_email" font="sansserif" href="myself%node@gateway.net">myself%node@gateway.net</ref> or <ref class="ltx_nolink ltx_email" font="sansserif" href="myself%node@gateway.net">myself%node@gateway.net</ref>.</p>
     </para>
   </section>
   <section inlist="toc" xml:id="S4">
@@ -59,7 +59,7 @@
     </tags>
     <title><tag close=" ">4</tag>Defined urls</title>
     <para xml:id="S4.p1">
-      <p>Myself: <ref class="ltx_url" font="typewriter" href="myself%node@gateway.net">myself%node@gateway.net</ref> or <ref class="ltx_email" font="sansserif" href="myself%node@gateway.net">myself%node@gateway.net</ref>.</p>
+      <p>Myself: <ref class="ltx_nolink ltx_url" font="typewriter" href="myself%node@gateway.net">myself%node@gateway.net</ref> or <ref class="ltx_nolink ltx_email" font="sansserif" href="myself%node@gateway.net">myself%node@gateway.net</ref>.</p>
     </para>
   </section>
   <section inlist="toc" xml:id="S5">
@@ -70,7 +70,7 @@
     </tags>
     <title><tag close=" ">5</tag>Bracketting</title>
     <para xml:id="S5.p1">
-      <p>Fancy url: <ref class="ltx_fancyurl" font="typewriter" href="http://example.com/~user">&lt;url: http://example.com/~user&gt;</ref> or <ref class="ltx_fancyurl" font="typewriter" href="http://example.com/~user">&lt;url: http://example.com/~user&gt;</ref>.</p>
+      <p>Fancy url: <ref class="ltx_nolink ltx_fancyurl" font="typewriter" href="http://example.com/~user">&lt;url: http://example.com/~user&gt;</ref> or <ref class="ltx_nolink ltx_fancyurl" font="typewriter" href="http://example.com/~user">&lt;url: http://example.com/~user&gt;</ref>.</p>
     </para>
   </section>
 </document>


### PR DESCRIPTION
This PR corrects the behavior of several packages (`url,hyperref,cleverref`) whose macros, or starred variants, do not create hyperlinks in pdf.

Fixes #2174
Fixes #2076