### PR TITLE
only run expl3-dependent tests in continuous integration

### DIFF
--- a/lib/LaTeXML/Util/Test.pm
+++ b/lib/LaTeXML/Util/Test.pm
@@ -86,12 +86,14 @@ sub check_requirements {
     next unless $reqmts;
     my @required_packages = ();
     my $texlive_min       = 0;
+    my $required_env;
     if (!(ref $reqmts)) {
       @required_packages = ($reqmts); }
     elsif (ref $reqmts eq 'ARRAY') {
       @required_packages = @$reqmts; }
     elsif (ref $reqmts eq 'HASH') {
       @required_packages = (ref $$reqmts{packages} eq 'ARRAY' ? @{ $$reqmts{packages} } : $$reqmts{packages});
+      $required_env      = $$reqmts{env};
       $texlive_min       = $$reqmts{texlive_min} || 0; }
     foreach my $reqmt (@required_packages) {
       if (pathname_kpsewhich($reqmt) || pathname_find($reqmt)) { }
@@ -103,6 +105,11 @@ sub check_requirements {
     # Check if specific texlive versions are required for this test
     if ($texlive_min && (texlive_version() < $texlive_min)) {
       my $message = "Minimal texlive $texlive_min requirement not met for $test";
+      diag("Skip: $message");
+      skip($message, $ntests);
+      return 0; }
+    elsif ($required_env && !$ENV{$required_env}) {
+      my $message = "$test is only checked in continuous integration. (use make test CI=true)";
       diag("Skip: $message");
       skip($message, $ntests);
       return 0; } }

--- a/t/50_structure.t
+++ b/t/50_structure.t
@@ -9,5 +9,6 @@ latexml_tests("t/structure",
     amsarticle => 'amsart.cls',
     csquotes   => 'csquotes.sty',
     glossary   => {
+      env => 'CI', # only run in continuous integration
       texlive_min => 2016,
       packages    => 'glossaries.sty' } });

--- a/t/80_complex.t
+++ b/t/80_complex.t
@@ -7,4 +7,6 @@ use LaTeXML::Util::Test;
 latexml_tests("t/complex",
   requires => {
     cleveref_minimal => 'cleveref.sty',
-    si               => { packages => 'siunitx.sty', texlive_min => 2015 } });
+    si               => {
+      env=>'CI', # only runs in continuous integration
+      packages => 'siunitx.sty', texlive_min => 2015 } });

--- a/t/83_expl3.t
+++ b/t/83_expl3.t
@@ -6,18 +6,14 @@ use strict;
 use warnings;
 use LaTeXML::Util::Test;
 
-if (!$ENV{"CI"}) {
-  plan skip_all => "Only checked in continuous integration. (use make test CI=true)";
-  done_testing();
-  exit;
-}
-
 latexml_tests("t/expl3",
   requires => {
     tilde_tricks => {
+      env => 'CI',
       texlive_min => 2018,
       packages    => 'expl3.sty' },
     xparse => {
+      env => 'CI',
       texlive_min => 2019,
       packages    => ['expl3.sty', 'xparse.sty']
     } });


### PR DESCRIPTION
This PR is essentially a repeat on my first attempt in #2045, and is one way to interpret the sentiment I recently expressed in #2175 and #2204.

Namely, I suggest we temporarily only run expl3-related tests in continuous integration, allowing systems where latexml's expl3 emulation is broken to still have a clean/successful installation. Those are currently two tests - glossary and si. Also, this is specifically targeted to the `0.8.8` release of latexml.

For the next, `0.8.9` release, I think Bruce has shown some convincing prototypes where both the performance in loading expl3 can be improved, as well as the robustness in interpretation, but that will require some sweeping changes to the pool-related internals of Core processing.

P.S. Attached with taking this route would be a suggestion to defer resolving #2204 until after the more ambitious approach to expl3 loading is in place.