### PR TITLE
\let skips more spaces than documented

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1400,7 +1400,7 @@ DefPrimitive('\divide Variable SkipKeyword:by Number', sub {
 
 # <let assignment> = \futurelet <control sequence><token><token>
 #   | \let<control sequence><equals><one optional space><token>
-DefPrimitive('\let Token SkipMatch:= Skip1Space Token', sub {
+DefPrimitive('\let SkipSpaces Token SkipSpaces SkipMatch:= Skip1Space Token', sub {
     my ($stomach, $token1, $token2) = @_;
     Let($token1, $token2);
     return; });

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1454,7 +1454,7 @@ DefPrimitive('\toksdef SkipSpaces Token SkipSpaces SkipMatch:=', sub {
 DefRegister('\lastpenalty', Number(0), readonly => 1);
 
 # \parshape !?!??
-DefPrimitive('\parshape SkipMatch:= Number', sub {
+DefPrimitive('\parshape SkipSpaces SkipMatch:= Number', sub {
     my ($stomach, $n) = @_;
     $n = $n->valueOf;
     my $gullet = $stomach->getGullet;
@@ -1847,7 +1847,7 @@ DefPrimitive('\char Number', sub {
 
 # Almost like a register (and \countdef), but different...
 # (including the preassignment to \relax!)
-DefPrimitive('\chardef Token SkipMatch:=', sub {
+DefPrimitive('\chardef Token SkipSpaces SkipMatch:=', sub {
     my ($stomach, $newcs) = @_;
     $STATE->assignMeaning($newcs, $STATE->lookupMeaning(T_CS('\relax')));    # Let w/o AfterAssignment
     my $value = $stomach->getGullet->readNumber();
@@ -1895,7 +1895,7 @@ DefConstructor('\delimiter Number',
     return; });
 
 # Almost like a register, but different...
-DefPrimitive('\mathchardef Token SkipMatch:=', sub {
+DefPrimitive('\mathchardef Token SkipSpaces SkipMatch:=', sub {
     my ($stomach, $newcs) = @_;
     $STATE->assignMeaning($newcs, $STATE->lookupMeaning(T_CS('\relax')));    # Let w/o AfterAssignment
     my $value = $stomach->getGullet->readNumber();
@@ -1927,7 +1927,7 @@ DefConstructor('\mathaccent Number Digested',
 DefPrimitive('\lastbox', sub {    # Hopefully, the correct box got seen!
     return pop(@LaTeXML::LIST); });
 
-DefPrimitive('\setbox Number SkipMatch:=', sub {
+DefPrimitive('\setbox Number SkipSpaces SkipMatch:=', sub {
     my ($stomach) = @_;
     no warnings 'recursion';
     my $box = 'box' . $_[1]->valueOf;
@@ -2554,7 +2554,7 @@ DefPrimitive('\errmessage{}', sub {
     return; });
 
 # TeX I/O primitives
-DefPrimitive('\openin Number SkipMatch:= SkipSpaces TeXFileName', sub {
+DefPrimitive('\openin Number SkipSpaces SkipMatch:= SkipSpaces TeXFileName', sub {
     my ($stomach, $port, $filename) = @_;
     # possibly should close $port if it's already been opened?
     $port     = ToString($port);
@@ -2608,7 +2608,7 @@ DefConditional('\ifeof Number', sub {
 
 # For output files, we'll write the data to a cached internal copy
 # rather than to the actual file system.
-DefPrimitive('\openout Number SkipMatch:= SkipSpaces TeXFileName', sub {
+DefPrimitive('\openout Number SkipSpaces SkipMatch:= SkipSpaces TeXFileName', sub {
     my ($stomach, $port, $filename) = @_;
     $port     = ToString($port);
     $filename = ToString($filename);

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1430,19 +1430,19 @@ sub shorthandDef {
   AfterAssignment();
   return; }
 
-DefPrimitive('\countdef Token SkipMatch:=', sub {
+DefPrimitive('\countdef SkipSpaces Token SkipSpaces SkipMatch:=', sub {
     shorthandDef($_[0], $_[1], '\count', Number(0)); });
 
-DefPrimitive('\dimendef Token SkipMatch:=', sub {
+DefPrimitive('\dimendef SkipSpaces Token SkipSpaces SkipMatch:=', sub {
     shorthandDef($_[0], $_[1], '\dimen', Dimension(0)); });
 
-DefPrimitive('\skipdef Token SkipMatch:=', sub {
+DefPrimitive('\skipdef SkipSpaces Token SkipSpaces SkipMatch:=', sub {
     shorthandDef($_[0], $_[1], '\skip', Glue(0)); });
 
-DefPrimitive('\muskipdef Token SkipMatch:=', sub {
+DefPrimitive('\muskipdef SkipSpaces Token SkipSpaces SkipMatch:=', sub {
     shorthandDef($_[0], $_[1], '\muskip', MuGlue(0)); });
 
-DefPrimitive('\toksdef Token SkipMatch:=', sub {
+DefPrimitive('\toksdef SkipSpaces Token SkipSpaces SkipMatch:=', sub {
     shorthandDef($_[0], $_[1], '\toks', Tokens()); });
 
 # NOTE: Get all these handled as registers

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1324,7 +1324,7 @@ sub lookupFontinfo {
 
 # This should eventually actually load the font metrics,
 # and tie-in to the FontMetrics data used by Font.
-DefPrimitive('\font Token SkipMatch:= SkipSpaces TeXFileName', sub {
+DefPrimitive('\font SkipSpaces Token SkipSpaces SkipMatch:= SkipSpaces TeXFileName', sub {
     my ($stomach, $cs, $name) = @_;
     my $gullet = $stomach->getGullet;
     $name = ToString($name);


### PR DESCRIPTION
Background: I was down a couple of different rabbit holes in debugging two almost-working Tikz diagrams, when I finally unwrapped the expansion onion to a discrepancy that had to do with a space given to an argument of `\let`, as in the minimal:
```tex
\def\set#1{\let#1=\foo}
\set{ \j} % this sets \j to the meaning of \foo, despite the space
```

And then I expanded it into my working test for pdftex:
```tex
\def\foo{foo}

\def\setA#1{\let#1=\foo}
\def\setB#1{\let #1=\foo}
\def\setC#1{\let  #1 =\foo}
\def\setD#1{\let    #1   = \foo}

\setA\a
\setB\b
\setC\c
\setD\d

test behind def: \a, \b, \c, \d

\let\e=\foo
\let \f=\foo
\let  \g =\foo
\let    \h   = \foo

test in plain sight: \e, \f, \g, \h
\bye
```
Every single one of these 8 macros expands to `foo` in the PDF. But variants `\c` and `\d` break in the master branch of latexml. After re-reading the documentation of `\let` in disbelief - which is what latexml is implementing today - I went and checked its `tex.web` source. And then I got to the `aha!` moments:

1. `\let` skips multiple spaces before its first argument Token, due to using `get_r_token`, which starts with `repeat get_token; until cur_tok<>space_token;` [line link in tex.web](https://tug.org/svn/texlive/trunk/Build/source/texk/web2c/tex.web?revision=57915&pathrev=68467&view=markup#l22792)

2. `\let` skips multiple spaces before the `=` sign delimiter, via the `let` procedure using `repeat get_token; until cur_cmd<>spacer;` [line link in tex.web](https://tug.org/svn/texlive/trunk/Build/source/texk/web2c/tex.web?revision=57915&pathrev=68467&view=markup#l22843)

Both of these are undocumented skips, as the TeXbook declares:
```
\let<control sequence><equals><one optional space><token>
```

At the same time, the texlive 2022 and texlive 2023 versions of `pgffor.code.tex` rely on the space-skipping behavior in order to correctly process all pieces of the `evaluate` key, as with my starting point ([full example here](https://texample.net/tikz/examples/dominoes/)):
```tex
\foreach \x [evaluate={\i=mod(\x+90,360); \j=int((\i<180)*2-1); \t=3;
    \sc=\x/\e; \n=int((\e-\x)/15+5); \X=\x/\e;}] in {10,25,...,\e} {
```

Miraculously, the master version of latexml does not encounter errors on that example, but it does something quite wrong, by `\let`-ing T_SPACE to `T_CS[\j]`, then again T_SPACE to `T_CS[\t]` ... , silently dropping the remaining contents until each `;` delimiter for pgf. 

The change in this PR leads to correctly processing each piece of `evaluate`, and I have a separate PR in the works which also addresses the pgf-specific calculation issues. I will open here as a draft, and investigate what else needs to change to get tests fully passing - as this modification of `\let` leads to our babel greek test to fail.