### PR TITLE
Fix quote

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1205,8 +1205,7 @@ Here are a couple of trivial examples of constructors:
   DefConstructor('\item[]',
     "<ltx:item>?#1(<ltx:tag>#1</ltx:tag>)");
   DefEnvironment('{quote}',   
-    '<ltx:quote>#body</ltx:quote>',
-    beforeDigest=>sub{ Let('\\\\','\@block@cr');});
+    '<ltx:quote>#body</ltx:quote>');
   DefConstructor('\footnote[]{}',
     "<ltx:note class='footnote' mark='#refnum'>#2</ltx:note>",
     mode=>'text',

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -1407,21 +1407,16 @@ DefConstructorI('\@add@flushleft', undef,
 #======================================================================-
 # C.6.1 Quotations and Verse
 #======================================================================-
-DefConstructor('\@block@cr[Dimension]', "<ltx:break/>\n",
-  reversion => Tokens(T_CS("\\\\"), T_CR));
+Let('\@block@cr', '\lx@newline');    # Obsolete, but in case still used
 DefEnvironment('{quote}',
   '<ltx:quote>#body</ltx:quote>',
-  beforeDigest => sub { Let('\\\\', '\@block@cr'); Let('\par', '\@block@cr') },
-  mode         => 'text');
+  mode => 'text');
 DefEnvironment('{quotation}',
   '<ltx:quote>#body</ltx:quote>',
-  beforeDigest => sub { Let('\\\\', '\@block@cr'); Let('\par', '\@block@cr') },
-  mode         => 'text');
-# NOTE: Handling of \\ within these environments?
+  mode => 'text');
 DefEnvironment('{verse}',
   '<ltx:quote role="verse">#body</ltx:quote>',
-  beforeDigest => sub { Let('\\\\', '\@block@cr'); Let('\par', '\@block@cr') },
-  mode         => 'text');
+  mode => 'text');
 
 #======================================================================
 # C.6.2 List-Making environments

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -929,7 +929,7 @@ DefConstructor('\boxed@text{}',
     . "</ltx:Math>",
   mode         => 'math', bounded => 1,
   beforeDigest => sub {
-    Let("\\\\", '\@block@cr'); },
+    Let("\\\\", '\lx@newline'); },
   alias => '\boxed');
 
 DefMath('\implies',   "\x{27F9}", role => 'ARROW', meaning => 'implies');

--- a/lib/LaTeXML/Package/csquotes.sty.ltxml
+++ b/lib/LaTeXML/Package/csquotes.sty.ltxml
@@ -235,8 +235,7 @@ Let('\csq@bquote@ii', '\csq@bquote@iii');
 DefMacro('\ltxml@mkblockquote@open', '\begingroup\ltxml@mkblockquote@open@i');
 DefPrimitive('\ltxml@mkblockquote@open@i', sub {
     DefEnvironment('{quote}', '<ltx:quote class="ltx_blockquote">#body</ltx:quote>',
-      beforeDigest => sub { Let('\\\\', '\@block@cr'); Let('\par', '\@block@cr') },
-      mode         => 'text'); });
+      mode => 'text'); });
 DefMacro('\ltxml@mkblockquote@close', '\endgroup');
 
 DefConstructor('\ltxml@mkblockquote@aopen', '<ltx:text class="ltx_inline-quote" _noautoclose="1">');
@@ -266,8 +265,7 @@ EoTeX
 DefMacro('\ltxml@blockenvironment@open', '\begingroup\ltxml@blockenvironment@open@i');
 DefPrimitive('\ltxml@blockenvironment@open@i', sub {
     DefEnvironment('{quote}', '<ltx:quote class="ltx_displayquote">#body</ltx:quote>',
-      beforeDigest => sub { Let('\\\\', '\@block@cr'); Let('\par', '\@block@cr') },
-      mode         => 'text'); });
+      mode => 'text'); });
 DefMacro('\ltxml@blockenvironment@close', '\endgroup');
 
 DefMacro('\ltxml@mkbegdispquote{}{}', '\ltxml@mkbegdispquote@aopen\mkbegdispquote{#1}{#2}');

--- a/t/expansion/environments.xml
+++ b/t/expansion/environments.xml
@@ -11,25 +11,22 @@
   </para>
   <para xml:id="p2">
     <quote>
-      <p>MY<break/>
-A Quote!</p>
+      <p>MY<break/>A Quote!</p>
     </quote>
   </para>
   <para xml:id="p3">
     <quote>
-      <p>1<break/>
-A Quote!</p>
+      <p>1<break/>A Quote!</p>
     </quote>
   </para>
   <para xml:id="p4">
     <quote>
-      <p>ONE<break/>
-A Quote!</p>
+      <p>ONE<break/>A Quote!</p>
     </quote>
   </para>
   <para xml:id="p5">
     <quote>
-<!--  %**** environments.tex Line 25 **** -->      <p>a + b</p>
+      <p>a + b</p>
     </quote>
   </para>
   <para xml:id="p6">


### PR DESCRIPTION
Continue simplifying blocks and such. In particular `\par` in quotes should just make new paragraphs, right?

Fixes #1978