### PR TITLE
tikz-related update to jheppub.sty.ltxml 

### DIFF
--- a/lib/LaTeXML/Package/jheppub.sty.ltxml
+++ b/lib/LaTeXML/Package/jheppub.sty.ltxml
@@ -20,14 +20,20 @@ use warnings;
 use LaTeXML::Package;
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-RequirePackage('hyperref');
-RequirePackage('color');
-RequirePackage('natbib');
 RequirePackage('amsmath');
 RequirePackage('amssymb');
+RequirePackage('amsthm');
+# RequirePackage('aliascnt');
 RequirePackage('epsfig');
 RequirePackage('graphicx');
+PassOptions('natbib', 'sty', 'numbers', 'compress');
+RequirePackage('natbib');
+RequirePackage('xcolor');
+RequirePackage('hyperref');
 RequirePackage('inst_support');
+RequirePackage('tikz');
+RequirePackage('tikz-cd');
+
 # \author[]{}
 DefMacro('\author[]{}',
   '\ifx.#1.\else\@institutemark{#1}\fi'
@@ -107,6 +113,8 @@ DefMacro('\subheader{}',         '');
 DefMacro('\xtumfont{}',          '\textsc{#1}');
 Let('\oldthebibliography',    '\thebibliography');
 Let('\endoldthebibliography', '\endthebibliography');
+DefMacro('\@fpheader', '');
+DefMacro('\@journal',  'jhep');
 
 #======================================================================
 1;


### PR DESCRIPTION
This PR originates from testing #2325 . It can be merged as a follow-up.

The jheppub.sty.ltxml binding was a little outdated. I noticed a case where `tikz-cd.sty` wasn't loading despite having fresh latexml support (arXiv:2112.10658).

As it turns out, `jheppub.sty` now has that as a dependency, as well as a handful of others. Added here.