### PR TITLE
Empty cells

### DIFF
--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -419,9 +419,9 @@ sub normalize_cell_sizes {
             . " Boxes=" . ToString($boxes)) if $LaTeXML::DEBUG{halign} && $LaTeXML::DEBUG{size};
         my $empty =
           (((!$cw) || $cw->valueOf < 1)
-            || (((!$ch) || $ch->valueOf < 1)
+            && (((!$ch) || $ch->valueOf < 1)
             && ((!$cd) || $cd->valueOf < 1))
-            || !(grep { !$_->getProperty('isSpace'); } $boxes->unlist)
+            || !(grep { !($_->getProperty('isSpace') || $_->getProperty('isHorizontalRule') || $_->getProperty('isVerticalRule')); } $boxes->unlist)
           ) && !preservedBoxes($boxes);
         $$cell{cwidth}  = $w || Dimension(0);
         $$cell{cheight} = $h || Dimension(0);

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -6341,7 +6341,7 @@ Then a switch of tag forms.</p>
             <tag role="refnum">22</tag>
           </tags>
           <MathFork>
-            <Math tex="\displaystyle x=y_{1}-y_{2}+y_{3}-y_{5}+y_{8}-\dots" text="x = ((((y _ 1 - y _ 2) + y _ 3) - y _ 5) + y _ 8) - dots" xml:id="S10.E22.m4">
+            <Math tex="\displaystyle x=y_{1}-y_{2}+y_{3}-y_{5}+y_{8}-\dots" text="x = ((((y _ 1 - y _ 2) + y _ 3) - y _ 5) + y _ 8) - dots" xml:id="S10.E22.m5">
               <XMath>
                 <XMApp>
                   <XMTok meaning="equals" role="RELOP">=</XMTok>
@@ -6450,6 +6450,7 @@ Then a switch of tag forms.</p>
           <MathFork>
             <text class="ltx_markedasmath">by foo</text>
             <MathBranch>
+              <td align="right"/>
               <td align="left"><text class="ltx_markedasmath">by foo</text></td>
             </MathBranch>
           </MathFork>
@@ -6509,6 +6510,7 @@ Then a switch of tag forms.</p>
           <MathFork>
             <text class="ltx_markedasmath">by baz</text>
             <MathBranch>
+              <td/>
               <td align="left"><text class="ltx_markedasmath">by baz</text></td>
             </MathBranch>
           </MathFork>
@@ -6576,6 +6578,7 @@ Then a switch of tag forms.</p>
           <MathFork>
             <text class="ltx_markedasmath">by Axiom 1.</text>
             <MathBranch>
+              <td/>
               <td align="left"><text class="ltx_markedasmath">by Axiom 1.</text></td>
             </MathBranch>
           </MathFork>

--- a/t/encoding/ly1.xml
+++ b/t/encoding/ly1.xml
@@ -72,7 +72,7 @@
           </tr>
           <tr>
             <td align="right" border="r" thead="row">´4x</td>
-            <td/>
+            <td align="center"></td>
             <td align="center">!</td>
             <td align="center">"</td>
             <td align="center">#</td>


### PR DESCRIPTION
Alignment cells should have *both* zero width and height to be considered empty (except for rule lines).

Fixes #1861