### PR TITLE
Mathvariant fixes

### DIFF
--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -1168,10 +1168,10 @@ sub Absent {
   return New('absent'); }
 
 sub InvisibleTimes {
-  return New('times', "\x{2062}", role => 'MULOP', font => LaTeXML::Common::Font->new()); }
+  return New('times', "\x{2062}", role => 'MULOP'); }
 
 sub InvisibleComma {
-  return New(undef, "\x{2063}", role => 'PUNCT', font => LaTeXML::Common::Font->new()); }
+  return New(undef, "\x{2063}", role => 'PUNCT'); }
 
 # Get n-th arg of an XMApp.
 # However, this is really only used to get the script out of a sub/super script
@@ -1406,19 +1406,22 @@ sub Fence {
     return InterpretDelimited(New($op, undef, ($decl_id ? (decl_id => $decl_id) : ())), @stuff); } }
 
 # Compose a complex relational operator from two tokens, such as >=, >>
+# (similar to CatSymbols, but specialized to relops)
 sub TwoPartRelop {
   my ($op1, $op2) = @_;
   $op1 = Lookup($op1);
   $op2 = Lookup($op2);
-  my $m1 = p_getTokenMeaning($op1);
-  my $m2 = p_getTokenMeaning($op2);
+  my $m1   = p_getTokenMeaning($op1);
+  my $m2   = p_getTokenMeaning($op2);
+  my $font = p_getAttribute($op1, '_font');
   my $meaning;
   if ($m1 eq $m2) {
     $meaning = "much-$m1"; }
   else {
     $meaning = "$m1-or-$m2"; }
   my $content = $op1->textContent . $op2->textContent;
-  return ['ltx:XMTok', { role => "RELOP", meaning => $meaning }, $content]; }
+  return ['ltx:XMTok', { role => "RELOP", meaning => $meaning, ($font ? (_font => $font) : ()) },
+    $content]; }
 
 # NOTE: It might be best to separate the multiple Formulae into separate XMath's???
 # but only at the top level!

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1619,7 +1619,8 @@ sub defmath_rewrite {
 
 sub defmath_common_constructor_options {
   my ($cs, $presentation, %options) = @_;
-  my $sizer = inferSizer($options{sizer}, $options{reversion});
+  my $sizer          = inferSizer($options{sizer}, $options{reversion});
+  my $presentation_s = $presentation && ToString($presentation);
   return (
     alias => $options{alias} || $cs->getString,
     (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
@@ -1645,8 +1646,8 @@ sub defmath_common_constructor_options {
       stretchy           => $options{stretchy},
       operator_stretchy  => $options{operator_stretchy},
       font               => ($options{mathstyle}
-        ? sub { LookupValue('font')->merge(mathstyle => $options{mathstyle})->specialize($presentation); }
-        : sub { LookupValue('font')->specialize($presentation); }),
+        ? sub { LookupValue('font')->merge(mathstyle => $options{mathstyle})->specialize($presentation_s); }
+        : sub { LookupValue('font')->specialize($presentation_s); }),
       lpadding => $options{lpadding},
       rpadding => $options{rpadding} },
     scope => $options{scope}); }

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -3875,7 +3875,9 @@ DefPrimitive('\@array@bindings [] AlignmentTemplate', sub {
     if ($str != 1) {
       $$attr{rowsep} = Dimension(($str - 1) . 'em'); }
     alignmentBindings($template, 'math', attributes => $attr);
-    MergeFont(mathstyle => 'text');
+    if (my $font = LookupValue('font')) {
+      if (($font->getMathstyle || 'text') eq 'display') {
+        MergeFont(mathstyle => 'text'); } }
     Let("\\\\",         '\@alignment@newline');
     Let('\lx@intercol', '\lx@math@intercol');
     return; });

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -6859,14 +6859,15 @@ DefConstructor('\lx@hack@bordermatrix{}', sub {
     my $n    = scalar(@rows) - 1;
     $col1->setAttribute(rowspan => $n);
     $coln->setAttribute(rowspan => $n);
+    my $pfont = $STATE->lookupValue('font')->specialize('(');
     $document->appendTree($col1,
       ['ltx:XMWrap', { depth => $d },
-        ['ltx:XMTok', { role   => 'OPEN', height  => 0, depth => $d, yoffset => $md }, '('],
-        ['ltx:XMTok', { height => $h,     yoffset => $md }, ' ']]);    # Effectively, a strut
+        ['ltx:XMTok', { role   => 'OPEN', height  => 0, depth => $d, yoffset => $md, font => $pfont }, '('],
+        ['ltx:XMTok', { height => $h,     yoffset => $md, font => $pfont }, ' ']]);   # Effectively, a strut
     $document->appendTree($coln,
       ['ltx:XMWrap', {},
-        ['ltx:XMTok', { role   => 'CLOSE', height => 0, depth => $d, yoffset => $md }, ')'],
-        ['ltx:XMTok', { height => $h, yoffset => $md }, ' ']]);
+        ['ltx:XMTok', { role   => 'CLOSE', height => 0, depth => $d, yoffset => $md, font => $pfont }, ')'],
+        ['ltx:XMTok', { height => $h, yoffset => $md, font => $pfont }, ' ']]);
     return; },
   reversion => '#1');
 
@@ -7291,7 +7292,9 @@ DefConstructor('\lx@apply OptionalKeyVals:XMath {}{}',
 DefConstructor('\lx@symbol OptionalKeyVals:XMath {}',
   "<ltx:XMTok $XMath_attributes>#2</ltx:XMTok>",
   reversion   => '#2',
-  afterDigest => sub { XMath_copy_keyvals(@_); });
+  afterDigest => sub {
+    $_[1]->setFont($_[1]->getArg(2)->getFont);
+    XMath_copy_keyvals(@_); });
 
 # Wrap the contents in an ltx:XMWrap, to stand as a single subtree & providing attributes
 # The ltx:XMWrap may be collapsed, later, by parsing

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -731,6 +731,9 @@ sub stylizeContent {
     $class = ($class ? $class . ' ' : '') . 'ltx_font_oldstyle'; }
   elsif ($font =~ /smallcaps/) {
     $class = ($class ? $class . ' ' : '') . 'ltx_font_smallcaps'; }
+  elsif ($variant) {    # Any left-over mathvariant? Punt to CSS
+    $class = ($class ? $class . ' ' : '') . 'ltx_mathvariant_' . $variant; }
+
   if ($opacity) {
     $cssstyle = ($cssstyle ? $cssstyle . ';' : '') . "opacity:$opacity"; }
 
@@ -738,8 +741,8 @@ sub stylizeContent {
   my %props = ($tag eq 'm:mo' ? opdict_lookup($text, $role) : ());
 
   # Resolve stretch & size
-  $stretchy = undef if ($tag ne 'm:mo');                          # Only allowed on m:mo!
-  $size     = undef if $stretchy;                                 # Ignore size, if we're stretching.
+  $stretchy = undef if ($tag ne 'm:mo');             # Only allowed on m:mo!
+  $size     = undef if $stretchy;                    # Ignore size, if we're stretching.
   my $stretchyhack = undef;
   if ($text =~ /^[\x{2061}\x{2062}\x{2063}]*$/) {    # invisible get no size or stretchiness
     $stretchy = $size = undef; }

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -721,8 +721,8 @@ sub stylizeContent {
     $variant = ($plane1hack && ($variant ne $u_variant) && ($variant =~ /^bold/)
       ? 'bold' : undef); }                       # Possibly keep variant bold
                                                  # Use class (css) to patchup some weak translations
-  if ($text =~ /^\p{Format}*$/) {                # Formatting (eg. InvisibleTImes)
-    $font = $variant = $color = $bgcolor = $opacity = undef; }
+  if ($text =~ /^\p{Format}*$/) {                # Only Formatting (eg. InvisibleTImes) (or empty)
+    $font = $variant = $color = $bgcolor = $opacity = undef; }    # Needs no viz. styling attributes
   elsif (!$font) { }
   elsif ($font =~ /caligraphic/) {
     # Note that this is unlikely to have effect when plane1 chars are used!

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -715,13 +715,15 @@ sub stylizeContent {
   my $u_variant  = $variant
     && ($plane1hack ? $plane1hackable{$variant}
     : ($plane1 ? $variant : undef));
-  my $u_text = $u_variant && unicode_convert($text, $u_variant);
+  my $u_text = ($tag ne 'm:mtext') && $u_variant && unicode_convert($text, $u_variant);
   if ((defined $u_text) && ($u_text ne '')) {    # didn't remap the text ? Keep text & variant
     $text    = $u_text;
     $variant = ($plane1hack && ($variant ne $u_variant) && ($variant =~ /^bold/)
       ? 'bold' : undef); }                       # Possibly keep variant bold
                                                  # Use class (css) to patchup some weak translations
-  if    (!$font) { }
+  if ($text =~ /^\p{Format}*$/) {                # Formatting (eg. InvisibleTImes)
+    $font = $variant = $color = $bgcolor = $opacity = undef; }
+  elsif (!$font) { }
   elsif ($font =~ /caligraphic/) {
     # Note that this is unlikely to have effect when plane1 chars are used!
     $class = ($class ? $class . ' ' : '') . 'ltx_font_mathcaligraphic'; }
@@ -733,6 +735,8 @@ sub stylizeContent {
     $class = ($class ? $class . ' ' : '') . 'ltx_font_smallcaps'; }
   elsif ($variant && ($variant ne 'normal')) {    # Any left-over mathvariant? Punt to CSS
     $class = ($class ? $class . ' ' : '') . 'ltx_mathvariant_' . $variant; }
+  if ($tag eq 'm:mtext') {
+    $variant = undef; }
 
   if ($opacity) {
     $cssstyle = ($cssstyle ? $cssstyle . ';' : '') . "opacity:$opacity"; }

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -18,8 +18,8 @@ use LaTeXML::Util::Unicode;
 use LaTeXML::Post;
 use LaTeXML::Common::Font;
 use List::Util qw(max);
-use base qw(LaTeXML::Post::MathProcessor);
-use base qw(Exporter);
+use base       qw(LaTeXML::Post::MathProcessor);
+use base       qw(Exporter);
 our @EXPORT = (
   qw( &DefMathML ),
   qw( &pmml &pmml_scriptsize &pmml_smaller
@@ -703,6 +703,8 @@ sub stylizeContent {
     elsif (!$variant)            { $variant = 'normal'; } }    # must say so explicitly.
   elsif ($font && !$variant) {
     Warn('unexpected', $font, undef, "Unrecognized font variant '$font'"); $variant = ''; }
+  elsif ($variant eq 'normal') {    # normal is default for any other tokens, so omit
+    $variant = undef; }
   # Should we map to Unicode's Plane 1 blocks for Mathematical Alphanumeric Symbols?
   # Only upper & lower case latin & greek, and also numerals can be mapped.
   # For each mathvariant, and for each of those 5 groups, there is a linear mapping,

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -731,7 +731,7 @@ sub stylizeContent {
     $class = ($class ? $class . ' ' : '') . 'ltx_font_oldstyle'; }
   elsif ($font =~ /smallcaps/) {
     $class = ($class ? $class . ' ' : '') . 'ltx_font_smallcaps'; }
-  elsif ($variant) {    # Any left-over mathvariant? Punt to CSS
+  elsif ($variant && ($variant ne 'normal')) {    # Any left-over mathvariant? Punt to CSS
     $class = ($class ? $class . ' ' : '') . 'ltx_mathvariant_' . $variant; }
 
   if ($opacity) {

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -462,6 +462,22 @@ span.ltx_framed       { display:inline-block; text-indent:0; } /* avoid padding/
 .ltx_font_smallcaps  { font-variant: small-caps; font-style:normal; }
 .ltx_font_oldstyle   { font-variant-numeric: oldstyle-nums; }
 .ltx_font_mathcaligraphic { font-family: "Lucida Calligraphy", "Zapf Chancery","URW Chancery L"; }
+/* Fallbacks for when content+mathvariant cannot be mapped to Unicode */
+.ltx_mathvariant_italic        { font-style: italic; }
+.ltx_mathvariant_bold          { font-weight: bold; }
+.ltx_mathvariant_bold-italic   { font-style: italic; font-weight: bold; }
+.ltx_mathvariant_sans-serif             { font-family: sans-serif; }
+.ltx_mathvariant-bold-sans-serif        { font-family: sans-serif; font-weight: bold; }
+.ltx_mathvariant-sans-serif-italic      { font-family: sans-serif; font-style: italic; }
+.ltx_mathvariant-bold-sans-serif-italic { font-family: sans-serif; font-style: italic; font-weight: bold; }
+.ltx_mathvariant_monospace     { font-family: monospace; }
+/* Can we say anything generic about double-struck, script or fraktur ? */
+.ltx_mathvariant_double-struck { font-weight: bold; }
+.ltx_mathvariant_script        { font-family: "Lucida Calligraphy", "Zapf Chancery","URW Chancery L", cursive; }
+.ltx_mathvariant_bold-script   { font-family: "Lucida Calligraphy", "Zapf Chancery","URW Chancery L", cursive; font-weight: bold; }
+.ltx_mathvariant-fraktur       { }/* ??? */
+.ltx_mathvariant_bold-fraktur  { font-weight: bold; }
+
 /*
 
 .ltx_font_mathscript { ? }

--- a/t/alignment/listing.xml
+++ b/t/alignment/listing.xml
@@ -513,7 +513,7 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
                   <XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
                   <XMTok font="italic" role="UNKNOWN">a</XMTok>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok color="#000000" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok font="italic" fontsize="70%" role="UNKNOWN">i</XMTok>
                     <XMTok font="italic" fontsize="70%" role="UNKNOWN">j</XMTok>
                   </XMApp>
@@ -565,7 +565,7 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
                   <XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
                   <XMTok font="italic" role="UNKNOWN">a</XMTok>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok color="#000000" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok font="italic" fontsize="70%" role="UNKNOWN">i</XMTok>
                     <XMTok font="italic" fontsize="70%" role="UNKNOWN">j</XMTok>
                   </XMApp>
@@ -622,7 +622,7 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
                     <XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
                     <XMTok font="italic" role="UNKNOWN">a</XMTok>
                     <XMApp>
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok color="#000000" meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok font="italic" fontsize="70%" role="UNKNOWN">i</XMTok>
                       <XMTok font="italic" fontsize="70%" role="UNKNOWN">j</XMTok>
                     </XMApp>
@@ -671,7 +671,7 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
                   <XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
                   <XMTok role="UNKNOWN">a</XMTok>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok fontsize="70%" role="UNKNOWN">i</XMTok>
                     <XMTok fontsize="70%" role="UNKNOWN">j</XMTok>
                   </XMApp>

--- a/t/alignment/plainmath.xml
+++ b/t/alignment/plainmath.xml
@@ -54,8 +54,8 @@
               </XMCell>
               <XMCell rowspan="2">
                 <XMWrap depth="6.8pt">
-                  <XMTok depth="6.8pt" font="italic" height="0" role="OPEN" yoffset="-6.8pt">(</XMTok>
-                  <XMTok font="italic" height="6.8pt" yoffset="-6.8pt"> </XMTok>
+                  <XMTok depth="6.8pt" height="0" role="OPEN" yoffset="-6.8pt">(</XMTok>
+                  <XMTok height="6.8pt" yoffset="-6.8pt"> </XMTok>
                 </XMWrap>
               </XMCell>
               <XMCell align="center">
@@ -66,8 +66,8 @@
               </XMCell>
               <XMCell rowspan="2">
                 <XMWrap>
-                  <XMTok depth="6.8pt" font="italic" height="0" role="CLOSE" yoffset="-6.8pt">)</XMTok>
-                  <XMTok font="italic" height="6.8pt" yoffset="-6.8pt"> </XMTok>
+                  <XMTok depth="6.8pt" height="0" role="CLOSE" yoffset="-6.8pt">)</XMTok>
+                  <XMTok height="6.8pt" yoffset="-6.8pt"> </XMTok>
                 </XMWrap>
               </XMCell>
             </XMRow>

--- a/t/babel/numprints.xml
+++ b/t/babel/numprints.xml
@@ -1212,7 +1212,7 @@ vs.
                   <XMDual>
                     <XMTok color="#0000FF" font="italic" meaning="123456.23e1" role="NUMBER">123456.23e1</XMTok>
                     <XMApp color="#0000FF">
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok color="#000000" meaning="times" role="MULOP">⁢</XMTok>
                       <XMText><text align="right" width="68.3pt"><Math mode="inline" tex="\textstyle 123{,}456" text="list@(123, 456)" xml:id="S3.p6.m3.m1">
                             <XMath>
                               <XMDual>
@@ -1317,7 +1317,7 @@ vs.
                   <XMDual>
                     <XMTok color="#0000FF" font="italic" meaning="14561234.562e12" role="NUMBER">14561234.562e12</XMTok>
                     <XMApp color="#0000FF">
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok color="#000000" meaning="times" role="MULOP">⁢</XMTok>
                       <XMText><text align="right" width="68.3pt"><Math mode="inline" tex="\textstyle 14{,}561{,}234" text="list@(14, 561, 234)" xml:id="S3.p6.m6.m1">
                             <XMath>
                               <XMDual>

--- a/t/complex/si.xml
+++ b/t/complex/si.xml
@@ -2877,7 +2877,7 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                       <XMTok lpadding="0pt" meaning="arcminute" role="UNKNOWN">′</XMTok>
                     </XMApp>
                     <XMApp>
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok color="#000000" meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok meaning="6" role="NUMBER">6</XMTok>
                       <XMTok font="italic" width="0pt">.</XMTok>
                       <XMTok lpadding="0pt" meaning="arcsecond" role="UNKNOWN">″</XMTok>

--- a/t/daemon/formats/lexmath.xml
+++ b/t/daemon/formats/lexmath.xml
@@ -32,7 +32,7 @@ Also <math id="p4.m3" class="ltx_Math" alttext="\mathit{func}" display="inline">
 
 <tbody><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
 <td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
-<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo>∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mo lspace="0.170em">⁢</mo><mrow><mo rspace="0em">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mrow><mtext>zero, </mtext><mtext mathvariant="italic">yes 0</mtext></mrow></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo>∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mo lspace="0.170em">⁢</mo><mrow><mo rspace="0em">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mrow><mtext>zero, </mtext><mtext class="ltx_mathvariant_italic" mathvariant="italic">yes 0</mtext></mrow></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
 <td class="ltx_eqn_cell ltx_eqn_center_padright"></td></tr></tbody>
 </table>
 </div>

--- a/t/daemon/formats/lexmath.xml
+++ b/t/daemon/formats/lexmath.xml
@@ -32,7 +32,7 @@ Also <math id="p4.m3" class="ltx_Math" alttext="\mathit{func}" display="inline">
 
 <tbody><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
 <td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
-<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo>∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mo lspace="0.170em">⁢</mo><mrow><mo rspace="0em">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mrow><mtext>zero, </mtext><mtext class="ltx_mathvariant_italic" mathvariant="italic">yes 0</mtext></mrow></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S0.Ex3.m1" class="ltx_Math" alttext="\int_{0}^{\infty}x\,dx=\text{zero, \it yes 0}" display="block"><semantics><mrow><mrow><msubsup><mo>∫</mo><mn>0</mn><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mo lspace="0.170em">⁢</mo><mrow><mo rspace="0em">𝑑</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mrow><mtext>zero, </mtext><mtext class="ltx_mathvariant_italic">yes 0</mtext></mrow></mrow><annotation encoding="application/x-llamapun">∫ start_POSTSUBSCRIPT 0 end_POSTSUBSCRIPT start_POSTSUPERSCRIPT ∞ end_POSTSUPERSCRIPT italic_x italic_d italic_x = zero, italic_yes italic_0</annotation></semantics></math></td>
 <td class="ltx_eqn_cell ltx_eqn_center_padright"></td></tr></tbody>
 </table>
 </div>

--- a/t/fonts/mathcolor.xml
+++ b/t/fonts/mathcolor.xml
@@ -17,7 +17,7 @@
     <p><Math mode="inline" tex="r{\color[rgb]{0,1,0}g\color[rgb]{1,1,0}y}" text="r * g * y" xml:id="p2.m1">
         <XMath>
           <XMApp color="#FF0000">
-            <XMTok meaning="times" role="MULOP">⁢</XMTok>
+            <XMTok color="#000000" meaning="times" role="MULOP">⁢</XMTok>
             <XMTok font="italic" role="UNKNOWN">r</XMTok>
             <XMTok color="#00FF00" font="italic" role="UNKNOWN">g</XMTok>
             <XMTok color="#FFFF00" font="italic" role="UNKNOWN">y</XMTok>
@@ -29,7 +29,7 @@
     <p><text color="#FF0000">R <Math mode="inline" tex="r\mbox{R}{\color[rgb]{0,1,0}g\mbox{G}\color[rgb]{1,1,0}y\mbox{Y}}r\mbox{R}" text="r * [R] * g * [G] * y * [Y] * r * [R]" xml:id="p3.m1">
           <XMath>
             <XMApp>
-              <XMTok meaning="times" role="MULOP">⁢</XMTok>
+              <XMTok color="#000000" meaning="times" role="MULOP">⁢</XMTok>
               <XMTok font="italic" role="UNKNOWN">r</XMTok>
               <XMText>R</XMText>
               <XMTok color="#00FF00" font="italic" role="UNKNOWN">g</XMTok>

--- a/t/math/ambiguous_relations.xml
+++ b/t/math/ambiguous_relations.xml
@@ -9,7 +9,7 @@
       <Math mode="display" tex="x&gt;=0" text="x &gt;= 0" xml:id="S0.Ex1.m1">
         <XMath>
           <XMApp>
-            <XMTok font="italic" meaning="greater-than-or-equals" role="RELOP">&gt;=</XMTok>
+            <XMTok meaning="greater-than-or-equals" role="RELOP">&gt;=</XMTok>
             <XMTok font="italic" role="UNKNOWN">x</XMTok>
             <XMTok meaning="0" role="NUMBER">0</XMTok>
           </XMApp>
@@ -22,7 +22,7 @@
       <Math mode="display" tex="x&lt;=0" text="x &lt;= 0" xml:id="S0.Ex2.m1">
         <XMath>
           <XMApp>
-            <XMTok font="italic" meaning="less-than-or-equals" role="RELOP">&lt;=</XMTok>
+            <XMTok meaning="less-than-or-equals" role="RELOP">&lt;=</XMTok>
             <XMTok font="italic" role="UNKNOWN">x</XMTok>
             <XMTok meaning="0" role="NUMBER">0</XMTok>
           </XMApp>
@@ -48,7 +48,7 @@
               </XMApp>
               <XMTok role="PUNCT">,</XMTok>
               <XMApp xml:id="S0.Ex3.m1.4">
-                <XMTok font="italic" meaning="greater-than-or-equals" role="RELOP">&gt;=</XMTok>
+                <XMTok meaning="greater-than-or-equals" role="RELOP">&gt;=</XMTok>
                 <XMTok font="italic" role="UNKNOWN" xml:id="S0.Ex3.m1.2">y</XMTok>
                 <XMTok meaning="0" role="NUMBER">0</XMTok>
               </XMApp>
@@ -91,7 +91,7 @@
               </XMApp>
               <XMTok role="PUNCT">,</XMTok>
               <XMApp xml:id="S0.Ex5.m1.4">
-                <XMTok font="italic" meaning="greater-than-or-equals" role="RELOP">&gt;=</XMTok>
+                <XMTok meaning="greater-than-or-equals" role="RELOP">&gt;=</XMTok>
                 <XMTok font="italic" role="UNKNOWN" xml:id="S0.Ex5.m1.2">y</XMTok>
                 <XMTok font="italic" role="UNKNOWN">z</XMTok>
               </XMApp>
@@ -122,7 +122,7 @@
       <Math mode="display" tex="a&lt;&lt;b" text="a &lt;&lt; b" xml:id="S0.Ex7.m1">
         <XMath>
           <XMApp>
-            <XMTok font="italic" meaning="much-less-than" role="RELOP">&lt;&lt;</XMTok>
+            <XMTok meaning="much-less-than" role="RELOP">&lt;&lt;</XMTok>
             <XMTok font="italic" role="UNKNOWN">a</XMTok>
             <XMTok font="italic" role="UNKNOWN">b</XMTok>
           </XMApp>
@@ -142,13 +142,13 @@
             </XMApp>
             <XMWrap>
               <XMApp xml:id="S0.Ex8.m1.3">
-                <XMTok font="italic" meaning="much-less-than" role="RELOP">&lt;&lt;</XMTok>
+                <XMTok meaning="much-less-than" role="RELOP">&lt;&lt;</XMTok>
                 <XMTok meaning="0" role="NUMBER">0</XMTok>
                 <XMTok font="italic" role="UNKNOWN" xml:id="S0.Ex8.m1.1">a</XMTok>
               </XMApp>
               <XMTok role="PUNCT">,</XMTok>
               <XMApp xml:id="S0.Ex8.m1.4">
-                <XMTok font="italic" meaning="much-greater-than" role="RELOP">&gt;&gt;</XMTok>
+                <XMTok meaning="much-greater-than" role="RELOP">&gt;&gt;</XMTok>
                 <XMTok font="italic" role="UNKNOWN" xml:id="S0.Ex8.m1.2">b</XMTok>
                 <XMTok meaning="1" role="NUMBER">1</XMTok>
               </XMApp>

--- a/t/math/compact_dual.xml
+++ b/t/math/compact_dual.xml
@@ -32,12 +32,12 @@
             <XMApp>
               <XMTok meaning="derivative-implicit-variable" role="SUPERSCRIPTOP" scriptpos="post1"/>
               <XMTok font="italic" role="UNKNOWN">f</XMTok>
-              <XMTok font="italic" fontsize="70%" meaning="2">′′</XMTok>
+              <XMTok fontsize="70%" meaning="2">′′</XMTok>
             </XMApp>
             <XMApp>
               <XMTok meaning="derivative-implicit-variable" role="SUPERSCRIPTOP" scriptpos="post1"/>
               <XMTok font="italic" role="UNKNOWN">g</XMTok>
-              <XMTok font="italic" fontsize="70%" meaning="3">′′′</XMTok>
+              <XMTok fontsize="70%" meaning="3">′′′</XMTok>
             </XMApp>
           </XMApp>
         </XMath>

--- a/t/math/declare.xml
+++ b/t/math/declare.xml
@@ -928,7 +928,7 @@
               </XMApp>
               <XMWrap>
                 <XMApp xml:id="S6.Ex11.m1.2">
-                  <XMTok decl_id="S6.XMD2" font="italic" name="plus" role="ADDOP">+</XMTok>
+                  <XMTok decl_id="S6.XMD2" name="plus" role="ADDOP">+</XMTok>
                   <XMTok font="italic" role="UNKNOWN">a</XMTok>
                   <XMTok font="italic" role="UNKNOWN">b</XMTok>
                 </XMApp>

--- a/t/theorem/amstheorem.xml
+++ b/t/theorem/amstheorem.xml
@@ -33,7 +33,7 @@ on the Kobayashi metric.</p>
                 <XMApp>
                   <XMTok font="upright" meaning="equals" role="RELOP">=</XMTok>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok role="UNKNOWN">d</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -42,7 +42,7 @@ on the Kobayashi metric.</p>
                     </XMApp>
                   </XMApp>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok role="UNKNOWN">h</XMTok>
                     <XMDual>
                       <XMRef idref="ThmAhlforsx1.p1.m1.1"/>
@@ -62,7 +62,7 @@ on the Kobayashi metric.</p>
                         <XMWrap>
                           <XMTok font="upright" role="OPEN" stretchy="false">|</XMTok>
                           <XMApp xml:id="ThmAhlforsx1.p1.m1.2">
-                            <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                            <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                             <XMTok role="UNKNOWN">d</XMTok>
                             <XMTok role="UNKNOWN">z</XMTok>
                           </XMApp>
@@ -89,7 +89,7 @@ on the Kobayashi metric.</p>
                   <XMTok font="upright" meaning="element-of" name="in" role="RELOP">∈</XMTok>
                   <XMTok role="UNKNOWN">h</XMTok>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
                       <XMTok role="UNKNOWN">C</XMTok>
@@ -178,7 +178,7 @@ then <Math mode="inline" tex="\omega\leq\omega_{r}" text="omega &lt;= omega _ r"
                 <XMApp>
                   <XMTok font="upright" meaning="less-than-or-equals" name="leq" role="RELOP">≤</XMTok>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok role="UNKNOWN">d</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -187,7 +187,7 @@ then <Math mode="inline" tex="\omega\leq\omega_{r}" text="omega &lt;= omega _ r"
                     </XMApp>
                   </XMApp>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok role="UNKNOWN">d</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -224,7 +224,7 @@ then <Math mode="inline" tex="\omega\leq\omega_{r}" text="omega &lt;= omega _ r"
                   <XMWrap>
                     <XMTok font="upright" role="OPEN" stretchy="false">{</XMTok>
                     <XMApp xml:id="S1.Thmthm1.p1.m1.2">
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok role="UNKNOWN">d</XMTok>
                       <XMApp>
                         <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -240,7 +240,7 @@ then <Math mode="inline" tex="\omega\leq\omega_{r}" text="omega &lt;= omega _ r"
                     <XMTok font="upright" name="dots" role="ID" xml:id="S1.Thmthm1.p1.m1.1">…</XMTok>
                     <XMTok font="upright" role="PUNCT">,</XMTok>
                     <XMApp xml:id="S1.Thmthm1.p1.m1.3">
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok role="UNKNOWN">d</XMTok>
                       <XMApp>
                         <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -574,7 +574,7 @@ on the Kobayashi metric.</p>
                 <XMApp>
                   <XMTok font="upright" meaning="equals" role="RELOP">=</XMTok>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok role="UNKNOWN">d</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -583,7 +583,7 @@ on the Kobayashi metric.</p>
                     </XMApp>
                   </XMApp>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok role="UNKNOWN">h</XMTok>
                     <XMDual>
                       <XMRef idref="ThmAhlforsx2.p1.m1.1"/>
@@ -603,7 +603,7 @@ on the Kobayashi metric.</p>
                         <XMWrap>
                           <XMTok font="upright" role="OPEN" stretchy="false">|</XMTok>
                           <XMApp xml:id="ThmAhlforsx2.p1.m1.2">
-                            <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                            <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                             <XMTok role="UNKNOWN">d</XMTok>
                             <XMTok role="UNKNOWN">z</XMTok>
                           </XMApp>
@@ -630,7 +630,7 @@ on the Kobayashi metric.</p>
                   <XMTok font="upright" meaning="element-of" name="in" role="RELOP">∈</XMTok>
                   <XMTok role="UNKNOWN">h</XMTok>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
                       <XMTok role="UNKNOWN">C</XMTok>
@@ -719,7 +719,7 @@ then <Math mode="inline" tex="\omega\leq\omega_{r}" text="omega &lt;= omega _ r"
                 <XMApp>
                   <XMTok font="upright" meaning="less-than-or-equals" name="leq" role="RELOP">≤</XMTok>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok role="UNKNOWN">d</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -728,7 +728,7 @@ then <Math mode="inline" tex="\omega\leq\omega_{r}" text="omega &lt;= omega _ r"
                     </XMApp>
                   </XMApp>
                   <XMApp>
-                    <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                    <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                     <XMTok role="UNKNOWN">d</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -765,7 +765,7 @@ then <Math mode="inline" tex="\omega\leq\omega_{r}" text="omega &lt;= omega _ r"
                   <XMWrap>
                     <XMTok font="upright" role="OPEN" stretchy="false">{</XMTok>
                     <XMApp xml:id="S4.Thmthmsw1.p1.m1.2">
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok role="UNKNOWN">d</XMTok>
                       <XMApp>
                         <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -781,7 +781,7 @@ then <Math mode="inline" tex="\omega\leq\omega_{r}" text="omega &lt;= omega _ r"
                     <XMTok font="upright" name="dots" role="ID" xml:id="S4.Thmthmsw1.p1.m1.1">…</XMTok>
                     <XMTok font="upright" role="PUNCT">,</XMTok>
                     <XMApp xml:id="S4.Thmthmsw1.p1.m1.3">
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok role="UNKNOWN">d</XMTok>
                       <XMApp>
                         <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>

--- a/t/theorem/latextheorem.xml
+++ b/t/theorem/latextheorem.xml
@@ -33,7 +33,7 @@
                   <XMWrap>
                     <XMTok font="upright" role="OPEN" stretchy="false">{</XMTok>
                     <XMApp xml:id="S1.Thmthm1.p1.m1.2">
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok role="UNKNOWN">d</XMTok>
                       <XMApp>
                         <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
@@ -49,7 +49,7 @@
                     <XMTok font="upright" name="dots" role="ID" xml:id="S1.Thmthm1.p1.m1.1">…</XMTok>
                     <XMTok font="upright" role="PUNCT">,</XMTok>
                     <XMApp xml:id="S1.Thmthm1.p1.m1.3">
-                      <XMTok meaning="times" role="MULOP">⁢</XMTok>
+                      <XMTok font="upright" meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok role="UNKNOWN">d</XMTok>
                       <XMApp>
                         <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>


### PR DESCRIPTION

First step, clean up erroneous, missing and/or redundant font declarations which lead to erroneous or redundant mathvariant declarations in the MathML. Typically happens when the appropriate font is not propagated while synthesizing symbols.

Then add classes, like `ltx_mathvariant_italic`, for cases where the mathvariant cannot be handled by remapping the Unicode.

Fixes #2021 
Fixes #2051