### PR TITLE
respect \@sanitize guard for \index 

### DIFF
--- a/lib/LaTeXML/Core/Tokens.pm
+++ b/lib/LaTeXML/Core/Tokens.pm
@@ -94,7 +94,11 @@ sub isBalanced {
   foreach my $t (@$self) {
     my $cc = $$t[1];    # INLINE
     $level++ if $cc == CC_BEGIN;
-    $level-- if $cc == CC_END; }
+    if ($cc == CC_END) {
+      $level--;
+      # Note that '{ }} {' is still unbalanced
+      # even though the left and right braces match in count.
+      last if $level < 0; } }
   return $level == 0; }
 
 # NOTE: Assumes each arg either undef or also Tokens

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4422,9 +4422,22 @@ our %index_style = (textbf => 'bold', bf => 'bold', textrm => '', rm => '',
 sub process_index_phrases {
   my ($gullet, $phrases, $inlist) = @_;
   my @expansion = ();
+  my @tokens    = $phrases->unlist;
+  # check we have a well-formed argument
+  return unless @tokens;
+  my $group_level = 0;
+  for my $t (@tokens) {
+    my $cc = $t->getCatcode;
+    if    ($cc == CC_BEGIN) { $group_level++; }
+    elsif ($cc == CC_END) {
+      $group_level--;
+      # discard if unbalanced close group;
+      last if ($group_level < 0); } }
+  if ($group_level != 0) {    # if a group is still open by the end, ill-formed, discard;
+    Warn("malformed", "indexentry", $gullet,
+      'index entry has unbalanced groups, discarding: "' . ToString($phrases) . '"');
+    return; }
   # Split the text into phrases, separated by "!"
-  my @tokens = $phrases->unlist;
-  return                      unless @tokens;
   push(@tokens, T_OTHER('!')) unless $tokens[-1]->getString eq '!';    # Add terminal !
   my @phrase = ();
   my @sortas = ();
@@ -4462,7 +4475,37 @@ sub process_index_phrases {
     T_BEGIN, @expansion, T_END);
   return @expansion; }
 
-DefMacro('\index{}', \&process_index_phrases);
+# read verbatim, as perl latex.ltx \@sanitize;
+# useful for \index (maybe others?)
+DefParameterType('SanitizedVerbatim', sub {
+    my ($gullet) = @_;
+    $gullet->readUntil(T_BEGIN);
+    # crucial: deactivate the backslash to avoid activating command sequences
+    # chars switched to CC_OTHER by \@sanitize: ' ', '\\', '$', '&', '#', '^', '_', '%', '~'
+    # some of those are already in state's "SPECIALS", so only adding the rest:
+    StartSemiverbatim(' ', '\\', '%');
+    my $arg = $gullet->readBalanced(1);
+    EndSemiverbatim();
+    # now that we have the semiverbatim tokens, retokenize with the standard catcode scheme,
+    # this may seem like wasted work, but it avoids very unfortunate error propagation in cases
+    # where the \index argument was malformed for one reason or another.
+    #
+    # the strangeness comes from the original TeX workflow requiring multiple conversion calls,
+    # alongside a call to the `makeidx` binary, which we don't do in latexml. This parameter type
+    # emulates one important aspect implied by those steps.
+    $arg = Tokenize(ToString($arg));
+    return $arg; },
+  beforeDigest => sub {
+    $_[0]->bgroup;
+    MergeFont(family => 'typewriter'); },
+  afterDigest => sub {
+    $_[0]->egroup; },
+  reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
+
+# real-world LaTeX \index
+DefMacro('\index SanitizedVerbatim', \&process_index_phrases);
+# simple \index for internal use in bindings with pre-sanitized arguments
+DefMacro('\lx@simple@index Plain', \&process_index_phrases);
 
 Tag('ltx:indexphrase',    afterClose => \&addIndexPhraseKey);
 Tag('ltx:glossaryphrase', afterClose => \&addIndexPhraseKey);

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4425,15 +4425,7 @@ sub process_index_phrases {
   my @tokens    = $phrases->unlist;
   # check we have a well-formed argument
   return unless @tokens;
-  my $group_level = 0;
-  for my $t (@tokens) {
-    my $cc = $t->getCatcode;
-    if    ($cc == CC_BEGIN) { $group_level++; }
-    elsif ($cc == CC_END) {
-      $group_level--;
-      # discard if unbalanced close group;
-      last if ($group_level < 0); } }
-  if ($group_level != 0) {    # if a group is still open by the end, ill-formed, discard;
+  if (!$phrases->isBalanced) {    # if ill-formed, discard;
     Warn("malformed", "indexentry", $gullet,
       'index entry has unbalanced groups, discarding: "' . ToString($phrases) . '"');
     return; }
@@ -4484,28 +4476,21 @@ DefParameterType('SanitizedVerbatim', sub {
     # chars switched to CC_OTHER by \@sanitize: ' ', '\\', '$', '&', '#', '^', '_', '%', '~'
     # some of those are already in state's "SPECIALS", so only adding the rest:
     StartSemiverbatim(' ', '\\', '%');
-    my $arg = $gullet->readBalanced(1);
+    my $arg = $gullet->readBalanced();
     EndSemiverbatim();
-    # now that we have the semiverbatim tokens, retokenize with the standard catcode scheme,
+    # now that we have the semiverbatim tokens, retokenize.
     # this may seem like wasted work, but it avoids very unfortunate error propagation in cases
     # where the \index argument was malformed for one reason or another.
     #
     # the strangeness comes from the original TeX workflow requiring multiple conversion calls,
     # alongside a call to the `makeidx` binary, which we don't do in latexml. This parameter type
     # emulates one important aspect implied by those steps.
-    $arg = Tokenize(ToString($arg));
+    $arg = TokenizeInternal(UnTeX($arg));
     return $arg; },
-  beforeDigest => sub {
-    $_[0]->bgroup;
-    MergeFont(family => 'typewriter'); },
-  afterDigest => sub {
-    $_[0]->egroup; },
   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
 
 # real-world LaTeX \index
 DefMacro('\index SanitizedVerbatim', \&process_index_phrases);
-# simple \index for internal use in bindings with pre-sanitized arguments
-DefMacro('\lx@simple@index Plain', \&process_index_phrases);
 
 Tag('ltx:indexphrase',    afterClose => \&addIndexPhraseKey);
 Tag('ltx:glossaryphrase', afterClose => \&addIndexPhraseKey);

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -4467,7 +4467,7 @@ sub process_index_phrases {
     T_BEGIN, @expansion, T_END);
   return @expansion; }
 
-# read verbatim, as perl latex.ltx \@sanitize;
+# read verbatim, as if with LaTeX's \@sanitize;
 # useful for \index (maybe others?)
 DefParameterType('SanitizedVerbatim', sub {
     my ($gullet) = @_;

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -1019,7 +1019,9 @@ DefKeyVal('LST', 'indexstyle', '');
 DefMacro('\lst@@indexstyle [Number] Until:\end', sub {
     lstSetClassStyle(lstClassName('index', $_[1]), $_[2]); });
 
-DefMacro('\lstindexmacro{}', '\index{{\ttfamily #1}}');
+# use the simple plain-argument index,
+# otherwise we need to double-check any relevant Semiverbatim cases
+DefMacro('\lstindexmacro{}', '\lx@simple@index{{\ttfamily #1}}');
 
 #======================================================================
 # 4.13 Column alignment

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -1019,9 +1019,7 @@ DefKeyVal('LST', 'indexstyle', '');
 DefMacro('\lst@@indexstyle [Number] Until:\end', sub {
     lstSetClassStyle(lstClassName('index', $_[1]), $_[2]); });
 
-# use the simple plain-argument index,
-# otherwise we need to double-check any relevant Semiverbatim cases
-DefMacro('\lstindexmacro{}', '\lx@simple@index{{\ttfamily #1}}');
+DefMacro('\lstindexmacro{}', '\index{{\ttfamily #1}}');
 
 #======================================================================
 # 4.13 Column alignment


### PR DESCRIPTION
Fixes [ar5iv#393](https://github.com/dginev/ar5iv/issues/393), 

Minimal motivating example:
<details>

```tex
\documentclass{article}
\usepackage{makeidx}
\makeindex
\begin{document}
\def\w{w}

\begin{itemize}
\item A\index{Choice Principle!({{\sf AC$^\{<\w}_\w$}})}

\item B\index{Choice Principle!({{\sf BC$^{<\w}_\w$}})}
\end{itemize}

\printindex

\end{document}
```

</details>

---

In a way this is an edge case problem in LaTeX documents which have an actual error in the argument of the `\index` command. The arXiv example is a particularly egregious case, where a big portion of a 70 page manuscript goes haywire due to a single malformed index argument.

pdflatex is largely immune to such problems, as the argument to `\index` is neutralized via `\@sanitize` and written in the auxiliary `.idx` file for second-stage processing. The `makeidx` binary can then (relatively quietly) veto malformed arguments, avoiding any errors in the main pdflatex workflow.

To this end, this PR adds the sanitization guard via a new parameter type - which then also retokenizes back to Plain catcodes. I then add the usual balanced-argument check, offering a warning in cases where the `\index` argument was ill-formed + discarding the entry. This matches pdflatex+makeidx "in spirit".

One tricky detail that was revealed by the tests is that if we have `DefMacro` bindings that expand into `\index`, there is some care needed for the tokens not to get mangled. There appear to be some subtle details around re-tokenizing spaces that I am not too certain about (they have to do with space skipping after a command sequence is completed). I wonder if I can implement the parameter type in a way that is more compatible for binding reuse.

Feedback welcome.