### PR TITLE
use Win32::ShellQuote for kpsewhich

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -75,9 +75,11 @@ WriteMakefile(NAME => 'LaTeXML',
     'URI'               => 0,
     'version'           => 0,
     # Windows terminal handling (see Common::Error)
+    # Windows argument escaping (see Util::Pathname)
     ($^O eq 'MSWin32'
       ? ('Win32::Console' => 0,
-        'Win32::Console::ANSI' => 0)
+        'Win32::Console::ANSI' => 0,
+        'Win32::ShellQuote'    => 0)
       : ()),
     # If we have an "old" version of XML::LibXML,
     # we also need XPathContext.

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2015,8 +2015,6 @@ sub FindFile_aux {
       return $file . '.ltxml' if -f ($file . '.ltxml'); }    # No need to search, just check if it exists.
     return $file if -f $file;    # No need to search, just check if it exists.
     return; }                    # otherwise we're never going to find it.
-  elsif (pathname_is_nasty($file)) {    # If it is a nasty filename, we won't touch it.
-    return; }                           # we DO NOT want to pass this to kpathse or such!
 
   # Note that the strategy is complicated by the fact that
   # (1) we prefer .ltxml bindings, if present
@@ -2025,7 +2023,7 @@ sub FindFile_aux {
   # (4) depending on switches we may EXCLUDE .ltxml OR raw tex OR allow both.
   # (5) we may allow interpreting raw TeX/sty/whatever files individually or broadly
   # (6) but we may also want to override an apparently "versioned" file, preferring the ltxml
-  my $paths         = LookupValue('SEARCHPATHS');
+  my $paths         = LookupValue('SEARCHPATHS') // [];
   my $urlbase       = LookupValue('URLBASE');
   my $nopaths       = LookupValue('REMOTE_REQUEST');
   my $ltxml_paths   = $nopaths ? [] : $paths;
@@ -2052,8 +2050,7 @@ sub FindFile_aux {
   # Otherwise, pass on to kpsewhich
   # Depending on flags, maybe search for ltxml in texmf or for plain tex in ours!
   # The main point, though, is to we make only ONE (more) call.
-  return if grep { pathname_is_nasty($_) } @$paths;    # SECURITY! No nasty paths in cmdline
-      # Do we need to sanitize these environment variables?
+  # Do we need to sanitize these environment variables?
   my @candidates = (((!$options{noltxml} && !$nopaths) ? ("$file.ltxml") : ()),
     (!$options{notex} ? ($file) : ()));
   local $ENV{TEXINPUTS} = join($Config::Config{'path_sep'},
@@ -2136,10 +2133,6 @@ sub FindFile_fallback {
         return $path; } } }
   else {
     return; } }
-
-sub pathname_is_nasty {
-  my ($pathname) = @_;
-  return $pathname =~ /[^\w\-_\+\=\/\\\.~\:\s]/; }
 
 sub maybeReportSearchPaths {
   if (LookupValue('SEARCHPATHS_REPORTED')) {


### PR DESCRIPTION
Better fix for #2293: after adding some Windows-specific escaping, kpsewhich can be called with arbitrary file names, even with special characters, and so `pathname_is_nasty` can be removed altogether. This supersedes #2295, #2294.

The `if (open(my $resfh, '-|', ...))` block can definitely be useful elsewhere. In Util::Pathname, there are two backticks left, and there are a few other not-quite-safe system calls in other modules. However, @brucemiller @dginev you should decide if and how to make that happen, e.g. a new Util module maybe?