### PR TITLE
avoid unexpected division by zero in image transform

### DIFF
--- a/lib/LaTeXML/Package/epsf.sty.ltxml
+++ b/lib/LaTeXML/Package/epsf.sty.ltxml
@@ -48,7 +48,7 @@ DefConstructor('\epsfbox[] Semiverbatim',
   properties => sub {
     my ($document, $bb, $graphic) = @_;
     my $clip    = LookupValue('epsf_clip');
-    my $options = ($clip ? ($bb ? "viewport=$bb, clip" : "clip") : '');
+    my $options = ($clip ? ($bb ? "viewport=" . ToString($bb) . ", clip" : "clip") : '');
     my ($file, @candidates) = image_candidates(ToString($graphic));
     my $w = LookupRegister('\epsfxsize');
     my $h = LookupRegister('\epsfysize');

--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -222,6 +222,7 @@ sub image_graphicx_size {
     elsif ($op eq 'scale-to') {
       # $a1 => width (pts), $a2 => height (pts), $a3 => preserve aspect ratio.
       if ($a3) {             # If keeping aspect ratio, ignore the most extreme request
+        return unless $w && $h;
         if ($a1 / $w < $a2 / $h) { $a2 = $h * $a1 / $w; }
         else                     { $a1 = $w * $a2 / $h; } }
       ($w, $h) = (ceil($a1 * $dppt), ceil($a2 * $dppt)); }


### PR DESCRIPTION
Fixes an unfortunate Fatal in arXiv:0710.5511

It is also curious to note that some diagnostic "die" messages from perl in post-processing go unnoticed in the arXiv build logs, as they do not use the latexml error-reporting API. So this paper was in the "no_messages" category. As in:

```
Illegal division by zero at /home/deyan/perl5/lib/perl5/LaTeXML/Util/Image.pm line 225.
Status:conversion:3
```

I also tracked down the underlying reason for the bug, which was a malformed `viewport` option - there was a missing `ToString` for serializing the optional argument of `\epsfbox` from `epsf.sty.ltxml`. I also noticed this macro is used in `epsfig.sty.ltxml`, but decided not to touch that in this PR.