### PR TITLE
pass package options in the right order

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -933,13 +933,13 @@ DefPrimitive('\DeclareOption{}{}', sub {
         DeclareOption(ToString($option), $code)); });
 
 DefPrimitive('\PassOptionsToPackage{}{}', sub {
-    my ($stomach, $name, $options) = @_;
+    my ($stomach, $options, $name) = @_;
     $name = ToString($name);
     $name =~ s/\s+//g;
     PassOptions($name, 'sty', split(/\s*,\s*/, ToString(Expand($options)))); });
 
 DefPrimitive('\PassOptionsToClass{}{}', sub {
-    my ($stomach, $name, $options) = @_;
+    my ($stomach, $options, $name) = @_;
     $name = ToString($name);
     $name =~ s/\s+//g;
     PassOptions($name, 'cls', split(/\s*,\s*/, ToString(Expand($options)))); });

--- a/lib/LaTeXML/Package/elsarticle.cls.ltxml
+++ b/lib/LaTeXML/Package/elsarticle.cls.ltxml
@@ -17,19 +17,22 @@ use LaTeXML::Package;
 
 # Generally ignorable options
 foreach my $option (qw(preprint final review
-  authoryear number numbers longtitle
   5p 3p 1p
-  times
   12pt 11pt 10pt
+  endfloat endfloats numafflabel doubleblind
   oneside twoside onecolumn twocolumn
+  longtitle lefttitle centertitle reversenotenum nopreprintline
   symbold ussrhead nameyear doublespacing reviewcopy)) {
   DeclareOption($option, undef); }
 
 DeclareOption('times', sub { AddToMacro(T_CS('\elsarticle.cls-h@@k'), '\RequirePackage{txfonts}'); });
 
-DeclareOption("seceqn", sub { AssignValue('@seceqn' => 1); });
-DeclareOption("secthm", sub { AssignValue('@secthm' => 1); });
-DeclareOption("amsthm", sub { AssignValue('@amsthm' => 1); });
+DeclareOption("seceqn",     sub { AssignValue('@seceqn' => 1); });
+DeclareOption("secthm",     sub { AssignValue('@secthm' => 1); });
+DeclareOption("amsthm",     sub { AssignValue('@amsthm' => 1); });
+DeclareOption('authoryear', sub { AssignValue('@biboptions', 'round,authoryear'); });
+DeclareOption('number',     sub { AssignValue('@biboptions', 'numbers'); });
+DeclareOption('numbers',    sub { AssignValue('@biboptions', 'numbers'); });
 
 # Anything else is for article.
 DeclareOption(undef, sub {
@@ -42,6 +45,9 @@ RequirePackage('elsart_support_core');    # Hopefully, this covers elsarticle
 RequirePackage('fleqn');
 RequirePackage('graphicx');
 RequirePackage('pifont');
+# number style inline citations by default
+my $natbib_opts = LookupValue('@biboptions') || 'numbers';
+PassOptions('natbib', 'sty', split(/\s*,\s*/, $natbib_opts));
 RequirePackage('natbib');
 RequirePackage('hyperref');
 # RequirePackage('endfloat');


### PR DESCRIPTION
Hello! Well I sure found an interesting example of what happens when argument lists get shuffled unintentionally.

Apparently `\PassOptionsToPackage` and `\PassOptionsToClass` have never really worked, as their arguments had been swapped.

I landed on this discovery when diagnozing why [ar5iv:2310.13021](https://ar5iv.labs.arxiv.org/html/2310.13021) used AuthorYear citation styles rather than the Number style used in the PDF. The source revealed the lines:

```tex
% if you need to pass options to natbib, use, e.g.:
%     \PassOptionsToPackage{numbers, compress}{natbib}
% before loading neurips_2023
\PassOptionsToPackage{numbers, compress}{natbib}
% ready for submission
% \usepackage{neurips_2023}

\usepackage[preprint]{neurips_2023}
```

which appears to have been supplied by the neurips conference organizers. Straightening up the argument order in the binding definition fixes the problem.