### PR TITLE
extra guards for empty lines for Mouth::readToken

### DIFF
--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -20,7 +20,7 @@ use LaTeXML::Core::Token;
 use LaTeXML::Core::Tokens;
 use LaTeXML::Util::Pathname;
 use Encode qw(decode);
-use base   qw(LaTeXML::Common::Object);
+use base qw(LaTeXML::Common::Object);
 
 our $READLINE_PROGRESS_QUANTUM = 25;
 
@@ -214,7 +214,7 @@ sub handle_escape {    # Read control sequence
   # Bit I believe that he does NOT mean within control sequences
   my $cs = "\\" . $ch;    # I need this standardized to be able to lookup tokens (A better way???)
   if ((defined $cc) && ($cc == CC_LETTER)) {    # For letter, read more letters for csname.
-    while ((($ch, $cc) = getNextChar($self)) && $ch && ($cc == CC_LETTER)) {
+    while ((($ch, $cc) = getNextChar($self)) && (length($ch) > 0) && ($cc == CC_LETTER)) {
       $cs .= $ch; }
     # We WILL skip spaces, but not till next token is read (in case catcode changes!!!!)
     $$self{skipping_spaces} = 1;
@@ -321,10 +321,10 @@ sub readToken {
       my ($ch, $cc);
       while ((($ch, $cc) = getNextChar($self)) && (defined $ch)
         && (($cc == CC_SPACE) || ($cc == CC_IGNORE))) { }
-      if ($ch && ($cc == CC_EOL)) {    # Eolch already? empty line!
-        $$self{colno} = $$self{nchars};    # ignore rest of line.
+      if ((defined $ch) && ($cc == CC_EOL)) {    # Eolch already? empty line!
+        $$self{colno} = $$self{nchars};          # ignore rest of line.
         return T_CS('\par'); }
-      elsif ($$self{colno} > $$self{nchars}) {    # Past end of line?
+      elsif (($$self{nchars} == 0) || ($$self{colno} > $$self{nchars})) {    # Past end of line?
             # If upcoming line is empty, and there is no recognizable EOL, fake one
         return T_MARKER('EOL') if $read_mode && ((!defined $eolch) || ($eolch ne "\r")); }
       else {    # Back up over peeked char
@@ -347,7 +347,6 @@ sub readToken {
     my $token = (defined $cc ? $DISPATCH[$cc] : undef);
     $token = &$token($self, $ch) if ref $token eq 'CODE';
     return $token if defined $token;    # Else, repeat till we get something or run out.
-
   }
   return; }
 

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -214,7 +214,7 @@ sub handle_escape {    # Read control sequence
   # Bit I believe that he does NOT mean within control sequences
   my $cs = "\\" . $ch;    # I need this standardized to be able to lookup tokens (A better way???)
   if ((defined $cc) && ($cc == CC_LETTER)) {    # For letter, read more letters for csname.
-    while ((($ch, $cc) = getNextChar($self)) && (length($ch) > 0) && ($cc == CC_LETTER)) {
+    while ((($ch, $cc) = getNextChar($self)) && (defined $ch) && ($cc == CC_LETTER)) {
       $cs .= $ch; }
     # We WILL skip spaces, but not till next token is read (in case catcode changes!!!!)
     $$self{skipping_spaces} = 1;


### PR DESCRIPTION
Fixes #2175

The regression is really subtle, so this PR definitely deserves a careful look-over. As Tim helpfully diagnosed in the issue, the underlying cause were the improvements from commit https://github.com/brucemiller/LaTeXML/commit/acaa51d9bdf4ae582c57f527fe34580290efac34 .

The remaining subtlety seemed to be revealed when babel.sty loads its english `.ini` file on a recent texlive (`babel-en.ini`). Every time that file read encounters a completely empty line, it seems to terminate the read early. Explaining *how* that happens is not something I can do with sufficient clarity at the moment, but it has to do with the interplay of `Gullet::readUntil`, `Mouth::readToken` and `Mouth::getNextChar`, where the `undef` from the empty line needs to be handled at just the right context point - or the assembled token list for the argument is incorrect, raising the higher level Errors of the regression.

I arrived at the PR contents by experiment - trying to tweak in a variety of contexts and settling on the first reasonable combination that worked out. The key change was adding a `$$self{nchars} == 0` check to the branch of `Mouth::readToken` that creates an EOL marker if a line is completely empty - tests continue to pass, and the regression is resolved.

I also changed a couple of checks relying on `$ch` to instead rely on `defined $ch` along the way, as I kept worrying about `0` chars.
