### PR TITLE
consistent ifthen.sty dependence in bindings

### DIFF
--- a/lib/LaTeXML/Package/hyperxmp.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperxmp.sty.ltxml
@@ -15,6 +15,8 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+RequirePackage('ifthen');
+
 # Basically, the effects of hyperxmp are already built
 # into the LaTeXML binding for hyperref.
 

--- a/lib/LaTeXML/Package/nicefrac.sty.ltxml
+++ b/lib/LaTeXML/Package/nicefrac.sty.ltxml
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
-#RequirePackage('ifthen');
+RequirePackage('ifthen');
 
 # Handy for cases where macros want to use math, but track the current text font
 # (examples, nicefrac, units...)

--- a/lib/LaTeXML/Package/ntheorem.sty.ltxml
+++ b/lib/LaTeXML/Package/ntheorem.sty.ltxml
@@ -21,6 +21,7 @@ use LaTeXML::Package;
 #   endmarks
 #   list of theorem (which should actually be covered in some postprocessor?)
 RequirePackage('amsthm');
+RequirePackage('ifthen');
 # but re-redefine from amsthm from LaTeX; use save note font as head font
 DefRegister('\thm@notefont' => Tokens(T_CS('\the'), T_CS('\thm@headfont')));
 

--- a/lib/LaTeXML/Package/pdfpages.sty.ltxml
+++ b/lib/LaTeXML/Package/pdfpages.sty.ltxml
@@ -15,6 +15,11 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+RequirePackage('ifthen');
+RequirePackage('calc');
+RequirePackage('eso-pic');
+RequirePackage('graphicx');
+
 #================================================================================
 # Includes a pdf into the output, possibly a subset of pages from the pdf.
 # Two options here

--- a/lib/LaTeXML/Package/rotating.sty.ltxml
+++ b/lib/LaTeXML/Package/rotating.sty.ltxml
@@ -24,9 +24,8 @@ ProcessOptions();
 # counterclockwise clockwise anticlockwise
 #  DeclareOption($option,undef); }
 
-# expected...
 RequirePackage('graphicx');
-#RequirePackage('ifthen');
+RequirePackage('ifthen');
 
 DefRegister('\rotFPtop' => Dimension('0pt'));
 DefRegister('\rotFPbot' => Dimension('0pt'));

--- a/lib/LaTeXML/Package/sidecap.sty.ltxml
+++ b/lib/LaTeXML/Package/sidecap.sty.ltxml
@@ -15,15 +15,17 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+RequirePackage('ifthen');
+
 #======================================================================
 # First draft stub;
 # ignore sidecaption-ness and just make a regular table/figure
-DefMacro('\SCtable[][]', '\table[#2]');
-DefMacro('\endSCtable',  '\endtable');
-DefMacro('\csname SCtable*\endcsname[][]', '\csname table*\endcsname[#2]');
-DefMacro('\csname endSCtable*\endcsname',  '\csname endtable*\endcsname');
-DefMacro('\SCfigure[][]', '\figure[#2]');
-DefMacro('\endSCfigure',  '\endfigure');
+DefMacro('\SCtable[][]',                    '\table[#2]');
+DefMacro('\endSCtable',                     '\endtable');
+DefMacro('\csname SCtable*\endcsname[][]',  '\csname table*\endcsname[#2]');
+DefMacro('\csname endSCtable*\endcsname',   '\csname endtable*\endcsname');
+DefMacro('\SCfigure[][]',                   '\figure[#2]');
+DefMacro('\endSCfigure',                    '\endfigure');
 DefMacro('\csname SCfigure*\endcsname[][]', '\csname figure*\endcsname[#2]');
 DefMacro('\csname endSCfigure*\endcsname',  '\csname endfigure*\endcsname');
 

--- a/lib/LaTeXML/Package/srcltx.sty.ltxml
+++ b/lib/LaTeXML/Package/srcltx.sty.ltxml
@@ -14,6 +14,7 @@ package LaTeXML::Package::Pool;
 use strict;
 use warnings;
 use LaTeXML::Package;
+RequirePackage('ifthen');
 
 #======================================================================
 DefMacro('\Input{}',          '\input{#1}');
@@ -24,4 +25,3 @@ DefMacro('\srcInputHook{}',   '');
 DefConditional('\ifSRCOK');
 #======================================================================
 1;
-


### PR DESCRIPTION
I was burning the midnight oil listening to interesting talks...

And happened to walk through the [error:undefined:\ifthenelse](https://corpora.mathweb.org/corpus/arxmliv/tex_to_html/error/undefined/%5Cifthenelse) CorTeX reports. Then I noticed that a number of the articles should have already had the macro supported.

It turns out that some of our bindings should have required `ifthen.sty`, as their raw `.sty` counterparts do - but didn't, since the Perl side never needed the dependency. However, in arXiv, some authors rely on these transitive dependencies being in place and don't load `ifthen` directly. So for their sake, here is a simple PR adding them in.