### PR TITLE
fix URLs for badges in the README

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -2,8 +2,9 @@
 
 =head1 L<LaTeXML|http://dlmf.nist.gov/LaTeXML/>
 
-=for html <a href="https://github.com/brucemiller/LaTeXML/actions?query=workflow%3ACI"><img src="https://github.com/brucemiller/LaTeXML/workflows/CI/badge.svg"></a>
-  <a href="https://raw.githubusercontent.com/brucemiller/LaTeXML/master/LICENSE"><img src="https://camo.githubusercontent.com/60ffad3138b8c6d483ff061480f4bb50f27be37a/687474703a2f2f696d672e736869656c64732e696f2f62616467652f6c6963656e73652d4343302d626c75652e737667" alt="license" data-canonical-src="http://img.shields.io/badge/license-CC0-blue.svg" style="max-width:100%;"></a>
+=for html <a href="https://github.com/brucemiller/LaTeXML/actions?query=workflow%3ALinux"><img src="https://github.com/brucemiller/LaTeXML/workflows/Linux/badge.svg"></a>
+  <a href="https://github.com/brucemiller/LaTeXML/actions?query=workflow%3AWindows"><img src="https://github.com/brucemiller/LaTeXML/workflows/Windows/badge.svg"></a>
+  <a href="https://raw.githubusercontent.com/brucemiller/LaTeXML/master/LICENSE"><img src="http://img.shields.io/badge/license-CC0-blue.svg" alt="license" data-canonical-src="http://img.shields.io/badge/license-CC0-blue.svg" style="max-width:100%;"></a>
   <a href="https://metacpan.org/release/LaTeXML"><img src="https://badge.fury.io/pl/LaTeXML.svg" alt="CPAN version" height="18"></a>
 
 LaTeXML is a TeX & LaTeX to XML, HTML, MathML, ePub, JATS, ... converter.


### PR DESCRIPTION
The badges in the README had URLs that no longer function, minor fixes:
 - our CI workflow is no longer named CI, so we need 2 badges - one for Linux, one for Windows
 - the CC0 license badge can simply point to the official URL, the old one has a "bad signature" today