### PR TITLE
allow () paren chars in defensive path check

### DIFF
--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2139,7 +2139,9 @@ sub FindFile_fallback {
 
 sub pathname_is_nasty {
   my ($pathname) = @_;
-  return $pathname =~ /[^\w\-_\+\=\/\\\.~\:\s)(]/; }
+  my $is_nasty = $pathname =~ /([^\w\-_\+\=\/\\\.~\:\s)(])/;
+  Warn('malformed', 'path', undef, "Path may be dangerous due to char '$1' skipping: $pathname") if $is_nasty;
+  return $is_nasty; }
 
 sub maybeReportSearchPaths {
   if (LookupValue('SEARCHPATHS_REPORTED')) {

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2139,7 +2139,7 @@ sub FindFile_fallback {
 
 sub pathname_is_nasty {
   my ($pathname) = @_;
-  return $pathname =~ /[^\w\-_\+\=\/\\\.~\:\s]/; }
+  return $pathname =~ /[^\w\-_\+\=\/\\\.~\:\s)(]/; }
 
 sub maybeReportSearchPaths {
   if (LookupValue('SEARCHPATHS_REPORTED')) {


### PR DESCRIPTION
Fixes #2293 . 

This PR is an alternative - or supplemental - approach to #2294. Here, I still keep the defensive checks as they are, but generally allow the `()` characters to be present. There may be a good case to merge both PRs.

I also started wondering how many other subtle cases may be silently prevented due to the pathname safety check, so I added a warning. Would be curious to see what variations we see in the next arXiv rerun.