### PR TITLE
subfiles.sty redefines only secondary {document} uses

### DIFF
--- a/lib/LaTeXML/Package/subfiles.sty.ltxml
+++ b/lib/LaTeXML/Package/subfiles.sty.ltxml
@@ -16,12 +16,14 @@ use warnings;
 use LaTeXML::Package;
 
 #======================================================================
-# Redefine \documentclass to do nothring
+# Redefine \documentclass to do nothing
 DefMacro('\documentclass OptionalSemiverbatim SkipSpaces Semiverbatim []', undef);
-# And {document} environment likewise
-DefEnvironment('{document}', "#body", beforeDigest => sub {
-    AssignValue(inPreamble => 0);
-    return; });
+# And {document} environment likewise, but only after the main document starts.
+AtBeginDocument(sub {
+    DefEnvironment('{document}', "#body", beforeDigest => sub {
+        AssignValue(inPreamble => 0);
+        return; });
+});
 # Define \subfiles to be \input
 Let('\subfile', '\input');
 


### PR DESCRIPTION
Fixes #2323

Our subfiles.sty binding is a little brave/simple and it only goes so far. To fix the reported issue, I think the key bit was processing the main/outer `{document}` as usual, while only redefining the environment on secondary uses (in the dependent files).

So I deferred the redefinition, allowing the reported example to work as expected. An even nicer test is to move the algorithm to a standalone file and use a main.tex:
```tex
\documentclass{article}

\usepackage{subfiles}
\usepackage[ruled]{algorithm2e}

\begin{document}
\subfile{alg}
\subfile{alg}
\subfile{alg}
\end{document}
```

which is a little closer to the package intention.