### PR TITLE
Digest some keys in thmtools; avoid error cascades in \hypertarget 

### DIFF
--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3061,7 +3061,7 @@ sub defineNewTheorem {
   $listname =~ s/\#/hash/g;
   $otherthmset = $otherthmset && ToString($otherthmset);
   $type        = undef if IsEmpty($type);
-  $within      = $within ? ToString($within) : undef;
+  $within      = $within ? ToString(Digest($within)) : undef;
 
   my $counter = $otherthmset || $thmset;
   $counter =~ s/\s+/./;    # convert spaces to period?

--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -227,6 +227,7 @@ sub localized_anchor {
   my ($document, $whatsit) = @_;
   my $model      = $STATE->getModel;
   my $node       = $document->getNode;
+  my $id         = $whatsit->getProperty('id');
   my @candidates = ($node);
   my $candidate;
   while ($candidate = pop(@candidates)) {
@@ -236,13 +237,12 @@ sub localized_anchor {
       unshift(@candidates, $candidate->childNodes); }
     elsif ($type = XML_TEXT_NODE) {
       last; } }
-  my $id = $whatsit->getProperty('id');
   if ($candidate) {
     my $anchor = $document->wrapNodes('ltx:anchor', $candidate);
     $anchor->setAttribute('xml:id', $id);
     $document->closeNode($anchor) if $document->isOpen($anchor); }
   else {
-    Error("No available insertion point for ltx:anchor, failing \\hypertarget to $id"); }
+    Warn("No available insertion point for ltx:anchor, failing \\hypertarget to $id"); }
   return; }
 
 # \hyperdef{category}{name}{text}

--- a/lib/LaTeXML/Package/thmtools.sty.ltxml
+++ b/lib/LaTeXML/Package/thmtools.sty.ltxml
@@ -70,9 +70,11 @@ sub thmtools_style {
 DefPrimitive('\declaretheorem OptionalKeyVals {}', sub {
     my ($stomach, $kv, $thmset) = @_;
     # Activate any requested style
-    my $name = ToString($thmset);
-    if (my $style = ToString($kv && $kv->getValue('style')) || 'plain') {
-      useTheoremStyle($style); }
+    my $name  = ToString($thmset);
+    my $style = $kv && $kv->getValue('style');
+    if ($style) {
+      $style = ToString(Digest($style)); }
+    useTheoremStyle($style || 'plain');
     thmtools_style($name, $kv);
     useTheoremStyle($name);
     my $type = ($kv


### PR DESCRIPTION
By the time I had checked the latest reported problem in [ar5iv#412](https://github.com/dginev/ar5iv/issues/412) I had it fixed, so filing the two extra `Digest` calls in this PR.

Separately, I am also filing a small softening of the `\hypertarget` error of inserting an `ltx:anchor` to a Warning, since it turns out when it occurs it can be really frequent (100+ times). We stumbled onto that when converting the [Linear Algebra textbook by Hefferon](https://hefferon.net/linearalgebra/) this week. I will probably file an issue to bookkeep some of the more subtle problems there, but this one seems clearcut. 