### PR TITLE
SkipSpaces between two OptionalMatch arguments in \pdfliteral

### DIFF
--- a/lib/LaTeXML/Core/Parameter.pm
+++ b/lib/LaTeXML/Core/Parameter.pm
@@ -95,6 +95,9 @@ sub read {
       "Missing argument " . Stringify($self) . " for " . Stringify($fordefn),
       "Ended at " . ToString($gullet->getLocator));
     $value = T_OTHER('missing'); }
+  elsif ($value && $$self{optional} && $$self{type} =~ /^OptionalMatch/) {
+    # experiment: skip spaces after a successful OptionalMatch read
+    $gullet->skipSpaces; }
   return $value; }
 
 # This is needed by structured parameter types like KeyVals

--- a/lib/LaTeXML/Package/pdfTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/pdfTeX.pool.ltxml
@@ -170,12 +170,12 @@ DefParameterType('OpenAnnotSpecification', sub {
     return; }
   , optional => 1, undigested => 1);
 
-DefPrimitive('\pdfannot OpenAnnotSpecification', undef);
+DefPrimitive('\pdfannot OpenAnnotSpecification', sub { (); });
 
 # \pdfstartlink [ rule spec ] [ attr spec ] action spec (h, m)
-DefPrimitive('\pdfstartlink', undef);
+DefPrimitiveI('\pdfstartlink', undef, sub { (); });
 # \pdfendlink (h, m)
-DefPrimitive('\pdfendlink', undef);
+DefPrimitiveI('\pdfendlink', undef, sub { (); });
 # \pdfoutline outline spec (h, v, m)
 # \pdfdest dest spec (h, v, m)
 # \pdfthread thread spec (h, v, m)
@@ -196,18 +196,18 @@ DefMacro('\pdfmapline{}',                         '');
 # \vadjust [ pre spec ] filler { vertical mode material } (h, m)
 DefMacro('\quitvmode', '');
 # \pdfliteral [ pdfliteral spec ] general text (h, v, m)
-DefPrimitive('\pdfliteral OptionalMatch:direct OptionalMatch:page GeneralText', undef);
+DefPrimitive('\pdfliteral OptionalMatch:direct SkipSpaces OptionalMatch:page GeneralText', sub { (); });
 # \special pdfspecial spec
 # \pdfresettimer
-DefPrimitive('\pdfresettimer',           undef);
-DefPrimitive('\pdfresettimerresettimer', undef);
+DefPrimitive('\pdfresettimer',           sub { (); });
+DefPrimitive('\pdfresettimerresettimer', sub { (); });
 # \pdfsetrandomseed number
 # \pdfnoligatures font
 # \pdfprimitive control sequence
 # TODO: https://tex.stackexchange.com/questions/13771/let-a-control-sequence-to-a-redefined-primitive
 DefMacro('\pdfprimitive DefToken', '#1');    # we can just ignore the advanced effects for now.
 # \pdfcolorstack stack number stack action general text
-DefPrimitive('\pdfcolorstack Number OptionalMatch:set OptionalMatch:push OptionalMatch:pop OptionalMatch:current', sub {
+DefPrimitive('\pdfcolorstack Number OptionalMatch:set SkipSpaces OptionalMatch:push SkipSpaces OptionalMatch:pop SkipSpaces OptionalMatch:current', sub {
     # for now, carefully read and discard all arguments
     my ($stomach, $number, $set, $push, $pop, $current) = @_;
     return if ($pop);

--- a/lib/LaTeXML/Package/pdfTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/pdfTeX.pool.ltxml
@@ -196,7 +196,7 @@ DefMacro('\pdfmapline{}',                         '');
 # \vadjust [ pre spec ] filler { vertical mode material } (h, m)
 DefMacro('\quitvmode', '');
 # \pdfliteral [ pdfliteral spec ] general text (h, v, m)
-DefPrimitive('\pdfliteral OptionalMatch:direct SkipSpaces OptionalMatch:page GeneralText', sub { (); });
+DefPrimitive('\pdfliteral OptionalMatch:direct OptionalMatch:page GeneralText', sub { (); });
 # \special pdfspecial spec
 # \pdfresettimer
 DefPrimitive('\pdfresettimer',           sub { (); });
@@ -207,7 +207,7 @@ DefPrimitive('\pdfresettimerresettimer', sub { (); });
 # TODO: https://tex.stackexchange.com/questions/13771/let-a-control-sequence-to-a-redefined-primitive
 DefMacro('\pdfprimitive DefToken', '#1');    # we can just ignore the advanced effects for now.
 # \pdfcolorstack stack number stack action general text
-DefPrimitive('\pdfcolorstack Number OptionalMatch:set SkipSpaces OptionalMatch:push SkipSpaces OptionalMatch:pop SkipSpaces OptionalMatch:current', sub {
+DefPrimitive('\pdfcolorstack Number OptionalMatch:set OptionalMatch:push OptionalMatch:pop OptionalMatch:current', sub {
     # for now, carefully read and discard all arguments
     my ($stomach, $number, $set, $push, $pop, $current) = @_;
     return if ($pop);


### PR DESCRIPTION
Minimal fix for https://github.com/arXiv/html_feedback/issues/258

The main issue was a need for adding the `SkipSpaces` parameter between two `OptionalMatch:` parameters in `\pdfliteral`, so that the arguments get read in appropriately, and then ignored (for now).

The minimal test snippet is:
```tex
\documentclass{article}
\begin{document}
\pdfliteral direct {2 Tr 0.5 w}%
test%
\pdfliteral direct {0 Tr 0 w}%
\end{document}
```

This kind of pattern would benefit from a test, but I think that can wait until we actually try to emulate some of the directives (e.g. turning `test` bold here).