### PR TITLE
Rename xsl context param to more targeted spansoup

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-bib-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-bib-xhtml.xsl
@@ -29,8 +29,8 @@
        ====================================================================== -->
 
   <!-- We don't really anticipate bibliographies appearing in inline contexts,
-       so we pretty much ignore the $context switches.
-       See the CONTEXT discussion in LaTeXML-common -->
+       so we pretty much ignore the $spansoup switches.
+       See the SPANSOUP discussion in LaTeXML-common -->
 
   <xsl:preserve-space elements="ltx:surname ltx_givenname ltx:lineage
                                 ltx:bib-title ltx:bib-subtitle ltx:bib-key
@@ -41,11 +41,11 @@
                                 ltx:bib-url ltx:bib-extract ltx:bib-note ltx:bib-data"/>
 
   <xsl:template match="ltx:biblist">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:choose>
       <xsl:when test="$USE_TWOCOLUMN_BIB">
         <xsl:apply-templates select="." mode="twocolumns">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
@@ -54,13 +54,13 @@
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:text>&#x0A;</xsl:text>
         </xsl:element>
@@ -69,13 +69,13 @@
   </xsl:template>
 
   <xsl:template match="ltx:biblist" mode="twocolumns">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="items"    select="ltx:bibitem"/>
     <xsl:param name="lines"    select="ltx:bibitem/ltx:bibblock | ltx:bibitem"/>
     <xsl:param name="halflines" select="ceiling(count($lines) div 2)"/>
     <xsl:param name="miditem" select="count($lines[position() &lt; $halflines]/parent::*) + 1"/>
     <xsl:call-template name="split-columns">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name="wrapper" select="'ul'"/>
       <xsl:with-param name="items"   select="$items"/>
       <xsl:with-param name="miditem" select="$miditem"/>
@@ -83,32 +83,32 @@
   </xsl:template>
 
   <xsl:template match="ltx:bibitem">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="li" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
 
       <xsl:choose>
         <xsl:when test='ltx:tags/ltx:tag[not(@role)]'>
           <xsl:apply-templates select='ltx:tags/ltx:tag[not(@role)]'>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:when>
         <xsl:when test="ltx:tags/ltx:tag[@role = 'refnum']">
           <xsl:apply-templates select="ltx:tags/ltx:tag[@role = 'refnum']">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:when>
       </xsl:choose>
       <xsl:apply-templates select='ltx:bibblock'>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -116,20 +116,20 @@
   <!-- potential future parameterization?
        choose which bibtag is used to display? -->
   <xsl:template match="ltx:bibitem/ltx:tags/ltx:tag[@role='refnum']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
         <xsl:call-template name="add_id"/>
         <xsl:call-template name="add_attributes"/>
         <xsl:apply-templates select="." mode="begin">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
         <xsl:value-of select="@open"/>
         <xsl:apply-templates>
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
         <xsl:value-of select="@close"/>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -137,19 +137,19 @@
   <!-- By default, I suppose, this should generate a span,
        but if you want openbib, use css: .ltx_bibblock{display:block;} -->
   <xsl:template match="ltx:bibblock">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="span" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-block-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-block-xhtml.xsl
@@ -33,20 +33,20 @@
   <xsl:template match="ltx:tags/ltx:tag[@role]"/>
 
   <xsl:template match="ltx:tag">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:value-of select="@open"/>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:value-of select="@close"/>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -54,24 +54,24 @@
   <!-- Most of these templates generate block-level elements but may appear
        in inline mode; they use f:blockelement so that they will generate
        a valid 'span' element instead.
-       See the CONTEXT discussion in LaTeXML-common -->
+       See the SPANSOUP discussion in LaTeXML-common -->
 
   <xsl:preserve-space elements="ltx:p"/>
   <xsl:template match="ltx:p">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'p')}" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+    <xsl:element name="{f:blockelement($spansoup,'p')}" namespace="{$html_ns}">
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -79,19 +79,19 @@
   <xsl:strip-space elements="ltx:quote"/>
 
   <xsl:template match="ltx:quote">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'blockquote')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'blockquote')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -100,19 +100,19 @@
   <xsl:strip-space elements="ltx:block"/>
 
   <xsl:template match="ltx:block">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'div')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'div')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -121,34 +121,34 @@
   <xsl:strip-space elements="ltx:listing"/>
 
   <xsl:template match="ltx:listing">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'div')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'div')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:listing" mode="classes">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates select="." mode="base-classes"/>
     <xsl:text> ltx_listing</xsl:text>
   </xsl:template>
 
   <xsl:template match="ltx:listing[@data]" mode="begin">
-    <xsl:param name="context"/>
-    <xsl:element name="{f:blockelement($context,'div')}" namespace="{$html_ns}">
+    <xsl:param name="spansoup"/>
+    <xsl:element name="{f:blockelement($spansoup,'div')}" namespace="{$html_ns}">
       <xsl:attribute name="class">ltx_listing_data</xsl:attribute>
       <xsl:element name="a" namespace="{$html_ns}">
         <xsl:call-template name="add_data_attribute">
@@ -167,19 +167,19 @@
 
   <xsl:preserve-space elements="ltx:listingline"/>
   <xsl:template match="ltx:listingline">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'div')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'div')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -204,14 +204,14 @@
   </xsl:param>
   <!-- Equation numbers on left, or default right? -->
   <xsl:template match="ltx:equation/ltx:tags/ltx:tag | ltx:equationgroup/ltx:tags/ltx:tag">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/>
+      <xsl:variable name="inline" select="'inline'"/>
       <xsl:attribute name="class">ltx_tag ltx_tag_<xsl:value-of select="local-name(../..)"/>
       <xsl:text> </xsl:text>
       <xsl:value-of select="f:if(ancestor-or-self::*[contains(@class,'ltx_leqno')],'ltx_align_left','ltx_align_right')"/></xsl:attribute>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -222,32 +222,32 @@
   <xsl:strip-space elements="ltx:equation ltx:equationgroup"/>
 
   <xsl:template match="ltx:equationgroup">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:choose>
       <xsl:when test="$USE_ALIGNED_EQUATIONS">
         <xsl:apply-templates select="." mode="aligned">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
         <xsl:apply-templates select="." mode="unaligned">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
   <xsl:template match="ltx:equation">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:choose>
       <xsl:when test="$USE_ALIGNED_EQUATIONS">
         <xsl:apply-templates select="." mode="aligned">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
         <xsl:apply-templates select="." mode="unaligned">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:otherwise>
     </xsl:choose>
@@ -261,109 +261,109 @@
   <xsl:template match="*" mode="unaligned-end"/>
 
   <xsl:template match="ltx:equationgroup" mode="unaligned">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="eqnopos"
                select="f:if(ancestor-or-self::*[contains(@class,'ltx_leqno')],'left','right')"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'div')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'div')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
         <xsl:with-param name="extra_classes" select="'ltx_eqn_div'"/>
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="unaligned-begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:if test="ltx:tags and not(descendant::ltx:equation[ltx:tags]) and $eqnopos='left'">
         <xsl:apply-templates select="ltx:tags">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:if>
       <xsl:apply-templates select="ltx:equationgroup | ltx:equation | ltx:p">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:if test="ltx:tags and not(descendant::ltx:equation[ltx:tags]) and $eqnopos='right'">
         <xsl:apply-templates select="ltx:tags">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:if>
       <xsl:apply-templates select="." mode="constraints">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="unaligned-end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:equation" mode="unaligned">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="eqnopos"
                select="f:if(ancestor-or-self::*[contains(@class,'ltx_leqno')],'left','right')"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'div')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'div')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
         <xsl:with-param name="extra_classes" select="'ltx_eqn_div'"/>
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="unaligned-begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:if test="ltx:tags and $eqnopos='left'">
         <xsl:apply-templates select="ltx:tags">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:if>
       <xsl:element name="span" namespace="{$html_ns}">
-        <xsl:variable name="context" select="'inline'"/><!-- override -->
+        <xsl:variable name="spansoup" select="'inline'"/><!-- override -->
         <!-- This should cover: ltx:Math, ltx:MathFork, ltx:text & Misc
              (ie. all of equation_model EXCEPT Meta & EquationMeta) -->
         <xsl:apply-templates select="ltx:Math | ltx:MathFork | ltx:text
                                      | ltx:inline-block | ltx:verbatim | ltx:break
                                      | ltx:graphics | ltx:svg | ltx:rawhtml | ltx:inline-para
                                      | ltx:tabular | ltx:picture" >
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:element>
       <xsl:if test="ltx:tags and $eqnopos='right'">
         <xsl:apply-templates select="ltx:tags">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:if>
       <xsl:apply-templates select="." mode="constraints">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="unaligned-end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
       </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:equationgroup|ltx:equation" mode="constraints">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates select="ltx:constraint[not(@hidden='true')]">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
   </xsl:template>
 
   <!-- by default (not inside an aligned equationgroup) -->
   <xsl:template match="ltx:MathFork">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates select="ltx:Math[1]">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
   </xsl:template>
 
@@ -460,32 +460,32 @@
        It establishes an outer table into which the contained equationgroups
        and equations are set. -->
   <xsl:template match="ltx:equationgroup" mode="aligned">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"
                select="f:maxcolumns(ltx:equation | ltx:equationgroup/ltx:equation)"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'table')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'table')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
         <xsl:with-param name="extra_classes" select="'ltx_eqn_table'"/>
       </xsl:call-template>
       <xsl:text>&#x0A;</xsl:text>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="aligned-begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="inalignment">
         <xsl:with-param name="ncolumns" select="$ncolumns"/>
         <xsl:with-param name="spanned" select="false()"/>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="aligned-end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -494,31 +494,31 @@
   <!-- Top-level aligned single equation establishes a table into which the equations
        rows are set. -->
   <xsl:template match="ltx:equation" mode="aligned">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns" select="f:countcolumns(.)"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'table')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'table')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
         <xsl:with-param name="extra_classes" select="'ltx_eqn_table'"/>
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="aligned-begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
       <xsl:apply-templates select="." mode="inalignment">
         <xsl:with-param name="ncolumns" select="$ncolumns"/>
         <xsl:with-param name="spanned" select="false()"/>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="aligned-end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -538,7 +538,7 @@
        [this mangled nesting keeps us from being able to use tbody!]
   -->
   <xsl:template name="eqnumtd">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="side"/>                                   <!-- left or right -->
     <xsl:param name="eqnopos"
                select="f:if(ancestor-or-self::*[contains(@class,'ltx_leqno')],'left','right')"/>
@@ -561,14 +561,14 @@
                                 | ancestor-or-self::ltx:equationgroup[position()=1][ltx:tags]/descendant::ltx:equation/ltx:constraint
                                 )"/>
           <xsl:text>&#x0A;</xsl:text>
-          <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}">
+          <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}">
             <xsl:attribute name="rowspan"><xsl:value-of select="$nrows"/></xsl:attribute>
             <xsl:attribute name="class">
               <xsl:value-of select="concat('ltx_eqn_cell ltx_eqn_eqno ltx_align_middle ltx_align_',$side)"/>
             </xsl:attribute>
             <xsl:apply-templates
                 select="ancestor-or-self::ltx:equationgroup[position()=1]/ltx:tags/ltx:tag[not(@role)]">
-              <xsl:with-param name="context" select="$context"/>
+              <xsl:with-param name="spansoup" select="$spansoup"/>
             </xsl:apply-templates>
             </xsl:element>
         </xsl:if>                                              <!--Else NOTHING (rowspan'd!) -->
@@ -590,13 +590,13 @@
                                 [ltx:Math or ltx:MathFork/ltx:MathBranch[not(ltx:tr or ltx:td)]]
                                 )"/>
           <xsl:text>&#x0A;</xsl:text>
-          <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}">
+          <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}">
             <xsl:attribute name="rowspan"><xsl:value-of select="$nrows"/></xsl:attribute>
             <xsl:attribute name="class">
               <xsl:value-of select="concat('ltx_eqn_cell ltx_eqn_eqno ltx_align_middle ltx_align_',$side)"/>
             </xsl:attribute>
             <xsl:apply-templates select="ancestor-or-self::ltx:equation[position()=1]/ltx:tags/ltx:tag[not(@role)]">
-              <xsl:with-param name="context" select="$context"/>
+              <xsl:with-param name="spansoup" select="$spansoup"/>
             </xsl:apply-templates>
           </xsl:element>
         </xsl:if>                                                      <!--Else NOTHING (rowspan'd!) -->
@@ -606,15 +606,15 @@
 
   <!-- Handle the equation left side, possibly including equation number -->
   <xsl:template name="eq-left">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="eqpos"
                select="f:if(ancestor-or-self::*[contains(@class,'ltx_fleqn')],'left','center')"/>
     <xsl:call-template name="eqnumtd">                         <!--Place left number, if any -->
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name='side' select="'left'"/>
     </xsl:call-template>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}">
       <xsl:attribute name="class">
       <xsl:value-of select="concat('ltx_eqn_cell ltx_eqn_',$eqpos,'_padleft')"/></xsl:attribute>
     </xsl:element>
@@ -623,12 +623,12 @@
   <!-- Handle the equation right side, possibly including equation number,
        and any extra padding "columns" needed to complete the row. -->
   <xsl:template name="eq-right">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="eqpos"
                select="f:if(ancestor-or-self::*[contains(@class,'ltx_fleqn')],'left','center')"/>
     <xsl:param name="extrapad" select="0"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}">
       <xsl:attribute name="class">
       <xsl:value-of select="concat('ltx_eqn_cell ltx_eqn_',$eqpos,'_padright')"/></xsl:attribute>
       <xsl:if test="$extrapad > 0">
@@ -638,7 +638,7 @@
       </xsl:if>
     </xsl:element>
     <xsl:call-template name="eqnumtd">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name='side' select="'right'"/>
     </xsl:call-template>
   </xsl:template>
@@ -647,19 +647,19 @@
        Synthesizing rows & columns out for aligned equations and equationgroups
   -->
   <xsl:template match="*" mode="inalignment-begin">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"/>
     <xsl:param name="spanned"/>
   </xsl:template>
   <xsl:template match="*" mode="inalignment-end">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"/>
     <xsl:param name="spanned"/>
   </xsl:template>
 
   <!-- for intertext type entries; these just span he content columns. -->
   <xsl:template match="ltx:p" mode="inalignment">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"/>
     <xsl:param name="spanned"/>
     <xsl:param name="eqpos"
@@ -668,15 +668,15 @@
     <xsl:choose>
       <xsl:when test="$spanned">
         <xsl:apply-templates select="." mode="ininalignment">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
           <xsl:with-param name="ncolumns" select="$ncolumns"/>
           <xsl:with-param name="spanned" select="$spanned"/>
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:element name="{f:blockelement($context,'tbody')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'tbody')}" namespace="{$html_ns}">
           <xsl:apply-templates select="." mode="ininalignment">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="ncolumns" select="$ncolumns"/>
             <xsl:with-param name="spanned" select="$spanned"/>
           </xsl:apply-templates>
@@ -686,35 +686,35 @@
   </xsl:template>
 
   <xsl:template match="ltx:p" mode="ininalignment">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"/>
     <xsl:param name="spanned"/>
-    <xsl:element name="{f:blockelement($context,'tr')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'tr')}" namespace="{$html_ns}">
       <xsl:attribute name="class">ltx_eqn_row ltx_align_baseline</xsl:attribute>
-      <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}">
+      <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}">
         <xsl:attribute name="class">ltx_eqn_cell ltx_align_left</xsl:attribute>
         <xsl:attribute name="style">white-space:normal;</xsl:attribute>
         <xsl:attribute name="colspan">
           <xsl:value-of select="3+$ncolumns"/>
         </xsl:attribute>
         <xsl:apply-templates select="." mode="begin">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
         <xsl:apply-templates select="." mode="inalignment-begin">
           <xsl:with-param name="ncolumns" select="$ncolumns"/>
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
           <xsl:with-param name="spanned" select="$spanned"/>
         </xsl:apply-templates>
         <xsl:apply-templates>
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
         <xsl:apply-templates select="." mode="inalignment-end">
           <xsl:with-param name="ncolumns" select="$ncolumns"/>
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
           <xsl:with-param name="spanned" select="$spanned"/>
         </xsl:apply-templates>
         <xsl:apply-templates select="." mode="end">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:element>
     </xsl:element>
@@ -723,7 +723,7 @@
   <!-- equationgroups, possibly nested, already within a table context.
        We'll wrap in a tbody (with ID), unless we're already spanned by an equation number. -->
   <xsl:template match="ltx:equationgroup" mode="inalignment">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"/>
     <xsl:param name="spanned"/> <!--If this group is (row)spanned by an equation number column. -->
     <xsl:choose>
@@ -731,10 +731,10 @@
       <xsl:when test="$spanned or (not(child::ltx:tags) and not(parent::ltx:equationgroup and @fragid))">
         <!-- but without tbody, if id hasn't been handled (by html:table), add dummy row -->
         <xsl:if test="@fragid and parent::ltx:equationgroup">
-          <xsl:element name="{f:blockelement($context,'tr')}" namespace="{$html_ns}">
+          <xsl:element name="{f:blockelement($spansoup,'tr')}" namespace="{$html_ns}">
           <xsl:call-template name="add_id"/>
           <xsl:attribute name="class">ltx_eqn_row</xsl:attribute>
-            <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}"> <!--Empty, too
+            <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}"> <!--Empty, too
 -->
               <xsl:attribute name="class">ltx_eqn_cell</xsl:attribute>
               <xsl:attribute name="colspan"><xsl:value-of select="$ncolumns+3"/></xsl:attribute>
@@ -743,20 +743,20 @@
         </xsl:if>
         <xsl:apply-templates select="." mode="ininalignment">
           <xsl:with-param name="ncolumns" select="$ncolumns"/>
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
           <xsl:with-param name="spanned" select="$spanned"/>
         </xsl:apply-templates>
       </xsl:when>
       <!-- otherwise, wrap equationgroup in a tbody -->
       <xsl:otherwise>
-        <xsl:element name="{f:blockelement($context,'tbody')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'tbody')}" namespace="{$html_ns}">
           <!-- If id hasn't been handled (by html:table), put it on tbody -->
           <xsl:if test="@fragid and parent::ltx:equationgroup">
             <xsl:call-template name="add_id"/>
           </xsl:if>
           <xsl:apply-templates select="." mode="ininalignment">
             <xsl:with-param name="ncolumns" select="$ncolumns"/>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="spanned" select="child::ltx:tags"/>
           </xsl:apply-templates>
         </xsl:element>
@@ -766,26 +766,26 @@
 
   <!-- innermost equationgroup; simply handle the content equations/equationgroups -->
   <xsl:template match="ltx:equationgroup" mode="ininalignment">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"/>
     <xsl:param name="spanned"/>
     <xsl:apply-templates select="." mode="inalignment-begin">
       <xsl:with-param name="ncolumns" select="$ncolumns"/>
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name="spanned" select="$spanned"/>
     </xsl:apply-templates>
     <xsl:apply-templates select="ltx:equationgroup | ltx:equation | ltx:p" mode="inalignment">
       <xsl:with-param name="ncolumns" select="$ncolumns"/>
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name="spanned" select="$spanned"/>
     </xsl:apply-templates>
     <xsl:apply-templates select="." mode="aligned-constraints">
       <xsl:with-param name="ncolumns" select="$ncolumns"/>
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
     <xsl:apply-templates select="." mode="inalignment-end">
       <xsl:with-param name="ncolumns" select="$ncolumns"/>
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name="spanned" select="$spanned"/>
     </xsl:apply-templates>
   </xsl:template>
@@ -793,7 +793,7 @@
   <!-- equation already within a table context.
        We'll wrap in a tbody (with ID), unless we're already spanned by an equation number. -->
   <xsl:template match="ltx:equation" mode="inalignment">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"/>
     <xsl:param name="spanned"/> <!--If this equation is (row)spanned by an equation number column. -->
     <!-- The main issue here is whether to wrap with a tbody (putting any id there),
@@ -805,21 +805,21 @@
       <xsl:when test="$spanned">
         <xsl:apply-templates select="." mode="ininalignment">
           <xsl:with-param name="ncolumns" select="$ncolumns"/>
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
           <xsl:with-param name="need_id" select="true()"/>
           <xsl:with-param name="spanned" select="$spanned"/>
         </xsl:apply-templates>
       </xsl:when>
       <!-- Otherwise, ALWAYS wrap equation in a tbody -->
       <xsl:otherwise>
-        <xsl:element name="{f:blockelement($context,'tbody')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'tbody')}" namespace="{$html_ns}">
           <!-- If id hasn't been handled (by outer html:table) put it on the tbody -->
           <xsl:if test="@fragid and parent::ltx:equationgroup">
             <xsl:call-template name="add_id"/>
           </xsl:if>
           <xsl:apply-templates select="." mode="ininalignment">
             <xsl:with-param name="ncolumns" select="$ncolumns"/>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="need_id" select="false()"/>
             <xsl:with-param name="spanned" select="child::ltx:tags"/>
           </xsl:apply-templates>
@@ -831,7 +831,7 @@
   <!-- innermost equation, already within a table and tbody.
        This is template must sort through all the MathFork's and recover the rows & columns -->
   <xsl:template match="ltx:equation" mode="ininalignment">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"/>
     <xsl:param name="need_id"/> <!--Need to put id in best, first row. -->
     <xsl:param name="spanned"/>
@@ -840,7 +840,7 @@
     <xsl:choose>
       <!-- Case 1: (possibly) Multi-line equation -->
       <xsl:when test="ltx:MathFork/ltx:MathBranch[1]/ltx:tr">
-        <xsl:element name="{f:blockelement($context,'tr')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'tr')}" namespace="{$html_ns}">
           <!-- Note that the id is only going on the 1st row! -->
           <xsl:if test="$need_id">
             <xsl:call-template name="add_id"/>
@@ -850,35 +850,35 @@
           </xsl:call-template>
           <xsl:apply-templates select="." mode="inalignment-begin">
             <xsl:with-param name="ncolumns" select="$ncolumns"/>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="spanned" select="$spanned"/>
           </xsl:apply-templates>
           <xsl:call-template name="eq-left">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:call-template>
           <xsl:apply-templates select="ltx:MathFork/ltx:MathBranch[1]/ltx:tr[1]/ltx:td"
                                mode="inalignment">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="spanned" select="$spanned"/>
           </xsl:apply-templates>
           <xsl:call-template name="eq-right">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="extrapad" select="$ncolumns - f:countcolumns(ltx:MathFork/ltx:MathBranch[1]/tr[1])"/>
           </xsl:call-template>
         </xsl:element>
         <xsl:for-each select="ltx:MathFork/ltx:MathBranch[1]/ltx:tr[position() &gt; 1]">
           <xsl:text>&#x0A;</xsl:text>
-          <xsl:element name="{f:blockelement($context,'tr')}" namespace="{$html_ns}">
+          <xsl:element name="{f:blockelement($spansoup,'tr')}" namespace="{$html_ns}">
             <xsl:attribute name="class">ltx_eqn_row ltx_align_baseline</xsl:attribute>
             <xsl:call-template name="eq-left">
-              <xsl:with-param name="context" select="$context"/>
+              <xsl:with-param name="spansoup" select="$spansoup"/>
             </xsl:call-template>
             <xsl:apply-templates select="ltx:td" mode="inalignment">
-              <xsl:with-param name="context" select="$context"/>
+              <xsl:with-param name="spansoup" select="$spansoup"/>
               <xsl:with-param name="spanned" select="$spanned"/>
             </xsl:apply-templates>
             <xsl:call-template name="eq-right">
-              <xsl:with-param name="context" select="$context"/>
+              <xsl:with-param name="spansoup" select="$spansoup"/>
               <!-- count carefully, here -->
               <xsl:with-param name="extrapad" select="$ncolumns - sum(ltx:td/@colspan) - count(ltx:td[not(@colspan)])"/>
             </xsl:call-template>
@@ -887,7 +887,7 @@
       </xsl:when>
       <!-- Case 2: Single line, (possibly) multiple columns -->
       <xsl:when test="ltx:MathFork/ltx:MathBranch[1]">
-        <xsl:element name="{f:blockelement($context,'tr')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'tr')}" namespace="{$html_ns}">
           <xsl:if test="$need_id"> <!--Don't duplicate id! -->
             <xsl:call-template name="add_id"/>
           </xsl:if>
@@ -896,26 +896,26 @@
           </xsl:call-template>
           <xsl:apply-templates select="." mode="inalignment-begin">
             <xsl:with-param name="ncolumns" select="$ncolumns"/>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="spanned" select="$spanned"/>
           </xsl:apply-templates>
           <xsl:call-template name="eq-left">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:call-template>
           <xsl:apply-templates select="ltx:MathFork/ltx:MathBranch[1]/*"
                                mode="inalignment">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="spanned" select="$spanned"/>
           </xsl:apply-templates>
           <xsl:call-template name="eq-right">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="extrapad" select="$ncolumns - f:countcolumns(ltx:MathFork/ltx:MathBranch[1])"/>
           </xsl:call-template>
         </xsl:element>
       </xsl:when>
       <!-- Case : default; just an unaligned equation, presumably within a group-->
       <xsl:otherwise>
-        <xsl:element name="{f:blockelement($context,'tr')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'tr')}" namespace="{$html_ns}">
           <xsl:if test="$need_id"> <!--Don't duplicate id! -->
             <xsl:call-template name="add_id"/>
           </xsl:if>
@@ -924,14 +924,14 @@
           </xsl:call-template>
           <xsl:apply-templates select="." mode="inalignment-begin">
             <xsl:with-param name="ncolumns" select="$ncolumns"/>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <xsl:with-param name="spanned" select="$spanned"/>
           </xsl:apply-templates>
           <xsl:call-template name="eq-left">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:call-template>
           <xsl:text>&#x0A;</xsl:text>
-          <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}">
+          <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}">
             <xsl:attribute name="class">
               <xsl:value-of select="concat('ltx_eqn_cell ltx_align_',$eqpos)"/>
             </xsl:attribute>
@@ -945,11 +945,11 @@
                                          | ltx:inline-block | ltx:verbatim | ltx:break
                                          | ltx:graphics | ltx:svg | ltx:rawhtml | ltx:inline-para
                                          | ltx:tabular | ltx:picture" >
-              <xsl:with-param name="context" select="$context"/>
+              <xsl:with-param name="spansoup" select="$spansoup"/>
             </xsl:apply-templates>
           </xsl:element>
           <xsl:call-template name="eq-right">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
             <!-- no extra columns, since we've already made the equation span -->
           </xsl:call-template>
         </xsl:element>
@@ -957,25 +957,25 @@
     </xsl:choose>
     <xsl:apply-templates select="." mode="aligned-constraints">
       <xsl:with-param name="ncolumns" select="$ncolumns"/>
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
     <xsl:apply-templates select="." mode="inalignment-end">
       <xsl:with-param name="ncolumns" select="$ncolumns"/>
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name="spanned" select="$spanned"/>
     </xsl:apply-templates>
   </xsl:template>
 
   <xsl:template match="ltx:equationgroup|ltx:equation" mode="aligned-constraints">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="ncolumns"/>
     <xsl:param name="eqpos"
                select="f:if(ancestor-or-self::*[contains(@class,'ltx_fleqn')],'left','center')"/>
     <xsl:if test="ltx:constraint[not(@hidden='true')]">
       <xsl:text>&#x0A;</xsl:text>
-      <xsl:element name="{f:blockelement($context,'tr')}" namespace="{$html_ns}">
+      <xsl:element name="{f:blockelement($spansoup,'tr')}" namespace="{$html_ns}">
           <xsl:attribute name="class">ltx_eqn_row</xsl:attribute>
-        <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}">
           <xsl:attribute name="class">ltx_eqn_cell ltx_align_right</xsl:attribute>
           <!-- the $ncolumns of math, plus whatever endpadding, but NOT the number-->
           <xsl:attribute name="colspan">
@@ -983,7 +983,7 @@
           <!--<xsl:value-of select="$ncolumns+2"/>-->
           </xsl:attribute>
           <xsl:apply-templates select="." mode="constraints">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:element>
@@ -991,22 +991,22 @@
   </xsl:template>
 
   <xsl:template match="ltx:constraint">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="context" select="'inline'"/><!-- override -->
+      <xsl:variable name="spansoup" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <!-- NOTE: This is pretty wacky.  Maybe we should move the text inside the equation? -->
   <xsl:template match="ltx:td" mode="inalignment">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}">
       <xsl:if test="@colspan">
         <xsl:attribute name="colspan"><xsl:value-of select="@colspan"/></xsl:attribute>
       </xsl:if>
@@ -1020,7 +1020,7 @@
           </xsl:with-param>
       </xsl:call-template>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:if test="(self::* = ../ltx:td[position()=last()])
                     and (parent::* = ../../ltx:tr[position()=last()])
@@ -1028,26 +1028,26 @@
         <!-- if we're the last td in the last tr in an equation followed by a text,
              insert the text here!-->
         <xsl:apply-templates select="ancestor::ltx:MathFork/following-sibling::ltx:text[1]/node()">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:if>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:Math" mode="inalignment">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'td')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'td')}" namespace="{$html_ns}">
       <xsl:call-template name="add_attributes">
         <xsl:with-param name="extra_classes" select="'ltx_eqn_cell ltx_align_center'"/>
       </xsl:call-template>
       <xsl:apply-templates select=".">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:if test="ancestor::ltx:MathFork/following-sibling::*[position()=1][self::ltx:text]">
         <!-- if we're followed by a text, insert the text here!-->
         <xsl:apply-templates select="ancestor::ltx:MathFork/following-sibling::ltx:text[1]/node()">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:if>
     </xsl:element>
@@ -1062,83 +1062,83 @@
   <xsl:strip-space elements="ltx:itemize ltx:enumerate ltx:description ltx:item
                              ltx:inline-itemize ltx:inline-enumerate ltx:inline-description ltx:inline-item"/>
   <xsl:template match="ltx:itemize">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'ul')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'ul')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:enumerate">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'ol')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'ol')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:description">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'dl')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'dl')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates mode='description'>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:item">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:choose>
       <xsl:when test="$SIMPLIFY_HTML">
-        <xsl:element name="{f:blockelement($context,'li')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'li')}" namespace="{$html_ns}">
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="*[local-name() != 'tags']">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:element name="{f:blockelement($context,'li')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'li')}" namespace="{$html_ns}">
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes">
             <xsl:with-param name="extra_style">
@@ -1149,12 +1149,12 @@
             </xsl:with-param>
           </xsl:call-template>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:choose>
             <xsl:when test="child::ltx:tags">
               <xsl:apply-templates select="ltx:tags/ltx:tag[not(@role)]">
-                <xsl:with-param name="context" select="$context"/>
+                <xsl:with-param name="spansoup" select="$spansoup"/>
               </xsl:apply-templates>
               <xsl:text> </xsl:text>
             </xsl:when>
@@ -1167,10 +1167,10 @@
             </xsl:otherwise>
           </xsl:choose>
           <xsl:apply-templates select="*[local-name() != 'tags']">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:otherwise>
@@ -1178,26 +1178,26 @@
   </xsl:template>
 
   <xsl:template match="ltx:item" mode="description">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'dt')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'dt')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="ltx:tags/ltx:tag[not(@role)]">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'dd')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'dd')}" namespace="{$html_ns}">
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="*[local-name() != 'tags']">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -1205,7 +1205,7 @@
   <!-- Tricky, perhaps: ltx:tag is typically within a title or caption
        so it's the GRANDPARENT's type we want to use here!-->
   <xsl:template match="ltx:tag" mode="classes">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates select="." mode="base-classes"/>
     <xsl:text> </xsl:text>
     <xsl:value-of select="concat('ltx_tag_',local-name(../..))"/>
@@ -1213,56 +1213,56 @@
 
   <!-- Inline forms of the above simply generate running text. -->
   <xsl:template match="ltx:inline-itemize | ltx:inline-enumerate | ltx:inline-description">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:inline-item">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:choose>
       <xsl:when test="child::ltx:tags">
         <xsl:element name="span" namespace="{$html_ns}">
-          <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+          <xsl:variable name="inline" select="'inline'"/><!-- override -->
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="ltx:tags/ltx:tag[not(@role)]">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:text> </xsl:text>
           <xsl:apply-templates select="*[local-name() != 'tags']">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:when>
       <xsl:otherwise>
         <xsl:element name="span" namespace="{$html_ns}">
-          <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+          <xsl:variable name="inline" select="'inline'"/><!-- override -->
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:element name="span" namespace="{$html_ns}">
             <xsl:attribute name="class">ltx_tag</xsl:attribute>
@@ -1270,10 +1270,10 @@
           </xsl:element>
           <xsl:text> </xsl:text>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:otherwise>
@@ -1290,7 +1290,7 @@
        $items is the list of items
        $miditem is the cut-off position -->
   <xsl:template name="split-columns">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="wrapper"/>
     <xsl:param name="items"/>
     <xsl:param name="miditem"/>
@@ -1308,13 +1308,13 @@
             <xsl:element name="{$wrapper}" namespace="{$html_ns}">
               <xsl:call-template name="add_attributes"/>
               <xsl:apply-templates select="." mode="begin">
-                <xsl:with-param name="context" select="$context"/>
+                <xsl:with-param name="spansoup" select="$spansoup"/>
               </xsl:apply-templates>
               <xsl:apply-templates select="$items[position() &lt; $miditem]">
-                <xsl:with-param name="context" select="$context"/>
+                <xsl:with-param name="spansoup" select="$spansoup"/>
               </xsl:apply-templates>
               <xsl:apply-templates select="." mode="end">
-                <xsl:with-param name="context" select="$context"/>
+                <xsl:with-param name="spansoup" select="$spansoup"/>
               </xsl:apply-templates>
               <xsl:text>&#x0A;</xsl:text>
             </xsl:element>
@@ -1327,13 +1327,13 @@
             <xsl:element name="{$wrapper}" namespace="{$html_ns}">
               <xsl:call-template name="add_attributes"/>
               <xsl:apply-templates select="." mode="begin">
-                <xsl:with-param name="context" select="$context"/>
+                <xsl:with-param name="spansoup" select="$spansoup"/>
               </xsl:apply-templates>
               <xsl:apply-templates select="$items[not(position() &lt; $miditem)]">
-                <xsl:with-param name="context" select="$context"/>
+                <xsl:with-param name="spansoup" select="$spansoup"/>
               </xsl:apply-templates>
               <xsl:apply-templates select="." mode="end">
-                <xsl:with-param name="context" select="$context"/>
+                <xsl:with-param name="spansoup" select="$spansoup"/>
               </xsl:apply-templates>
               <xsl:text>&#x0A;</xsl:text>
             </xsl:element>
@@ -1346,13 +1346,13 @@
         <xsl:element name="{$wrapper}" namespace="{$html_ns}">
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="$items">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:text>&#x0A;</xsl:text>
         </xsl:element>
@@ -1362,16 +1362,16 @@
   </xsl:template>
 
   <xsl:template match="ltx:pagination">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-common.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-common.xsl
@@ -198,17 +198,17 @@
   </func:function>
 
   <!-- ======================================================================
-       CONTEXT
+       SPANSOUP
        Note that LaTeXML's schema (modeled after latex) is more permissive about
        'miscellaneous' elements (such as tables, inline-blocks, etc) within
        inline context than HTML/HTML5. More than a validity problem, HTML5 parsers
        will rewrite the DOM to suit itself, resulting in flawed display.
-       Virtually all LaTeXML templates take a 'context' parameter that should be either
+       Virtually all LaTeXML templates take a 'spansoup' parameter that should be either
        'inline' or (currently) anything else. Templates that generate elements
-       that only accept inline markup should pass $context 'inline' to templates
+       that only accept inline markup should pass $spansoup 'inline' to templates
        called or applied within.  Any block level templates (that expect to be
        used in such a context) should accomodate by using
-       f:blockelement($context,'element')
+       f:blockelement($spansoup,'element')
        where 'element' is the html element they would normally generate.
        If this is used in an inline context, 'span' will be used instead,
        maintaining validity and avoiding DOM rewrites.
@@ -216,10 +216,10 @@
        which will set the display property appropriately.
   -->
   <func:function name="f:blockelement">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="blocktag"/>
     <xsl:choose>
-      <xsl:when test="$context = 'inline'">
+      <xsl:when test="$spansoup = 'inline'">
         <func:result>span</func:result>
       </xsl:when>
       <xsl:otherwise>
@@ -337,13 +337,13 @@
        they'll resume with the normal templates.
   -->
   <xsl:template match="*" mode='copy-foreign'>
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="{local-name()}" namespace="{namespace-uri()}">
       <xsl:for-each select="@*">
         <xsl:apply-templates select="." mode="copy-attribute"/>
       </xsl:for-each>
       <xsl:apply-templates mode='copy-foreign'>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -365,9 +365,9 @@
 
   <!-- Embedded latexml, however, gets treated with the usual templates! -->
   <xsl:template match="ltx:*" mode='copy-foreign'>
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates select="." >
-      <xsl:with-param name="context"/>
+      <xsl:with-param name="spansoup"/>
     </xsl:apply-templates>
   </xsl:template>
 

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
@@ -54,7 +54,7 @@
   <xsl:template match="ltx:listing[@data]" mode="begin"/>
 
   <xsl:template match="ltx:TOC">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:if test="ltx:toclist/descendant::ltx:tocentry">
       <xsl:text>&#x0A;</xsl:text>
       <xsl:element name="nav" namespace="{$html_ns}">
@@ -64,15 +64,15 @@
         </xsl:call-template>
         <xsl:if test="ltx:title">
           <xsl:element name="h6" namespace="{$html_ns}">
-            <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+            <xsl:variable name="inline" select="'inline'"/><!-- override -->
             <xsl:attribute name="class">ltx_title ltx_title_contents</xsl:attribute>
             <xsl:apply-templates select="ltx:title/node()">
-              <xsl:with-param name="context" select="$innercontext"/>
+              <xsl:with-param name="spansoup" select="$inline"/>
             </xsl:apply-templates>
           </xsl:element>
         </xsl:if>
         <xsl:apply-templates>
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:element>
     </xsl:if>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-inline-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-inline-xhtml.xsl
@@ -28,25 +28,25 @@
 
   <!-- Most of these templates generate elements that format thier contents
        in inline mode, and so set the inner context to 'inline'.
-       See the CONTEXT discussion in LaTeXML-common -->
+       See the SPANSOUP discussion in LaTeXML-common -->
 
   <xsl:preserve-space elements="ltx:text"/>
   <xsl:template match="ltx:text">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
         <xsl:with-param name="extra_classes" select="f:if(@width,'ltx_inline-block','')"/>
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -55,21 +55,21 @@
        in order to take effect (eg. background color, etc).
        Note that "contains" is NOT the right test for @class....-->
   <xsl:template match="ltx:text[contains(@class,'ltx_phantom')]">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:element name="span" namespace="{$html_ns}">
         <xsl:attribute name="style">visibility:hidden</xsl:attribute>
         <xsl:apply-templates select="." mode="begin">
-          <xsl:with-param name="context" select="$innercontext"/>
+          <xsl:with-param name="spansoup" select="$inline"/>
         </xsl:apply-templates>
         <xsl:apply-templates>
-          <xsl:with-param name="context" select="$innercontext"/>
+          <xsl:with-param name="spansoup" select="$inline"/>
         </xsl:apply-templates>
         <xsl:apply-templates select="." mode="end">
-          <xsl:with-param name="context" select="$innercontext"/>
+          <xsl:with-param name="spansoup" select="$inline"/>
         </xsl:apply-templates>
       </xsl:element>
     </xsl:element>
@@ -77,76 +77,76 @@
 
   <xsl:preserve-space elements="ltx:emph"/>
   <xsl:template match="ltx:emph">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="em" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:preserve-space elements="ltx:del"/>
   <xsl:template match="ltx:del">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="del" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:preserve-space elements="ltx:sub"/>
   <xsl:template match="ltx:sub">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="sub" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:preserve-space elements="ltx:sup"/>
   <xsl:template match="ltx:sup">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="sup" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -155,26 +155,26 @@
 
   <xsl:preserve-space elements="ltx:glossaryref"/>
   <xsl:template match="ltx:glossaryref[@href]">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="a" namespace="{$html_ns}">
       <xsl:attribute name="href"><xsl:value-of select="f:url(@href)"/></xsl:attribute>
       <xsl:apply-templates select="." mode="inner">
-        <xsl:with-param name="context" select="context"/>
+        <xsl:with-param name="spansoup" select="spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:glossaryref">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates select="." mode="inner">
-      <xsl:with-param name="context" select="context"/>
+      <xsl:with-param name="spansoup" select="spansoup"/>
     </xsl:apply-templates>
   </xsl:template>
 
   <xsl:template match="ltx:glossaryref" mode="inner">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="{f:if(contains(@show,'short'),'abbr','span')}" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:if test="@href">
         <xsl:attribute name="href"><xsl:value-of select="f:url(@href)"/></xsl:attribute>
       </xsl:if>
@@ -182,19 +182,19 @@
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:rule" mode="styling">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates select="." mode="base-styling"/>
     <xsl:choose>
       <xsl:when test="@color">
@@ -206,16 +206,16 @@
   </xsl:template>
 
   <xsl:template match="ltx:rule">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:if test="string(@width)!='0.0pt'">&#xA0;</xsl:if>
     </xsl:element>
@@ -223,41 +223,41 @@
 
   <xsl:preserve-space elements="ltx:ref"/>
   <xsl:template match="ltx:ref">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:choose>
       <xsl:when test="not(@href) or @href='' or contains(@class,'ltx_nolink')">
         <xsl:element name="span" namespace="{$html_ns}">
-          <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+          <xsl:variable name="inline" select="'inline'"/><!-- override -->
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes">
             <xsl:with-param name="extra_classes" select="'ltx_ref_self'"/>
           </xsl:call-template>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:when>
       <xsl:otherwise>
         <xsl:element name="a" namespace="{$html_ns}">
-          <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+          <xsl:variable name="inline" select="'inline'"/><!-- override -->
           <xsl:attribute name="href"><xsl:value-of select="f:url(@href)"/></xsl:attribute>
           <xsl:attribute name="title"><xsl:value-of select="@title"/></xsl:attribute>
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:otherwise>
@@ -265,39 +265,39 @@
   </xsl:template>
 
   <xsl:template match="ltx:ref//ltx:ref">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:preserve-space elements="ltx:anchor"/>
   <xsl:template match="ltx:anchor">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="a" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:attribute name="name"><xsl:value-of select="@xml:id"/></xsl:attribute>
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -306,19 +306,19 @@
   <xsl:preserve-space elements="ltx:cite"/>
   <xsl:template match="ltx:cite"/>
   <xsl:template match="ltx:cite[child::*[not(self::ltx:bibref) or @show!='nothing']]">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="cite" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-meta-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-meta-xhtml.xsl
@@ -25,31 +25,31 @@
        ltx:note, ltx:indexmark, ltx:rdf, ltx:ERROR
        ====================================================================== -->
 
-  <!-- Only a few generated elements need $context switches.
-       See the CONTEXT discussion in LaTeXML-common -->
+  <!-- Only a few generated elements need $spansoup switches.
+       See the SPANSOUP discussion in LaTeXML-common -->
 
   <!-- normally hidden, but should be exposable various ways.
        The role will likely distinguish various modes of footnote, endnote,
        and other annotation -->
   <xsl:preserve-space elements="ltx:note"/>
   <xsl:template match="ltx:note">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:call-template name="note-mark">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:call-template>
       <xsl:element name="span" namespace="{$html_ns}">
         <xsl:attribute name="class">ltx_note_outer</xsl:attribute>
         <xsl:element name="span" namespace="{$html_ns}">
           <xsl:attribute name="class">ltx_note_content</xsl:attribute>
           <xsl:call-template name="note-mark">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:call-template>
           <xsl:if test="not(@role = 'footnote')">
             <xsl:element name="span" namespace="{$html_ns}">
@@ -59,10 +59,10 @@
             </xsl:element>
           </xsl:if>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:element>
@@ -87,19 +87,19 @@
   <!-- Actually, this ought to be annoyingly visible -->
   <xsl:preserve-space elements="ltx:ERROR"/>
   <xsl:template match="ltx:ERROR">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -110,19 +110,19 @@
   <!-- but the phrases it contains may be used in back-ref situations -->
   <xsl:preserve-space elements="ltx:indexphrase"/>
   <xsl:template match="ltx:indexphrase">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -130,18 +130,18 @@
   <!-- Typically will end up with css display:none -->
   <xsl:preserve-space elements="ltx:rdf"/>
   <xsl:template match="ltx:rdf">
-    <xsl:param name="context"/>
-    <xsl:element name="{f:blockelement($context,'div')}" namespace="{$html_ns}">
+    <xsl:param name="spansoup"/>
+    <xsl:element name="{f:blockelement($spansoup,'div')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
     <xsl:text>&#x0A;</xsl:text>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-misc-xhtml.xsl
@@ -26,25 +26,25 @@
        ltx:inline-block, ltx:verbatim, ltx:break, ltx:graphics, ltx:svg, ltx:rawhtml
        ====================================================================== -->
 
-  <!-- Only a few generated elements need $context switches.
-       See the CONTEXT discussion in LaTeXML-common -->
+  <!-- Only a few generated elements need $spansoup switches.
+       See the SPANSOUP discussion in LaTeXML-common -->
 
   <xsl:strip-space elements="ltx:inline-block"/>
 
   <!-- Note that html does NOT have an inline-block element; so we must
-       continue in an inline context (probably generating span's inside),
+       continue in an inline context (generating spans inside),
        but CSS will hopefully set appropriate display properties.
        BUT, let's only do that if we're actually in an inline context!
        In block context, just make a div-->
   <xsl:template match="ltx:inline-block">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <!-- bug in libxslt!?!?!? putting these in the 'correct' place gives redefinition error! -->
     <xsl:text>&#x0A;</xsl:text>
     <xsl:choose>
       <xsl:when test="@angle | @xtranslate | @ytranslate | @xscale | @yscale ">
-        <xsl:element name="{f:blockelement($context,'div')}" namespace="{$html_ns}">
-          <!--<xsl:variable name="innercontext" select="'inline'"/>--><!-- override -->
-          <xsl:variable name="innercontext" select="$context"/><!-- override -->
+        <xsl:element name="{f:blockelement($spansoup,'div')}" namespace="{$html_ns}">
+          <!--<xsl:variable name="inline" select="'inline'"/>--><!-- override -->
+          <xsl:variable name="inline" select="$spansoup"/><!-- override -->
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes">
             <xsl:with-param name="extra_classes" select="'ltx_transformed_outer'"/>
@@ -53,13 +53,13 @@
             <xsl:attribute name="class">ltx_transformed_inner</xsl:attribute>
             <xsl:call-template name="add_transformable_attributes"/>
             <xsl:apply-templates select="." mode="begin">
-              <xsl:with-param name="context" select="$innercontext"/>
+              <xsl:with-param name="spansoup" select="$inline"/>
             </xsl:apply-templates>
             <xsl:apply-templates>
-              <xsl:with-param name="context" select="$innercontext"/>
+              <xsl:with-param name="spansoup" select="$inline"/>
             </xsl:apply-templates>
             <xsl:apply-templates select="." mode="end">
-              <xsl:with-param name="context" select="$innercontext"/>
+              <xsl:with-param name="spansoup" select="$inline"/>
             </xsl:apply-templates>
             <xsl:text>&#x0A;</xsl:text>
           </xsl:element>
@@ -67,17 +67,17 @@
       </xsl:when>
       <xsl:otherwise>
         <xsl:element name="span" namespace="{$html_ns}">
-          <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+          <xsl:variable name="inline" select="'inline'"/><!-- override -->
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:text>&#x0A;</xsl:text>
         </xsl:element>
@@ -86,20 +86,20 @@
   </xsl:template>
 
   <xsl:template match="ltx:verbatim">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:choose>
       <xsl:when test="contains(text(),'&#xA;')">
         <xsl:element name="pre" namespace="{$html_ns}">
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:when>
@@ -108,13 +108,13 @@
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:otherwise>
@@ -122,15 +122,15 @@
   </xsl:template>
 
   <xsl:template match="ltx:break">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="br" namespace="{$html_ns}">
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -140,7 +140,7 @@
        ====================================================================== -->
 
   <xsl:template match="ltx:graphics">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="img" namespace="{$html_ns}">
       <xsl:attribute name="src"><xsl:value-of select="f:url(@imagesrc)"/></xsl:attribute>
       <xsl:call-template name="add_id"/>
@@ -179,10 +179,10 @@
         </xsl:otherwise>
       </xsl:choose>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -190,7 +190,7 @@
   <!-- svg graphics should use the object tag, rather than img,
        to preserve any interactivity. -->
   <xsl:template match="ltx:graphics[f:ends-with(@imagesrc,'.svg')='true']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:variable name="description">
       <xsl:choose>
         <xsl:when test="@description">
@@ -231,17 +231,17 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <!-- fallback text for screen reader/browser combinations
            which do not accept the aria-label -->
       <xsl:if test="$description!=''">
-        <xsl:element name="{f:blockelement($context,'p')}" namespace="{$html_ns}">
+        <xsl:element name="{f:blockelement($spansoup,'p')}" namespace="{$html_ns}">
           <xsl:value-of select="$description"/>
         </xsl:element>
       </xsl:if>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-para-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-para-xhtml.xsl
@@ -27,43 +27,43 @@
   <!-- Most of these templates generate block-level elements but may appear
        in inline mode; they use f:blockelement so that they will generate
        a valid 'span' element instead.
-       See the CONTEXT discussion in LaTeXML-common -->
+       See the SPANSOUP discussion in LaTeXML-common -->
 
   <xsl:strip-space elements="ltx:para ltx:inline-para"/>
 
   <xsl:template match="ltx:para">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'div')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'div')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:inline-para">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -80,19 +80,19 @@
   <xsl:template match="ltx:theorem/ltx:tags | ltx:proof/ltx:tags"/>
 
   <xsl:template match="ltx:theorem | ltx:proof">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -108,7 +108,7 @@
   <xsl:template match="ltx:figure/ltx:tags | ltx:table/ltx:tags | ltx:float/ltx:tags"/>
 
   <xsl:template match="ltx:figure | ltx:table | ltx:float">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:choose>
       <xsl:when test="@angle | @xtranslate | @ytranslate | @xscale | @yscale ">
@@ -121,22 +121,22 @@
             <xsl:attribute name="class">ltx_transformed_inner</xsl:attribute>
             <xsl:call-template name="add_transformable_attributes"/>
             <xsl:apply-templates select="." mode="begin">
-              <xsl:with-param name="context" select="$context"/>
+              <xsl:with-param name="spansoup" select="$spansoup"/>
             </xsl:apply-templates>
-            <xsl:element name="{f:if($USE_HTML5,f:blockelement($context,'figure'),'div')}" namespace="{$html_ns}">
+            <xsl:element name="{f:if($USE_HTML5,f:blockelement($spansoup,'figure'),'div')}" namespace="{$html_ns}">
               <xsl:apply-templates select="." mode="inner">
-                <xsl:with-param name="context" select="$context"/>
+                <xsl:with-param name="spansoup" select="$spansoup"/>
               </xsl:apply-templates>
             </xsl:element>
           </xsl:element>
         </xsl:element>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:element name="{f:if($USE_HTML5,f:blockelement($context,'figure'),'div')}" namespace="{$html_ns}">
+        <xsl:element name="{f:if($USE_HTML5,f:blockelement($spansoup,'figure'),'div')}" namespace="{$html_ns}">
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="inner">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:otherwise>
@@ -144,9 +144,9 @@
   </xsl:template>
 
   <xsl:template match="ltx:figure | ltx:table | ltx:float" mode="inner">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates select="." mode="begin">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
     <xsl:choose>
       <xsl:when test="count(ltx:figure | ltx:table | ltx:tabular | ltx:float | ltx:graphics | ltx:inline-para | ltx:inline-block | ltx:listing | ltx:p) > 1">
@@ -160,7 +160,7 @@
                                      | following-sibling::ltx:inline-para
                                      | following-sibling::ltx:inline-block
                                      | following-sibling::ltx:p]">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
         <xsl:element name="div" namespace="{$html_ns}">
           <xsl:choose>
@@ -182,7 +182,7 @@
               <xsl:otherwise>
                 <xsl:text>&#x0A;</xsl:text>
                 <xsl:element name="div" namespace="{$html_ns}">
-                  <xsl:attribute name="class">ltx_flex_cell 
+                  <xsl:attribute name="class">ltx_flex_cell
                   <xsl:if test="contains(@class,'ltx_flex_size_1')">ltx_flex_size_1</xsl:if>
                   <xsl:if test="contains(@class,'ltx_flex_size_2')">ltx_flex_size_2</xsl:if>
                   <xsl:if test="contains(@class,'ltx_flex_size_3')">ltx_flex_size_3</xsl:if>
@@ -190,7 +190,7 @@
                   <xsl:if test="contains(@class,'ltx_flex_size_many')">ltx_flex_size_many</xsl:if>
                   </xsl:attribute>
                   <xsl:apply-templates select=".">
-                    <xsl:with-param name="context" select="$context"/>
+                    <xsl:with-param name="spansoup" select="$spansoup"/>
                   </xsl:apply-templates>
                 </xsl:element>
               </xsl:otherwise>
@@ -207,37 +207,37 @@
                                      | preceding-sibling::ltx:inline-para
                                      | preceding-sibling::ltx:inline-block
                                      | preceding-sibling::ltx:p]">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
         <xsl:apply-templates>
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:apply-templates select="." mode="end">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
     <xsl:text>&#x0A;</xsl:text>
   </xsl:template>
 
   <xsl:preserve-space elements="ltx:caption"/>
   <xsl:template match="ltx:caption">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:if($USE_HTML5,f:blockelement($context,'figcaption'),'div')}"
+    <xsl:element name="{f:if($USE_HTML5,f:blockelement($spansoup,'figcaption'),'div')}"
                  namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -32,9 +32,9 @@
        ====================================================================== -->
 
   <!-- We don't really anticipate document structure appearing in inline contexts,
-       so we pretty much ignore the $context switches.
+       so we pretty much ignore the $spansoup switches.
        However, a few elements like title do switch to inline.
-       See the CONTEXT discussion in LaTeXML-common -->
+       See the SPANSOUP discussion in LaTeXML-common -->
 
   <xsl:strip-space elements="ltx:document ltx:part ltx:chapter ltx:section ltx:subsection
                              ltx:subsubsection ltx:paragraph ltx:subparagraph
@@ -55,20 +55,20 @@
                        | ltx:paragraph | ltx:subparagraph
                        | ltx:bibliography | ltx:appendix | ltx:index | ltx:glossary
                        | ltx:slide">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="{f:if($USE_HTML5,f:if(local-name(.) = 'document','article','section'),'div')}"
                  namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -76,21 +76,21 @@
 
   <!-- same, but move author to end -->
   <xsl:template match="ltx:sidebar">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="{f:if($USE_HTML5,'article','div')}"
                  namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="*[not(./ltx:creator)]">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:call-template name="sidebarauthordate"/>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -98,58 +98,58 @@
 
 
   <xsl:template match="ltx:abstract">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:if test="@name">
         <xsl:element name="h6" namespace="{$html_ns}">
-          <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+          <xsl:variable name="inline" select="'inline'"/><!-- override -->
           <xsl:attribute name="class">ltx_title ltx_title_abstract</xsl:attribute>
           <xsl:apply-templates select="@name">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:if>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:acknowledgements">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:if test="@name">
         <xsl:text>&#x0A;</xsl:text>
         <xsl:element name="h6" namespace="{$html_ns}">
-          <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+          <xsl:variable name="inline" select="'inline'"/><!-- override -->
           <xsl:attribute name="class">ltx_title ltx_title_acknowledgements</xsl:attribute>
           <xsl:apply-templates select="@name">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:text>.</xsl:text>
         </xsl:element>
       </xsl:if>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -157,30 +157,30 @@
 
   <xsl:preserve-space elements="ltx:keywords"/>
   <xsl:template match="ltx:keywords">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:if test="@name">
         <xsl:text>&#x0A;</xsl:text>
         <xsl:element name="h6" namespace="{$html_ns}">
-          <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+          <xsl:variable name="inline" select="'inline'"/><!-- override -->
           <xsl:attribute name="class">ltx_title ltx_title_keywords</xsl:attribute>
           <xsl:apply-templates select="@name">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
           <xsl:text>: </xsl:text>
         </xsl:element>
       </xsl:if>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -188,16 +188,16 @@
 
   <xsl:preserve-space elements="ltx:classification"/>
   <xsl:template match="ltx:classification">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:element name="h6" namespace="{$html_ns}"> <!--should be italic ? -->
-        <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+        <xsl:variable name="inline" select="'inline'"/><!-- override -->
         <xsl:attribute name="class">ltx_title ltx_title_classification</xsl:attribute>
         <xsl:choose>
           <xsl:when test='@scheme'><xsl:value-of select='@scheme'/></xsl:when>
@@ -206,10 +206,10 @@
         <xsl:text>: </xsl:text>
       </xsl:element>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -319,13 +319,13 @@
 
   <xsl:preserve-space elements="ltx:title"/>
   <xsl:template match="ltx:title">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <!-- Skip title, if the parent has a titlepage, or if writing a cv! -->
     <xsl:if test="not(parent::*/child::ltx:titlepage)">
       <xsl:text>&#x0A;</xsl:text>
       <!-- In html5, could have wrapped in hgroup, but that was deprecated -->
       <xsl:call-template name="maketitle">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:call-template>
     </xsl:if>
   </xsl:template>
@@ -333,20 +333,20 @@
   <xsl:strip-space elements="ltx:titlepage"/>
 
   <xsl:template match="ltx:titlepage">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -362,20 +362,20 @@
        However, need to define it here, so it's precedence against
        plain ole ltx:title can be better controlled-->
   <xsl:template match="ltx:theorem/ltx:title | ltx:proof/ltx:title">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="h6" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -387,44 +387,44 @@
      name="{concat('h',f:section-head-level(parent::*))}"
      name="{f:if($USE_HTML5,'h1',concat('h',f:section-head-level(parent::*)))}" -->
   <xsl:template name="maketitle">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="{concat('h',f:section-head-level(parent::*))}" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
     <!-- include parent's subtitle, author & date (if any)-->
     <xsl:apply-templates select="../ltx:subtitle" mode="intitle">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
     <xsl:if test="not(parent::ltx:sidebar)">
       <xsl:call-template name="authors">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:call-template>
       <xsl:if test="not(//ltx:navigation/ltx:ref[@rel='up'])">
         <xsl:call-template name="dates">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
           <xsl:with-param name="dates" select="../ltx:date"/>
         </xsl:call-template>
       </xsl:if>
     </xsl:if>
     <xsl:apply-templates select="." mode="end">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:apply-templates select="parent::*" mode="auto-toc">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
   </xsl:template>
 
   <xsl:template name="sidebarauthordate">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="div" namespace="{$html_ns}">
         <xsl:attribute name="class">ltx_sidebar_authors</xsl:attribute>
         <xsl:if test="ltx:creator[@role='author']">
@@ -432,12 +432,12 @@
           <xsl:element name="div" namespace="{$html_ns}">
             <xsl:attribute name="class">ltx_authors</xsl:attribute>
             <xsl:apply-templates select="ltx:creator[@role='author']" mode="intitle">
-              <xsl:with-param name="context" select="$context"/>
+              <xsl:with-param name="spansoup" select="$spansoup"/>
             </xsl:apply-templates>
           </xsl:element>
         </xsl:if>
       <xsl:call-template name="dates">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
         <xsl:with-param name="dates" select="ltx:date"/>
       </xsl:call-template>
     </xsl:element>
@@ -445,13 +445,13 @@
 
   <!-- try to accomodate multiple authors in single block, vs each one as a block -->
   <xsl:template name="authors">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:if test="../ltx:creator[@role='author']">
       <xsl:text>&#x0A;</xsl:text>
       <xsl:element name="div" namespace="{$html_ns}">
         <xsl:attribute name="class">ltx_authors</xsl:attribute>
         <xsl:apply-templates select="../ltx:creator[@role='author']" mode="intitle">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:element>
     </xsl:if>
@@ -493,40 +493,40 @@
 
   <!-- Format an author 'inline' as part of an author block -->
   <xsl:template match="ltx:creator[@role='author']" mode="intitle">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:if test="@before">
       <xsl:element name="span" namespace="{$html_ns}">
-        <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+        <xsl:variable name="inline" select="'inline'"/><!-- override -->
         <xsl:attribute name="class">ltx_author_before</xsl:attribute>
         <xsl:value-of select="@before"/>
       </xsl:element>
     </xsl:if>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="ltx:personname">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:if test="ltx:contact">
         <xsl:element name="span" namespace="{$html_ns}">
           <xsl:attribute name="class">ltx_author_notes</xsl:attribute>
           <xsl:apply-templates select="ltx:contact">
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:if>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
     <xsl:if test="@after">
       <xsl:element name="span" namespace="{$html_ns}">
-        <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+        <xsl:variable name="inline" select="'inline'"/><!-- override -->
         <xsl:attribute name="class">ltx_author_after</xsl:attribute>
         <xsl:value-of select="@after"/>
       </xsl:element>
@@ -535,144 +535,144 @@
 
   <xsl:preserve-space elements="ltx:personname"/>
   <xsl:template match="ltx:personname">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:choose>
         <xsl:when test="@href">
           <xsl:element name="a" namespace="{$html_ns}">
             <xsl:attribute name="href"><xsl:value-of select="f:url(@href)"/></xsl:attribute>
             <xsl:apply-templates>
-              <xsl:with-param name="context" select="$innercontext"/>
+              <xsl:with-param name="spansoup" select="$inline"/>
             </xsl:apply-templates>
           </xsl:element>
         </xsl:when>
         <xsl:otherwise>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$innercontext"/>
+            <xsl:with-param name="spansoup" select="$inline"/>
           </xsl:apply-templates>
         </xsl:otherwise>
       </xsl:choose>
       <xsl:text>&#x0A;</xsl:text>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:preserve-space elements="ltx:contact"/>
   <xsl:template match="ltx:contact[@role='address' or @role='affiliation']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:contact[@role='email']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:element name="a" namespace="{$html_ns}">
         <xsl:attribute name="href"><xsl:value-of select="concat('mailto:',text())"/></xsl:attribute>
         <xsl:apply-templates>
-          <xsl:with-param name="context" select="$innercontext"/>
+          <xsl:with-param name="spansoup" select="$inline"/>
         </xsl:apply-templates>
       </xsl:element>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:contact[@role='orcid']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
     <xsl:text>&#x0A;</xsl:text>
   </xsl:template>
 
   <xsl:template match="ltx:contact[@role='homepage']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:element name="a" namespace="{$html_ns}">
         <xsl:attribute name="href"><xsl:value-of select="text()"/></xsl:attribute>
         <xsl:apply-templates>
-          <xsl:with-param name="context" select="$innercontext"/>
+          <xsl:with-param name="spansoup" select="$inline"/>
         </xsl:apply-templates>
       </xsl:element>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:contact[@role='dedicatory' or @role='mobile']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes">
       </xsl:call-template>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -687,7 +687,7 @@
   <xsl:template match="ltx:date"/>
 
   <xsl:template name="dates">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="dates" select="ltx:date"/>
     <xsl:if test="$dates and normalize-space(string($dates))">
       <xsl:text>&#x0A;</xsl:text>
@@ -695,25 +695,25 @@
       <xsl:element name="div" namespace="{$html_ns}">
         <xsl:attribute name="class">ltx_dates</xsl:attribute>
         <xsl:apply-templates select="." mode="begin">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
         <xsl:text>(</xsl:text>
         <xsl:apply-templates select="$dates" mode="intitle">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
         <xsl:text>)</xsl:text>
         <xsl:apply-templates select="." mode="end">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:element>
     </xsl:if>
   </xsl:template>
 
   <xsl:template match="ltx:date" mode="intitle">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:if test="@name"><xsl:value-of select="@name"/><xsl:text> </xsl:text></xsl:if>
     <xsl:apply-templates select="node()">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
     <xsl:if test="following-sibling::ltx:date"><xsl:text>; </xsl:text></xsl:if>
   </xsl:template>
@@ -723,20 +723,20 @@
 
   <!-- NOTE: Probably should support font, punct, etc, right? -->
   <xsl:template match="ltx:subtitle" mode="intitle">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <!-- Originally, html5 seemed to suggest using h2 here, but that is retracted-->
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
@@ -752,11 +752,11 @@
   <xsl:strip-space elements="ltx:indexlist ltx:indexentry"/>
 
   <xsl:template match="ltx:indexlist">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:choose>
       <xsl:when test="$USE_TWOCOLUMN_INDEX and not(ancestor::ltx:indexlist)">
         <xsl:apply-templates select="." mode="twocolumn">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
@@ -765,13 +765,13 @@
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates>
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:otherwise>
@@ -779,14 +779,14 @@
   </xsl:template>
 
   <xsl:template match="ltx:indexlist" mode="twocolumn">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="items"    select="ltx:indexentry"/>
     <xsl:param name="lines"    select="descendant::ltx:indexphrase"/>
     <xsl:param name="halflines" select="ceiling(count($lines) div 2)"/>
     <xsl:param name="miditem"
                select="count($lines[position() &lt; $halflines]/ancestor::ltx:indexentry[parent::ltx:indexlist[parent::ltx:index]]) + 1"/>
     <xsl:call-template name="split-columns">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name="wrapper" select="'ul'"/>
       <xsl:with-param name="items"   select="$items"/>
       <xsl:with-param name="miditem" select="$miditem"/>
@@ -794,44 +794,44 @@
   </xsl:template>
 
   <xsl:template match="ltx:indexentry">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="li" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="ltx:indexphrase">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="ltx:indexrefs">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="ltx:indexlist">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:preserve-space elements="ltx:indexrefs"/>
   <xsl:template match="ltx:indexrefs">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="span" namespace="{$html_ns}">
-      <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+      <xsl:variable name="inline" select="'inline'"/><!-- override -->
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$innercontext"/>
+        <xsl:with-param name="spansoup" select="$inline"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
@@ -843,11 +843,11 @@
   <xsl:strip-space elements="ltx:glossarlist ltx:glossaryentry"/>
 
   <xsl:template match="ltx:glossarylist">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:choose>
       <xsl:when test="$USE_TWOCOLUMN_GLOSSARY">
         <xsl:apply-templates select="." mode="twocolumn">
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
@@ -856,13 +856,13 @@
           <xsl:call-template name="add_id"/>
           <xsl:call-template name="add_attributes"/>
           <xsl:apply-templates select="." mode="begin">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="ltx:glossaryentry">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
           <xsl:apply-templates select="." mode="end">
-            <xsl:with-param name="context" select="$context"/>
+            <xsl:with-param name="spansoup" select="$spansoup"/>
           </xsl:apply-templates>
         </xsl:element>
       </xsl:otherwise>
@@ -870,12 +870,12 @@
   </xsl:template>
 
   <xsl:template match="ltx:glossarylist" mode="twocolumn">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="items"    select="ltx:glossaryentry"/>
     <xsl:param name="miditem"
                select="ceiling(count($items) div 2)+1"/>
     <xsl:call-template name="split-columns">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name="wrapper" select="'dl'"/>
       <xsl:with-param name="items"   select="$items"/>
       <xsl:with-param name="miditem" select="$miditem"/>
@@ -883,28 +883,28 @@
   </xsl:template>
 
   <xsl:template match="ltx:glossaryentry">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="dt" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="ltx:glossaryphrase[@role='label']">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="dd" namespace="{$html_ns}">
       <xsl:apply-templates select="ltx:glossaryphrase[@role='definition']">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="ltx:indexrefs">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-tabular-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-tabular-xhtml.xsl
@@ -26,109 +26,109 @@
 
   <!-- LaTeXML allows tabular in both block & inline contexts, but HTML does not;
        In inline contexts, we just generate span (but with appropriate CSS).
-       See the CONTEXT discussion in LaTeXML-common -->
+       See the SPANSOUP discussion in LaTeXML-common -->
 
   <xsl:strip-space elements="ltx:tabular ltx:thead ltx:tbody ltx:tfoot ltx:tr"/>
   <xsl:preserve-space elements="ltx:td"/>
 
   <xsl:template match="ltx:tabular">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'table')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'table')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:thead">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'thead')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'thead')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:tbody">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'tbody')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'tbody')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:tfoot">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'tfoot')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'tfoot')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:tr">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,'tr')}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,'tr')}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <xsl:call-template name="add_attributes"/>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:td">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:element name="{f:blockelement($context,f:if(@thead,'th','td'))}" namespace="{$html_ns}">
+    <xsl:element name="{f:blockelement($spansoup,f:if(@thead,'th','td'))}" namespace="{$html_ns}">
       <xsl:call-template name="add_id"/>
       <!-- generally, align & width should be covered by CSS -->
       <xsl:call-template name="add_attributes">
@@ -144,7 +144,7 @@
           </xsl:if>
           <!-- attempt to simulate rowspan when simulating table.
                Actually, I think we need empty <td> for the spanned cells! -->
-          <xsl:if test="@rowspan and $context = 'inline'">
+          <xsl:if test="@rowspan and $spansoup = 'inline'">
             <xsl:if test="@thead or @border">
               <xsl:text> </xsl:text>
             </xsl:if>
@@ -152,7 +152,7 @@
             <xsl:text> </xsl:text>
             <xsl:value-of select="f:class-pref('ltx_rowspan_',@rowspan)"/>
           </xsl:if>
-          <xsl:if test="@colspan and $context = 'inline'">
+          <xsl:if test="@colspan and $spansoup = 'inline'">
             <xsl:if test="@thead or @border or @rowspan">
               <xsl:text> </xsl:text>
             </xsl:if>
@@ -184,7 +184,7 @@
         </xsl:with-param>
       </xsl:call-template>
       <!-- add colspan, rowspan but NOT on fake td elements -->
-      <xsl:if test="$context != 'inline'">
+      <xsl:if test="$spansoup != 'inline'">
         <xsl:if test="@colspan">
           <xsl:attribute name='colspan'><xsl:value-of select='@colspan'/></xsl:attribute>
         </xsl:if>
@@ -193,13 +193,13 @@
         </xsl:if>
       </xsl:if>
       <xsl:apply-templates select="." mode="begin">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="end">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-webpage-xhtml.xsl
@@ -41,8 +41,8 @@
   <xsl:param name="META_VIEWPORT"></xsl:param>
 
   <!-- We don't really anticipate page structure appearing in inline contexts,
-       so we pretty much ignore the $context switches.
-       See the CONTEXT discussion in LaTeXML-common -->
+       so we pretty much ignore the $spansoup switches.
+       See the SPANSOUP discussion in LaTeXML-common -->
 
   <!--  ======================================================================
        The Page
@@ -582,43 +582,43 @@
 
   <!-- explicitly requested TOC -->
   <xsl:template match="ltx:TOC[@format='short']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="{f:if($USE_HTML5,'nav','div')}" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
         <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
       </xsl:call-template>
       <xsl:apply-templates mode="short">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:TOC[@format='veryshort']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="{f:if($USE_HTML5,'nav','div')}" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
         <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
       </xsl:call-template>
       <xsl:apply-templates mode="veryshort">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:TOC[@format='normal2']">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:element name="{f:if($USE_HTML5,'nav','div')}" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
         <xsl:with-param name="extra_classes" select="f:class-pref('ltx_toc_',@lists)"/>
       </xsl:call-template>
       <xsl:apply-templates mode="normal2">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:TOC">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:if test="ltx:toclist/descendant::ltx:tocentry">
       <xsl:text>&#x0A;</xsl:text>
       <xsl:element name="{f:if($USE_HTML5,'nav','div')}" namespace="{$html_ns}">
@@ -627,22 +627,22 @@
         </xsl:call-template>
         <xsl:if test="ltx:title">
           <xsl:element name="h6" namespace="{$html_ns}">
-            <xsl:variable name="innercontext" select="'inline'"/><!-- override -->
+            <xsl:variable name="inline" select="'inline'"/><!-- override -->
             <xsl:attribute name="class">ltx_title ltx_title_contents</xsl:attribute>
             <xsl:apply-templates select="ltx:title/node()">
-              <xsl:with-param name="context" select="$innercontext"/>
+              <xsl:with-param name="spansoup" select="$inline"/>
             </xsl:apply-templates>
           </xsl:element>
         </xsl:if>
         <xsl:apply-templates>
-          <xsl:with-param name="context" select="$context"/>
+          <xsl:with-param name="spansoup" select="$spansoup"/>
         </xsl:apply-templates>
       </xsl:element>
     </xsl:if>
   </xsl:template>
 
   <xsl:template match="ltx:toclist" mode="short">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
@@ -650,13 +650,13 @@
       </xsl:call-template>
       <xsl:text>&#x0A;&#x2666; </xsl:text>
       <xsl:apply-templates mode="short">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:toclist" mode="veryshort">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="div" namespace="{$html_ns}">
       <xsl:call-template name='add_attributes'>
@@ -664,40 +664,40 @@
       </xsl:call-template>
       <xsl:text>&#x2666;</xsl:text>
       <xsl:apply-templates mode="veryshort">
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:toclist">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="ol" namespace="{$html_ns}">
       <xsl:call-template name='add_id'/>
       <xsl:call-template name='add_attributes'/>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
       <xsl:text>&#x0A;</xsl:text>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:toclist" mode="normal2">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:apply-templates select="." mode="twocolumn">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
   </xsl:template>
   <xsl:template match="ltx:toclist" mode="twocolumn">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:param name="items"    select="ltx:tocentry"/>
     <xsl:param name="lines"    select="descendant::ltx:tocentry"/>
     <xsl:param name="halflines" select="ceiling(count($lines) div 2)"/>
     <xsl:param name="miditem"
                select="count($lines[position() &lt; $halflines]/ancestor::ltx:tocentry[parent::ltx:toclist[parent::ltx:TOC]]) + 1"/>
     <xsl:call-template name="split-columns">
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
       <xsl:with-param name="wrapper" select="'ul'"/>
       <xsl:with-param name="items"   select="$items"/>
       <xsl:with-param name="miditem" select="$miditem"/>
@@ -705,29 +705,29 @@
   </xsl:template>
 
   <xsl:template match="ltx:tocentry">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:text>&#x0A;</xsl:text>
     <xsl:element name="li" namespace="{$html_ns}">
       <xsl:call-template name='add_id'/>
       <xsl:call-template name='add_attributes'/>
       <xsl:apply-templates>
-        <xsl:with-param name="context" select="$context"/>
+        <xsl:with-param name="spansoup" select="$spansoup"/>
       </xsl:apply-templates>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ltx:tocentry" mode="short">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates>
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
     <xsl:text> &#x2666; </xsl:text>
   </xsl:template>
 
   <xsl:template match="ltx:tocentry" mode="veryshort">
-    <xsl:param name="context"/>
+    <xsl:param name="spansoup"/>
     <xsl:apply-templates>
-      <xsl:with-param name="context" select="$context"/>
+      <xsl:with-param name="spansoup" select="$spansoup"/>
     </xsl:apply-templates>
     <xsl:text>&#x2666;</xsl:text>
   </xsl:template>


### PR DESCRIPTION
This PR only contains a cleanup renaming (hopefully).

Motivated by the `context` and `mode` keywords in our XSLT files being too similarly vague to encounter in the same template, and trying to pin down more accurate names.

In the process I also moved `innercontext` to `inline`, since it was always set to the constant value of `'inline'`. I am even wondering if that needed a dedicated variable or a simple string would do?

Certainly more tweaking is possible here (e.g. now that we are claiming the param is a simple boolean toggle, it can be changed to using a boolean true/false). But it's a start resolve some of the naming difficulties I had.