### PR TITLE
emulate \DontPrintSemicolon in algorithm2e.sty

### DIFF
--- a/lib/LaTeXML/Package/algorithm2e.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithm2e.sty.ltxml
@@ -77,9 +77,9 @@ for my $env (qw(algorithm2e algorithm algorithm*)) {
       Let('\parbox', '\lx@algo@parbox');
       Let("\\\\",    '\lx@algo@par');
       Let('\strut',  '\lx@algo@strut');
-      AssignCatcode("\r" => CC_SPACE);    # NOT CC_EOL, so newlines don't turn to \par!
-                                          #    AssignCatcode("\r" => 13);
-          #    Let(T_ACTIVE("\r"), '\relax');    # More appropriate than \par, I think?
+      # AssignCatcode("\r" => CC_SPACE);    # NOT CC_EOL, so newlines don't turn to \par!
+      #    AssignCatcode("\r" => 13);
+      #    Let(T_ACTIVE("\r"), '\relax');    # More appropriate than \par, I think?
 
       #    Let('\vtop','\relax');      # ?
       DefMacro('\;', '\ifmmode\@mathsemicolon\else\@endalgoln\fi');
@@ -121,17 +121,19 @@ DefMacro('\algocf@Noline{}', '\lx@algo@endline\lx@algo@startline \@marker{NoL}\l
 
 #DefMacro('\@endalgocfline',  'EOL');
 DefMacro('\algocf@endline', sub {
-    if (LookupValue('algorithm_dont_print_semicolon')) {
-      return (); }
-    else {
-      return (T_OTHER(';')); } }, locked => 1);
+    return LookupValue('algorithm_dont_print_semicolon') ? () : (T_OTHER(';')); },
+  locked => 1);
 #DefMacro('\lx@algo@lastpar', 'PRELASTPAR\the\everypar\lx@algo@@endline');
 #DefMacro('\@endalgoln',  '\@endalgocfline\lx@algo@par');
 DefMacro('\@endalgoln', '\@endalgocfline');
 #DefMacro('\@endalgocfline',  '\algocf@endline\@marker{EOL}\lx@algo@par\let\lx@algo@parx\relax');
 DefMacro('\@endalgocfline', '\algocf@endline\@marker{EOL}\lx@algo@par');
-DefMacro('\PrintSemicolon', sub { AssignValue('algorithm_dont_print_semicolon', 0); return (); }, locked => 1);
-DefMacro('\DontPrintSemicolon', sub { AssignValue('algorithm_dont_print_semicolon', 1); return (); }, locked => 1);
+DefMacro('\PrintSemicolon', sub {
+    AssignValue('algorithm_dont_print_semicolon', 0, 'global');
+    return (); }, locked => 1);
+DefMacro('\DontPrintSemicolon', sub {
+    AssignValue('algorithm_dont_print_semicolon', 1, 'global');
+    return (); }, locked => 1);
 # Annoying: sometimes these are ended by authors \; (which ends the line)
 # sometimes the author omits that.
 # And sometimes the enclosing caller appends a \par afterwards!

--- a/lib/LaTeXML/Package/algorithm2e.sty.ltxml
+++ b/lib/LaTeXML/Package/algorithm2e.sty.ltxml
@@ -120,11 +120,18 @@ DefMacro('\algocf@Vsline{}', '\lx@algo@endline\lx@algo@startline \@marker{VsL}\l
 DefMacro('\algocf@Noline{}', '\lx@algo@endline\lx@algo@startline \@marker{NoL}\lx@algo@advlevel \lx@strippar{#1} \@marker{ENDNoLINE}');
 
 #DefMacro('\@endalgocfline',  'EOL');
+DefMacro('\algocf@endline', sub {
+    if (LookupValue('algorithm_dont_print_semicolon')) {
+      return (); }
+    else {
+      return (T_OTHER(';')); } }, locked => 1);
 #DefMacro('\lx@algo@lastpar', 'PRELASTPAR\the\everypar\lx@algo@@endline');
 #DefMacro('\@endalgoln',  '\@endalgocfline\lx@algo@par');
 DefMacro('\@endalgoln', '\@endalgocfline');
 #DefMacro('\@endalgocfline',  '\algocf@endline\@marker{EOL}\lx@algo@par\let\lx@algo@parx\relax');
 DefMacro('\@endalgocfline', '\algocf@endline\@marker{EOL}\lx@algo@par');
+DefMacro('\PrintSemicolon', sub { AssignValue('algorithm_dont_print_semicolon', 0); return (); }, locked => 1);
+DefMacro('\DontPrintSemicolon', sub { AssignValue('algorithm_dont_print_semicolon', 1); return (); }, locked => 1);
 # Annoying: sometimes these are ended by authors \; (which ends the line)
 # sometimes the author omits that.
 # And sometimes the enclosing caller appends a \par afterwards!


### PR DESCRIPTION
Fixes https://github.com/dginev/ar5iv/issues/423

Since algorithm2e.sty is emulated in Perl, with some very special considerations for the ends of lines, I think this is the best way to also support the `\DontPrintSemicolon` without losing the line endings.

There is probably a possible refactor that relies on the native interpretation more, but that could be deferred...

Running example:
```tex
\documentclass{article}
\usepackage{algorithm2e}
\begin{document}
\begin{algorithm}
\DontPrintSemicolon
line 1

line 2\;
line 3\;
\For{$t = 1, 2, \ldots, T$} {
    line 1\;
    line 2\;
    line 3\;
}
\end{algorithm}
\end{document}
```