### PR TITLE
add \ion for mnras.cls and friends

### DIFF
--- a/lib/LaTeXML/Package/mn2e_support.sty.ltxml
+++ b/lib/LaTeXML/Package/mn2e_support.sty.ltxml
@@ -148,6 +148,7 @@ DefMath('\leqslant', "\x{2A7D}", role => 'RELOP',
 DefMath('\geqslant', "\x{2A7E}", role => 'RELOP',
   meaning => 'greater-than-or-equals');
 DefPrimitiveI('\micron', undef, UTF(0xB5) . "m");
+DefMacro('\ion{}{}', '\text{#1\,\textsc{\lowercase{#2}}}');
 
 DefMacro('\rmn{}',      '\mathrm{#1}');
 DefMacro('\romn{}',     '\mathrm{#1}');


### PR DESCRIPTION
I got pinged that this was missing and it seemed faster to make the PR than an issue.

mnras.cls has a recent addition of `\ion`, which I transferred as-is to the binding.

Will fix arXiv:2311.17062