### PR TITLE
use U+2217 for multiplication asterisk

### DIFF
--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -4806,12 +4806,12 @@ DefMathI('+', undef, '+', role => 'ADDOP', meaning => 'plus');
 DefMathI('-', undef, '-', role => 'ADDOP', meaning => 'minus');
 ## Redefine, if we want Unicode minus
 ##DefMathI('-', undef, "\x{2212}", role => 'ADDOP',   meaning  => 'minus');
-DefMathI('*', undef, '*', role => 'MULOP',   meaning => 'times');
-DefMathI('/', undef, '/', role => 'MULOP',   meaning => 'divide');
-DefMathI('!', undef, '!', role => 'POSTFIX', meaning => 'factorial');
-DefMathI(',', undef, ',', role => 'PUNCT');
-DefMathI('.', undef, '.', role => 'PERIOD');
-DefMathI(';', undef, ';', role => 'PUNCT');
+DefMathI('*', undef, "\x{2217}", role => 'MULOP',   meaning => 'times');
+DefMathI('/', undef, '/',        role => 'MULOP',   meaning => 'divide');
+DefMathI('!', undef, '!',        role => 'POSTFIX', meaning => 'factorial');
+DefMathI(',', undef, ',',        role => 'PUNCT');
+DefMathI('.', undef, '.',        role => 'PERIOD');
+DefMathI(';', undef, ';',        role => 'PUNCT');
 DefMathI('(', undef, '(', role => 'OPEN',      stretchy => 'false');
 DefMathI(')', undef, ')', role => 'CLOSE',     stretchy => 'false');
 DefMathI('[', undef, '[', role => 'OPEN',      stretchy => 'false');

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -6464,7 +6464,7 @@ Then a switch of tag forms.</p>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
                       <XMTok font="italic" role="UNKNOWN">y</XMTok>
-                      <XMTok fontsize="70%" meaning="times" role="MULOP">*</XMTok>
+                      <XMTok fontsize="70%" meaning="times" role="MULOP">∗</XMTok>
                     </XMApp>
                   </XMApp>
                 </XMApp>
@@ -6487,7 +6487,7 @@ Then a switch of tag forms.</p>
                         <XMApp>
                           <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
                           <XMTok font="italic" role="UNKNOWN">y</XMTok>
-                          <XMTok fontsize="70%" meaning="times" role="MULOP">*</XMTok>
+                          <XMTok fontsize="70%" meaning="times" role="MULOP">∗</XMTok>
                         </XMApp>
                       </XMApp>
                     </XMApp>
@@ -7120,7 +7120,7 @@ Then a switch of tag forms.</p>
     <title><tag close=" ">11</tag>Stepped lines</title>
     <para xml:id="S11.p1">
       <equation xml:id="S11.Ex81">
-        <Math class="ltx_math_unparsed" mode="display" tex="\begin{gathered}x=1,\quad x+1=2\\&#10;y=2\end{gathered}" text="[1*  ]@x@=@1@,@quad@x@+@1@=@2@[ over]@[2*  ]@y@=@2@[ over]" xml:id="S11.Ex81.m1">
+        <Math class="ltx_math_unparsed" mode="display" tex="\begin{gathered}x=1,\quad x+1=2\\&#10;y=2\end{gathered}" text="[1∗  ]@x@=@1@,@quad@x@+@1@=@2@[ over]@[2∗  ]@y@=@2@[ over]" xml:id="S11.Ex81.m1">
           <XMath>
             <XMDual>
               <XMWrap rule="Anything,">
@@ -7152,7 +7152,7 @@ Then a switch of tag forms.</p>
                           <XMTok meaning="times" role="MULOP">⁢</XMTok>
                           <XMText xml:id="S11.Ex81.m1.1"><text width="0.0pt">1</text><Math mode="inline" tex="*" text="*" xml:id="S11.Ex81.m1.m1">
                               <XMath>
-                                <XMTok meaning="times" role="MULOP">*</XMTok>
+                                <XMTok meaning="times" role="MULOP">∗</XMTok>
                               </XMath>
                             </Math>  </XMText>
                           <XMTok font="italic" role="UNKNOWN" xml:id="S11.Ex81.m1.2">x</XMTok>
@@ -7184,7 +7184,7 @@ Then a switch of tag forms.</p>
                         <XMTok meaning="times" role="MULOP">⁢</XMTok>
                         <XMText xml:id="S11.Ex81.m1.12"><text width="0.0pt">2</text><Math mode="inline" tex="*" text="*" xml:id="S11.Ex81.m1.m2">
                             <XMath>
-                              <XMTok meaning="times" role="MULOP">*</XMTok>
+                              <XMTok meaning="times" role="MULOP">∗</XMTok>
                             </XMath>
                           </Math>  </XMText>
                         <XMTok font="italic" role="UNKNOWN" xml:id="S11.Ex81.m1.13">y</XMTok>

--- a/t/babel/numprints.xml
+++ b/t/babel/numprints.xml
@@ -479,7 +479,7 @@ vs.
             </XMath>
           </Math><text class="ltx_number">-123,456</text>; <text class="ltx_number">3.141,592,7<Math mode="inline" tex="{}*{}" text="*" xml:id="S2.SS0.SSS0.Px8.p2.m2">
               <XMath>
-                <XMTok meaning="times" role="MULOP">*</XMTok>
+                <XMTok meaning="times" role="MULOP">∗</XMTok>
               </XMath>
             </Math>10<sup>-32</sup></text></p>
       </para>

--- a/t/fonts/abxtest.xml
+++ b/t/fonts/abxtest.xml
@@ -102,7 +102,7 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="*" text="*" xml:id="S0.SS0.SSS0.Px2.p2.m7">
                 <XMath>
-                  <XMTok meaning="times" role="MULOP">*</XMTok>
+                  <XMTok meaning="times" role="MULOP">∗</XMTok>
                 </XMath>
               </Math></td>
             <td align="left"><text font="typewriter">*</text></td>

--- a/t/parse/compose.xml
+++ b/t/parse/compose.xml
@@ -23,7 +23,7 @@
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">(</XMTok>
                   <XMApp xml:id="S1.Ex1.m1.2">
-                    <XMTok meaning="compose" role="COMPOSEOP">*</XMTok>
+                    <XMTok meaning="compose" role="COMPOSEOP">∗</XMTok>
                     <XMTok font="italic" role="FUNCTION">f</XMTok>
                     <XMTok font="italic" role="FUNCTION">g</XMTok>
                   </XMApp>
@@ -52,9 +52,9 @@
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">(</XMTok>
                   <XMApp xml:id="S1.Ex2.m1.2">
-                    <XMTok meaning="compose" role="COMPOSEOP">*</XMTok>
+                    <XMTok meaning="compose" role="COMPOSEOP">∗</XMTok>
                     <XMApp>
-                      <XMTok meaning="compose" role="COMPOSEOP">*</XMTok>
+                      <XMTok meaning="compose" role="COMPOSEOP">∗</XMTok>
                       <XMTok font="italic" role="FUNCTION">f</XMTok>
                       <XMTok font="italic" role="FUNCTION">g</XMTok>
                     </XMApp>
@@ -95,7 +95,7 @@
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">(</XMTok>
                   <XMApp xml:id="S2.Ex3.m1.2">
-                    <XMTok meaning="compose" role="COMPOSEOP">*</XMTok>
+                    <XMTok meaning="compose" role="COMPOSEOP">∗</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
                       <XMTok font="italic" role="ID">y</XMTok>
@@ -128,7 +128,7 @@
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">(</XMTok>
                   <XMApp xml:id="S2.Ex4.m1.2">
-                    <XMTok meaning="compose" role="COMPOSEOP">*</XMTok>
+                    <XMTok meaning="compose" role="COMPOSEOP">∗</XMTok>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok font="italic" role="ID">y</XMTok>
@@ -165,7 +165,7 @@
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">(</XMTok>
                   <XMApp xml:id="S2.Ex5.m1.2">
-                    <XMTok meaning="compose" role="COMPOSEOP">*</XMTok>
+                    <XMTok meaning="compose" role="COMPOSEOP">∗</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
                       <XMTok font="italic" role="ID">y</XMTok>
@@ -198,7 +198,7 @@
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">(</XMTok>
                   <XMApp xml:id="S2.Ex6.m1.2">
-                    <XMTok meaning="compose" role="COMPOSEOP">*</XMTok>
+                    <XMTok meaning="compose" role="COMPOSEOP">∗</XMTok>
                     <XMTok font="italic" role="FUNCTION">f</XMTok>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>


### PR DESCRIPTION
Fix #2318 the 'right way' by patching the existing `DefMathI` call.