### PR TITLE
Small fixes to schema docs

### DIFF
--- a/lib/LaTeXML/Common/Model/RelaxNG.pm
+++ b/lib/LaTeXML/Common/Model/RelaxNG.pm
@@ -105,7 +105,7 @@ sub filterNames {
       && ((($name =~ /^!(.*)$/) && !(defined $$hash{$1}))    # Negated name, but name not present?
         || (!defined $$hash{ '!' . $name }))) {              # Or negation of name not present
       $filtered{$name} = 1; } }
-  return sort keys %filtered; }
+  return (sort keys %filtered); }
 
 # Return two hashrefs for content & attributes
 sub extractContent {
@@ -476,7 +476,10 @@ sub simplify {
           elsif (($combination eq 'group') && ($prevc ne 'group')) {    # Use old combination!?!?!?!?
             $combination = $prevc; } }
         $$self{defs}{$qname} = simplifyCombination(['combination', $combination,
-            ($prev ? @$prev : ()), @xargs]);
+            # careful, if $prev is a triple [$op,$name,@stuff] and we flatten it,
+            # we should not treat $op and $name as @stuff.
+            # We should either drop them, or not flatten at all. Drop for now.
+            ($prev ? @$prev[2 .. $#{$prev}] : ()), @xargs]);
         $$self{def_combiner}{$qname} = $combination;
         return ([$op, $qname, @args]); } }
     else {
@@ -708,7 +711,6 @@ sub getSymbolUses {
     my @uses = sort keys %$uses;
     @uses = grep { !/\bSVG./ } @uses if $SKIP_SVG;                      # !!!
     return join(', ',
-      (map { /^pattern:[^:]*:(.*)$/ ? ('\patternref{' . cleanTeX($1) . '}')     : () } @uses),
       (map { /^pattern:[^:]*:(.*)$/ ? ('\patternref{' . cleanTeX($1) . '}')     : () } @uses),
       (map { /^element:(.*)$/       ? ('\elementref{' . cleanTeXName($1) . '}') : () } @uses)); }
   else {


### PR DESCRIPTION
To use an example, say the [LaTeXML-common](https://math.nist.gov/~BMiller/LaTeXML/manual/schema/LaTeXML-common/) schema docs page has two visible issues today:
 - The list of items in "Used By:" is shown twice
 - some "Expansion:" entries have directive keywords sneaking in
    - for example "(combination  |  choice  |  combination  |  group  |" in Para.class

I *think* I have identified the causes for the two mishaps. For "used by" a line of code was duplicated, so just removing that.

For the expansion case, it seems more subtle, as it is hard for me to follow the various cases of data structure management for the "combination" cases. I *think* I traced the source of the issue to a peculiar call to `simplifyCombination` which flattens a triple to an array, and then mistreats the `op` and `name` keywords as data, leading to them showing up in the docs page. Dropping them early when preparing the arguments for that method call avoids the issue - but one should double-check if `$prev` is reliably a triple of this kind, as I am not 100% sure.