### PR TITLE
remove unnecessary pathname_is_nasty check on search paths

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2025,7 +2025,7 @@ sub FindFile_aux {
   # (4) depending on switches we may EXCLUDE .ltxml OR raw tex OR allow both.
   # (5) we may allow interpreting raw TeX/sty/whatever files individually or broadly
   # (6) but we may also want to override an apparently "versioned" file, preferring the ltxml
-  my $paths         = LookupValue('SEARCHPATHS');
+  my $paths         = LookupValue('SEARCHPATHS') // [];
   my $urlbase       = LookupValue('URLBASE');
   my $nopaths       = LookupValue('REMOTE_REQUEST');
   my $ltxml_paths   = $nopaths ? [] : $paths;
@@ -2052,7 +2052,6 @@ sub FindFile_aux {
   # Otherwise, pass on to kpsewhich
   # Depending on flags, maybe search for ltxml in texmf or for plain tex in ours!
   # The main point, though, is to we make only ONE (more) call.
-  return if grep { pathname_is_nasty($_) } @$paths;    # SECURITY! No nasty paths in cmdline
       # Do we need to sanitize these environment variables?
   my @candidates = (((!$options{noltxml} && !$nopaths) ? ("$file.ltxml") : ()),
     (!$options{notex} ? ($file) : ()));


### PR DESCRIPTION
Fix #2293 (and its older duplicate #1864).

The `pathname_is_nasty` check on the `$paths` array is not needed: the paths are inserted into an environment variable, not the command line.