### PR TITLE
Color tweaks

### DIFF
--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -20,8 +20,9 @@ use LaTeXML::Common::Number;
 use LaTeXML::Common::Dimension;
 use LaTeXML::Common::Font::Metric;
 use LaTeXML::Common::Font::StandardMetrics;
+use LaTeXML::Common::Color;
 use List::Util qw(min max sum);
-use base qw(LaTeXML::Common::Object);
+use base       qw(LaTeXML::Common::Object);
 
 # Note that this has evolved way beynond just "font",
 # but covers text properties (or even display properties) in general
@@ -34,7 +35,7 @@ DebuggableFeature('size-detailed', "Show sizing of boxes in detail");
 my $DEFFAMILY     = 'serif';      # [CONSTANT]
 my $DEFSERIES     = 'medium';     # [CONSTANT]
 my $DEFSHAPE      = 'upright';    # [CONSTANT]
-my $DEFCOLOR      = 'black';      # [CONSTANT]
+my $DEFCOLOR      = Black;        # [CONSTANT]
 my $DEFBACKGROUND = undef;        # [CONSTANT] no color; transparent
 my $DEFOPACITY    = '1';          # [CONSTANT]
 my $DEFENCODING   = 'OT1';        # [CONSTANT]
@@ -871,7 +872,7 @@ The attributes are
  size   : TINY, Tiny, tiny, SMALL, Small, small,
           normal, Normal, large, Large, LARGE,
           huge, Huge, HUGE, gigantic, Gigantic, GIGANTIC
- color  : any named color, default is black
+ color  : any named color, default is Black
 
 They are usually merged against the current font, attempting to mimic the,
 sometimes counter-intuitive, way that TeX does it,  particularly for math

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -4647,7 +4647,7 @@ Likely values include (the values aren't required to be in this set):
  shape  : upright, italic, slanted, smallcaps
  size   : tiny, footnote, small, normal, large,
           Large, LARGE, huge, Huge
- color  : any named color, default is black
+ color  : any color, default is Black
 
 Some families will only be used in math.
 This function returns nothing so it can be easily used in beforeDigest, afterDigest.

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4994,10 +4994,11 @@ sub picScale {
 
 sub picProperties {
   my (%props) = @_;
-  if (($props{stroke} || 'black') ne 'none') {
+  if (($props{stroke} || '') ne 'none') {
     $props{thick} = ptValue(LookupRegister('\@wholewidth')); }
   if (my $arrowlength = LookupValue('arrowlength')) {
     $props{arrowlength} = ptValue($arrowlength); }
+  $props{color} = Black unless defined $props{color};
   return %props; }
 
 #----------------------------------------------------------------------
@@ -5061,11 +5062,11 @@ DefConstructor('\lx@pic@put Pair{}',
   mode  => 'text');
 
 DefConstructor('\line Pair:Number {Float}',
-  "<ltx:line points='#points' stroke='black' stroke-width='#thick'/>",
+  "<ltx:line points='#points' stroke='#color' stroke-width='#thick'/>",
   alias      => '\line',
   properties => sub { picProperties(points => '0,0 ' . slopeToPicCoord($_[1], $_[2])->pxValue()); });
 DefConstructor('\vector Pair:Number {Float}',
-  "<ltx:line points='#points' stroke='black' stroke-width='#thick' terminators='->'"
+  "<ltx:line points='#points' stroke='#color' stroke-width='#thick' terminators='->'"
     . " arrowlength='#arrowlength'/>",
   alias      => '\vector',
   properties => sub { picProperties(points => '0,0 ' . slopeToPicCoord($_[1], $_[2])->pxValue()); });
@@ -5075,11 +5076,11 @@ DefConstructor('\circle OptionalMatch:* {Float}',
   properties => sub {
     my ($stomach, $filled, $dia) = @_;
     picProperties(radius => picScale($dia)->multiply(0.5)->pxValue,
-      ($filled ? 'fill' : 'stroke') => 'black'); });
+      ($filled ? 'fill' : 'stroke') => Black); });
 
 DefConstructor('\oval [Float] Pair []',
   "<ltx:rect x='#x' y='#y' width='#width' height='#height' rx='#radius'"
-    . "  stroke='black' fill='none' part='#3' stroke-width='#thick'/>",
+    . "  stroke='#color' fill='none' part='#3' stroke-width='#thick'/>",
   alias      => '\oval',
   properties => sub {
     my ($stomach, $r, $size, $part) = @_;
@@ -5095,7 +5096,7 @@ DefConstructor('\oval [Float] Pair []',
     ); });
 
 DefConstructor('\qbezier [Number] Pair Pair Pair',
-"<ltx:bezier ?#1(displayedpoints='#1') points='&ptValue(#pt)' stroke='black' stroke-width='#thick' />",
+"<ltx:bezier ?#1(displayedpoints='#1') points='&ptValue(#pt)' stroke='#color' stroke-width='#thick' />",
   alias      => '\qbezier',
   properties => sub {
     picProperties(pt => PairList(picScale($_[2]), picScale($_[3]), picScale($_[4]))); });
@@ -5110,7 +5111,7 @@ DefConstructor('\lx@pic@bezier {Number} Pair Pair Pair',
 # Generic boxing command (frames, dash, etc)
 DefConstructor('\pic@makebox@ Undigested RequiredKeyVals Pair []{}',
   "?#framed(<ltx:rect x='0' y='0' width='#fwidth' height='#fheight'"
-    . " stroke='black' stroke-width='#thick' fill='none' stroke-dasharray='#dash'/>)()"
+    . " stroke='#color' stroke-width='#thick' fill='none' stroke-dasharray='#dash'/>)()"
     . "<ltx:g class='makebox' innerwidth='#width' innerheight='#height' innerdepth='#depth'"
     . " transform='translate(#xshift,#yshift)'>#box</ltx:g>",
   reversion    => '#1#3[#4]{#5}',

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -1947,7 +1947,7 @@ sub adjustBoxColor {
   my ($box) = @_;
   my $font = LookupValue('font');
   if (my $color = $font && $font->getColor) {
-    if ($color ne 'black') {
+    if (!Black->equals($color)) {
       adjustBoxColor_rec($color, {}, $box); } }
   return; }
 
@@ -2402,7 +2402,7 @@ DefConstructor('\vrule RuleSpecification',
     elsif ((defined $w) && ($w == 0)) {
       $whatsit->setProperty(invisible => 1); }
     if (my $color = LookupValue('font')->getColor) {
-      if ($color ne 'black') {
+      if (!Black->equals($color)) {
         $whatsit->setProperty(color => $color); } }
     return; });
 
@@ -2432,7 +2432,7 @@ DefConstructor('\hrule RuleSpecification',
         $alignment->addLine('t');
         $whatsit->setProperty(isHorizontalRule => 1) } }    # Marked as rule within alignment
     if (my $color = LookupValue('font')->getColor) {
-      if ($color ne 'black') {
+      if (!Black->equals($color)) {
         $whatsit->setProperty(color => $color); } }
     return; });
 

--- a/lib/LaTeXML/Package/diagbox.sty.ltxml
+++ b/lib/LaTeXML/Package/diagbox.sty.ltxml
@@ -145,7 +145,7 @@ DefConstructor('\lx@diagbox RequiredKeyVals:diagbox {}[]{}',
       M         => $M,     Mx    => $Mx, My => $My, Mw => $Bw, Mh => $Mh,
       line1     => $line1, line2 => $line2,
       linewidth => ($kv && $kv->getValue('linewidth')) || '0.4',
-      linecolor => ($kv && $kv->getValue('linecolor')) || 'black'); }
+      linecolor => ($kv && $kv->getValue('linecolor')) || Black); }
 );
 
 # slashbox compatibility

--- a/lib/LaTeXML/Package/makecell.sty.ltxml
+++ b/lib/LaTeXML/Package/makecell.sty.ltxml
@@ -56,7 +56,7 @@ DefMacro('\lx@diag@head{}{}',
 
 DefConstructor('\lx@diagheads {}{} {}{}{}',
   "<ltx:picture width='&pxValue(#width)' height='&pxValue(#height)'>"
-    . "<ltx:line points='#line' stroke='black' stroke-width='0.4'/>"
+    . "<ltx:line points='#line' stroke='#color' stroke-width='0.4'/>"
     . "<ltx:g transform='translate(#Ax,#Ay)' innerwidth='#Aw' innerheight='#Ah' innerdepth='#Ad'>"
     . "<ltx:inline-block>#A</ltx:inline-block>"
     . "</ltx:g>"
@@ -84,9 +84,9 @@ DefConstructor('\lx@diagheads {}{} {}{}{}',
     my $pxppt = Dimension('1pt')->pxValue(10);
     $whatsit->setProperties(
       width => Dimension($w / $pxppt . 'pt'), height => Dimension($h / $pxppt . 'pt'),
-      A     => $A, Ax => $Ax, Ay => $Ay, Aw => $Aw, Ah => $Ah,
-      B     => $B, Bx => $Bx, By => $By, Bw => $Bw, Bh => $Bh,
-      line  => $line); }
+      A     => $A,    Ax    => $Ax, Ay => $Ay, Aw => $Aw, Ah => $Ah,
+      B     => $B,    Bx    => $Bx, By => $By, Bw => $Bw, Bh => $Bh,
+      line  => $line, color => Black); }
 );
 #======================================================================
 1;

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -445,7 +445,7 @@ AtBeginDocument('\def\XC@mcolor{\pgfsetcolor{.}}');
 # Implementation
 
 DefMacro('\pgfsys@color@rgb{}{}{}',
-  '\pgfsys@color@rgb@stroke{#1}{#2}{#3}\pgfsys@color@rgb@fill{#1}{#2}{#3}');
+  '\ifpgfpicture\pgfsys@color@rgb@stroke{#1}{#2}{#3}\pgfsys@color@rgb@fill{#1}{#2}{#3}\fi');
 
 DefMacro('\lxSVG@RGB{}{}{}',    sub { Explode(Color('rgb',  $_[1], $_[2], $_[3])->toHex); });
 DefMacro('\lxSVG@CMYK{}{}{}{}', sub { Explode(Color('cmyk', $_[1], $_[2], $_[3], $_[4])->toHex); });

--- a/lib/LaTeXML/Package/wasysym.sty.ltxml
+++ b/lib/LaTeXML/Package/wasysym.sty.ltxml
@@ -23,7 +23,7 @@ use LaTeXML::Package;
 
 #======================================================================
 
-DefPrimitiveI('\ataribox', undef, "\x{26CB}", font => { color => 'white', background => 'black' }, bounded => 1);
+DefPrimitiveI('\ataribox', undef, "\x{26CB}", font => { color => White, background => Black }, bounded => 1);
 DefMathI('\Join',       undef, "\x{2a1d}");
 DefMathI('\Box',        undef, "\x{25a1}");
 DefMathI('\Diamond',    undef, "\x{25c7}");

--- a/t/alignment/cells.xml
+++ b/t/alignment/cells.xml
@@ -363,7 +363,7 @@
         <thead>
           <tr>
             <td align="left" border="l r t" class="ltx_nopad" thead="column row"><picture height="41.34" tex="\diaghead(4,1){\hskip 119.50148pt}{{\color[rgb]{1,0,0}\shortstack[r]{Diag \\&#10;Column Head I}}}{{\color[rgb]{1,0,0}\shortstack[l]{Diag Column \\&#10;Head II}}}" width="165.35" xml:id="S10.p1.pic1">
-                <line points="0,0, 165.35,41.3375" stroke="black" stroke-width="0.4"/>
+                <line points="0,0, 165.35,41.3375" stroke="#000000" stroke-width="0.4"/>
                 <g innerheight="25.91" innerwidth="93.02" transform="translate(72.33,0)">
                   <inline-block>
                     <inline-block align="right">

--- a/t/alignment/diagboxtest.xml
+++ b/t/alignment/diagboxtest.xml
@@ -12,7 +12,7 @@
         <tr>
           <td align="left" border="r t" thead="column row">NW</td>
           <td align="center" border="r t" class="ltx_nopad" thead="column"><picture height="18.92" tex="\diagbox[dir={NW}]{{\shortstack[l]{A}}}{{\shortstack[r]{B}}}{}" width="20.76" xml:id="p1.pic1">
-              <line points="0,18.92 20.76,0" stroke="black" stroke-width="0.4"/>
+              <line points="0,18.92 20.76,0" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="9.46" innerwidth="10.38" transform="translate(0,0)">
                 <inline-block>
                   <inline-block align="left">
@@ -34,7 +34,7 @@
         <tr>
           <td align="left" border="r t" thead="row">SE</td>
           <td align="center" border="r t" class="ltx_nopad"><picture height="18.92" tex="\diagbox[dir={SE}]{{\shortstack[l]{A}}}{{\shortstack[r]{B}}}{}" width="20.76" xml:id="p1.pic2">
-              <line points="0,18.92 20.76,0" stroke="black" stroke-width="0.4"/>
+              <line points="0,18.92 20.76,0" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="9.46" innerwidth="10.38" transform="translate(0,0)">
                 <inline-block>
                   <inline-block align="left">
@@ -54,7 +54,7 @@
         <tr>
           <td align="left" border="r t" thead="row">SW</td>
           <td align="center" border="r t" class="ltx_nopad"><picture height="18.92" tex="\diagbox[dir={SW}]{{\shortstack[l]{A}}}{{\shortstack[r]{B}}}{}" width="20.76" xml:id="p1.pic3">
-              <line points="0,0, 20.76,18.92" stroke="black" stroke-width="0.4"/>
+              <line points="0,0, 20.76,18.92" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="9.46" innerwidth="10.38" transform="translate(0,9.46)">
                 <inline-block>
                   <inline-block align="left">
@@ -74,7 +74,7 @@
         <tr>
           <td align="left" border="b r t" thead="row">NE</td>
           <td align="center" border="b r t" class="ltx_nopad"><picture height="18.92" tex="\diagbox[dir={NE}]{{\shortstack[l]{A}}}{{\shortstack[r]{B}}}{}" width="20.76" xml:id="p1.pic4">
-              <line points="0,0, 20.76,18.92" stroke="black" stroke-width="0.4"/>
+              <line points="0,0, 20.76,18.92" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="9.46" innerwidth="10.38" transform="translate(0,9.46)">
                 <inline-block>
                   <inline-block align="left">
@@ -100,8 +100,8 @@
         <tr>
           <td align="left" border="r t" thead="column row">NW</td>
           <td align="center" border="r t" class="ltx_nopad" thead="column"><picture height="24.27" tex="\diagbox[dir={NW}]{{\shortstack[l]{A}}}{{\shortstack[r]{B}}}{{\shortstack[l]{M%&#10;}}}" width="28.74" xml:id="p2.pic1">
-              <line points="14.37,24.27 28.74,0" stroke="black" stroke-width="0.4"/>
-              <line points="0,12.135 28.74,0" stroke="black" stroke-width="0.4"/>
+              <line points="14.37,24.27 28.74,0" stroke="#000000" stroke-width="0.4"/>
+              <line points="0,12.135 28.74,0" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="9.46" innerwidth="10.38" transform="translate(0,0)">
                 <inline-block>
                   <inline-block align="left">
@@ -130,8 +130,8 @@
         <tr>
           <td align="left" border="r t" thead="row">SE</td>
           <td align="center" border="r t" class="ltx_nopad"><picture height="24.27" tex="\diagbox[dir={SE}]{{\shortstack[l]{A}}}{{\shortstack[r]{B}}}{{\shortstack[r]{M%&#10;}}}" width="28.74" xml:id="p2.pic2">
-              <line points="0,24.27 28.74,12.135" stroke="black" stroke-width="0.4"/>
-              <line points="0,24.27 14.37,0" stroke="black" stroke-width="0.4"/>
+              <line points="0,24.27 28.74,12.135" stroke="#000000" stroke-width="0.4"/>
+              <line points="0,24.27 14.37,0" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="9.46" innerwidth="10.38" transform="translate(0,0)">
                 <inline-block>
                   <inline-block align="left">
@@ -158,8 +158,8 @@
         <tr>
           <td align="left" border="r t" thead="row">SW</td>
           <td align="center" border="r t" class="ltx_nopad"><picture height="24.27" tex="\diagbox[dir={SW}]{{\shortstack[l]{A}}}{{\shortstack[r]{B}}}{{\shortstack[l]{M%&#10;}}}" width="28.74" xml:id="p2.pic3">
-              <line points="0,12.135 28.74,24.27" stroke="black" stroke-width="0.4"/>
-              <line points="14.37,0 28.74,24.27" stroke="black" stroke-width="0.4"/>
+              <line points="0,12.135 28.74,24.27" stroke="#000000" stroke-width="0.4"/>
+              <line points="14.37,0 28.74,24.27" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="9.46" innerwidth="10.38" transform="translate(0,14.81)">
                 <inline-block>
                   <inline-block align="left">
@@ -186,8 +186,8 @@
         <tr>
           <td align="left" border="b r t" thead="row">NE</td>
           <td align="center" border="b r t" class="ltx_nopad"><picture height="24.27" tex="\diagbox[dir={NE}]{{\shortstack[l]{A}}}{{\shortstack[r]{B}}}{{\shortstack[r]{M%&#10;}}}" width="28.74" xml:id="p2.pic4">
-              <line points="0,0 14.37,24.27" stroke="black" stroke-width="0.4"/>
-              <line points="0,0 28.74,12.135" stroke="black" stroke-width="0.4"/>
+              <line points="0,0 14.37,24.27" stroke="#000000" stroke-width="0.4"/>
+              <line points="0,0 28.74,12.135" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="9.46" innerwidth="10.38" transform="translate(0,14.81)">
                 <inline-block>
                   <inline-block align="left">
@@ -220,8 +220,8 @@
         <tr>
           <td align="left" border="r t" thead="column row">NW</td>
           <td align="center" border="r t" class="ltx_nopad" thead="column"><picture height="60.79" tex="\diagbox[dir={NW}]{{\shortstack[l]{Word\\&#10;A}}}{{\shortstack[r]{Word\\&#10;B}}}{{\shortstack[l]{Word\\&#10;M}}}" width="86.63" xml:id="p3.pic1">
-              <line points="43.315,60.79 86.63,0" stroke="black" stroke-width="0.4"/>
-              <line points="0,30.395 86.63,0" stroke="black" stroke-width="0.4"/>
+              <line points="43.315,60.79 86.63,0" stroke="#000000" stroke-width="0.4"/>
+              <line points="0,30.395 86.63,0" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="23.22" innerwidth="33.09" transform="translate(0,0)">
                 <inline-block>
                   <inline-block align="left">
@@ -253,8 +253,8 @@
         <tr>
           <td align="left" border="r t" thead="row">SE</td>
           <td align="center" border="r t" class="ltx_nopad"><picture height="60.79" tex="\diagbox[dir={SE}]{{\shortstack[l]{Word\\&#10;A}}}{{\shortstack[r]{Word\\&#10;B}}}{{\shortstack[r]{Word\\&#10;M}}}" width="86.63" xml:id="p3.pic2">
-              <line points="0,60.79 86.63,30.395" stroke="black" stroke-width="0.4"/>
-              <line points="0,60.79 43.315,0" stroke="black" stroke-width="0.4"/>
+              <line points="0,60.79 86.63,30.395" stroke="#000000" stroke-width="0.4"/>
+              <line points="0,60.79 43.315,0" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="23.22" innerwidth="33.09" transform="translate(0,0)">
                 <inline-block>
                   <inline-block align="left">
@@ -284,8 +284,8 @@
         <tr>
           <td align="left" border="r t" thead="row">SW</td>
           <td align="center" border="r t" class="ltx_nopad"><picture height="60.79" tex="\diagbox[dir={SW}]{{\shortstack[l]{Word\\&#10;A}}}{{\shortstack[r]{Word\\&#10;B}}}{{\shortstack[l]{Word\\&#10;M}}}" width="86.63" xml:id="p3.pic3">
-              <line points="0,30.395 86.63,60.79" stroke="black" stroke-width="0.4"/>
-              <line points="43.315,0 86.63,60.79" stroke="black" stroke-width="0.4"/>
+              <line points="0,30.395 86.63,60.79" stroke="#000000" stroke-width="0.4"/>
+              <line points="43.315,0 86.63,60.79" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="23.22" innerwidth="33.09" transform="translate(0,37.57)">
                 <inline-block>
                   <inline-block align="left">
@@ -315,8 +315,8 @@
         <tr>
           <td align="left" border="b r t" thead="row">NE</td>
           <td align="center" border="b r t" class="ltx_nopad"><picture height="60.79" tex="\diagbox[dir={NE}]{{\shortstack[l]{Word\\&#10;A}}}{{\shortstack[r]{Word\\&#10;B}}}{{\shortstack[r]{Word\\&#10;M}}}" width="86.63" xml:id="p3.pic4">
-              <line points="0,0 43.315,60.79" stroke="black" stroke-width="0.4"/>
-              <line points="0,0 86.63,30.395" stroke="black" stroke-width="0.4"/>
+              <line points="0,0 43.315,60.79" stroke="#000000" stroke-width="0.4"/>
+              <line points="0,0 86.63,30.395" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="23.22" innerwidth="33.09" transform="translate(0,37.57)">
                 <inline-block>
                   <inline-block align="left">
@@ -354,7 +354,7 @@
       <thead>
         <tr>
           <td align="center" border="l r t" class="ltx_nopad" thead="column row"><picture height="18.26" tex="\diagbox[dir={SW},width=56.9055pt]{{\shortstack[l]{num}}}{{\shortstack[r]{%&#10;alpha}}}{}" width="78.74" xml:id="p5.pic1">
-              <line points="0,0, 78.74,18.26" stroke="black" stroke-width="0.4"/>
+              <line points="0,0, 78.74,18.26" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="5.96" innerwidth="26.52" transform="translate(0,12.3)">
                 <inline-block>
                   <inline-block align="left">
@@ -393,7 +393,7 @@
       <thead>
         <tr>
           <td align="center" border="l r t" class="ltx_nopad" thead="column row"><picture height="18.26" tex="\diagbox[dir={NW},width=56.9055pt]{{\shortstack[l]{num}}}{{\shortstack[r]{%&#10;alpha}}}{}" width="78.74" xml:id="p6.pic1">
-              <line points="0,18.26 78.74,0" stroke="black" stroke-width="0.4"/>
+              <line points="0,18.26 78.74,0" stroke="#000000" stroke-width="0.4"/>
               <g class="ltx_svg_fog" innerheight="5.96" innerwidth="26.52" transform="translate(0,0)">
                 <inline-block>
                   <inline-block align="left">

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -3158,12 +3158,12 @@ Then a switch of tag forms.</p>
                   <XMArray name="gathered" vattach="top">
                     <XMRow>
                       <XMCell align="center">
-                        <XMText framecolor="black" framed="rectangle" width="113.8pt" xml:id="S6.Ex46.m1.1">first</XMText>
+                        <XMText framecolor="#000000" framed="rectangle" width="113.8pt" xml:id="S6.Ex46.m1.1">first</XMText>
                       </XMCell>
                     </XMRow>
                     <XMRow>
                       <XMCell align="center">
-                        <XMText framecolor="black" framed="rectangle" width="113.8pt" xml:id="S6.Ex46.m1.2">last</XMText>
+                        <XMText framecolor="#000000" framed="rectangle" width="113.8pt" xml:id="S6.Ex46.m1.2">last</XMText>
                       </XMCell>
                     </XMRow>
                   </XMArray>
@@ -7303,10 +7303,10 @@ Then a switch of tag forms.</p>
       <equationgroup class="ltx_eqn_align" xml:id="S12.EGx10">
         <equation xml:id="S12.Ex83">
           <MathFork>
-            <text class="ltx_markedasmath" framecolor="black" framed="rectangle" width="284.5pt">Part 1</text>
+            <text class="ltx_markedasmath" framecolor="#000000" framed="rectangle" width="284.5pt">Part 1</text>
             <MathBranch>
               <td/>
-              <td align="left"><text class="ltx_markedasmath" framecolor="black" framed="rectangle" width="284.5pt">Part 1</text></td>
+              <td align="left"><text class="ltx_markedasmath" framecolor="#000000" framed="rectangle" width="284.5pt">Part 1</text></td>
             </MathBranch>
           </MathFork>
         </equation>
@@ -7317,7 +7317,7 @@ Then a switch of tag forms.</p>
                 <XMApp>
                   <XMTok meaning="equals" role="RELOP">=</XMTok>
                   <XMTok meaning="absent"/>
-                  <XMText class="ltx_markedasmath" framecolor="black" framed="rectangle" width="227.6pt">2nd line</XMText>
+                  <XMText class="ltx_markedasmath" framecolor="#000000" framed="rectangle" width="227.6pt">2nd line</XMText>
                 </XMApp>
               </XMath>
             </Math>
@@ -7327,7 +7327,7 @@ Then a switch of tag forms.</p>
                     <XMTok meaning="equals" role="RELOP">=</XMTok>
                   </XMath>
                 </Math></td>
-              <td align="left"><text class="ltx_markedasmath" framecolor="black" framed="rectangle" width="227.6pt">2nd line</text></td>
+              <td align="left"><text class="ltx_markedasmath" framecolor="#000000" framed="rectangle" width="227.6pt">2nd line</text></td>
             </MathBranch>
           </MathFork>
         </equation>
@@ -7338,7 +7338,7 @@ Then a switch of tag forms.</p>
                 <XMApp>
                   <XMTok meaning="plus" role="ADDOP">+</XMTok>
                   <XMTok meaning="19" role="NUMBER">19</XMTok>
-                  <XMText framecolor="black" framed="rectangle" width="113.8pt"> last part</XMText>
+                  <XMText framecolor="#000000" framed="rectangle" width="113.8pt"> last part</XMText>
                 </XMApp>
               </XMath>
             </Math>
@@ -7352,7 +7352,7 @@ Then a switch of tag forms.</p>
                   <XMath>
                     <XMApp>
                       <XMTok meaning="plus" role="ADDOP">+</XMTok>
-                      <XMText framecolor="black" framed="rectangle" width="113.8pt"> last part</XMText>
+                      <XMText framecolor="#000000" framed="rectangle" width="113.8pt"> last part</XMText>
                     </XMApp>
                   </XMath>
                 </Math></td>
@@ -7373,19 +7373,19 @@ Then a switch of tag forms.</p>
               <XMath>
                 <XMApp>
                   <XMTok meaning="equals" role="RELOP">=</XMTok>
-                  <XMText class="ltx_markedasmath" framecolor="black" framed="rectangle" width="42.7pt">1</XMText>
-                  <XMText framecolor="black" framed="rectangle" width="85.4pt">2</XMText>
+                  <XMText class="ltx_markedasmath" framecolor="#000000" framed="rectangle" width="42.7pt">1</XMText>
+                  <XMText framecolor="#000000" framed="rectangle" width="85.4pt">2</XMText>
                 </XMApp>
               </XMath>
             </Math>
             <MathBranch>
-              <td align="right"><text class="ltx_markedasmath" framecolor="black" framed="rectangle" width="42.7pt">1</text></td>
+              <td align="right"><text class="ltx_markedasmath" framecolor="#000000" framed="rectangle" width="42.7pt">1</text></td>
               <td align="left"><Math mode="inline" tex="\displaystyle=\framebox[85.35826pt]{2}" text="absent = [2]" xml:id="S12.E27.m2">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="equals" role="RELOP">=</XMTok>
                       <XMTok meaning="absent"/>
-                      <XMText framecolor="black" framed="rectangle" width="85.4pt">2</XMText>
+                      <XMText framecolor="#000000" framed="rectangle" width="85.4pt">2</XMText>
                     </XMApp>
                   </XMath>
                 </Math></td>
@@ -7402,19 +7402,19 @@ Then a switch of tag forms.</p>
               <XMath>
                 <XMApp>
                   <XMTok meaning="equals" role="RELOP">=</XMTok>
-                  <XMText class="ltx_markedasmath" framecolor="black" framed="rectangle" width="42.7pt">3</XMText>
-                  <XMText framecolor="black" framed="rectangle" width="56.9pt">4</XMText>
+                  <XMText class="ltx_markedasmath" framecolor="#000000" framed="rectangle" width="42.7pt">3</XMText>
+                  <XMText framecolor="#000000" framed="rectangle" width="56.9pt">4</XMText>
                 </XMApp>
               </XMath>
             </Math>
             <MathBranch>
-              <td align="right"><text class="ltx_markedasmath" framecolor="black" framed="rectangle" width="42.7pt">3</text></td>
+              <td align="right"><text class="ltx_markedasmath" framecolor="#000000" framed="rectangle" width="42.7pt">3</text></td>
               <td align="left"><Math mode="inline" tex="\displaystyle=\framebox[56.9055pt]{4}" text="absent = [4]" xml:id="S12.E28.m2">
                   <XMath>
                     <XMApp>
                       <XMTok meaning="equals" role="RELOP">=</XMTok>
                       <XMTok meaning="absent"/>
-                      <XMText framecolor="black" framed="rectangle" width="56.9pt">4</XMText>
+                      <XMText framecolor="#000000" framed="rectangle" width="56.9pt">4</XMText>
                     </XMApp>
                   </XMath>
                 </Math></td>

--- a/t/fonts/cancels.xml
+++ b/t/fonts/cancels.xml
@@ -106,7 +106,7 @@
         </tr>
         <tr>
           <td align="left" border="r" thead="row">purple plain</td>
-          <td align="center">stuff <del class="downdiagonalstrike" color="#FF00FF"><text color="black">stuff</text></del> stuff</td>
+          <td align="center">stuff <del class="downdiagonalstrike" color="#FF00FF"><text color="#000000">stuff</text></del> stuff</td>
           <td align="center"><Math mode="inline" tex="a+\cancel{b-c}+d" text="a + cancel@(b - c) + d" xml:id="p1.m5">
               <XMath>
                 <XMApp>
@@ -127,7 +127,7 @@
         </tr>
         <tr>
           <td align="left" border="r" thead="row">red back</td>
-          <td align="center">stuff <del class="updiagonalstrike" color="#FF0000"><text color="black">stuff</text></del> stuff</td>
+          <td align="center">stuff <del class="updiagonalstrike" color="#FF0000"><text color="#000000">stuff</text></del> stuff</td>
           <td align="center"><Math mode="inline" tex="a+\bcancel{b-c}+d" text="a + cancel@(b - c) + d" xml:id="p1.m6">
               <XMath>
                 <XMApp>
@@ -148,7 +148,7 @@
         </tr>
         <tr>
           <td align="left" border="r" thead="row">blue cross</td>
-          <td align="center">stuff <del class="downdiagonalstrike updiagonalstrike" color="#0000FF"><text color="black">stuff</text></del> stuff</td>
+          <td align="center">stuff <del class="downdiagonalstrike updiagonalstrike" color="#0000FF"><text color="#000000">stuff</text></del> stuff</td>
           <td align="center"><Math mode="inline" tex="a+\xcancel{b-c}+d" text="a + cancel@(b - c) + d" xml:id="p1.m7">
               <XMath>
                 <XMApp>

--- a/t/fonts/wasysym.xml
+++ b/t/fonts/wasysym.xml
@@ -57,7 +57,7 @@
     </equation>
   </para>
   <para class="ltx_noindent" xml:id="p3">
-    <p>♂♀¤☎⌕🕒↯⇨▶◀▲▼⌀⦰∢⌑✠☺☹☻☼✓⍾<text backgroundcolor="black" color="white">⛋</text>¢‰¦∴⋈℧<break/>∼≈≋〰〰➿➿➿<break/>□⌧☑⎔⬡⬠<text class="ltx_nounicode">\octagon</text>⚹⚹✡<break/>𝅘𝅥𝅮𝅘𝅥𝅗𝅥𝅝♫<break/>○●<text class="ltx_nounicode">\Leftcircle</text>◖<text class="ltx_nounicode">\Rightcircle</text>◗◐◑↺↻<break/>ðÐþÞɔǝ<break/>♈☊☋🌕🌑☾☽☉☿♀♁♂♃♄⛢♆♇<break/>♈♉♊♋♌♍♎♏♐♑♒♓☌☍<break/>⋆⍟⎕⍋⍒⍞⍝⌹⍐⍗⍇⍈⍀⌿m<text width="0pt" xoffset="-0.8em">~</text>
+    <p>♂♀¤☎⌕🕒↯⇨▶◀▲▼⌀⦰∢⌑✠☺☹☻☼✓⍾<text backgroundcolor="#000000" color="#FFFFFF">⛋</text>¢‰¦∴⋈℧<break/>∼≈≋〰〰➿➿➿<break/>□⌧☑⎔⬡⬠<text class="ltx_nounicode">\octagon</text>⚹⚹✡<break/>𝅘𝅥𝅮𝅘𝅥𝅗𝅥𝅝♫<break/>○●<text class="ltx_nounicode">\Leftcircle</text>◖<text class="ltx_nounicode">\Rightcircle</text>◗◐◑↺↻<break/>ðÐþÞɔǝ<break/>♈☊☋🌕🌑☾☽☉☿♀♁♂♃♄⛢♆♇<break/>♈♉♊♋♌♍♎♏♐♑♒♓☌☍<break/>⋆⍟⎕⍋⍒⍞⍝⌹⍐⍗⍇⍈⍀⌿m<text width="0pt" xoffset="-0.8em">~</text>
 m<text width="0pt" xoffset="-1em">—</text>
 m<text width="0pt" xoffset="-0.66em">∘</text>
 <text yoffset="2.2pt">-</text></p>

--- a/t/graphics/colors.xml
+++ b/t/graphics/colors.xml
@@ -13,7 +13,7 @@
     </tags>
     <title><tag close=" ">1</tag>Predefined colors</title>
     <para xml:id="S1.p1">
-      <p><text color="#000000">Black</text> vs. <text color="#000000">Black</text>.</p>
+      <p>Black vs. Black.</p>
     </para>
     <para xml:id="S1.p2">
       <p><text color="#FFFFFF">White</text> vs. <text color="#FFFFFF">White</text>.</p>

--- a/t/graphics/graphrot.xml
+++ b/t/graphics/graphrot.xml
@@ -247,19 +247,19 @@ End here</p>
       <tabular vattach="middle">
         <tbody>
           <tr>
-            <td align="center" border="l r t"><text framecolor="black" framed="rectangle">—<inline-block angle="0" depth="18.0pt" height="25.0pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="72.3pt" xtranslate="0pt" ytranslate="26.96pt">
+            <td align="center" border="l r t"><text framecolor="#000000" framed="rectangle">—<inline-block angle="0" depth="18.0pt" height="25.0pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="72.3pt" xtranslate="0pt" ytranslate="26.96pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text framecolor="black" framed="rectangle">—<inline-block angle="-40" depth="60.2pt" height="19.1pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="83.0pt" xtranslate="5.35pt" ytranslate="-15.06pt">
+            <td align="center" border="r t"><text framecolor="#000000" framed="rectangle">—<inline-block angle="-40" depth="60.2pt" height="19.1pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="83.0pt" xtranslate="5.35pt" ytranslate="-15.06pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text framecolor="black" framed="rectangle">—<inline-block angle="-80" depth="74.3pt" height="4.3pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="54.8pt" xtranslate="-8.71pt" ytranslate="-29.49pt">
+            <td align="center" border="r t"><text framecolor="#000000" framed="rectangle">—<inline-block angle="-80" depth="74.3pt" height="4.3pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="54.8pt" xtranslate="-8.71pt" ytranslate="-29.49pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
@@ -290,19 +290,19 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
               </Math></td>
           </tr>
           <tr>
-            <td align="center" border="l r t"><text framecolor="black" framed="rectangle">—<inline-block angle="-120" depth="75.1pt" height="9.0pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="73.3pt" xtranslate="0.53pt" ytranslate="-27.56pt">
+            <td align="center" border="l r t"><text framecolor="#000000" framed="rectangle">—<inline-block angle="-120" depth="75.1pt" height="9.0pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="73.3pt" xtranslate="0.53pt" ytranslate="-27.56pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text framecolor="black" framed="rectangle">—<inline-block angle="-160" depth="48.2pt" height="16.9pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="82.6pt" xtranslate="5.16pt" ytranslate="-10.16pt">
+            <td align="center" border="r t"><text framecolor="#000000" framed="rectangle">—<inline-block angle="-160" depth="48.2pt" height="16.9pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="82.6pt" xtranslate="5.16pt" ytranslate="-10.16pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text framecolor="black" framed="rectangle">—<inline-block angle="-200" depth="23.5pt" height="41.6pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="82.6pt" xtranslate="5.16pt" ytranslate="21.39pt">
+            <td align="center" border="r t"><text framecolor="#000000" framed="rectangle">—<inline-block angle="-200" depth="23.5pt" height="41.6pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="82.6pt" xtranslate="5.16pt" ytranslate="21.39pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
@@ -333,19 +333,19 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
               </Math></td>
           </tr>
           <tr>
-            <td align="center" border="l r t"><text framecolor="black" framed="rectangle">—<inline-block angle="-240" depth="12.5pt" height="71.6pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="73.3pt" xtranslate="0.53pt" ytranslate="0.91pt">
+            <td align="center" border="l r t"><text framecolor="#000000" framed="rectangle">—<inline-block angle="-240" depth="12.5pt" height="71.6pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="73.3pt" xtranslate="0.53pt" ytranslate="0.91pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text framecolor="black" framed="rectangle">—<inline-block angle="-280" depth="3.1pt" height="75.5pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="54.8pt" xtranslate="-8.71pt" ytranslate="-5.74pt">
+            <td align="center" border="r t"><text framecolor="#000000" framed="rectangle">—<inline-block angle="-280" depth="3.1pt" height="75.5pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="54.8pt" xtranslate="-8.71pt" ytranslate="-5.74pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>
                     </inline-block></p>
                 </inline-block>—</text></td>
-            <td align="center" border="r t"><text framecolor="black" framed="rectangle">—<inline-block angle="-320" depth="13.8pt" height="65.6pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="83.0pt" xtranslate="5.35pt" ytranslate="4.55pt">
+            <td align="center" border="r t"><text framecolor="#000000" framed="rectangle">—<inline-block angle="-320" depth="13.8pt" height="65.6pt" innerdepth="18.0pt" innerheight="25.0pt" innerwidth="72.3pt" width="83.0pt" xtranslate="5.35pt" ytranslate="4.55pt">
                   <p><inline-block class="ltx_parbox" framed="rectangle" vattach="middle" width="72.3pt">
                       <p>Save
 the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.gov/LaTeXML/">Kitty!</ref> Save the whale</p>

--- a/t/graphics/picture.xml
+++ b/t/graphics/picture.xml
@@ -25,7 +25,7 @@
         </Math>
 <picture fill="none" height="100.0pt" stroke="none" tex="\begin{picture}(100.0,100.0)\put(0.0,0.0){\line(1,0){100.0}}&#10;\end{picture}" unitlength="1.0pt" width="100.0pt" xml:id="S1.p1.pic1">
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 138.37,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 138.37,0" stroke="#000000" stroke-width="0.4"/>
           </g>
         </picture></p>
     </para>
@@ -53,48 +53,48 @@
       <para xml:id="S2.SS1.p3">
         <picture fill="none" height="100.0pt" stroke="none" tex="\begin{picture}(100.0,100.0)\put(0.0,0.0){\line(1,0){100.0}}&#10;\put(0.0,0.0){\line(1,1){50.0}}&#10;\put(0.0,0.0){\line(0,1){100.0}}&#10;\end{picture}" unitlength="1.0pt" width="100.0pt" xml:id="S2.SS1.p3.pic1">
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 138.37,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 138.37,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 69.19,69.19" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 69.19,69.19" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 0,138.37" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,138.37" stroke="#000000" stroke-width="0.4"/>
           </g>
         </picture>
         <picture fill="none" height="100.0pt" stroke="none" tex="\begin{picture}(1.0,1.0)\put(0.0,0.0){\line(1,0){1.0}}&#10;\put(0.0,0.0){\line(1,1){0.5}}&#10;\put(0.0,0.0){\line(0,1){1.0}}&#10;\end{picture}" unitlength="100.0pt" width="100.0pt" xml:id="S2.SS1.p3.pic2">
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 138.37,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 138.37,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 69.19,69.19" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 69.19,69.19" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 0,138.37" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,138.37" stroke="#000000" stroke-width="0.4"/>
           </g>
         </picture>
       </para>
       <para xml:id="S2.SS1.p4">
         <picture fill="none" height="100.0pt" stroke="none" tex="\begin{picture}(100.0,100.0)\put(0.0,0.0){\line(1,0){100.0}}&#10;\put(0.0,0.0){\line(1,1){50.0}}&#10;\put(0.0,0.0){\line(0,1){100.0}}&#10;\end{picture}" unitlength="1.0pt" width="100.0pt" xml:id="S2.SS1.p4.pic1">
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 138.37,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 138.37,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 69.19,69.19" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 69.19,69.19" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 0,138.37" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,138.37" stroke="#000000" stroke-width="0.4"/>
           </g>
         </picture>
         <picture fill="none" height="100.0pt" stroke="none" tex="\begin{picture}(100.0,100.0)\put(0.0,0.0){\line(1,0){100.0}}&#10;\put(0.0,0.0){\line(1,1){50.0}}&#10;\put(0.0,0.0){\line(0,1){100.0}}&#10;\end{picture}" unitlength="1.0pt" width="100.0pt" xml:id="S2.SS1.p4.pic2">
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 138.37,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 138.37,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 69.19,69.19" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 69.19,69.19" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 0,138.37" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,138.37" stroke="#000000" stroke-width="0.4"/>
           </g>
         </picture>
       </para>
@@ -110,13 +110,13 @@
         <picture fill="none" height="100.0pt" origin-x="-100.0pt" origin-y="-100.0pt" stroke="none" tex="\begin{picture}(100.0,100.0)(-100.0,-100.0)\put(0.0,0.0){\vector(-1,0){100.0}}&#10;\put(0.0,0.0){\vector(-1,-1){100.0}}&#10;\put(0.0,0.0){\vector(0,-1){100.0}}&#10;\end{picture}" unitlength="1.0pt" width="100.0pt" xml:id="S2.SS2.p1.pic1">
           <g transform="translate(138.37,138.37)">
             <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-              <line points="0,0 -138.37,0" stroke="black" stroke-width="0.4" terminators="-&gt;"/>
+              <line points="0,0 -138.37,0" stroke="#000000" stroke-width="0.4" terminators="-&gt;"/>
             </g>
             <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-              <line points="0,0 -138.37,-138.37" stroke="black" stroke-width="0.4" terminators="-&gt;"/>
+              <line points="0,0 -138.37,-138.37" stroke="#000000" stroke-width="0.4" terminators="-&gt;"/>
             </g>
             <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-              <line points="0,0 0,-138.37" stroke="black" stroke-width="0.4" terminators="-&gt;"/>
+              <line points="0,0 0,-138.37" stroke="#000000" stroke-width="0.4" terminators="-&gt;"/>
             </g>
           </g>
         </picture>
@@ -135,25 +135,25 @@
             <text font="bold">A</text>
           </g>
           <g innerdepth="0.0pt" innerheight="6.8pt" innerwidth="7.5pt" transform="translate(20.76,20.76)">
-            <rect fill="none" height="15.0pt" stroke="black" stroke-width="0.4" width="15.0pt" x="0" y="0"/>
+            <rect fill="none" height="15.0pt" stroke="#000000" stroke-width="0.4" width="15.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="6.8pt" innerwidth="7.5pt" transform="translate(5.19,5.65)">
               <text>A</text>
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="6.8pt" innerwidth="7.5pt" transform="translate(41.51,41.51)">
-            <rect fill="none" height="15.0pt" stroke="black" stroke-width="0.4" width="15.0pt" x="0" y="0"/>
+            <rect fill="none" height="15.0pt" stroke="#000000" stroke-width="0.4" width="15.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="6.8pt" innerwidth="7.5pt" transform="translate(5.19,5.65)">
               <text font="bold">A</text>
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="6.8pt" innerwidth="7.5pt" transform="translate(62.27,62.27)">
-            <rect fill="none" height="15.0pt" stroke="black" stroke-width="0.4" width="15.0pt" x="0" y="0"/>
+            <rect fill="none" height="15.0pt" stroke="#000000" stroke-width="0.4" width="15.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="6.8pt" innerwidth="7.5pt" transform="translate(5.19,5.65)">
               <text>A</text>
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="36.3pt" innerwidth="7.6pt" transform="translate(83.02,41.51)">
-            <rect fill="none" height="36.3pt" stroke="black" stroke-width="0.4" width="7.6pt" x="0" y="0"/>
+            <rect fill="none" height="36.3pt" stroke="#000000" stroke-width="0.4" width="7.6pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="36.3pt" innerwidth="7.6pt" transform="translate(0,0)">
               <inline-block>
                 <p>A</p>
@@ -164,7 +164,7 @@
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="36.3pt" innerwidth="7.6pt" transform="translate(103.78,27.67)">
-            <rect fill="none" height="80.0pt" stroke="black" stroke-width="0.4" width="15.0pt" x="0" y="0"/>
+            <rect fill="none" height="80.0pt" stroke="#000000" stroke-width="0.4" width="15.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="36.3pt" innerwidth="7.6pt" transform="translate(5.09,30.21)">
               <inline-block>
                 <p>A</p>
@@ -184,19 +184,19 @@
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="4.3pt" innerwidth="5.3pt" transform="translate(27.67,0)">
-            <rect fill="none" height="10.0pt" stroke="black" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
+            <rect fill="none" height="10.0pt" stroke="#000000" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="4.3pt" innerwidth="5.3pt" transform="translate(3.27,3.94)">
               <text>x</text>
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="4.3pt" innerwidth="5.3pt" transform="translate(55.35,0)">
-            <rect fill="none" height="10.0pt" stroke="black" stroke-dasharray="2.0" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
+            <rect fill="none" height="10.0pt" stroke="#000000" stroke-dasharray="2.0" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="4.3pt" innerwidth="5.3pt" transform="translate(3.27,3.94)">
               <text>x</text>
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="4.3pt" innerwidth="5.3pt" transform="translate(83.02,0)">
-            <rect fill="none" height="4.3pt" stroke="black" stroke-width="0.4" width="5.3pt" x="0" y="0"/>
+            <rect fill="none" height="4.3pt" stroke="#000000" stroke-width="0.4" width="5.3pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="4.3pt" innerwidth="5.3pt" transform="translate(0,0)">
               <text>x</text>
             </g>
@@ -266,46 +266,46 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
       <para xml:id="S2.SS4.p2">
         <picture fill="none" height="120.0pt" stroke="none" tex="\begin{picture}(120.0,120.0)\put(0.0,0.0){\line(1,0){120.0}}&#10;\put(0.0,20.0){\line(1,0){120.0}}&#10;\put(0.0,40.0){\line(1,0){120.0}}&#10;\put(0.0,60.0){\line(1,0){120.0}}&#10;\put(0.0,80.0){\line(1,0){120.0}}&#10;\put(0.0,100.0){\line(1,0){120.0}}&#10;\put(0.0,120.0){\line(1,0){120.0}}&#10;\put(0.0,0.0){\line(0,1){120.0}}&#10;\put(20.0,0.0){\line(0,1){120.0}}&#10;\put(40.0,0.0){\line(0,1){120.0}}&#10;\put(60.0,0.0){\line(0,1){120.0}}&#10;\put(80.0,0.0){\line(0,1){120.0}}&#10;\put(100.0,0.0){\line(0,1){120.0}}&#10;\put(120.0,0.0){\line(0,1){120.0}}&#10;\put(0.0,20.0){Xg}&#10;\put(60.0,20.0){$Xg$}&#10;\put(40.0,20.0){\makebox(0.0,0.0)[]{Xg}}&#10;\put(100.0,20.0){\makebox(0.0,0.0)[]{$Xg$}}&#10;\put(0.0,60.0){\makebox(20.0,20.0)[tl]{Xg}}&#10;\put(20.0,60.0){\makebox(20.0,20.0)[t]{Xg}}&#10;\put(40.0,60.0){\makebox(20.0,20.0)[tr]{Xg}}&#10;\put(0.0,80.0){\makebox(20.0,20.0)[l]{Xg}}&#10;\put(20.0,80.0){\makebox(20.0,20.0)[]{Xg}}&#10;\put(40.0,80.0){\makebox(20.0,20.0)[r]{Xg}}&#10;\put(0.0,100.0){\makebox(20.0,20.0)[bl]{Xg}}&#10;\put(20.0,100.0){\makebox(20.0,20.0)[b]{Xg}}&#10;\put(40.0,100.0){\makebox(20.0,20.0)[br]{Xg}}&#10;\put(60.0,60.0){\makebox(20.0,20.0)[tl]{$Xg$}}&#10;\put(80.0,60.0){\makebox(20.0,20.0)[t]{$Xg$}}&#10;\put(100.0,60.0){\makebox(20.0,20.0)[tr]{$Xg$}}&#10;\put(60.0,80.0){\makebox(20.0,20.0)[l]{$Xg$}}&#10;\put(80.0,80.0){\makebox(20.0,20.0)[]{$Xg$}}&#10;\put(100.0,80.0){\makebox(20.0,20.0)[r]{$Xg$}}&#10;\put(60.0,100.0){\makebox(20.0,20.0)[bl]{$Xg$}}&#10;\put(80.0,100.0){\makebox(20.0,20.0)[b]{$Xg$}}&#10;\put(100.0,100.0){\makebox(20.0,20.0)[br]{$Xg$}}&#10;\end{picture}" unitlength="1.0pt" width="120.0pt" xml:id="S2.SS4.p2.pic1">
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 166.04,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 166.04,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,27.67)">
-            <line points="0,0 166.04,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 166.04,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,55.35)">
-            <line points="0,0 166.04,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 166.04,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,83.02)">
-            <line points="0,0 166.04,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 166.04,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,110.7)">
-            <line points="0,0 166.04,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 166.04,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,138.37)">
-            <line points="0,0 166.04,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 166.04,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,166.04)">
-            <line points="0,0 166.04,0" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 166.04,0" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-            <line points="0,0 0,166.04" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,166.04" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(27.67,0)">
-            <line points="0,0 0,166.04" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,166.04" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(55.35,0)">
-            <line points="0,0 0,166.04" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,166.04" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(83.02,0)">
-            <line points="0,0 0,166.04" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,166.04" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(110.7,0)">
-            <line points="0,0 0,166.04" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,166.04" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(138.37,0)">
-            <line points="0,0 0,166.04" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,166.04" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(166.04,0)">
-            <line points="0,0 0,166.04" stroke="black" stroke-width="0.4"/>
+            <line points="0,0 0,166.04" stroke="#000000" stroke-width="0.4"/>
           </g>
           <g innerdepth="1.9pt" innerheight="6.8pt" innerwidth="12.5pt" transform="translate(0,27.67)">
             <text>Xg</text>
@@ -514,15 +514,15 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
       <para xml:id="S2.SS5.p1">
         <picture fill="none" height="100.0pt" stroke="none" tex="\begin{picture}(100.0,100.0)\put(20.0,20.0){\circle{30.0}\vector(0,1){15.0}%&#10;\circle*{5.0}}&#10;\put(70.0,70.0){\oval(60.0,30.0)}&#10;\put(70.0,20.0){\oval(45.0,30.0)}&#10;\end{picture}" unitlength="1.0pt" width="100.0pt" xml:id="S2.SS5.p1.pic1">
           <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(27.67,27.67)">
-            <circle r="20.76" stroke="black" stroke-width="0.4" x="0" y="0"/>
-            <line points="0,0 0,20.76" stroke="black" stroke-width="0.4" terminators="-&gt;"/>
-            <circle fill="black" r="3.46" stroke-width="0.4" x="0" y="0"/>
+            <circle r="20.76" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
+            <line points="0,0 0,20.76" stroke="#000000" stroke-width="0.4" terminators="-&gt;"/>
+            <circle fill="#000000" r="3.46" stroke-width="0.4" x="0" y="0"/>
           </g>
           <g innerdepth="0.0pt" innerheight="30.0pt" innerwidth="60.0pt" transform="translate(96.86,96.86)">
-            <rect fill="none" height="30.0pt" rx="15.0pt" stroke="black" stroke-width="0.4" width="60.0pt" x="-30.0pt" y="-15.0pt"/>
+            <rect fill="none" height="30.0pt" rx="15.0pt" stroke="#000000" stroke-width="0.4" width="60.0pt" x="-30.0pt" y="-15.0pt"/>
           </g>
           <g innerdepth="0.0pt" innerheight="30.0pt" innerwidth="45.0pt" transform="translate(96.86,27.67)">
-            <rect fill="none" height="30.0pt" rx="15.0pt" stroke="black" stroke-width="0.4" width="45.0pt" x="-22.5pt" y="-15.0pt"/>
+            <rect fill="none" height="30.0pt" rx="15.0pt" stroke="#000000" stroke-width="0.4" width="45.0pt" x="-22.5pt" y="-15.0pt"/>
           </g>
         </picture>
       </para>
@@ -536,8 +536,8 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
       <title><tag close=" ">2.6</tag>Curves:</title>
       <para xml:id="S2.SS6.p1">
         <picture fill="none" height="100.0pt" stroke="none" tex="\begin{picture}(100.0,100.0)\qbezier(40.0,80.0)(80.0,120.0)(100.0,80.0)%&#10;\qbezier[50](40.0,89.0)(80.0,129.0)(100.0,89.0)\end{picture}" unitlength="1.0pt" width="100.0pt" xml:id="S2.SS6.p1.pic1">
-          <bezier points="40,80 80,120 100,80" stroke="black" stroke-width="0.4"/>
-          <bezier displayedpoints="50" points="40,89 80,129 100,89" stroke="black" stroke-width="0.4"/>
+          <bezier points="40,80 80,120 100,80" stroke="#000000" stroke-width="0.4"/>
+          <bezier displayedpoints="50" points="40,89 80,129 100,89" stroke="#000000" stroke-width="0.4"/>
         </picture>
       </para>
     </subsection>
@@ -588,36 +588,36 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
       <para xml:id="S2.SS7.p2">
         <picture fill="none" height="100.0pt" stroke="none" tex="\begin{picture}(100.0,100.0)\put(10.0,10.0){\circle{5.0}}&#10;\put(20.0,20.0){\framebox(10.0,10.0)[]{\circle{5.0}}}&#10;\put(30.0,30.0){\framebox(10.0,10.0)[l]{\circle{5.0}}}&#10;\put(40.0,40.0){\framebox(10.0,10.0)[r]{\circle{5.0}}}&#10;\put(50.0,50.0){\framebox(10.0,10.0)[t]{\circle{5.0}}}&#10;\put(60.0,60.0){\framebox(10.0,10.0)[b]{\circle{5.0}}}&#10;\end{picture}" unitlength="1.0pt" width="100.0pt" xml:id="S2.SS7.p2.pic1">
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(13.84,13.84)">
-            <circle r="3.46" stroke="black" stroke-width="0.4" x="0" y="0"/>
+            <circle r="3.46" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(27.67,27.67)">
-            <rect fill="none" height="10.0pt" stroke="black" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
+            <rect fill="none" height="10.0pt" stroke="#000000" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="0.0pt" innerwidth="0.0pt" transform="translate(6.92,6.92)">
-              <circle r="3.46" stroke="black" stroke-width="0.4" x="0" y="0"/>
+              <circle r="3.46" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(41.51,41.51)">
-            <rect fill="none" height="10.0pt" stroke="black" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
+            <rect fill="none" height="10.0pt" stroke="#000000" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="0.0pt" innerwidth="0.0pt" transform="translate(0,6.92)">
-              <circle r="3.46" stroke="black" stroke-width="0.4" x="0" y="0"/>
+              <circle r="3.46" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(55.35,55.35)">
-            <rect fill="none" height="10.0pt" stroke="black" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
+            <rect fill="none" height="10.0pt" stroke="#000000" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="0.0pt" innerwidth="0.0pt" transform="translate(13.84,6.92)">
-              <circle r="3.46" stroke="black" stroke-width="0.4" x="0" y="0"/>
+              <circle r="3.46" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(69.19,69.19)">
-            <rect fill="none" height="10.0pt" stroke="black" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
+            <rect fill="none" height="10.0pt" stroke="#000000" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="0.0pt" innerwidth="0.0pt" transform="translate(6.92,13.84)">
-              <circle r="3.46" stroke="black" stroke-width="0.4" x="0" y="0"/>
+              <circle r="3.46" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(83.02,83.02)">
-            <rect fill="none" height="10.0pt" stroke="black" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
+            <rect fill="none" height="10.0pt" stroke="#000000" stroke-width="0.4" width="10.0pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="0.0pt" innerwidth="0.0pt" transform="translate(6.92,0)">
-              <circle r="3.46" stroke="black" stroke-width="0.4" x="0" y="0"/>
+              <circle r="3.46" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
             </g>
           </g>
         </picture>
@@ -635,16 +635,16 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
       <picture fill="none" height="100.0pt" origin-x="-30.0pt" origin-y="0.0pt" stroke="none" tex="\begin{picture}(100.0,100.0)(-30.0,0.0)\put(11.0,11.0){\vector(1,1){33.0}}&#10;\put(44.0,44.0){\line(1,1){23.5}}&#10;\put(75.5,71.0){\vector(1,0){24.5}}&#10;\put(100.0,71.0){\line(1,0){20.0}}&#10;\put(0.0,0.0){O}&#10;\put(33.0,43.0){$\vec{r}$}&#10;\put(93.0,78.0){$\vec{p}$}&#10;\put(71.0,71.0){\circle{10.0}}&#10;\put(11.0,11.0){\circle*{3.0}}&#10;\put(66.5,68.0){$\times$}&#10;\put(58.0,75.0){$\vec{L}$}&#10;\end{picture}" unitlength="1.0pt" width="100.0pt" xml:id="S3.p1.pic1">
         <g transform="translate(41.51,0)">
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(15.22,15.22)">
-            <line points="0,0 45.66,45.66" stroke="black" stroke-width="0.8" terminators="-&gt;"/>
+            <line points="0,0 45.66,45.66" stroke="#000000" stroke-width="0.8" terminators="-&gt;"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(60.88,60.88)">
-            <line points="0,0 32.52,32.52" stroke="black" stroke-width="0.8"/>
+            <line points="0,0 32.52,32.52" stroke="#000000" stroke-width="0.8"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(104.47,98.24)">
-            <line points="0,0 33.9,0" stroke="black" stroke-width="0.8" terminators="-&gt;"/>
+            <line points="0,0 33.9,0" stroke="#000000" stroke-width="0.8" terminators="-&gt;"/>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(138.37,98.24)">
-            <line points="0,0 27.67,0" stroke="black" stroke-width="0.8"/>
+            <line points="0,0 27.67,0" stroke="#000000" stroke-width="0.8"/>
           </g>
           <g innerdepth="0.0pt" innerheight="6.8pt" innerwidth="7.8pt" transform="translate(0,0)">
             <text>O</text>
@@ -670,10 +670,10 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </Math>
           </g>
           <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(98.24,98.24)">
-            <circle r="6.92" stroke="black" stroke-width="0.8" x="0" y="0"/>
+            <circle r="6.92" stroke="#000000" stroke-width="0.8" x="0" y="0"/>
           </g>
           <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(15.22,15.22)">
-            <circle fill="black" r="2.08" stroke-width="0.8" x="0" y="0"/>
+            <circle fill="#000000" r="2.08" stroke-width="0.8" x="0" y="0"/>
           </g>
           <g innerdepth="0.8pt" innerheight="5.8pt" innerwidth="7.8pt" transform="translate(92.02,94.09)">
             <Math mode="inline" tex="\times" text="*" xml:id="S3.p1.pic1.m3">
@@ -732,22 +732,22 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
           </g>
         </g>
         <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(41.51,55.35)">
-          <line points="0,0 55.35,0" stroke="black" stroke-width="0.4"/>
+          <line points="0,0 55.35,0" stroke="#000000" stroke-width="0.4"/>
         </g>
         <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(41.51,27.67)">
-          <line points="0,0 55.35,0" stroke="black" stroke-width="0.4"/>
+          <line points="0,0 55.35,0" stroke="#000000" stroke-width="0.4"/>
         </g>
         <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(41.51,0)">
-          <line points="0,0 55.35,0" stroke="black" stroke-width="0.4"/>
+          <line points="0,0 55.35,0" stroke="#000000" stroke-width="0.4"/>
         </g>
         <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(41.51,0)">
-          <line points="0,0 0,55.35" stroke="black" stroke-width="0.4"/>
+          <line points="0,0 0,55.35" stroke="#000000" stroke-width="0.4"/>
         </g>
         <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(69.19,0)">
-          <line points="0,0 0,55.35" stroke="black" stroke-width="0.4"/>
+          <line points="0,0 0,55.35" stroke="#000000" stroke-width="0.4"/>
         </g>
         <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(96.86,0)">
-          <line points="0,0 0,55.35" stroke="black" stroke-width="0.4"/>
+          <line points="0,0 0,55.35" stroke="#000000" stroke-width="0.4"/>
         </g>
         <g innerdepth="1.9pt" innerheight="4.3pt" innerwidth="5.3pt" transform="translate(69.19,78.87)">
           <g class="makebox" innerdepth="1.9pt" innerheight="4.3pt" innerwidth="5.3pt" transform="translate(-3.64,-4.32)">
@@ -881,7 +881,7 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="4.3pt" innerwidth="4.7pt" transform="translate(0,91.01)">
-            <rect fill="none" height="15.2pt" stroke="black" stroke-width="0.4" width="5.1pt" x="0" y="0"/>
+            <rect fill="none" height="15.2pt" stroke="#000000" stroke-width="0.4" width="5.1pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="4.3pt" innerwidth="4.7pt" transform="translate(0.26,7.52)">
               <Math mode="inline" tex="s" text="s" xml:id="S4.F2.pic1.m1">
                 <XMath>
@@ -896,7 +896,7 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="6.8pt" innerwidth="8.0pt" transform="translate(10.5,91.01)">
-            <rect fill="none" height="15.2pt" stroke="black" stroke-width="0.4" width="20.2pt" x="0" y="0"/>
+            <rect fill="none" height="15.2pt" stroke="#000000" stroke-width="0.4" width="20.2pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="6.8pt" innerwidth="8.0pt" transform="translate(8.5,5.77)">
               <Math mode="inline" tex="E" text="E" xml:id="S4.F2.pic1.m2">
                 <XMath>
@@ -911,7 +911,7 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </g>
           </g>
           <g innerdepth="1.9pt" innerheight="6.9pt" innerwidth="6.0pt" transform="translate(42,91.01)">
-            <rect fill="none" height="15.2pt" stroke="black" stroke-width="0.4" width="58.2pt" x="0" y="0"/>
+            <rect fill="none" height="15.2pt" stroke="#000000" stroke-width="0.4" width="58.2pt" x="0" y="0"/>
             <g class="makebox" innerdepth="1.9pt" innerheight="6.9pt" innerwidth="6.0pt" transform="translate(36.12,4.35)">
               <Math mode="inline" tex="f" text="f" xml:id="S4.F2.pic1.m3">
                 <XMath>
@@ -949,7 +949,7 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="4.3pt" innerwidth="4.7pt" transform="translate(0,45.5)">
-            <rect fill="none" height="15.2pt" stroke="black" stroke-width="0.4" width="5.1pt" x="0" y="0"/>
+            <rect fill="none" height="15.2pt" stroke="#000000" stroke-width="0.4" width="5.1pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="4.3pt" innerwidth="4.7pt" transform="translate(0.26,7.52)">
               <Math mode="inline" tex="s" text="s" xml:id="S4.F2.pic1.m6">
                 <XMath>
@@ -964,7 +964,7 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="6.8pt" innerwidth="8.0pt" transform="translate(10.5,45.5)">
-            <rect fill="none" height="15.2pt" stroke="black" stroke-width="0.4" width="27.8pt" x="0" y="0"/>
+            <rect fill="none" height="15.2pt" stroke="#000000" stroke-width="0.4" width="27.8pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="6.8pt" innerwidth="8.0pt" transform="translate(13.75,5.77)">
               <Math mode="inline" tex="E" text="E" xml:id="S4.F2.pic1.m7">
                 <XMath>
@@ -979,7 +979,7 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </g>
           </g>
           <g innerdepth="1.9pt" innerheight="6.9pt" innerwidth="6.0pt" transform="translate(52.51,45.5)">
-            <rect fill="none" height="15.2pt" stroke="black" stroke-width="0.4" width="131.5pt" x="0" y="0"/>
+            <rect fill="none" height="15.2pt" stroke="#000000" stroke-width="0.4" width="131.5pt" x="0" y="0"/>
             <g class="makebox" innerdepth="1.9pt" innerheight="6.9pt" innerwidth="6.0pt" transform="translate(86.88,4.35)">
               <Math mode="inline" tex="f" text="f" xml:id="S4.F2.pic1.m8">
                 <XMath>
@@ -1017,7 +1017,7 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="4.3pt" innerwidth="4.7pt" transform="translate(0,0)">
-            <rect fill="none" height="15.2pt" stroke="black" stroke-width="0.4" width="5.1pt" x="0" y="0"/>
+            <rect fill="none" height="15.2pt" stroke="#000000" stroke-width="0.4" width="5.1pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="4.3pt" innerwidth="4.7pt" transform="translate(0.26,7.52)">
               <Math mode="inline" tex="s" text="s" xml:id="S4.F2.pic1.m11">
                 <XMath>
@@ -1032,7 +1032,7 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </g>
           </g>
           <g innerdepth="0.0pt" innerheight="6.8pt" innerwidth="8.0pt" transform="translate(10.5,0)">
-            <rect fill="none" height="15.2pt" stroke="black" stroke-width="0.4" width="37.9pt" x="0" y="0"/>
+            <rect fill="none" height="15.2pt" stroke="#000000" stroke-width="0.4" width="37.9pt" x="0" y="0"/>
             <g class="makebox" innerdepth="0.0pt" innerheight="6.8pt" innerwidth="8.0pt" transform="translate(20.75,5.77)">
               <Math mode="inline" tex="E" text="E" xml:id="S4.F2.pic1.m12">
                 <XMath>
@@ -1047,7 +1047,7 @@ vs. <picture fill="none" height="12.0pt" stroke="none" tex="\begin{picture}(12.0
             </g>
           </g>
           <g innerdepth="1.9pt" innerheight="6.9pt" innerwidth="6.0pt" transform="translate(66.51,0)">
-            <rect fill="none" height="15.2pt" stroke="black" stroke-width="0.4" width="283.3pt" x="0" y="0"/>
+            <rect fill="none" height="15.2pt" stroke="#000000" stroke-width="0.4" width="283.3pt" x="0" y="0"/>
             <g class="makebox" innerdepth="1.9pt" innerheight="6.9pt" innerwidth="6.0pt" transform="translate(191.89,4.35)">
               <Math mode="inline" tex="f" text="f" xml:id="S4.F2.pic1.m13">
                 <XMath>
@@ -1150,142 +1150,142 @@ square.</caption>
 <picture fill="none" height="75.9pt" origin-x="-30.4pt" origin-y="-39.2pt" stroke="none" tex="\begin{picture}(2.4,3.0)(-1.2,-1.55)\put(0.0,0.0){\line(1,0){0.05}}\put(0.1,0.%&#10;0){\line(1,0){0.05}}\put(0.2,0.0){\line(1,0){0.05}}\put(0.3,0.0){\line(1,0){0.%&#10;05}}\put(0.4,0.0){\line(1,0){0.05}}\put(0.5,0.0){\line(1,0){0.05}}\put(0.6,0.0%&#10;){\line(1,0){0.05}}\put(0.7,0.0){\line(1,0){0.05}}\put(0.8,0.0){\line(1,0){0.0%&#10;5}}\put(0.9,0.0){\line(1,0){0.05}}&#10;\put(0.0,0.0){\line(0,1){0.05}}\put(0.0,0.1){\line(0,1){0.05}}\put(0.0,0.2){%&#10;\line(0,1){0.05}}\put(0.0,0.3){\line(0,1){0.05}}\put(0.0,0.4){\line(0,1){0.05}%&#10;}\put(0.0,0.5){\line(0,1){0.05}}\put(0.0,0.6){\line(0,1){0.05}}\put(0.0,0.7){%&#10;\line(0,1){0.05}}\put(0.0,0.8){\line(0,1){0.05}}\put(0.0,0.9){\line(0,1){0.05}%&#10;}&#10;\put(0.0,0.0){\line(-1,0){0.05}}\put(-0.1,0.0){\line(-1,0){0.05}}\put(-0.2,0.0%&#10;){\line(-1,0){0.05}}\put(-0.3,0.0){\line(-1,0){0.05}}\put(-0.4,0.0){\line(-1,0%&#10;){0.05}}\put(-0.5,0.0){\line(-1,0){0.05}}\put(-0.6,0.0){\line(-1,0){0.05}}\put%&#10;(-0.7,0.0){\line(-1,0){0.05}}\put(-0.8,0.0){\line(-1,0){0.05}}\put(-0.9,0.0){%&#10;\line(-1,0){0.05}}&#10;\put(0.0,0.0){\line(0,-1){0.05}}\put(0.0,-0.1){\line(0,-1){0.05}}\put(0.0,-0.2%&#10;){\line(0,-1){0.05}}\put(0.0,-0.3){\line(0,-1){0.05}}\put(0.0,-0.4){\line(0,-1%&#10;){0.05}}\put(0.0,-0.5){\line(0,-1){0.05}}\put(0.0,-0.6){\line(0,-1){0.05}}\put%&#10;(0.0,-0.7){\line(0,-1){0.05}}\put(0.0,-0.8){\line(0,-1){0.05}}\put(0.0,-0.9){%&#10;\line(0,-1){0.05}}&#10;\put(0.0,0.0){\circle{2.0}}&#10;\put(0.0,0.0){\circle*{0.15}}\put(1.0,0.0){\circle*{0.15}}\put(0.0,1.0){%&#10;\circle*{0.15}}\put(-1.0,0.0){\circle*{0.15}}\put(0.0,-1.0){\circle*{0.15}}\end{picture}" unitlength="25.3pt" width="60.7pt" xml:id="S4.T1.pic1">
                 <g transform="translate(42,54.25)">
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(3.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(7,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(10.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(14,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(17.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(21,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(24.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(28,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(31.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,3.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,7)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,10.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,14)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,17.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,21)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,24.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,28)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,31.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-3.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-7,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-10.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-14,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-17.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-21,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-24.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-28,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-31.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-3.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-7)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-10.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-14)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-17.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-21)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-24.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-28)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-31.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <circle r="35" stroke="black" stroke-width="0.4" x="0" y="0"/>
+                    <circle r="35" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(35,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-35,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,-35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                 </g>
               </picture></td>
@@ -1414,139 +1414,139 @@ square.</caption>
 <picture fill="none" height="75.9pt" origin-x="-30.4pt" origin-y="-39.2pt" stroke="none" tex="\begin{picture}(2.4,3.0)(-1.2,-1.55)\put(0.0,0.0){\line(1,0){0.05}}\put(0.1,0.%&#10;0){\line(1,0){0.05}}\put(0.2,0.0){\line(1,0){0.05}}\put(0.3,0.0){\line(1,0){0.%&#10;05}}\put(0.4,0.0){\line(1,0){0.05}}\put(0.5,0.0){\line(1,0){0.05}}\put(0.6,0.0%&#10;){\line(1,0){0.05}}\put(0.7,0.0){\line(1,0){0.05}}\put(0.8,0.0){\line(1,0){0.0%&#10;5}}\put(0.9,0.0){\line(1,0){0.05}}&#10;\put(0.0,0.0){\line(0,1){0.05}}\put(0.0,0.1){\line(0,1){0.05}}\put(0.0,0.2){%&#10;\line(0,1){0.05}}\put(0.0,0.3){\line(0,1){0.05}}\put(0.0,0.4){\line(0,1){0.05}%&#10;}\put(0.0,0.5){\line(0,1){0.05}}\put(0.0,0.6){\line(0,1){0.05}}\put(0.0,0.7){%&#10;\line(0,1){0.05}}\put(0.0,0.8){\line(0,1){0.05}}\put(0.0,0.9){\line(0,1){0.05}%&#10;}&#10;\put(0.0,0.0){\line(-1,0){0.05}}\put(-0.1,0.0){\line(-1,0){0.05}}\put(-0.2,0.0%&#10;){\line(-1,0){0.05}}\put(-0.3,0.0){\line(-1,0){0.05}}\put(-0.4,0.0){\line(-1,0%&#10;){0.05}}\put(-0.5,0.0){\line(-1,0){0.05}}\put(-0.6,0.0){\line(-1,0){0.05}}\put%&#10;(-0.7,0.0){\line(-1,0){0.05}}\put(-0.8,0.0){\line(-1,0){0.05}}\put(-0.9,0.0){%&#10;\line(-1,0){0.05}}&#10;\put(0.0,0.0){\line(0,-1){0.05}}\put(0.0,-0.1){\line(0,-1){0.05}}\put(0.0,-0.2%&#10;){\line(0,-1){0.05}}\put(0.0,-0.3){\line(0,-1){0.05}}\put(0.0,-0.4){\line(0,-1%&#10;){0.05}}\put(0.0,-0.5){\line(0,-1){0.05}}\put(0.0,-0.6){\line(0,-1){0.05}}\put%&#10;(0.0,-0.7){\line(0,-1){0.05}}\put(0.0,-0.8){\line(0,-1){0.05}}\put(0.0,-0.9){%&#10;\line(0,-1){0.05}}&#10;\put(0.0,0.0){\circle{2.0}}&#10;\put(0.5,0.5){\circle*{0.15}}\put(-0.5,0.5){\circle*{0.15}}\put(0.5,-0.5){%&#10;\circle*{0.15}}\put(-0.5,-0.5){\circle*{0.15}}\end{picture}" unitlength="25.3pt" width="60.7pt" xml:id="S4.T1.pic2">
                 <g transform="translate(42,54.25)">
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(3.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(7,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(10.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(14,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(17.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(21,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(24.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(28,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(31.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,3.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,7)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,10.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,14)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,17.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,21)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,24.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,28)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,31.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-3.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-7,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-10.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-14,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-17.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-21,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-24.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-28,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-31.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-3.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-7)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-10.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-14)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-17.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-21)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-24.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-28)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-31.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <circle r="35" stroke="black" stroke-width="0.4" x="0" y="0"/>
+                    <circle r="35" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(17.5,17.5)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-17.5,17.5)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(17.5,-17.5)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-17.5,-17.5)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                 </g>
               </picture></td>
@@ -1631,154 +1631,154 @@ square.</caption>
 <picture fill="none" height="75.9pt" origin-x="-30.4pt" origin-y="-39.2pt" stroke="none" tex="\begin{picture}(2.4,3.0)(-1.2,-1.55)\put(0.0,0.0){\line(1,0){0.05}}\put(0.1,0.%&#10;0){\line(1,0){0.05}}\put(0.2,0.0){\line(1,0){0.05}}\put(0.3,0.0){\line(1,0){0.%&#10;05}}\put(0.4,0.0){\line(1,0){0.05}}\put(0.5,0.0){\line(1,0){0.05}}\put(0.6,0.0%&#10;){\line(1,0){0.05}}\put(0.7,0.0){\line(1,0){0.05}}\put(0.8,0.0){\line(1,0){0.0%&#10;5}}\put(0.9,0.0){\line(1,0){0.05}}&#10;\put(0.0,0.0){\line(0,1){0.05}}\put(0.0,0.1){\line(0,1){0.05}}\put(0.0,0.2){%&#10;\line(0,1){0.05}}\put(0.0,0.3){\line(0,1){0.05}}\put(0.0,0.4){\line(0,1){0.05}%&#10;}\put(0.0,0.5){\line(0,1){0.05}}\put(0.0,0.6){\line(0,1){0.05}}\put(0.0,0.7){%&#10;\line(0,1){0.05}}\put(0.0,0.8){\line(0,1){0.05}}\put(0.0,0.9){\line(0,1){0.05}%&#10;}&#10;\put(0.0,0.0){\line(-1,0){0.05}}\put(-0.1,0.0){\line(-1,0){0.05}}\put(-0.2,0.0%&#10;){\line(-1,0){0.05}}\put(-0.3,0.0){\line(-1,0){0.05}}\put(-0.4,0.0){\line(-1,0%&#10;){0.05}}\put(-0.5,0.0){\line(-1,0){0.05}}\put(-0.6,0.0){\line(-1,0){0.05}}\put%&#10;(-0.7,0.0){\line(-1,0){0.05}}\put(-0.8,0.0){\line(-1,0){0.05}}\put(-0.9,0.0){%&#10;\line(-1,0){0.05}}&#10;\put(0.0,0.0){\line(0,-1){0.05}}\put(0.0,-0.1){\line(0,-1){0.05}}\put(0.0,-0.2%&#10;){\line(0,-1){0.05}}\put(0.0,-0.3){\line(0,-1){0.05}}\put(0.0,-0.4){\line(0,-1%&#10;){0.05}}\put(0.0,-0.5){\line(0,-1){0.05}}\put(0.0,-0.6){\line(0,-1){0.05}}\put%&#10;(0.0,-0.7){\line(0,-1){0.05}}\put(0.0,-0.8){\line(0,-1){0.05}}\put(0.0,-0.9){%&#10;\line(0,-1){0.05}}&#10;\put(0.0,0.0){\circle{2.0}}&#10;\put(0.0,0.0){\circle*{0.15}}\put(-1.0,0.0){\circle*{0.15}}\put(1.0,0.0){%&#10;\circle*{0.15}}\put(0.0,-1.0){\circle*{0.15}}\put(0.0,1.0){\circle*{0.15}}\put%&#10;(0.5,0.5){\circle*{0.15}}\put(-0.5,0.5){\circle*{0.15}}\put(0.5,-0.5){\circle*%&#10;{0.15}}\put(-0.5,-0.5){\circle*{0.15}}\end{picture}" unitlength="25.3pt" width="60.7pt" xml:id="S4.T1.pic3">
                 <g transform="translate(42,54.25)">
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(3.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(7,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(10.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(14,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(17.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(21,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(24.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(28,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(31.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,3.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,7)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,10.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,14)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,17.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,21)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,24.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,28)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,31.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-3.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-7,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-10.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-14,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-17.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-21,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-24.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-28,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-31.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-3.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-7)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-10.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-14)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-17.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-21)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-24.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-28)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-31.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <circle r="35" stroke="black" stroke-width="0.4" x="0" y="0"/>
+                    <circle r="35" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-35,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(35,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,-35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(17.5,17.5)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-17.5,17.5)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(17.5,-17.5)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-17.5,-17.5)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                 </g>
               </picture></td>
@@ -1946,148 +1946,148 @@ square.</caption>
 <picture fill="none" height="75.9pt" origin-x="-30.4pt" origin-y="-39.2pt" stroke="none" tex="\begin{picture}(2.4,3.0)(-1.2,-1.55)\put(0.0,0.0){\line(1,0){0.05}}\put(0.1,0.%&#10;0){\line(1,0){0.05}}\put(0.2,0.0){\line(1,0){0.05}}\put(0.3,0.0){\line(1,0){0.%&#10;05}}\put(0.4,0.0){\line(1,0){0.05}}\put(0.5,0.0){\line(1,0){0.05}}\put(0.6,0.0%&#10;){\line(1,0){0.05}}\put(0.7,0.0){\line(1,0){0.05}}\put(0.8,0.0){\line(1,0){0.0%&#10;5}}\put(0.9,0.0){\line(1,0){0.05}}&#10;\put(0.0,0.0){\line(0,1){0.05}}\put(0.0,0.1){\line(0,1){0.05}}\put(0.0,0.2){%&#10;\line(0,1){0.05}}\put(0.0,0.3){\line(0,1){0.05}}\put(0.0,0.4){\line(0,1){0.05}%&#10;}\put(0.0,0.5){\line(0,1){0.05}}\put(0.0,0.6){\line(0,1){0.05}}\put(0.0,0.7){%&#10;\line(0,1){0.05}}\put(0.0,0.8){\line(0,1){0.05}}\put(0.0,0.9){\line(0,1){0.05}%&#10;}&#10;\put(0.0,0.0){\line(-1,0){0.05}}\put(-0.1,0.0){\line(-1,0){0.05}}\put(-0.2,0.0%&#10;){\line(-1,0){0.05}}\put(-0.3,0.0){\line(-1,0){0.05}}\put(-0.4,0.0){\line(-1,0%&#10;){0.05}}\put(-0.5,0.0){\line(-1,0){0.05}}\put(-0.6,0.0){\line(-1,0){0.05}}\put%&#10;(-0.7,0.0){\line(-1,0){0.05}}\put(-0.8,0.0){\line(-1,0){0.05}}\put(-0.9,0.0){%&#10;\line(-1,0){0.05}}&#10;\put(0.0,0.0){\line(0,-1){0.05}}\put(0.0,-0.1){\line(0,-1){0.05}}\put(0.0,-0.2%&#10;){\line(0,-1){0.05}}\put(0.0,-0.3){\line(0,-1){0.05}}\put(0.0,-0.4){\line(0,-1%&#10;){0.05}}\put(0.0,-0.5){\line(0,-1){0.05}}\put(0.0,-0.6){\line(0,-1){0.05}}\put%&#10;(0.0,-0.7){\line(0,-1){0.05}}\put(0.0,-0.8){\line(0,-1){0.05}}\put(0.0,-0.9){%&#10;\line(0,-1){0.05}}&#10;\put(0.0,0.0){\circle{2.0}}&#10;\put(0.0,0.0){\circle*{0.15}}\put(0.8165,0.0){\circle*{0.15}}\put(-0.8165,0.0)%&#10;{\circle*{0.15}}\put(0.408,0.707){\circle*{0.15}}\put(-0.408,0.707){\circle*{0%&#10;.15}}\put(0.408,-0.707){\circle*{0.15}}\put(-0.408,-0.707){\circle*{0.15}}\end{picture}" unitlength="25.3pt" width="60.7pt" xml:id="S4.T1.pic4">
                 <g transform="translate(42,54.25)">
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(3.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(7,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(10.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(14,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(17.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(21,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(24.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(28,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(31.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,3.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,7)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,10.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,14)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,17.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,21)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,24.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,28)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,31.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-3.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-7,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-10.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-14,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-17.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-21,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-24.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-28,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-31.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-3.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-7)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-10.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-14)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-17.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-21)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-24.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-28)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-31.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <circle r="35" stroke="black" stroke-width="0.4" x="0" y="0"/>
+                    <circle r="35" stroke="#000000" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(28.58,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-28.58,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(14.28,24.75)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-14.28,24.75)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(14.28,-24.75)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-14.28,-24.75)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                 </g>
               </picture></td>
@@ -2255,163 +2255,163 @@ square.</caption>
 <picture fill="none" height="75.9pt" origin-x="-30.4pt" origin-y="-39.2pt" stroke="none" tex="\begin{picture}(2.4,3.0)(-1.2,-1.55)\put(0.0,0.0){\line(1,0){0.05}}\put(0.1,0.%&#10;0){\line(1,0){0.05}}\put(0.2,0.0){\line(1,0){0.05}}\put(0.3,0.0){\line(1,0){0.%&#10;05}}\put(0.4,0.0){\line(1,0){0.05}}\put(0.5,0.0){\line(1,0){0.05}}\put(0.6,0.0%&#10;){\line(1,0){0.05}}\put(0.7,0.0){\line(1,0){0.05}}\put(0.8,0.0){\line(1,0){0.0%&#10;5}}\put(0.9,0.0){\line(1,0){0.05}}&#10;\put(0.0,0.0){\line(0,1){0.05}}\put(0.0,0.1){\line(0,1){0.05}}\put(0.0,0.2){%&#10;\line(0,1){0.05}}\put(0.0,0.3){\line(0,1){0.05}}\put(0.0,0.4){\line(0,1){0.05}%&#10;}\put(0.0,0.5){\line(0,1){0.05}}\put(0.0,0.6){\line(0,1){0.05}}\put(0.0,0.7){%&#10;\line(0,1){0.05}}\put(0.0,0.8){\line(0,1){0.05}}\put(0.0,0.9){\line(0,1){0.05}%&#10;}&#10;\put(0.0,0.0){\line(-1,0){0.05}}\put(-0.1,0.0){\line(-1,0){0.05}}\put(-0.2,0.0%&#10;){\line(-1,0){0.05}}\put(-0.3,0.0){\line(-1,0){0.05}}\put(-0.4,0.0){\line(-1,0%&#10;){0.05}}\put(-0.5,0.0){\line(-1,0){0.05}}\put(-0.6,0.0){\line(-1,0){0.05}}\put%&#10;(-0.7,0.0){\line(-1,0){0.05}}\put(-0.8,0.0){\line(-1,0){0.05}}\put(-0.9,0.0){%&#10;\line(-1,0){0.05}}&#10;\put(0.0,0.0){\line(0,-1){0.05}}\put(0.0,-0.1){\line(0,-1){0.05}}\put(0.0,-0.2%&#10;){\line(0,-1){0.05}}\put(0.0,-0.3){\line(0,-1){0.05}}\put(0.0,-0.4){\line(0,-1%&#10;){0.05}}\put(0.0,-0.5){\line(0,-1){0.05}}\put(0.0,-0.6){\line(0,-1){0.05}}\put%&#10;(0.0,-0.7){\line(0,-1){0.05}}\put(0.0,-0.8){\line(0,-1){0.05}}\put(0.0,-0.9){%&#10;\line(0,-1){0.05}}&#10;\put(-1.0,1.0){\line(1,0){2.0}}&#10;\put(-1.0,1.0){\line(0,-1){2.0}}&#10;\put(1.0,-1.0){\line(-1,0){2.0}}&#10;\put(1.0,-1.0){\line(0,1){2.0}}&#10;\put(0.0,0.0){\circle*{0.15}}\put(1.0,0.0){\circle*{0.15}}\put(-1.0,0.0){%&#10;\circle*{0.15}}\put(0.0,1.0){\circle*{0.15}}\put(0.0,-1.0){\circle*{0.15}}\put%&#10;(1.0,1.0){\circle*{0.15}}\put(-1.0,1.0){\circle*{0.15}}\put(1.0,-1.0){\circle*%&#10;{0.15}}\put(-1.0,-1.0){\circle*{0.15}}\end{picture}" unitlength="25.3pt" width="60.7pt" xml:id="S4.T1.pic5">
                 <g transform="translate(42,54.25)">
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(3.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(7,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(10.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(14,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(17.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(21,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(24.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(28,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(31.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,3.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,7)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,10.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,14)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,17.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,21)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,24.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,28)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,31.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-3.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-7,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-10.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-14,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-17.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-21,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-24.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-28,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-31.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-3.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-7)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-10.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-14)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-17.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-21)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-24.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-28)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-31.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-35,35)">
-                    <line points="0,0 70,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 70,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-35,35)">
-                    <line points="0,0 0,-70" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-70" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(35,-35)">
-                    <line points="0,0 -70,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -70,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(35,-35)">
-                    <line points="0,0 0,70" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,70" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(35,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-35,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,-35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(35,35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-35,35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(35,-35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-35,-35)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                 </g>
               </picture></td>
@@ -2563,148 +2563,148 @@ square.</caption>
 <picture fill="none" height="75.9pt" origin-x="-30.4pt" origin-y="-39.2pt" stroke="none" tex="\begin{picture}(2.4,3.0)(-1.2,-1.55)\put(0.0,0.0){\line(1,0){0.05}}\put(0.1,0.%&#10;0){\line(1,0){0.05}}\put(0.2,0.0){\line(1,0){0.05}}\put(0.3,0.0){\line(1,0){0.%&#10;05}}\put(0.4,0.0){\line(1,0){0.05}}\put(0.5,0.0){\line(1,0){0.05}}\put(0.6,0.0%&#10;){\line(1,0){0.05}}\put(0.7,0.0){\line(1,0){0.05}}\put(0.8,0.0){\line(1,0){0.0%&#10;5}}\put(0.9,0.0){\line(1,0){0.05}}&#10;\put(0.0,0.0){\line(0,1){0.05}}\put(0.0,0.1){\line(0,1){0.05}}\put(0.0,0.2){%&#10;\line(0,1){0.05}}\put(0.0,0.3){\line(0,1){0.05}}\put(0.0,0.4){\line(0,1){0.05}%&#10;}\put(0.0,0.5){\line(0,1){0.05}}\put(0.0,0.6){\line(0,1){0.05}}\put(0.0,0.7){%&#10;\line(0,1){0.05}}\put(0.0,0.8){\line(0,1){0.05}}\put(0.0,0.9){\line(0,1){0.05}%&#10;}&#10;\put(0.0,0.0){\line(-1,0){0.05}}\put(-0.1,0.0){\line(-1,0){0.05}}\put(-0.2,0.0%&#10;){\line(-1,0){0.05}}\put(-0.3,0.0){\line(-1,0){0.05}}\put(-0.4,0.0){\line(-1,0%&#10;){0.05}}\put(-0.5,0.0){\line(-1,0){0.05}}\put(-0.6,0.0){\line(-1,0){0.05}}\put%&#10;(-0.7,0.0){\line(-1,0){0.05}}\put(-0.8,0.0){\line(-1,0){0.05}}\put(-0.9,0.0){%&#10;\line(-1,0){0.05}}&#10;\put(0.0,0.0){\line(0,-1){0.05}}\put(0.0,-0.1){\line(0,-1){0.05}}\put(0.0,-0.2%&#10;){\line(0,-1){0.05}}\put(0.0,-0.3){\line(0,-1){0.05}}\put(0.0,-0.4){\line(0,-1%&#10;){0.05}}\put(0.0,-0.5){\line(0,-1){0.05}}\put(0.0,-0.6){\line(0,-1){0.05}}\put%&#10;(0.0,-0.7){\line(0,-1){0.05}}\put(0.0,-0.8){\line(0,-1){0.05}}\put(0.0,-0.9){%&#10;\line(0,-1){0.05}}&#10;\put(-1.0,1.0){\line(1,0){2.0}}&#10;\put(-1.0,1.0){\line(0,-1){2.0}}&#10;\put(1.0,-1.0){\line(-1,0){2.0}}&#10;\put(1.0,-1.0){\line(0,1){2.0}}&#10;\put(0.577,0.577){\circle*{0.15}}\put(-0.577,0.577){\circle*{0.15}}\put(0.577,%&#10;-0.577){\circle*{0.15}}\put(-0.577,-0.577){\circle*{0.15}}\end{picture}" unitlength="25.3pt" width="60.7pt" xml:id="S4.T1.pic6">
                 <g transform="translate(42,54.25)">
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(3.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(7,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(10.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(14,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(17.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(21,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(24.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(28,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(31.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,3.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,7)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,10.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,14)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,17.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,21)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,24.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,28)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,31.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-3.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-7,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-10.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-14,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-17.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-21,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-24.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-28,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-31.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-3.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-7)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-10.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-14)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-17.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-21)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-24.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-28)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-31.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-35,35)">
-                    <line points="0,0 70,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 70,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-35,35)">
-                    <line points="0,0 0,-70" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-70" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(35,-35)">
-                    <line points="0,0 -70,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -70,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(35,-35)">
-                    <line points="0,0 0,70" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,70" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(20.2,20.2)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-20.2,20.2)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(20.2,-20.2)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-20.2,-20.2)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                 </g>
               </picture></td>
@@ -2797,163 +2797,163 @@ square.</caption>
 <picture fill="none" height="75.9pt" origin-x="-30.4pt" origin-y="-39.2pt" stroke="none" tex="\begin{picture}(2.4,3.0)(-1.2,-1.55)\put(0.0,0.0){\line(1,0){0.05}}\put(0.1,0.%&#10;0){\line(1,0){0.05}}\put(0.2,0.0){\line(1,0){0.05}}\put(0.3,0.0){\line(1,0){0.%&#10;05}}\put(0.4,0.0){\line(1,0){0.05}}\put(0.5,0.0){\line(1,0){0.05}}\put(0.6,0.0%&#10;){\line(1,0){0.05}}\put(0.7,0.0){\line(1,0){0.05}}\put(0.8,0.0){\line(1,0){0.0%&#10;5}}\put(0.9,0.0){\line(1,0){0.05}}&#10;\put(0.0,0.0){\line(0,1){0.05}}\put(0.0,0.1){\line(0,1){0.05}}\put(0.0,0.2){%&#10;\line(0,1){0.05}}\put(0.0,0.3){\line(0,1){0.05}}\put(0.0,0.4){\line(0,1){0.05}%&#10;}\put(0.0,0.5){\line(0,1){0.05}}\put(0.0,0.6){\line(0,1){0.05}}\put(0.0,0.7){%&#10;\line(0,1){0.05}}\put(0.0,0.8){\line(0,1){0.05}}\put(0.0,0.9){\line(0,1){0.05}%&#10;}&#10;\put(0.0,0.0){\line(-1,0){0.05}}\put(-0.1,0.0){\line(-1,0){0.05}}\put(-0.2,0.0%&#10;){\line(-1,0){0.05}}\put(-0.3,0.0){\line(-1,0){0.05}}\put(-0.4,0.0){\line(-1,0%&#10;){0.05}}\put(-0.5,0.0){\line(-1,0){0.05}}\put(-0.6,0.0){\line(-1,0){0.05}}\put%&#10;(-0.7,0.0){\line(-1,0){0.05}}\put(-0.8,0.0){\line(-1,0){0.05}}\put(-0.9,0.0){%&#10;\line(-1,0){0.05}}&#10;\put(0.0,0.0){\line(0,-1){0.05}}\put(0.0,-0.1){\line(0,-1){0.05}}\put(0.0,-0.2%&#10;){\line(0,-1){0.05}}\put(0.0,-0.3){\line(0,-1){0.05}}\put(0.0,-0.4){\line(0,-1%&#10;){0.05}}\put(0.0,-0.5){\line(0,-1){0.05}}\put(0.0,-0.6){\line(0,-1){0.05}}\put%&#10;(0.0,-0.7){\line(0,-1){0.05}}\put(0.0,-0.8){\line(0,-1){0.05}}\put(0.0,-0.9){%&#10;\line(0,-1){0.05}}&#10;\put(-1.0,1.0){\line(1,0){2.0}}&#10;\put(-1.0,1.0){\line(0,-1){2.0}}&#10;\put(1.0,-1.0){\line(-1,0){2.0}}&#10;\put(1.0,-1.0){\line(0,1){2.0}}&#10;\put(0.0,0.0){\circle*{0.15}}\put(0.7746,0.0){\circle*{0.15}}\put(-0.7746,0.0)%&#10;{\circle*{0.15}}\put(0.0,0.7746){\circle*{0.15}}\put(0.0,-0.7746){\circle*{0.1%&#10;5}}\put(0.7746,0.7746){\circle*{0.15}}\put(-0.7746,0.7746){\circle*{0.15}}\put%&#10;(0.7746,-0.7746){\circle*{0.15}}\put(-0.7746,-0.7746){\circle*{0.15}}\end{picture}" unitlength="25.3pt" width="60.7pt" xml:id="S4.T1.pic7">
                 <g transform="translate(42,54.25)">
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(3.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(7,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(10.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(14,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(17.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(21,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(24.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(28,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(31.5,0)">
-                    <line points="0,0 1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,3.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,7)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,10.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,14)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,17.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,21)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,24.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,28)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,31.5)">
-                    <line points="0,0 0,1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-3.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-7,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-10.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-14,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-17.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-21,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-24.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-28,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-31.5,0)">
-                    <line points="0,0 -1.75,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -1.75,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,0)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-3.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-7)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-10.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-14)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-17.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-21)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-24.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-28)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(0,-31.5)">
-                    <line points="0,0 0,-1.75" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-1.75" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-35,35)">
-                    <line points="0,0 70,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 70,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(-35,35)">
-                    <line points="0,0 0,-70" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,-70" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(35,-35)">
-                    <line points="0,0 -70,0" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 -70,0" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="0.0pt" transform="translate(35,-35)">
-                    <line points="0,0 0,70" stroke="black" stroke-width="0.4"/>
+                    <line points="0,0 0,70" stroke="#000000" stroke-width="0.4"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(27.11,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-27.11,0)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,27.11)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(0,-27.11)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(27.11,27.11)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-27.11,27.11)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(27.11,-27.11)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                   <g innerdepth="0.0pt" innerheight="7.5pt" innerwidth="5.0pt" transform="translate(-27.11,-27.11)">
-                    <circle fill="black" r="2.63" stroke-width="0.4" x="0" y="0"/>
+                    <circle fill="#000000" r="2.63" stroke-width="0.4" x="0" y="0"/>
                   </g>
                 </g>
               </picture></td>

--- a/t/graphics/xcolors.xml
+++ b/t/graphics/xcolors.xml
@@ -332,307 +332,307 @@ A=100*13 = 1300pt;</p>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">red</text></td>
-            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 0</text></td>
-            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1 0</text></td>
-            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1</text></td>
-            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF0000</text></td>
-            <td align="left"><text backgroundcolor="#4D4D4D" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3</text></td>
+            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 0</text></td>
+            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1 0</text></td>
+            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1</text></td>
+            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF0000</text></td>
+            <td align="left"><text backgroundcolor="#4D4D4D" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">green</text></td>
-            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 0</text></td>
-            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 1 0</text></td>
-            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3333 1 1</text></td>
-            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 00FF00</text></td>
-            <td align="left"><text backgroundcolor="#969696" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.59</text></td>
+            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 0</text></td>
+            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 1 0</text></td>
+            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3333 1 1</text></td>
+            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 00FF00</text></td>
+            <td align="left"><text backgroundcolor="#969696" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.59</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">blue</text></td>
-            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1</text></td>
-            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 0 0</text></td>
-            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6667 1 1</text></td>
-            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0000FF</text></td>
-            <td align="left"><text backgroundcolor="#1C1C1C" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.11</text></td>
+            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1</text></td>
+            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 0 0</text></td>
+            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6667 1 1</text></td>
+            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0000FF</text></td>
+            <td align="left"><text backgroundcolor="#1C1C1C" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.11</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">cyan</text></td>
-            <td align="left"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1</text></td>
-            <td align="left"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 0 0</text></td>
-            <td align="left"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 1 1</text></td>
-            <td align="left"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 00FFFF</text></td>
-            <td align="left"><text backgroundcolor="#B3B3B3" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.7</text></td>
+            <td align="left"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1</text></td>
+            <td align="left"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 0 0</text></td>
+            <td align="left"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 1 1</text></td>
+            <td align="left"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 00FFFF</text></td>
+            <td align="left"><text backgroundcolor="#B3B3B3" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.7</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">magenta</text></td>
-            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 1</text></td>
-            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 0 0</text></td>
-            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.8333 1 1</text></td>
-            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF00FF</text></td>
-            <td align="left"><text backgroundcolor="#696969" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.41</text></td>
+            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 1</text></td>
+            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 0 0</text></td>
+            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.8333 1 1</text></td>
+            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF00FF</text></td>
+            <td align="left"><text backgroundcolor="#696969" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.41</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">yellow</text></td>
-            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 0</text></td>
-            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1 0</text></td>
-            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.1667 1 1</text></td>
-            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFFF00</text></td>
-            <td align="left"><text backgroundcolor="#E3E3E3" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.89</text></td>
+            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 0</text></td>
+            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1 0</text></td>
+            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.1667 1 1</text></td>
+            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFFF00</text></td>
+            <td align="left"><text backgroundcolor="#E3E3E3" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.89</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">orange</text></td>
-            <td align="left"><text backgroundcolor="#FF8000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0.5 0</text></td>
-            <td align="left"><text backgroundcolor="#FF8000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.5 1 0</text></td>
-            <td align="left"><text backgroundcolor="#FF7F00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.0833 1 1</text></td>
-            <td align="left"><text backgroundcolor="#FF8000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF8000</text></td>
-            <td align="left"><text backgroundcolor="#989898" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.595</text></td>
+            <td align="left"><text backgroundcolor="#FF8000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0.5 0</text></td>
+            <td align="left"><text backgroundcolor="#FF8000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.5 1 0</text></td>
+            <td align="left"><text backgroundcolor="#FF7F00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.0833 1 1</text></td>
+            <td align="left"><text backgroundcolor="#FF8000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF8000</text></td>
+            <td align="left"><text backgroundcolor="#989898" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.595</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">violet</text></td>
-            <td align="left"><text backgroundcolor="#800080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0 0.5</text></td>
-            <td align="left"><text backgroundcolor="#800080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.5 0 0.5</text></td>
-            <td align="left"><text backgroundcolor="#7F0080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.8333 1 0.5</text></td>
-            <td align="left"><text backgroundcolor="#800080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 800080</text></td>
-            <td align="left"><text backgroundcolor="#343434" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.205</text></td>
+            <td align="left"><text backgroundcolor="#800080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0 0.5</text></td>
+            <td align="left"><text backgroundcolor="#800080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.5 0 0.5</text></td>
+            <td align="left"><text backgroundcolor="#7F0080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.8333 1 0.5</text></td>
+            <td align="left"><text backgroundcolor="#800080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 800080</text></td>
+            <td align="left"><text backgroundcolor="#343434" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.205</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">purple</text></td>
-            <td align="left"><text backgroundcolor="#BF0040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0 0.25</text></td>
-            <td align="left"><text backgroundcolor="#BF0040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.75 0.5 0.25</text></td>
-            <td align="left"><text backgroundcolor="#BF0040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.9444 1 0.75</text></td>
-            <td align="left"><text backgroundcolor="#BF0040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> BF0040</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.2525</text></td>
+            <td align="left"><text backgroundcolor="#BF0040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0 0.25</text></td>
+            <td align="left"><text backgroundcolor="#BF0040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.75 0.5 0.25</text></td>
+            <td align="left"><text backgroundcolor="#BF0040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.9444 1 0.75</text></td>
+            <td align="left"><text backgroundcolor="#BF0040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> BF0040</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.2525</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">brown</text></td>
-            <td align="left"><text backgroundcolor="#BF8040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0.5 0.25</text></td>
-            <td align="left"><text backgroundcolor="#BF8040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.25 0.5 0.25</text></td>
-            <td align="left"><text backgroundcolor="#BF7F40" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.0833 0.6667 0.75</text></td>
-            <td align="left"><text backgroundcolor="#BF8040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> BF8040</text></td>
-            <td align="left"><text backgroundcolor="#8C8C8C" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5475</text></td>
+            <td align="left"><text backgroundcolor="#BF8040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0.5 0.25</text></td>
+            <td align="left"><text backgroundcolor="#BF8040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.25 0.5 0.25</text></td>
+            <td align="left"><text backgroundcolor="#BF7F40" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.0833 0.6667 0.75</text></td>
+            <td align="left"><text backgroundcolor="#BF8040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> BF8040</text></td>
+            <td align="left"><text backgroundcolor="#8C8C8C" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5475</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">pink</text></td>
-            <td align="left"><text backgroundcolor="#FFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0.75 0.75</text></td>
-            <td align="left"><text backgroundcolor="#FFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.25 0.25 0</text></td>
-            <td align="left"><text backgroundcolor="#FFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.25 1</text></td>
-            <td align="left"><text backgroundcolor="#FFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFBFBF</text></td>
-            <td align="left"><text backgroundcolor="#D2D2D2" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.825</text></td>
+            <td align="left"><text backgroundcolor="#FFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0.75 0.75</text></td>
+            <td align="left"><text backgroundcolor="#FFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.25 0.25 0</text></td>
+            <td align="left"><text backgroundcolor="#FFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.25 1</text></td>
+            <td align="left"><text backgroundcolor="#FFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFBFBF</text></td>
+            <td align="left"><text backgroundcolor="#D2D2D2" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.825</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">olive</text></td>
-            <td align="left"><text backgroundcolor="#808000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 0</text></td>
-            <td align="left"><text backgroundcolor="#808000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1 0.5</text></td>
-            <td align="left"><text backgroundcolor="#7F8000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.1667 1 0.5</text></td>
-            <td align="left"><text backgroundcolor="#808000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 808000</text></td>
-            <td align="left"><text backgroundcolor="#636363" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.39</text></td>
+            <td align="left"><text backgroundcolor="#808000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 0</text></td>
+            <td align="left"><text backgroundcolor="#808000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1 0.5</text></td>
+            <td align="left"><text backgroundcolor="#7F8000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.1667 1 0.5</text></td>
+            <td align="left"><text backgroundcolor="#808000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 808000</text></td>
+            <td align="left"><text backgroundcolor="#636363" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.39</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">black</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 1</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 000000</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 1</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 000000</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">darkgray</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 0.25 0.25</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.75</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.25</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 404040</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 0.25 0.25</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.75</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.25</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 404040</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">gray</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 0.5</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.5</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.5</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 808080</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 0.5</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.5</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.5</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 808080</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">lightgray</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0.75 0.75</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.25</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.75</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> BFBFBF</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0.75 0.75</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.25</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.75</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> BFBFBF</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">white</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 1</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFFFFF</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 1</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFFFFF</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1</text></td>
           </tr>
           <tr>
             <td align="left" border="t" thead="row"><text font="sansserif" fontsize="90%">-red</text></td>
-            <td align="left" border="t"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1</text></td>
-            <td align="left" border="t"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 0 0</text></td>
-            <td align="left" border="t"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 1 1</text></td>
-            <td align="left" border="t"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 00FFFF</text></td>
-            <td align="left" border="t"><text backgroundcolor="#B3B3B3" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.7</text></td>
+            <td align="left" border="t"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1</text></td>
+            <td align="left" border="t"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 0 0</text></td>
+            <td align="left" border="t"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 1 1</text></td>
+            <td align="left" border="t"><text backgroundcolor="#00FFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 00FFFF</text></td>
+            <td align="left" border="t"><text backgroundcolor="#B3B3B3" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.7</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-green</text></td>
-            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 1</text></td>
-            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 0 0</text></td>
-            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.8333 1 1</text></td>
-            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF00FF</text></td>
-            <td align="left"><text backgroundcolor="#696969" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.41</text></td>
+            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 1</text></td>
+            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 0 0</text></td>
+            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.8333 1 1</text></td>
+            <td align="left"><text backgroundcolor="#FF00FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF00FF</text></td>
+            <td align="left"><text backgroundcolor="#696969" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.41</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-blue</text></td>
-            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 0</text></td>
-            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1 0</text></td>
-            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.1667 1 1</text></td>
-            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFFF00</text></td>
-            <td align="left"><text backgroundcolor="#E3E3E3" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.89</text></td>
+            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 0</text></td>
+            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1 0</text></td>
+            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.1667 1 1</text></td>
+            <td align="left"><text backgroundcolor="#FFFF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFFF00</text></td>
+            <td align="left"><text backgroundcolor="#E3E3E3" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.89</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-cyan</text></td>
-            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 0</text></td>
-            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1 0</text></td>
-            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1</text></td>
-            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF0000</text></td>
-            <td align="left"><text backgroundcolor="#4D4D4D" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3</text></td>
+            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 0</text></td>
+            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1 0</text></td>
+            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 1</text></td>
+            <td align="left"><text backgroundcolor="#FF0000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FF0000</text></td>
+            <td align="left"><text backgroundcolor="#4D4D4D" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-magenta</text></td>
-            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 0</text></td>
-            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 1 0</text></td>
-            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3333 1 1</text></td>
-            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 00FF00</text></td>
-            <td align="left"><text backgroundcolor="#969696" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.59</text></td>
+            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 1 0</text></td>
+            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0 1 0</text></td>
+            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3333 1 1</text></td>
+            <td align="left"><text backgroundcolor="#00FF00" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 00FF00</text></td>
+            <td align="left"><text backgroundcolor="#969696" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.59</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-yellow</text></td>
-            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1</text></td>
-            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 0 0</text></td>
-            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6667 1 1</text></td>
-            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0000FF</text></td>
-            <td align="left"><text backgroundcolor="#1C1C1C" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.11</text></td>
+            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1</text></td>
+            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 0 0</text></td>
+            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6667 1 1</text></td>
+            <td align="left"><text backgroundcolor="#0000FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0000FF</text></td>
+            <td align="left"><text backgroundcolor="#1C1C1C" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.11</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-orange</text></td>
-            <td align="left"><text backgroundcolor="#0080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.5 1</text></td>
-            <td align="left"><text backgroundcolor="#0080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0.5 0 0</text></td>
-            <td align="left"><text backgroundcolor="#0080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5833 1 1</text></td>
-            <td align="left"><text backgroundcolor="#0080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0080FF</text></td>
-            <td align="left"><text backgroundcolor="#676767" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.405</text></td>
+            <td align="left"><text backgroundcolor="#0080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.5 1</text></td>
+            <td align="left"><text backgroundcolor="#0080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 0.5 0 0</text></td>
+            <td align="left"><text backgroundcolor="#0080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5833 1 1</text></td>
+            <td align="left"><text backgroundcolor="#0080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0080FF</text></td>
+            <td align="left"><text backgroundcolor="#676767" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.405</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-violet</text></td>
-            <td align="left"><text backgroundcolor="#80FF80" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 1 0.5</text></td>
-            <td align="left"><text backgroundcolor="#80FF80" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0 0.5 0</text></td>
-            <td align="left"><text backgroundcolor="#80FF80" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3333 0.5 1</text></td>
-            <td align="left"><text backgroundcolor="#80FF80" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 80FF80</text></td>
-            <td align="left"><text backgroundcolor="#CBCBCB" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.795</text></td>
+            <td align="left"><text backgroundcolor="#80FF80" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 1 0.5</text></td>
+            <td align="left"><text backgroundcolor="#80FF80" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0 0.5 0</text></td>
+            <td align="left"><text backgroundcolor="#80FF80" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3333 0.5 1</text></td>
+            <td align="left"><text backgroundcolor="#80FF80" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 80FF80</text></td>
+            <td align="left"><text backgroundcolor="#CBCBCB" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.795</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-purple</text></td>
-            <td align="left"><text backgroundcolor="#40FFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 1 0.75</text></td>
-            <td align="left"><text backgroundcolor="#40FFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0 0.25 0</text></td>
-            <td align="left"><text backgroundcolor="#40FFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4444 0.75 1</text></td>
-            <td align="left"><text backgroundcolor="#40FFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 40FFBF</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.7475</text></td>
+            <td align="left"><text backgroundcolor="#40FFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 1 0.75</text></td>
+            <td align="left"><text backgroundcolor="#40FFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0 0.25 0</text></td>
+            <td align="left"><text backgroundcolor="#40FFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4444 0.75 1</text></td>
+            <td align="left"><text backgroundcolor="#40FFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 40FFBF</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.7475</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-brown</text></td>
-            <td align="left"><text backgroundcolor="#4080BF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 0.5 0.75</text></td>
-            <td align="left"><text backgroundcolor="#4080BF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.25 0 0.25</text></td>
-            <td align="left"><text backgroundcolor="#4080BF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5833 0.6667 0.75</text></td>
-            <td align="left"><text backgroundcolor="#4080BF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 4080BF</text></td>
-            <td align="left"><text backgroundcolor="#737373" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4525</text></td>
+            <td align="left"><text backgroundcolor="#4080BF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 0.5 0.75</text></td>
+            <td align="left"><text backgroundcolor="#4080BF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.25 0 0.25</text></td>
+            <td align="left"><text backgroundcolor="#4080BF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5833 0.6667 0.75</text></td>
+            <td align="left"><text backgroundcolor="#4080BF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 4080BF</text></td>
+            <td align="left"><text backgroundcolor="#737373" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4525</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-pink</text></td>
-            <td align="left"><text backgroundcolor="#004040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.25 0.25</text></td>
-            <td align="left"><text backgroundcolor="#004040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 0 0 0.75</text></td>
-            <td align="left"><text backgroundcolor="#004040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 1 0.25</text></td>
-            <td align="left"><text backgroundcolor="#004040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 004040</text></td>
-            <td align="left"><text backgroundcolor="#2D2D2D" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.175</text></td>
+            <td align="left"><text backgroundcolor="#004040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.25 0.25</text></td>
+            <td align="left"><text backgroundcolor="#004040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 0 0 0.75</text></td>
+            <td align="left"><text backgroundcolor="#004040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 1 0.25</text></td>
+            <td align="left"><text backgroundcolor="#004040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 004040</text></td>
+            <td align="left"><text backgroundcolor="#2D2D2D" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.175</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-olive</text></td>
-            <td align="left"><text backgroundcolor="#8080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 1</text></td>
-            <td align="left"><text backgroundcolor="#8080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 0 0</text></td>
-            <td align="left"><text backgroundcolor="#8080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6667 0.5 1</text></td>
-            <td align="left"><text backgroundcolor="#8080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 8080FF</text></td>
-            <td align="left"><text backgroundcolor="#8E8E8E" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.555</text></td>
+            <td align="left"><text backgroundcolor="#8080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 1</text></td>
+            <td align="left"><text backgroundcolor="#8080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 0 0</text></td>
+            <td align="left"><text backgroundcolor="#8080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6667 0.5 1</text></td>
+            <td align="left"><text backgroundcolor="#8080FF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 8080FF</text></td>
+            <td align="left"><text backgroundcolor="#8E8E8E" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.555</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-black</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 1</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFFFFF</text></td>
-            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1 1 1</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 1</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FFFFFF</text></td>
+            <td align="left"><text backgroundcolor="#FFFFFF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 1</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-darkgray</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0.75 0.75</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.25</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.75</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> BFBFBF</text></td>
-            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75 0.75 0.75</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.25</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.75</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> BFBFBF</text></td>
+            <td align="left"><text backgroundcolor="#BFBFBF" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.75</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-gray</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 0.5</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.5</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.5</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 808080</text></td>
-            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5 0.5 0.5</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.5</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.5</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 808080</text></td>
+            <td align="left"><text backgroundcolor="#808080" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.5</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-lightgray</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 0.25 0.25</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.75</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.25</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 404040</text></td>
-            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25 0.25 0.25</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 0.75</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0.25</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 404040</text></td>
+            <td align="left"><text backgroundcolor="#404040" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.25</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-white</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 1</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 000000</text></td>
-            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0 1</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0 0</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 000000</text></td>
+            <td align="left"><text backgroundcolor="#000000" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0</text></td>
           </tr>
           <tr>
             <td align="left" border="t" thead="row"><text font="sansserif" fontsize="90%">JungleGreen</text></td>
-            <td align="left" border="t"><text backgroundcolor="#03FF7A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.01 1 0.48</text></td>
-            <td align="left" border="t"><text backgroundcolor="#03FF7A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.99 0 0.52 0</text></td>
-            <td align="left" border="t"><text backgroundcolor="#03FF7A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4125 0.99 1</text></td>
-            <td align="left" border="t"><text backgroundcolor="#03FF7A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 03FF7A</text></td>
-            <td align="left" border="t"><text backgroundcolor="#A5A5A5" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6458</text></td>
+            <td align="left" border="t"><text backgroundcolor="#03FF7A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.01 1 0.48</text></td>
+            <td align="left" border="t"><text backgroundcolor="#03FF7A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.99 0 0.52 0</text></td>
+            <td align="left" border="t"><text backgroundcolor="#03FF7A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4125 0.99 1</text></td>
+            <td align="left" border="t"><text backgroundcolor="#03FF7A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 03FF7A</text></td>
+            <td align="left" border="t"><text backgroundcolor="#A5A5A5" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6458</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">DarkOrchid</text></td>
-            <td align="left"><text backgroundcolor="#9933CC" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6 0.2 0.8</text></td>
-            <td align="left"><text backgroundcolor="#9933CC" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4 0.8 0.2 0</text></td>
-            <td align="left"><text backgroundcolor="#9933CC" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.7778 0.75 0.8</text></td>
-            <td align="left"><text backgroundcolor="#9933CC" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 9933CC</text></td>
-            <td align="left"><text backgroundcolor="#626262" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.386</text></td>
+            <td align="left"><text backgroundcolor="#9933CC" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.6 0.2 0.8</text></td>
+            <td align="left"><text backgroundcolor="#9933CC" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4 0.8 0.2 0</text></td>
+            <td align="left"><text backgroundcolor="#9933CC" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.7778 0.75 0.8</text></td>
+            <td align="left"><text backgroundcolor="#9933CC" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 9933CC</text></td>
+            <td align="left"><text backgroundcolor="#626262" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.386</text></td>
           </tr>
           <tr>
             <td align="left" border="t" thead="row"><text font="sansserif" fontsize="90%">-JungleGreen</text></td>
-            <td align="left" border="t"><text backgroundcolor="#FC0085" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.99 0 0.52</text></td>
-            <td align="left" border="t"><text backgroundcolor="#FC0085" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.99 0.47 0.01</text></td>
-            <td align="left" border="t"><text backgroundcolor="#FC0085" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.9125 1 0.99</text></td>
-            <td align="left" border="t"><text backgroundcolor="#FC0085" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FC0085</text></td>
-            <td align="left" border="t"><text backgroundcolor="#5A5A5A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3542</text></td>
+            <td align="left" border="t"><text backgroundcolor="#FC0085" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.99 0 0.52</text></td>
+            <td align="left" border="t"><text backgroundcolor="#FC0085" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0 0.99 0.47 0.01</text></td>
+            <td align="left" border="t"><text backgroundcolor="#FC0085" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.9125 1 0.99</text></td>
+            <td align="left" border="t"><text backgroundcolor="#FC0085" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> FC0085</text></td>
+            <td align="left" border="t"><text backgroundcolor="#5A5A5A" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.3542</text></td>
           </tr>
           <tr>
             <td align="left" thead="row"><text font="sansserif" fontsize="90%">-DarkOrchid</text></td>
-            <td align="left"><text backgroundcolor="#66CC33" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4 0.8 0.2</text></td>
-            <td align="left"><text backgroundcolor="#66CC33" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4 0 0.6 0.2</text></td>
-            <td align="left"><text backgroundcolor="#66CC33" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.2778 0.75 0.8</text></td>
-            <td align="left"><text backgroundcolor="#66CC33" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 66CC33</text></td>
-            <td align="left"><text backgroundcolor="#9D9D9D" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="black" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.614</text></td>
+            <td align="left"><text backgroundcolor="#66CC33" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4 0.8 0.2</text></td>
+            <td align="left"><text backgroundcolor="#66CC33" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.4 0 0.6 0.2</text></td>
+            <td align="left"><text backgroundcolor="#66CC33" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.2778 0.75 0.8</text></td>
+            <td align="left"><text backgroundcolor="#66CC33" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 66CC33</text></td>
+            <td align="left"><text backgroundcolor="#9D9D9D" class="ltx_phantom" cssstyle="padding:0.0pt" font="sansserif" fontsize="90%" framecolor="#000000" framed="rectangle">XX</text><text font="sansserif" fontsize="90%"> 0.614</text></td>
           </tr>
         </tbody>
       </tabular>
@@ -679,7 +679,7 @@ A=100*13 = 1300pt;</p>
       <p><text color="#0074C9">Sky blue</text></p>
     </para>
     <para xml:id="S12.p8">
-      <p><text color="#000000">Black</text></p>
+      <p>Black</p>
     </para>
   </section>
 </document>

--- a/t/structure/enum.xml
+++ b/t/structure/enum.xml
@@ -166,9 +166,9 @@
       <enumerate xml:id="S2.I5">
         <item xml:id="S2.I5.i1">
           <tags>
-            <tag><text framecolor="black" framed="rectangle">1</text></tag>
-            <tag role="refnum"><text framecolor="black" framed="rectangle">1</text></tag>
-            <tag role="typerefnum">item <text framecolor="black" framed="rectangle">1</text></tag>
+            <tag><text framecolor="#000000" framed="rectangle">1</text></tag>
+            <tag role="refnum"><text framecolor="#000000" framed="rectangle">1</text></tag>
+            <tag role="typerefnum">item <text framecolor="#000000" framed="rectangle">1</text></tag>
           </tags>
           <para xml:id="S2.I5.i1.p1">
             <p>Line one</p>
@@ -176,9 +176,9 @@
         </item>
         <item xml:id="S2.I5.i2">
           <tags>
-            <tag><text framecolor="black" framed="rectangle">2</text></tag>
-            <tag role="refnum"><text framecolor="black" framed="rectangle">2</text></tag>
-            <tag role="typerefnum">item <text framecolor="black" framed="rectangle">2</text></tag>
+            <tag><text framecolor="#000000" framed="rectangle">2</text></tag>
+            <tag role="refnum"><text framecolor="#000000" framed="rectangle">2</text></tag>
+            <tag role="typerefnum">item <text framecolor="#000000" framed="rectangle">2</text></tag>
           </tags>
           <para xml:id="S2.I5.i2.p1">
             <p>Line two</p>


### PR DESCRIPTION
The actual issue fix was a simple one liner in the pgf driver, but it turned up some inconsistency in color defaulting. The most interesting bit is the test for black in `TeX.pool` which affects how color adapts to a box being moved, copied, etc.  The rest is just consistency that `black` becomes `Black()`, and thus `#000000`.

Fixes #1945