### PR TITLE
replicate framed padding and border width

### DIFF
--- a/lib/LaTeXML/Package/framed.sty.ltxml
+++ b/lib/LaTeXML/Package/framed.sty.ltxml
@@ -107,7 +107,8 @@ DefEnvironment('{snugshade*}', sub {
 DefEnvironment('{leftbar}', sub {
     my ($document, %props) = @_;
     $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
-    insertBlock($document, $props{body}, framed => 'left', framecolor => $props{framecolor}); },
+    insertBlock($document, $props{body}, framed => 'left', framecolor => $props{framecolor},
+      cssstyle => 'border-width:3pt;padding-left:10pt'); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par'); },

--- a/lib/LaTeXML/Package/framed.sty.ltxml
+++ b/lib/LaTeXML/Package/framed.sty.ltxml
@@ -148,7 +148,7 @@ DefMacro('\LastFrameCommand',  '\FrameCommand');
 # \FrameRule (used for \fboxrule)
 # \FrameSep (used for \fboxsep)
 DefRegister('\FrameRule' => LookupRegister('\fboxrule'));
-DefRegister('\FrameSep'  => Dimension('12pt'));
+DefRegister('\FrameSep'  => Dimension(LookupRegister('\fboxsep')->valueOf * 3));
 
 #======================================================================
 # \makeFramed, \endMakeFramed; {MakeFramed}

--- a/lib/LaTeXML/Package/framed.sty.ltxml
+++ b/lib/LaTeXML/Package/framed.sty.ltxml
@@ -121,7 +121,8 @@ DefEnvironment('{titled-frame} Undigested', sub {
     $_[0]->maybeCloseElement('ltx:p');    # this starts a new vertical block
     insertBlock($document, $props{body},
       framed          => 'rectangle', framecolor => $props{framecolor},
-      backgroundcolor => $props{backgroundcolor}); },
+      backgroundcolor => $props{backgroundcolor},
+      cssstyle        => 'padding:8pt;border-width:2pt'); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par'); },
@@ -130,8 +131,8 @@ DefEnvironment('{titled-frame} Undigested', sub {
   properties => sub { (framecolor => LookupValue('color_TFFrameColor'),
       backgroundcolor => LookupValue('font')->getBackground); });
 DefMacro('\@titledframe@title{}',
-  '\@@titledframe@title{{\pagecolor{TFFrameColor}\textcolor{TFTitleColor} {#1}}}');
-DefConstructor('\@@titledframe@title{}', "<ltx:text cssstyle='display:block;width:100%;'>#1</ltx:text>");
+'\@@titledframe@title{{\fboxsep8pt\fboxrule2pt\pagecolor{TFFrameColor}\textcolor{TFTitleColor} {#1}}}');
+DefConstructor('\@@titledframe@title{}', "<ltx:text cssstyle='display:block;margin:-8pt -8pt 8pt -8pt;padding:8pt'>#1</ltx:text>");
 
 #======================================================================
 # Customization:

--- a/lib/LaTeXML/Package/framed.sty.ltxml
+++ b/lib/LaTeXML/Package/framed.sty.ltxml
@@ -147,7 +147,7 @@ DefMacro('\LastFrameCommand',  '\FrameCommand');
 
 # \FrameRule (used for \fboxrule)
 # \FrameSep (used for \fboxsep)
-DefRegister('\FrameRule' => Dimension('0.4pt'));
+DefRegister('\FrameRule' => LookupRegister('\fboxrule'));
 DefRegister('\FrameSep'  => Dimension('12pt'));
 
 #======================================================================

--- a/lib/LaTeXML/Package/framed.sty.ltxml
+++ b/lib/LaTeXML/Package/framed.sty.ltxml
@@ -24,12 +24,13 @@ DefEnvironment('{framed}', sub {
     insertBlock($document, $props{body},
       framed     => 'rectangle',
       framecolor => $props{framecolor},
-      cssstyle   => 'padding:' . $props{margin} . 'pt'); },
+      cssstyle   => 'padding:' . $props{margin} . 'pt;border-width:' . $props{border} . 'pt'); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par'); },
   properties => sub { (framecolor => Black,
-      margin => LookupRegister('\FrameSep')->ptValue); });
+      margin => LookupRegister('\FrameSep')->ptValue,
+      border => LookupRegister('\FrameRule')->ptValue); });
 
 # {oframed} "open" framed box, the top/bottom is open when it splits across pages.
 # That shouldn't matter for us (?)
@@ -39,12 +40,13 @@ DefEnvironment('{oframed}', sub {
     insertBlock($document, $props{body},
       framed     => 'rectangle',
       framecolor => $props{framecolor},
-      cssstyle   => 'padding:' . $props{margin} . 'pt'); },
+      cssstyle   => 'padding:' . $props{margin} . 'pt;border-width:' . $props{border} . 'pt'); },
   beforeDigest => sub {
     Let('\par', '\inner@par');
     Let('\\\\', '\inner@par'); },
   properties => sub { (framecolor => Black,
-      margin => LookupRegister('\FrameSep')->ptValue); });
+      margin => LookupRegister('\FrameSep')->ptValue,
+      border => LookupRegister('\FrameRule')->ptValue); });
 
 # {shaded} a shaded box; uses "shadecolor" for background color; otherwise, no frame.
 # Note that the shading "bleeds" into the margin (whatever that means)

--- a/t/graphics/framed.xml
+++ b/t/graphics/framed.xml
@@ -14,21 +14,21 @@
     </tags>
     <title><tag close=" ">1</tag>Basics</title>
     <para xml:id="S1.p1">
-      <p cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">This is stuff that’s framed.</p>
+      <p cssstyle="padding:9pt;border-width:0.4pt" framecolor="#000000" framed="rectangle">This is stuff that’s framed.</p>
     </para>
     <para xml:id="S1.p2">
       <p>Note that the</p>
-      <p cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">framed</p>
+      <p cssstyle="padding:9pt;border-width:0.4pt" framecolor="#000000" framed="rectangle">framed</p>
       <p>stuff is a block!</p>
     </para>
     <para xml:id="S1.p3">
-      <inline-block cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">
+      <inline-block cssstyle="padding:9pt;border-width:0.4pt" framecolor="#000000" framed="rectangle">
         <p>This is stuff that’s framed.</p>
         <p>And it can hold multiple paragraphs.</p>
       </inline-block>
     </para>
     <para xml:id="S1.p4">
-      <p cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">And even stuff in multiple Paragraphs.</p>
+      <p cssstyle="padding:9pt;border-width:0.4pt" framecolor="#000000" framed="rectangle">And even stuff in multiple Paragraphs.</p>
     </para>
     <paragraph inlist="toc" xml:id="S1.SS0.SSS0.Px1">
       <title>Does this work?</title>
@@ -45,16 +45,16 @@
     </tags>
     <title><tag close=" ">2</tag>Variants</title>
     <para xml:id="S2.p1">
-      <p cssstyle="padding:12pt" framecolor="#000000" framed="rectangle">This is stuff that’s framed, but would stay open at page breaks.
+      <p cssstyle="padding:9pt;border-width:0.4pt" framecolor="#000000" framed="rectangle">This is stuff that’s framed, but would stay open at page breaks.
 This doesn’t make so much sense for LaTeXML, so it’s pretty much
 the same.</p>
     </para>
     <para xml:id="S2.p2">
-      <p backgroundcolor="#80BF80" cssstyle="padding:12pt">This is stuff that’s shaded green;
+      <p backgroundcolor="#80BF80" cssstyle="padding:9pt">This is stuff that’s shaded green;
 should fade into the margin, whatever that means.</p>
     </para>
     <para xml:id="S2.p3">
-      <p backgroundcolor="#80BF80" cssstyle="padding:12pt">This is stuff that’s shaded green;
+      <p backgroundcolor="#80BF80" cssstyle="padding:9pt">This is stuff that’s shaded green;
 it should end sharply at the margin.</p>
     </para>
     <para xml:id="S2.p4">
@@ -66,10 +66,10 @@ fading into the margin.</p>
 ending sharply at the margin.</p>
     </para>
     <para xml:id="S2.p6">
-      <p framecolor="#000000" framed="left">This is with a left bar, like a changebar?</p>
+      <p cssstyle="border-width:3pt;padding-left:10pt" framecolor="#000000" framed="left">This is with a left bar, like a changebar?</p>
     </para>
     <para xml:id="S2.p7">
-      <p framecolor="#8080BF" framed="rectangle"><text backgroundcolor="#8080BF" color="#FFFFFF" cssstyle="display:block;width:100%;">A Titled Frame</text>
+      <p cssstyle="padding:8pt;border-width:2pt" framecolor="#8080BF" framed="rectangle"><text backgroundcolor="#8080BF" color="#FFFFFF" cssstyle="display:block;margin:-8pt -8pt 8pt -8pt;padding:8pt">A Titled Frame</text>
 This is a titled frame.</p>
     </para>
   </section>

--- a/t/theorem/ntheorem.xml
+++ b/t/theorem/ntheorem.xml
@@ -1474,7 +1474,7 @@ The first Kappa-Theorem has been given in <ref labelref="LABEL:kappatheorem1" sh
         <tag role="typerefnum">§1.2</tag>
       </tags>
       <title><tag close=" ">1.2</tag>Framed and Shaded Theorems</title>
-      <theorem class="ltx_theorem_importantTheorem" cssstyle="padding:12pt;" framed="rectangle" inlist="thm theorem:importantTheorem" xml:id="ThmTheorem9">
+      <theorem class="ltx_theorem_importantTheorem" cssstyle="padding:9pt;" framed="rectangle" inlist="thm theorem:importantTheorem" xml:id="ThmTheorem9">
         <tags>
           <tag>Theorem 9</tag>
           <tag role="refnum">9</tag>


### PR DESCRIPTION
Fix #2224, mostly. Remaining discrepancies:
- vertical spacing is different, but this seems unavoidable: as far as I can tell, CSS padding behaves differently than `\fboxsep`;
- LaTeXML does not indent the content, unless the box is at the start of an `<ltx:para>`; I presume this requires starting a new `<ltx:para>` for each box, but I promised a CSS only PR, and I am afraid of breaking something else.