### PR TITLE
[minor] add required packages for xfrac

### DIFF
--- a/lib/LaTeXML/Package/xfrac.sty.ltxml
+++ b/lib/LaTeXML/Package/xfrac.sty.ltxml
@@ -15,7 +15,10 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+RequirePackage('amstext');
+RequirePackage('graphicx');
 RequirePackage('nicefrac');
+
 DefMacro('\sfrac[]{}[]{}', '\ensuremath{\@UnitsNiceFrac{#2}{#4}}');
 
 DefMacro('\DeclareInstance{}{}{}{}',             '');


### PR DESCRIPTION
This was a very easy fix for arXiv:2301.13344 [log here](https://ar5iv.labs.arxiv.org/log/2301.13344), which wasn't finding `\graphicspath` during conversion.

As it turns out, xfrac.sty on texlive 2022 has the following line:
```tex
\RequirePackage{amstext,graphicx,l3keys2e,textcomp,xparse,xtemplate}
\ProvidesExplPackage{xfrac}{2022-06-22}{}
```

I think adding the latex 3 pieces is too much for now, but adding the more common LaTeX 2 entries should be smooth sailing.

The PR upgrades the arXiv article from Error to Warning severity (some unparsed math).