### PR TITLE
Set lspace and rspace for zero-wdith space mo 

### DIFF
--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -755,6 +755,8 @@ sub stylizeContent {
     $stretchy = $size = undef;
     # If requested, switch implied mo to space
     if ($text eq "\x{2062}" and not($invisibletimes)) {
+      # and set lspace/rspace to 0 until we have browser interop.
+      $props{lspace} = $props{rspace} = $props{force_lspace} = $props{force_rspace} = '0em';
       $text = "\x{200B}"; } }
   if ($size) {
     if ($size eq ($LaTeXML::MathML::SIZE || 'text')) {    # If default size, no need to mention.
@@ -801,6 +803,9 @@ sub stylizeContent {
     # Store spacing for later spacing resolution
     (defined $props{lspace} ? (_lspace => $props{lspace}) : ()),
     (defined $props{rspace} ? (_rspace => $props{rspace}) : ()),
+    # explicitly set for zero-width space, until we get browser interop
+    (defined $props{force_lspace} ? (lspace => $props{force_lspace}) : ()),
+    (defined $props{force_rspace} ? (rspace => $props{force_rspace}) : ()),
   ); }
 
 # Generally, $item in the following ought to be a string.


### PR DESCRIPTION
A bit of an unfortunate follow-up to #2303 , based on observing that we get the default `0.27...em` spacing for any zero-width Unicode chars not yet in the MathML operator dictionary.

See the [discussion in mathml-core](https://github.com/w3c/mathml-core/issues/209#issuecomment-1924012036) for more details, as well as [an example codepen](https://codepen.io/dginev/pen/zYbjGNj).

Setting the lspace/rspace attributes explicitly feels like we are reverse-patching the defaults, but without the rendering looking normal, it seems that it causes more harm than good to switch away from invisible times.