### PR TITLE
emulate \cf@encoding transitions in \bbl@switch

### DIFF
--- a/lib/LaTeXML/Package/babel_support.sty.ltxml
+++ b/lib/LaTeXML/Package/babel_support.sty.ltxml
@@ -151,6 +151,7 @@ DefPrimitive('\ltx@bbl@select@language{}', sub {
     $language = ToString(Expand($language));
     my $iso = $$bbl_language_map{$language};
     MergeFont(language => $iso) if $iso;
+    DefMacroI('\cf@encoding', undef, ExplodeText(LookupValue('font')->getEncoding));
     return; });
 
 # pretend we've got hyphenation patterns for ANY language.

--- a/lib/LaTeXML/Package/babel_support.sty.ltxml
+++ b/lib/LaTeXML/Package/babel_support.sty.ltxml
@@ -148,10 +148,10 @@ EoTeX
 
 DefPrimitive('\ltx@bbl@select@language{}', sub {
     my ($stomach, $language) = @_;
+    DefMacroI('\cf@encoding', undef, Expand(T_CS('\f@encoding')));
     $language = ToString(Expand($language));
     my $iso = $$bbl_language_map{$language};
     MergeFont(language => $iso) if $iso;
-    DefMacroI('\cf@encoding', undef, ExplodeText(LookupValue('font')->getEncoding));
     return; });
 
 # pretend we've got hyphenation patterns for ANY language.


### PR DESCRIPTION
Fixes #2175

To quote Bruce from our discussion today: "this should buy us another couple of releases".

We may approach the question differently in a hypothetical world where latexml loads `latex.ltx` in its entirety.

For now, this PR extends the custom guards we have for `\bbl@switch`, which are hosted at `babel_support.sty.ltxml`, to also track the low-level behavior of updating `\cf@encoding` with concrete tokens, as needed by a babel language switch.

Hopefully CI passes on all older texlives, I have confirmed texlive 2022 and 2023 succeed.