### PR TITLE
--noinvisibletimes: choose zero-width space over invisible times

### DIFF
--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -36,7 +36,7 @@ my ($format, $extension, $is_html, $urlstyle) = (undef, undef, undef, 'server');
 my ($numbersections) = (1);
 my ($stylesheet, $defaultresources, $icon, @css, @javascript, @xsltparameters);
 my ($mathimagemag) = (1.75);
-my ($linelength, $plane1, $hackplane1, $mathstylize) = (undef, undef, undef, undef);
+my ($linelength, $plane1, $hackplane1, $invisibletimes) = (undef, undef, undef, undef);
 my ($dographics, $svg, $picimages) = (undef, undef, undef);
 my @graphicsmaps = ();
 my ($split, $splitat, $splitpath, $splitnaming) = (undef, 'section', undef, 'id');
@@ -123,7 +123,7 @@ GetOptions("quiet" => sub { $verbosity--; },
   "mathsvg"                     => sub { addMathFormat('svg'); },
   "nomathsvg"                   => sub { removeMathFormat('svg'); },
   "linelength=i"                => \$linelength,
-  "mathstylize=s"               => \$mathstylize,
+  "invisibletimes!"             => \$invisibletimes,
   "plane1!"                     => \$plane1,
   "hackplane1!"                 => \$hackplane1,
   "presentationmathml|pmml"     => sub { addMathFormat('pmml'); },
@@ -473,9 +473,10 @@ sub assemble_postprocessors {
           require LaTeXML::Post::MathML::Presentation;
           push(@mprocs, LaTeXML::Post::MathML::Presentation->new(
               linelength => $linelength,
-              (defined $plane1 ? (plane1      => $plane1)      : (plane1 => 1)),
-              ($hackplane1     ? (hackplane1  => 1)            : ()),
-              ($mathstylize    ? (mathstylize => $mathstylize) : ()),
+              (defined $plane1         ? (plane1         => $plane1) : (plane1 => 1)),
+              ($hackplane1             ? (hackplane1     => 1)       : ()),
+              (defined $invisibletimes ? (invisibletimes => $invisibletimes) :
+                  (invisibletimes => 1)),
               %OPTIONS)); }
         elsif ($fmt eq 'cmml') {
           require LaTeXML::Post::MathML::Content;

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -36,8 +36,8 @@ my ($format, $extension, $is_html, $urlstyle) = (undef, undef, undef, 'server');
 my ($numbersections) = (1);
 my ($stylesheet, $defaultresources, $icon, @css, @javascript, @xsltparameters);
 my ($mathimagemag) = (1.75);
-my ($linelength, $plane1, $hackplane1) = (undef, undef, undef);
-my ($dographics, $svg, $picimages)     = (undef, undef, undef);
+my ($linelength, $plane1, $hackplane1, $mathstylize) = (undef, undef, undef, undef);
+my ($dographics, $svg, $picimages) = (undef, undef, undef);
 my @graphicsmaps = ();
 my ($split, $splitat, $splitpath, $splitnaming) = (undef, 'section', undef, 'id');
 my ($navtoc) = (undef);
@@ -123,6 +123,7 @@ GetOptions("quiet" => sub { $verbosity--; },
   "mathsvg"                     => sub { addMathFormat('svg'); },
   "nomathsvg"                   => sub { removeMathFormat('svg'); },
   "linelength=i"                => \$linelength,
+  "mathstylize=s"               => \$mathstylize,
   "plane1!"                     => \$plane1,
   "hackplane1!"                 => \$hackplane1,
   "presentationmathml|pmml"     => sub { addMathFormat('pmml'); },
@@ -472,8 +473,9 @@ sub assemble_postprocessors {
           require LaTeXML::Post::MathML::Presentation;
           push(@mprocs, LaTeXML::Post::MathML::Presentation->new(
               linelength => $linelength,
-              (defined $plane1 ? (plane1     => $plane1) : (plane1 => 1)),
-              ($hackplane1     ? (hackplane1 => 1)       : ()),
+              (defined $plane1 ? (plane1      => $plane1)      : (plane1 => 1)),
+              ($hackplane1     ? (hackplane1  => 1)            : ()),
+              ($mathstylize    ? (mathstylize => $mathstylize) : ()),
               %OPTIONS)); }
         elsif ($fmt eq 'cmml') {
           require LaTeXML::Post::MathML::Content;

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -506,8 +506,9 @@ sub convert_post {
           require LaTeXML::Post::MathML::Presentation;
           push(@mprocs, LaTeXML::Post::MathML::Presentation->new(
               linelength => $$opts{linelength},
-              (defined $$opts{plane1} ? (plane1     => $$opts{plane1}) : (plane1 => 1)),
-              ($$opts{hackplane1}     ? (hackplane1 => 1)              : ()),
+              (defined $$opts{plane1} ? (plane1      => $$opts{plane1})      : (plane1 => 1)),
+              ($$opts{hackplane1}     ? (hackplane1  => 1)                   : ()),
+              ($$opts{mathstylize}    ? (mathstylize => $$opts{mathstylize}) : ()),
               %PostOPS)); }
         elsif ($fmt eq 'cmml') {
           require LaTeXML::Post::MathML::Content;

--- a/lib/LaTeXML.pm
+++ b/lib/LaTeXML.pm
@@ -506,9 +506,10 @@ sub convert_post {
           require LaTeXML::Post::MathML::Presentation;
           push(@mprocs, LaTeXML::Post::MathML::Presentation->new(
               linelength => $$opts{linelength},
-              (defined $$opts{plane1} ? (plane1      => $$opts{plane1})      : (plane1 => 1)),
-              ($$opts{hackplane1}     ? (hackplane1  => 1)                   : ()),
-              ($$opts{mathstylize}    ? (mathstylize => $$opts{mathstylize}) : ()),
+              (defined $$opts{plane1}         ? (plane1         => $$opts{plane1}) : (plane1 => 1)),
+              ($$opts{hackplane1}             ? (hackplane1     => 1)              : ()),
+              (defined $$opts{invisibletimes} ? (invisibletimes => $$opts{invisibletimes}) :
+                  (invisibletimes => 1)),
               %PostOPS)); }
         elsif ($fmt eq 'cmml') {
           require LaTeXML::Post::MathML::Content;

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -94,7 +94,7 @@ sub getopt_specification {
     # However, IF combining, then will need to support a id/ref mechanism.
     "mathimagemagnification=f"    => \$$opts{mathimagemag},
     "linelength=i"                => \$$opts{linelength},
-    "mathstylize=s"               => \$$opts{mathstylize},
+    "invisibletimes!"             => \$$opts{invisibletimes},
     "plane1!"                     => \$$opts{plane1},
     "hackplane1!"                 => \$$opts{hackplane1},
     "mathimages"                  => sub { addMathFormat($opts, 'images'); },

--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -94,6 +94,7 @@ sub getopt_specification {
     # However, IF combining, then will need to support a id/ref mechanism.
     "mathimagemagnification=f"    => \$$opts{mathimagemag},
     "linelength=i"                => \$$opts{linelength},
+    "mathstylize=s"               => \$$opts{mathstylize},
     "plane1!"                     => \$$opts{plane1},
     "hackplane1!"                 => \$$opts{hackplane1},
     "mathimages"                  => sub { addMathFormat($opts, 'images'); },

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -18,8 +18,8 @@ use LaTeXML::Util::Unicode;
 use LaTeXML::Post;
 use LaTeXML::Common::Font;
 use List::Util qw(max);
-use base       qw(LaTeXML::Post::MathProcessor);
-use base       qw(Exporter);
+use base qw(LaTeXML::Post::MathProcessor);
+use base qw(Exporter);
 our @EXPORT = (
   qw( &DefMathML ),
   qw( &pmml &pmml_scriptsize &pmml_smaller
@@ -710,9 +710,10 @@ sub stylizeContent {
   # For each mathvariant, and for each of those 5 groups, there is a linear mapping,
   # EXCEPT for chars defined before Plain 1, which already exist in lower blocks.
   # Get desired mapping strategy
-  my $plane1     = $$LaTeXML::Post::MATHPROCESSOR{plane1};
-  my $plane1hack = $$LaTeXML::Post::MATHPROCESSOR{hackplane1};
-  my $u_variant  = $variant
+  my $plane1      = $$LaTeXML::Post::MATHPROCESSOR{plane1};
+  my $plane1hack  = $$LaTeXML::Post::MATHPROCESSOR{hackplane1};
+  my $mathstylize = $$LaTeXML::Post::MATHPROCESSOR{mathstylize} || '';
+  my $u_variant   = $variant
     && ($plane1hack ? $plane1hackable{$variant}
     : ($plane1 ? $variant : undef));
   my $u_text = ($tag ne 'm:mtext') && $u_variant && unicode_convert($text, $u_variant);
@@ -749,7 +750,11 @@ sub stylizeContent {
   $size     = undef if $stretchy;                    # Ignore size, if we're stretching.
   my $stretchyhack = undef;
   if ($text =~ /^[\x{2061}\x{2062}\x{2063}]*$/) {    # invisible get no size or stretchiness
-    $stretchy = $size = undef; }
+    $stretchy = $size = undef;
+    # If requested, switch implied mo to space
+    if ($text eq "\x{2062}" and $mathstylize eq 'mo_implied_space') {
+      $text = "\x{200B}";
+  } }
   if ($size) {
     if ($size eq ($LaTeXML::MathML::SIZE || 'text')) {    # If default size, no need to mention.
       $size = undef; }
@@ -1075,7 +1080,7 @@ sub space_walk {
     space_walk($self, $prev);
     while (my $next = shift(@nodes)) {
       my $invisop;    # Save Invisible operators as potential target for (l|r)space
-      if (($$next[0] eq 'm:mo') && $$next[2] && ($$next[2] =~ /^[\x{2061}\x{2062}\x{2063}]*$/)) {
+      if (($$next[0] eq 'm:mo') && $$next[2] && ($$next[2] =~ /^[\x{200B}\x{2061}\x{2062}\x{2063}]*$/)) {
         $invisop = $next;
         $next    = shift(@nodes);
         last unless $next; }

--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -710,10 +710,12 @@ sub stylizeContent {
   # For each mathvariant, and for each of those 5 groups, there is a linear mapping,
   # EXCEPT for chars defined before Plain 1, which already exist in lower blocks.
   # Get desired mapping strategy
-  my $plane1      = $$LaTeXML::Post::MATHPROCESSOR{plane1};
-  my $plane1hack  = $$LaTeXML::Post::MATHPROCESSOR{hackplane1};
-  my $mathstylize = $$LaTeXML::Post::MATHPROCESSOR{mathstylize} || '';
-  my $u_variant   = $variant
+  my $plane1         = $$LaTeXML::Post::MATHPROCESSOR{plane1};
+  my $plane1hack     = $$LaTeXML::Post::MATHPROCESSOR{hackplane1};
+  my $invisibletimes = $$LaTeXML::Post::MATHPROCESSOR{invisibletimes};
+  # just in case, default to "true" (classic behavior), if not specified
+  $invisibletimes = 1 unless defined $invisibletimes;
+  my $u_variant = $variant
     && ($plane1hack ? $plane1hackable{$variant}
     : ($plane1 ? $variant : undef));
   my $u_text = ($tag ne 'm:mtext') && $u_variant && unicode_convert($text, $u_variant);
@@ -752,9 +754,8 @@ sub stylizeContent {
   if ($text =~ /^[\x{2061}\x{2062}\x{2063}]*$/) {    # invisible get no size or stretchiness
     $stretchy = $size = undef;
     # If requested, switch implied mo to space
-    if ($text eq "\x{2062}" and $mathstylize eq 'mo_implied_space') {
-      $text = "\x{200B}";
-  } }
+    if ($text eq "\x{2062}" and not($invisibletimes)) {
+      $text = "\x{200B}"; } }
   if ($size) {
     if ($size eq ($LaTeXML::MathML::SIZE || 'text')) {    # If default size, no need to mention.
       $size = undef; }


### PR DESCRIPTION
Fixes #1941 . At least it allows it to be fixed, via a new option.

Here is a draft following some offline discussions on allowing a customization switch for preferring zero-width space (U+200B) over invisible times (U+2062) in implied `<mo>` elements.

The PR minimally touches up the character in post-processing, via the `MathML::stylizeContent` sub.

An easy test is:
```
$ latexmlc 'literal:2x' --whatsin=math --dest=test.html \
  --noinvisibletimes
```

I have exposed the option in latexmlpost and latexmlc. But not yet in latexmlmath (maybe later).