### PR TITLE
Adopt a more consistent naming convention for latexml-specific contro…

### DIFF
--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -21,8 +21,8 @@ use LaTeXML::Common::XML;
 use LaTeXML::Common::Dimension;
 use LaTeXML::Core::Alignment::Template;
 use List::Util qw(max sum);
-use base qw(LaTeXML::Core::Whatsit);
-use base qw(Exporter);
+use base       qw(LaTeXML::Core::Whatsit);
+use base       qw(Exporter);
 our @EXPORT = (qw(
     &ReadAlignmentTemplate &MatrixTemplate));
 
@@ -36,7 +36,7 @@ our @EXPORT = (qw(
 #
 # An Alignment object is a sort of fake Whatsit;
 # It takes some magic to sneak it into the Digestion stream
-# (see TeX.pool \@start@alignment), but it needs to be created
+# (see TeX.pool \lx@begin@alignment), but it needs to be created
 # BEFORE the contents of the alignment are digested,
 # since we stuff a lot of information into it
 # (row, column boxes, borders, spacing, etc...)
@@ -196,7 +196,7 @@ sub getColumnBefore {
   my ($self) = @_;
   my $column;
   if (($column = $self->currentColumn) && !$$column{omitted}) {
-    return Tokens(T_CS('\@column@before'), @{ $$column{before} }); }
+    return Tokens(T_CS('\lx@alignment@column@before'), @{ $$column{before} }); }
   else {
     return Tokens(); } }
 
@@ -204,7 +204,7 @@ sub getColumnAfter {
   my ($self) = @_;
   my $column;
   if (($column = $self->currentColumn) && !$$column{omitted}) {
-    return Tokens(@{ $$column{after} }, T_CS('\@column@after')); }
+    return Tokens(@{ $$column{after} }, T_CS('\lx@alignment@column@after')); }
   else {
     return Tokens(); } }
 
@@ -219,7 +219,7 @@ sub startRow {
   if ($pseudorow) {
     $self->currentRow->{pseudorow} = 1; }
   else {
-    push(@LaTeXML::LIST, $stomach->digest(T_CS('\@row@before'))); }
+    push(@LaTeXML::LIST, $stomach->digest(T_CS('\lx@alignment@row@before'))); }
   $$self{in_row} = 1;
   $STATE->assignValue(alignmentStartColumn => 0);    # ???
   return; }
@@ -229,7 +229,7 @@ sub endRow {
   return unless $$self{in_row};
   $self->endColumn() if $$self{in_column};
   $STATE->getStomach->egroup;                        # Grouping around ROW!
-                                                     #  Digest(T_CS('\@row@after'));
+                                                     #  Digest(T_CS('\lx@alignment@row@after'));
   $$self{in_row} = undef;
   return; }
 

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -225,14 +225,14 @@ sub handleTemplate {
   local $LaTeXML::CURRENT_TOKEN = $token;
   my $post = $alignment->getColumnAfter;
   $LaTeXML::ALIGN_STATE = 1000000;
-  ### NOTE: Truly fishy smuggling w/ \hidden@cr
+  ### NOTE: Truly fishy smuggling w/ \lx@hidden@cr
   my $arg;
-  if (($type eq 'cr') && $hidden) {    # \hidden@cr gets an argument as payload!!!!!
+  if (($type eq 'cr') && $hidden) {    # \lx@hidden@cr gets an argument as payload!!!!!
     $arg = readArg($self); }
   Debug("Halign $alignment: column after " . ToString($post)) if $LaTeXML::DEBUG{halign};
   if ((($type eq 'cr') || ($type eq 'crcr'))
     && $$alignment{in_row} && !$alignment->currentRow->{pseudorow}) {
-    unshift(@{ $$self{pushback} }, T_CS('\@row@after')); }
+    unshift(@{ $$self{pushback} }, T_CS('\lx@alignment@row@after')); }
   if ($arg) {
     unshift(@{ $$self{pushback} }, T_BEGIN, $arg->unlist, T_END); }
   unshift(@{ $$self{pushback} }, $token);
@@ -241,12 +241,12 @@ sub handleTemplate {
 
 # If it is a column ending token, Returns the token, a keyword and whether it is "hidden"
 our @column_ends = (    # besides T_ALIGN
-  [T_CS('\cr'),           'cr',     0],
-  [T_CS('\crcr'),         'crcr',   0],
-  [T_CS('\hidden@cr'),    'cr',     1],
-  [T_CS('\hidden@crcr'),  'crcr',   1],
-  [T_CS('\hidden@align'), 'insert', 1],
-  [T_CS('\span'),         'span',   0]);
+  [T_CS('\cr'),              'cr',     0],
+  [T_CS('\crcr'),            'crcr',   0],
+  [T_CS('\lx@hidden@cr'),    'cr',     1],
+  [T_CS('\lx@hidden@crcr'),  'crcr',   1],
+  [T_CS('\lx@hidden@align'), 'insert', 1],
+  [T_CS('\span'),            'span',   0]);
 
 sub isColumnEnd {
   my ($self, $token) = @_;

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -98,8 +98,8 @@ sub digestNextBody {
 
   while (defined($token = $$self{gullet}->getPendingComment || $$self{gullet}->readXToken(1))) {
     if ($alignment && scalar(@LaTeXML::LIST) && (Equals($token, T_ALIGN) ||
-        Equals($token, T_CS('\cr')) || Equals($token, T_CS('\hidden@cr')) ||
-        Equals($token, T_CS('\hidden@crcr')))) {
+        Equals($token, T_CS('\cr')) || Equals($token, T_CS('\lx@hidden@cr')) ||
+        Equals($token, T_CS('\lx@hidden@crcr')))) {
       # at least \over calls in here without the intent to passing through the alignment.
       # So if we already have some digested boxes available, return them here.
       $$self{gullet}->unread($token);

--- a/lib/LaTeXML/Engine/Base_Deprecated.pool.ltxml
+++ b/lib/LaTeXML/Engine/Base_Deprecated.pool.ltxml
@@ -33,11 +33,121 @@ DefMacro('\lx@DEPRECATE{}{}', \&Deprecate);
 DefMacro('\@ERROR',
   '\lx@DEPRECATE{\@ERROR}{\lx@ERROR}\lx@ERROR');
 
+DefMacro('\@@eqno',
+  '\lx@DEPRECATE{\@@eqno}{\lx@eqno}\lx@eqno');
+
+DefMacro('\LTX@nonumber',
+  '\lx@DEPRECATE{\LTX@nonumber}{\lx@equation@nonumber}\lx@equation@nonumber');
+
 DefMacro('\normal@par',
   '\lx@DEPRECATE{\normnal@par}{\lx@normal@par}\lx@normal@par');
 DefMacro('\inner@par',
   '\lx@DEPRECATE{\inner@par}{\lx@normal@par}\lx@normal@par');    # Obsolete, but in case still used...
 
+DefMacro('\hidden@bgroup',
+  '\lx@DEPRECATE{\hidden@bgroup}{\lx@hidden@bgroup}\lx@hidden@bgroup');
+DefMacro('\hidden@egroup',
+  '\lx@DEPRECATE{\hidden@egroup}{\lx@hidden@egroup}\lx@hidden@egroup');
+DefMacro('\right@hidden@egroup',
+  '\lx@DEPRECATE{\right@hidden@egroup}{\lx@hidden@egroup@right}\lx@hidden@egroup@right');
+
+DefMacro('\hidden@align',
+  '\lx@DEPRECATE{\hidden@align}{\lx@hidden@align}\lx@hidden@align');
+DefMacro('\hidden@noalign',
+  '\lx@DEPRECATE{\hidden@noalign}{\lx@hidden@noalign}\lx@hidden@noalign');
+DefMacro('\hidden@cr',
+  '\lx@DEPRECATE{\hidden@cr}{\lx@hidden@cr}\lx@hidden@cr');
+DefMacro('\hidden@crc',
+  '\lx@DEPRECATE{\hidden@crcr}{\lx@hidden@crcr}\lx@hidden@crcr');
+
+DefMacro('\@start@alignment',
+  '\lx@DEPRECATE{\@start@alignment}{\lx@start@alignment}\lx@start@alignment');
+DefMacro('\@finish@alignment',
+  '\lx@DEPRECATE{\@finish@alignment}{\lx@finish@alignment}\lx@finish@alignment');
+DefMacro('\@close@alignment',
+  '\lx@DEPRECATE{\@close@alignment}{\lx@close@alignment}\lx@close@alignment');
+DefMacro('\if@in@alignment',
+  '\lx@DEPRECATE{\if@in@alignment}{\if@in@lx@alignment}\if@in@lx@alignment ');
+
+DefMacro('\@alignment@hline',
+  '\lx@DEPRECATE{\@alignment@hline}{\lx@alignment@hline}\lx@alignment@hline');
+DefMacro('\@alignment@newline',
+  '\lx@DEPRECATE{\@alignment@newline}{\lx@alignment@newline}\lx@alignment@newline');
+DefMacro('\@alignment@newline@noskip',
+'\lx@DEPRECATE{\@alignment@newline@noskip}{\lx@alignment@newline@noskip}\lx@alignment@newline@noskip');
+DefMacro('\@alignment@newline@marker',
+'\lx@DEPRECATE{\@alignment@newline@marker}{\lx@alignment@newline@marker}\lx@alignment@newline@marker');
+DefMacro('\@alignment@newline@markertall',
+'\lx@DEPRECATE{\@alignment@newline@markertall}{\lx@alignment@newline@markertall}\lx@alignment@newline@markertall');
+DefMacro('\@alignment@column',
+  '\lx@DEPRECATE{\@alignment@column}{\lx@alignment@column}\lx@alignment@column');
+DefMacro('\@alignment@ncolumns',
+  '\lx@DEPRECATE{\@alignment@ncolumns}{\lx@alignment@ncolumns}\lx@alignment@ncolumns');
+DefMacro('\@alignment@bindings',
+  '\lx@DEPRECATE{\@alignment@bindings}{\lx@alignment@bindings}\lx@alignment@bindings');
+
+DefMacro('\@row@before',
+  '\lx@DEPRECATE{\@row@before}{\lx@alignment@row@before}\lx@alignment@row@before');
+DefMacro('\@row@after',
+  '\lx@DEPRECATE{\@row@after}{\lx@alignment@row@after}\lx@alignment@row@after');
+DefMacro('\@column@before',
+  '\lx@DEPRECATE{\@column@before}{\lx@alignment@column@before}\lx@alignment@column@before');
+DefMacro('\@column@after',
+  '\lx@DEPRECATE{\@column@after}{\lx@alignment@column@after}\lx@alignment@column@after');
+
+DefMacro('\@tabular@begin@heading',
+  '\lx@DEPRECATE{\@tabular@begin@heading}{\lx@alignment@begin@heading}\lx@alignment@begin@heading');
+DefMacro('\@tabular@end@heading',
+  '\lx@DEPRECATE{\@tabular@end@heading}{\lx@alignment@end@heading}\lx@alignment@end@heading');
+
+DefMacro('\@multicolumn',
+  '\lx@DEPRECATE{\@multicolumn}{\lx@alignment@multicolumn}\lx@alignment@multicolumn');
+
+DefMacro('\@dollar@in@normalmode',
+  '\lx@DEPRECATE{\@dollar@in@normalmode}{\lx@dollar@in@normalmode}\lx@dollar@in@normalmode');
+DefMacro('\@dollar@in@mathmode',
+  '\lx@DEPRECATE{\@dollar@in@mathmode}{\lx@dollar@in@mathmode}\lx@dollar@in@mathmode');
+DefMacro('\@dollar@in@textmode',
+  '\lx@DEPRECATE{\@dollar@in@textmode}{\lx@dollar@in@textmode}\lx@dollar@in@tecxtmode');
+
+DefMacro('\math@underline',
+  '\lx@DEPRECATE{\math@underline}{\lx@math@underline}\lx@math@underline');
+DefMacro('\text@underline',
+  '\lx@DEPRECATE{\text@underline}{\lx@text@underline}\lx@text@underline');
+DefMacro('\math@overleftarrow',
+  '\lx@DEPRECATE{\math@overleftarrow}{\lx@math@overleftarrow}\lx@math@overleftarrow');
+DefMacro('\math@overrightarrow',
+  '\lx@DEPRECATE{\math@overrightarrow}{\lx@math@overrightarrow}\lx@math@overrightarrow');
+
+DefMacro('\@@BEGININLINEMATH',
+  '\lx@DEPRECATE{\@@BEGININLINEMATH}{\lx@begin@inline@math}\lx@begin@inlineh@math');
+DefMacro('\@@ENDINLINEMATH',
+  '\lx@DEPRECATE{\@@ENDINLINEMATH}{\lx@end@inline@math}\lx@end@inline@math');
+DefMacro('\@@BEGINDISPLAYMATH',
+  '\lx@DEPRECATE{\@@BEGINDISPLAYMATH}{\lx@begin@display@math}\lx@begin@display@math');
+DefMacro('\@@ENDDISPLAYMATH',
+  '\lx@DEPRECATE{\@@ENDDISPLAYMATH}{\lx@end@display@math}\lx@end@display@math');
+
+DefMacro('\@@BEGININLINETEXT',
+  '\lx@DEPRECATE{\@@BEGININLINETEXT}{\lx@begin@inmath@text}\lx@begin@inmath@text');
+DefMacro('\@@ENDINLINETEXT',
+  '\lx@DEPRECATE{\@@ENDINLINETEXT}{\lx@end@inmath@text}\lx@end@inmath@text');
+
+DefMacro('\@@FLOATINGSUBSCRIPT',
+  '\lx@DEPRECATE{\@@FLOATINGSUBSCRIPT}{\lx@floating@subscript}\lx@floating@subscript');
+DefMacro('\@@FLOATINGSUPERSCRIPT',
+  '\lx@DEPRECATE{\@@FLOATINGSUPERSCRIPT}{\lx@floating@superscript}\lx@floating@superscript');
+DefMacro('\@@POSTSUBSCRIPT',
+  '\lx@DEPRECATE{\@@POSTSUBSCRIPT}{\lx@post@subscript}\lx@post@subscript');
+DefMacro('\@@POSTSUPERSCRIPT',
+  '\lx@DEPRECATE{\@@POSTSUPERSCRIPT}{\lx@post@superscript}\lx@post@superscript');
+
+DefMacro('\@ASSERT@MEANING',
+  '\lx@DEPRECATE{\@ASSERT@MEANING}{\lx@assert@meaning}\lx@assert@meaning');
+
+#======================================================================
+# Older deprecations
+# (but there was no warning mechanism then)
 #----------------------------------------------------------------------
 # This group should be renamed to \lx@somethings and deprecated
 # NOTE: work through this systematically!

--- a/lib/LaTeXML/Engine/Base_Schema.pool.ltxml
+++ b/lib/LaTeXML/Engine/Base_Schema.pool.ltxml
@@ -40,20 +40,19 @@ Tag('ltx:document', afterOpen => sub {
         if ($bg ne 'white') {
           $document->setAttribute($root, backgroundcolor => $bg); } } } });
 #======================================================================
-
-DefMacroI("\\\@empty", undef, Tokens());
-
-#======================================================================
 # Core ID functionality.
 #======================================================================
+
+DefMacroI('\lx@empty', undef, Tokens());
+
 # DOCUMENTID is the ID of the document
 # AND prefixes IDs on all other elements.
 if (my $docid = LookupValue('DOCUMENTID')) {
   # Wrap in T_OTHER so funny chars don't screw up (no space!)
   DefMacroI('\thedocument@ID', undef, T_OTHER($docid)); }
 else {
-  Let('\thedocument@ID', '\@empty'); }
-NewCounter('@XMARG', 'document', idprefix => 'XM');
+  Let('\thedocument@ID', '\lx@empty'); }
+NewCounter('@lx@xmarg', 'document', idprefix => 'XM');
 
 #======================================================================
 

--- a/lib/LaTeXML/Engine/Base_Utility.pool.ltxml
+++ b/lib/LaTeXML/Engine/Base_Utility.pool.ltxml
@@ -16,11 +16,11 @@ use warnings;
 use LaTeXML::Package;
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-#**********************************************************************
-# LaTeX has a very particular notion of "Undefined",
+#======================================================================
+# LaTeX has a very particular, but useful, notion of "Undefined",
 # so let's get that squared away at the outset; it's useful for TeX, too!
 # Naturally, it uses \csname to check, which ends up DEFINING the possibly undefined macro as \relax
-DefMacro('\@ifundefined{}{}{}', sub {
+DefMacro('\lx@ifundefined{}{}{}', sub {
     my ($gullet, $name, $if, $else) = @_;
     my $cs = T_CS('\\' . ToString(Expand($name)));
     if (IsDefined($cs)) {

--- a/lib/LaTeXML/Engine/Base_XMath.pool.ltxml
+++ b/lib/LaTeXML/Engine/Base_XMath.pool.ltxml
@@ -31,7 +31,8 @@ use LaTeXML::Package;
 #
 # The following constructor (see how it's used in DefMath), adds meaning attributes
 # whereever it seems sensible on the presentation branch, after it has been generated.
-DefConstructor('\@ASSERT@MEANING{}{}', '#2',
+# This appears to be obsolete/no-longer-used, but keep for future reference.
+DefConstructor('\lx@assert@meaning{}{}', '#2',
   reversion      => '#2',
   afterConstruct => sub {
     my ($document, $whatsit) = @_;
@@ -577,18 +578,18 @@ DefPrimitive('\lx@gen@matrix@bindings RequiredKeyVals:lx@GEN', sub {
           : (repeated => [{@colspec}]))),
       'math',
       (keys %attributes ? (attributes => {%attributes}) : ()));    # });
-    Let("\\\\",         '\@alignment@newline');
-    Let('\lx@intercol', '\lx@math@intercol');
-    Let('\@row@before', '\@empty');    # Disable special row treatment (eg. numbering) unless requested
-    Let('\@row@after',  '\@empty');
+    Let("\\\\",                     '\lx@alignment@newline');
+    Let('\lx@intercol',             '\lx@math@intercol');
+    Let('\lx@alignment@row@before', '\lx@empty'); # Disable special row treatment (eg. numbering) unless requested
+    Let('\lx@alignment@row@after',  '\lx@empty');
 });
 
 DefPrimitive('\lx@end@gen@matrix', sub { $_[0]->egroup; });
 
 DefMacro('\lx@gen@plain@matrix{}{}',
   '\lx@gen@matrix@bindings{#1}'
-    . '\lx@gen@plain@matrix@{#1}{\@start@alignment#2\@finish@alignment}'
-    #    . '\lx@gen@plain@matrix@{#1}{\@start@alignment#2\cr\@finish@alignment}'
+    . '\lx@gen@plain@matrix@{#1}{\lx@begin@alignment#2\lx@end@alignment}'
+    #    . '\lx@gen@plain@matrix@{#1}{\lx@begin@alignment#2\cr\lx@end@alignment}'
     . '\lx@end@gen@matrix');
 
 # The delimiters on a matrix are presumably just for notation or readability (not an operator);
@@ -659,15 +660,15 @@ DefPrimitive('\lx@gen@cases@bindings RequiredKeyVals:lx@GEN', sub {
               ($condtext ? (T_CS('\lx@cases@end@condition')) : ()),
               T_CS('\hfil')) }]),
       'math');
-    Let("\\\\",         '\@alignment@newline');
+    Let("\\\\",         '\lx@alignment@newline');
     Let('\lx@intercol', '\lx@math@intercol');
-    DefMacro('\@row@before', '');    # Don't inherit counter stepping from containing environments
-    DefMacro('\@row@after',  '');
+    DefMacro('\lx@alignment@row@before', ''); # Don't inherit counter stepping from containing environments
+    DefMacro('\lx@alignment@row@after',  '');
 });
 
 DefMacro('\lx@gen@plain@cases{}{}',
   '\lx@gen@cases@bindings{#1}'
-    . '\lx@gen@plain@cases@{#1}{\@start@alignment#2\@finish@alignment}'
+    . '\lx@gen@plain@cases@{#1}{\lx@begin@alignment#2\lx@end@alignment}'
     . '\lx@end@gen@cases');
 DefPrimitive('\lx@end@gen@cases', sub { $_[0]->egroup; });
 
@@ -754,7 +755,7 @@ sub closeMathFork {
 # that is synthesized from other math content within a ltx:MathFork.
 sub MathWhatsit {
   my (@items) = @_;
-  my $hbgd = LookupDefinition(T_CS('\@hidden@bgroup'));
+  my $hbgd = LookupDefinition(T_CS('\lx@hidden@bgroup'));
   @items = map { ((ref $_ eq 'LaTeXML::Core::Whatsit') && ($_->getDefinition eq $hbgd)
       ? $_->getBody->unlist : ($_)) }
     map { $_->unlist } grep { $_ } @items;
@@ -765,9 +766,9 @@ sub MathWhatsit {
   my @styles = grep { UnTeX($_) eq '\displaystyle' } @items;
   if (@styles) {
     @items = ($styles[0], grep { UnTeX($_) ne '\displaystyle' } @items); }
-  return LaTeXML::Core::Whatsit->new(LookupDefinition(T_CS('\@@BEGININLINEMATH')), [],
+  return LaTeXML::Core::Whatsit->new(LookupDefinition(T_CS('\lx@begin@inline@math')), [],
     body    => List(@items, mode => 'math'),
-    trailer => T_CS('\@@ENDINLINEMATH'),
+    trailer => T_CS('\\lx@end@inline@math'),
     locator => $locator, isMath => 1); }
 
 #======================================================================

--- a/lib/LaTeXML/Engine/BibTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/BibTeX.pool.ltxml
@@ -170,7 +170,7 @@ DefPrimitive('\bibentry@create Semiverbatim', sub {
 # Processing Entries
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Math ID's within the bibliography.
-DefMacro('\the@XMARG@ID', '\the@lx@bibliography@ID.XM\arabic{@XMARG}');
+DefMacro('\the@lx@xmarg@ID', '\the@lx@bibliography@ID.XM\arabic{@lx@xmarg}');
 
 DefEnvironment('{bibtex@bibliography}',
   "<ltx:bibliography xml:id='#id' "

--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -33,6 +33,9 @@ LOAD_LATEX();
 # Apparently LaTeX does NOT define \magnification,
 # and babel uses that to determine whether we're runing LaTeX!!!
 Let('\magnification', '\@undefined');
+Let('\@empty',        '\lx@empty');
+Let('\@ifundefined',  '\lx@ifundefined');
+
 #**********************************************************************
 # Basic \documentclass & \documentstyle
 
@@ -735,11 +738,11 @@ DefConstructor('\@@unnumbered@section{} Undigested OptionalUndigested Undigested
     my %props = RefStepID($type);
     if ($type eq 'appendix') {
       $props{backmatterelement} = LookupMapping('BACKMATTER_ELEMENT', 'ltx:' . $type); }
-    $props{title} = Digest(T_CS('\@hidden@bgroup'),
-      Invocation(T_CS('\lx@format@title@font@@'), $type), $title, T_CS('\@hidden@egroup'));
+    $props{title} = Digest(T_CS('\lx@hidden@bgroup'),
+      Invocation(T_CS('\lx@format@title@font@@'), $type), $title, T_CS('\lx@hidden@egroup'));
     $props{toctitle} = $toctitle
-      && Digest(T_CS('\@hidden@bgroup'), Invocation(T_CS('\lx@format@toctitle@font@@'), $type),
-      $toctitle, T_CS('\@hidden@egroup'));
+      && Digest(T_CS('\lx@hidden@bgroup'), Invocation(T_CS('\lx@format@toctitle@font@@'), $type),
+      $toctitle, T_CS('\lx@hidden@egroup'));
     return %props; });
 
 #======================================================================
@@ -1980,12 +1983,12 @@ DefMacroI('\verb', undef, sub {
     my $body  = $gullet->readUntil($delim);
     EndSemiverbatim();
     Tokens(
-      T_CS('\@hidden@bgroup'),
+      T_CS('\lx@hidden@bgroup'),
       ($starred ? T_CS('\lx@use@visiblespace') : ()),
       Invocation(T_CS('\@internal@verb'),
         ($starred ? T_OTHER('*') : Tokens()),
         Tokens($init), $body),
-      T_CS('\@hidden@egroup'))->unlist; });
+      T_CS('\lx@hidden@egroup'))->unlist; });
 
 DefPrimitive('\lx@use@visiblespace', sub {
     my ($stomach, $star) = @_;
@@ -2028,7 +2031,7 @@ DefMacroI('\@eqnnum', undef, '(\theequation)', locked => 1);
 DefMacro('\fnum@equation', '\@eqnnum');
 
 # Redefined from TeX.pool, since with LaTeX we presumably have a more complete numbering system
-DefConstructorI('\@@BEGINDISPLAYMATH', undef,
+DefConstructorI('\lx@begin@display@math', undef,
   "<ltx:equation xml:id='#id'>"
     . "<ltx:Math mode='display'>"
     . "<ltx:XMath>"
@@ -2099,8 +2102,8 @@ sub beforeEquation {
         ($numbered ? RefStepCounter($ctr) : RefStepID($ctr)) }, 'global'); }
   else {
     AssignValue(EQUATIONROW_TAGS => {}, 'global'); }
-  Let('\@@ENDDISPLAYMATH',   '\lx@eDM@in@equation');
-  Let('\@@BEGINDISPLAYMATH', '\lx@bDM@in@equation');
+  Let('\lx@end@display@math',   '\lx@eDM@in@equation');
+  Let('\lx@begin@display@math', '\lx@bDM@in@equation');
   return; }
 
 # Note peculiar usages of \[,\],$$ WITHIN displayed math, like {equation}.
@@ -2110,19 +2113,20 @@ sub beforeEquation {
 # sort of text insertion (eg \footnote)!
 # So, we've got to dance around with redefinitions!!
 # SIDE NOTE: \[,\] are really just $$ w/ appropriate error checking!
-Let('\lx@saved@BEGINDISPLAYMATH', '\@@BEGINDISPLAYMATH');
-Let('\lx@saved@ENDDISPLAYMATH',   '\@@ENDDISPLAYMATH');
+Let('\lx@saved@begin@display@math', '\lx@begin@display@math');
+Let('\lx@saved@end@display@math',   '\lx@end@display@math');
 
-DefMacro('\lx@bDM@in@equation', '\lx@saved@BEGINDISPLAYMATH\let\@@ENDDISPLAYMATH\lx@saved@ENDDISPLAYMATH');
+DefMacro('\lx@bDM@in@equation',
+  '\lx@saved@begin@display@math\let\lx@end@display@math\lx@saved@end@display@math');
 DefMacro('\lx@eDM@in@equation',
   '\lx@retract@eqnno\lx@begin@fake@intertext'
-    . '\let\lx@saved@BEGINDISPLAYMATH\@@BEGINDISPLAYMATH\let\lx@saved@bdm\['
-    . '\let\@@BEGINDISPLAYMATH\lx@end@fake@intertext'
+    . '\let\lx@saved@begin@display@math\lx@begin@display@math\let\lx@saved@bdm\['
+    . '\let\lx@begin@display@math\lx@end@fake@intertext'
     . '\let\[\lx@end@fake@intertext');
 
 DefMacro('\lx@begin@fake@intertext', '\end{equation}');
 DefMacro('\lx@end@fake@intertext',
-  '\let\@@BEGINDISPLAYMATH\lx@saved@BEGINDISPLAYMATH\let\[\lx@saved@bdm' .
+  '\let\lx@begin@display@math\lx@saved@begin@display@math\let\[\lx@saved@bdm' .
     '\begin{equation}');
 DefPrimitive('\lx@retract@eqnno', sub { retractEquation(); });
 
@@ -2150,7 +2154,6 @@ DefPrimitiveI('\lx@equation@nonumber', undef, sub {
       else {
         retractEquation(); } }
     return; });
-Let('\@LTX@nonumber', '\lx@equation@nonumber');
 
 # Set this equation's number explicitly (eg ams's \tag)
 DefMacroI('\lx@equation@settag', undef, '\lx@equation@retract\lx@equation@settag@');
@@ -2229,10 +2232,10 @@ DefEnvironment('{equation*}',
     afterEquation($_[1]); },
   locked => 1);
 
-DefMacro('\[', '\@@BEGINDISPLAYMATH');
-DefMacro('\]', '\@@ENDDISPLAYMATH');
-DefMacro('\(', '\@@BEGININLINEMATH');
-DefMacro('\)', '\@@ENDINLINEMATH');
+DefMacro('\[', '\lx@begin@display@math');
+DefMacro('\]', '\lx@end@display@math');
+DefMacro('\(', '\lx@begin@inline@math');
+DefMacro('\)', '\\lx@end@inline@math');
 
 # Keep from expanding too early, if in alignments, or such.
 DefMacroI('\ensuremath', undef,
@@ -2355,8 +2358,8 @@ DefConditionalI('\if@in@firstcolumn', undef, sub {
 # A bit more defensiveness, since people abuse eqnarray so badly.
 # Eg. &&\lefteqn{...}  whatever?!?!
 DefMacro('\lefteqn{}',
-'\if@in@firstcolumn\multicolumn{3}{l}{\@ADDCLASS{ltx_eqn_lefteqn}\@@BEGININLINEMATH \displaystyle #1\@@ENDINLINEMATH\mbox{}}'
-    . '\else\rlap{\@@BEGININLINEMATH\displaystyle #1\@@ENDINLINEMATH}\fi');
+'\if@in@firstcolumn\multicolumn{3}{l}{\@ADDCLASS{ltx_eqn_lefteqn}\lx@begin@inline@math \displaystyle #1\\lx@end@inline@math\mbox{}}'
+    . '\else\rlap{\lx@begin@inline@math\displaystyle #1\\lx@end@inline@math}\fi');
 # \intertext (in amsmath)
 
 Let('\displ@y', '\displaystyle');    # good enough?
@@ -2366,18 +2369,18 @@ DefMacro('\@lign', '');              # good enough?
 DefMacroI('\eqnarray', undef,
   '\@eqnarray@bindings\@@eqnarray'
     . '\@equationgroup@numbering{numbered=1,preset=1,deferretract=1,grouped=1,aligned=1}'
-    . '\@start@alignment',
+    . '\lx@begin@alignment',
   locked => 1);
 DefMacroI('\endeqnarray', undef,
-  '\cr\@finish@alignment\end@eqnarray',
+  '\cr\lx@end@alignment\end@eqnarray',
   locked => 1);
 DefMacro('\csname eqnarray*\endcsname',
   '\@eqnarray@bindings\@@eqnarray'
     . '\@equationgroup@numbering{numbered=1,preset=1,retract=1,grouped=1,aligned=1}'
-    . '\@start@alignment',
+    . '\lx@begin@alignment',
   locked => 1);
 DefMacro('\csname endeqnarray*\endcsname',
-  '\@finish@alignment\end@eqnarray',
+  '\lx@end@alignment\end@eqnarray',
   locked => 1);
 
 DefPrimitive('\@eqnarray@bindings', sub {
@@ -2385,8 +2388,8 @@ DefPrimitive('\@eqnarray@bindings', sub {
 
 DefPrimitiveI('\eqnarray@row@before@', undef, sub { beforeEquation(); });
 DefPrimitiveI('\eqnarray@row@after@',  undef, sub { afterEquation(); });
-DefMacroI('\eqnarray@row@before', undef, '\hidden@noalign{\eqnarray@row@before@}');
-DefMacroI('\eqnarray@row@after',  undef, '\hidden@noalign{\eqnarray@row@after@}');
+DefMacroI('\eqnarray@row@before', undef, '\lx@hidden@noalign{\eqnarray@row@before@}');
+DefMacroI('\eqnarray@row@after',  undef, '\lx@hidden@noalign{\eqnarray@row@after@}');
 
 sub eqnarrayBindings {
   my $col1 = { before => Tokens(T_CS('\hfil'), T_MATH, T_CS('\displaystyle')),
@@ -2420,17 +2423,17 @@ sub eqnarrayBindings {
       closeColumn => sub { $_[0]->closeElement('ltx:_Capture_'); },
       properties  => { preserve_structure => 1, attributes => {%attributes} }));
 
-  Let("\\\\",                    '\@alignment@newline');
-  Let('\lx@intercol',            '\lx@math@intercol');
-  Let('\@row@before',            '\eqnarray@row@before');
-  Let('\@row@after',             '\eqnarray@row@after');
-  Let('\lx@eqnarray@save@label', '\label');
-  Let('\label',                  '\lx@eqnarray@label');
+  Let("\\\\",                     '\lx@alignment@newline');
+  Let('\lx@intercol',             '\lx@math@intercol');
+  Let('\lx@alignment@row@before', '\eqnarray@row@before');
+  Let('\lx@alignment@row@after',  '\eqnarray@row@after');
+  Let('\lx@eqnarray@save@label',  '\label');
+  Let('\label',                   '\lx@eqnarray@label');
   return; }
 
-# A \label preceding \lefteqn throws of the implied \omit,e tc; so wrap in \hidden@align
+# A \label preceding \lefteqn throws of the implied \omit,e tc; so wrap in \lx@hidden@align
 DefMacro('\lx@eqnarray@label Semiverbatim',
-  '\hidden@noalign{\lx@eqnarray@save@label{#1}}');
+  '\lx@hidden@noalign{\lx@eqnarray@save@label{#1}}');
 
 DefConstructor('\@@eqnarray SkipSpaces DigestedBody',
   '#1',
@@ -2785,6 +2788,10 @@ DefPrimitive('\DeclareTextAccentDefault{}{}',
 # TODO: Need to convert these DefPrimitive's into DefConstroctors
 # that add a preable PI!!!!!!!!!
 
+DefMacro('\fontencoding{}', '\lx@fontencoding{#1}');
+DefMacroI('\f@encoding',  undef, sub { ExplodeText(LookupValue('font')->getEncoding); });
+DefMacroI('\cf@encoding', undef, sub { ExplodeText(LookupValue('font')->getEncoding); });
+
 DefPrimitive('\DeclareTextComposite{}{}{}{}',
   sub { ignoredDefinition('DeclareTextComposite', $_[1]); });
 DefPrimitive('\DeclareTextCompositeCommand{}{}{}{}',
@@ -2877,6 +2884,7 @@ DefPrimitive('\DeclareFontEncoding{}{}{}', sub {
     }
     return;
 });
+
 DefMacroI('\LastDeclaredEncoding', undef, '');
 DefPrimitive('\DeclareFontSubstitution{}{}{}{}', undef);
 DefPrimitive('\DeclareFontEncodingDefaults{}{}', undef);
@@ -3685,9 +3693,9 @@ DefRegister('\marginparpush', Dimension(0));
 DefRegister('\tabbingsep' => Dimension(0));
 
 DefMacroI('\tabbing', undef,
-  '\par\@tabbing@bindings\@@tabbing\@start@alignment');
+  '\par\@tabbing@bindings\@@tabbing\lx@begin@alignment');
 DefMacroI('\endtabbing', undef,
-  '\@finish@alignment\@end@tabbing\par');
+  '\lx@end@alignment\@end@tabbing\par');
 DefPrimitiveI('\@end@tabbing', undef, sub { $_[0]->egroup; });
 DefConstructor('\@@tabbing SkipSpaces DigestedBody',
   '#1',
@@ -3794,7 +3802,7 @@ DefRegister('\lx@arstrut',           Dimension('0pt'));
 DefRegister('\lx@default@tabcolsep', Dimension('6pt'));
 DefRegister('\tabcolsep',            Dimension('6pt'));
 DefMacroI('\arraystretch', undef, "1");
-Let('\@tabularcr', '\@alignment@newline');
+Let('\@tabularcr', '\lx@alignment@newline');
 AssignValue(GUESS_TABULAR_HEADERS => 1)    # Defaults to yes
   unless defined LookupValue('GUESS_TABULAR_HEADERS');
 
@@ -3819,11 +3827,13 @@ sub tabularBindings {
   # NOTE: Fit this back in!!!!!!!
   # # Do like AddToMacro, but NOT global!
   foreach my $name ('@row@before', '@row@after', '@column@before', '@column@after') {
-    my $cs = '\\' . $name;
+    my $cs = '\\lx@alignment' . $name;
     DefMacroI($cs, undef,
       Tokens(LookupDefinition(T_CS($cs))->getExpansion->unlist,
         T_CS('\@tabular' . $name))); }
   return; }
+
+Let('\tabularnewline', '\relax');
 
 # Keyvals are for attributes for the alignment.
 # Typical keys are width, vattach,...
@@ -3844,12 +3854,12 @@ DefMacroI('\@tabular@column@before', undef, '');
 DefMacroI('\@tabular@column@after',  undef, '');
 
 # The Core alignment support is in LaTeXML::Core::Alignment and in TeX.ltxml
-##DefMacro('\tabular[]{}', '\@tabular@bindings{#2}\@@tabular[#1]{#2}\@start@alignment');
+##DefMacro('\tabular[]{}', '\@tabular@bindings{#2}\@@tabular[#1]{#2}\lx@begin@alignment');
 DefMacro('\tabular[]{}',
-  '\@tabular@bindings{#2}[vattach=#1]\@@tabular[#1]{#2}\@start@alignment\@tabular@before',
+  '\@tabular@bindings{#2}[vattach=#1]\@@tabular[#1]{#2}\lx@begin@alignment\@tabular@before',
   locked => 1);
 DefMacroI('\endtabular', undef,
-  '\@tabular@after\@finish@alignment\@end@tabular',
+  '\@tabular@after\lx@end@alignment\@end@tabular',
   locked => 1);
 DefPrimitiveI('\@end@tabular', undef, sub { $_[0]->egroup; });
 #DefMacroI('\@end@tabular', undef, undef);
@@ -3871,17 +3881,17 @@ DefConstructor('\@@tabular[] Undigested DigestedBody',
   mode   => 'text');
 
 DefMacro('\csname tabular*\endcsname{Dimension}[]{}',
-###  '\@tabular@bindings{#3}\@@tabular@{#1}[#2]{#3}\@start@alignment');
-  '\@tabular@bindings{#3}[width=#1,vattach=#2]\@@tabular@{#1}[#2]{#3}\@start@alignment');
+###  '\@tabular@bindings{#3}\@@tabular@{#1}[#2]{#3}\lx@begin@alignment');
+  '\@tabular@bindings{#3}[width=#1,vattach=#2]\@@tabular@{#1}[#2]{#3}\lx@begin@alignment');
 DefMacro('\csname endtabular*\endcsname',
-  '\@finish@alignment\@end@tabular@');
+  '\lx@end@alignment\@end@tabular@');
 DefConstructor('\@@tabular@{Dimension}[] Undigested DigestedBody',
   '#4',
   beforeDigest => sub { $_[0]->bgroup; },
   reversion    => '\begin{tabular*}{#1}[#2]{#3}#4\end{tabular*}',
   mode         => 'text');
 DefPrimitive('\@end@tabular@', sub { $_[0]->egroup; });
-Let('\multicolumn', '\@multicolumn');
+Let('\multicolumn', '\lx@alignment@multicolumn');
 
 # A weird bit that sometimes gets invoked by Cargo Cult programmers...
 # to \noalign in the defn of \hline! Bizarre! (see latex.ltx)
@@ -3912,9 +3922,6 @@ DefRegister('\arraycolsep',            Dimension('5pt'));
 DefRegister('\arrayrulewidth',         Dimension('0.4pt'));
 DefRegister('\doublerulesep',          Dimension('2pt'));
 DefMacro('\extracolsep{}', Tokens());
-#DefMacroI('\tabularnewline', undef, Tokens());
-#Let('\tabularnewline', '\cr');
-#DefMacroI('\tabularnewline', undef, '\cr'); # ???
 #======================================================================
 # Array and similar environments
 
@@ -3933,14 +3940,14 @@ DefPrimitive('\@array@bindings [] AlignmentTemplate', sub {
     if (my $font = LookupValue('font')) {
       if (($font->getMathstyle || 'text') eq 'display') {
         MergeFont(mathstyle => 'text'); } }
-    Let("\\\\",         '\@alignment@newline');
+    Let("\\\\",         '\lx@alignment@newline');
     Let('\lx@intercol', '\lx@math@intercol');
     return; });
 
 DefMacro('\array[]{}',
-  '\@array@bindings[#1]{#2}\@@array[#1]{#2}\@start@alignment');
+  '\@array@bindings[#1]{#2}\@@array[#1]{#2}\lx@begin@alignment');
 DefMacroI('\endarray', undef,
-  '\@finish@alignment\@end@array');
+  '\lx@end@alignment\@end@array');
 DefPrimitiveI('\@end@array', undef, sub { $_[0]->egroup; });
 DefConstructor('\@@array[] Undigested DigestedBody',
   '#3',

--- a/lib/LaTeXML/Engine/TeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX.pool.ltxml
@@ -140,8 +140,8 @@ if (!($LaTeXML::DEBUG{compiled} || $LaTeXML::DEBUG{compiling})) {
     \gdef\@currnamestack{#4}');
 }
 DefMacroI(T_CS('\@currnamestack'), undef, Tokens());
-Let('\@currname', '\@empty');
-Let('\@currext',  '\@empty');
+Let('\@currname', '\lx@empty');
+Let('\@currext',  '\lx@empty');
 
 #======================================================================
 # After all other rewrites have acted, a little cleanup

--- a/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
@@ -45,10 +45,12 @@ DefPrimitive(T_END, sub {
 # These are for those screwy cases where you need to create a group like box,
 # more than just bgroup, egroup,
 # BUT you DON'T want extra {, } showing up in any untex-ing.
-DefConstructor('\@hidden@bgroup', '#body', beforeDigest => sub { $_[0]->bgroup; }, captureBody => 1,
-  reversion => sub { Revert($_[0]->getProperty('body')); });
-DefConstructor('\@hidden@egroup', '', afterDigest => sub { $_[0]->egroup; },
-  reversion => '');
+DefConstructor('\lx@hidden@bgroup', '#body',
+  beforeDigest => sub { $_[0]->bgroup; }, captureBody => 1,
+  reversion    => sub { Revert($_[0]->getProperty('body')); });
+DefConstructor('\lx@hidden@egroup', '',
+  afterDigest => sub { $_[0]->egroup; },
+  reversion   => '');
 
 #======================================================================
 DefMacro('\lx@nounicode {}', '\ifmmode\lx@math@nounicode#1\else\lx@text@nounicode#1\fi');
@@ -144,8 +146,8 @@ DefParameterType('VBoxContents', sub {
 AssignValue(TEXT_MODE_BINDINGS  => []);
 AssignValue(HTEXT_MODE_BINDINGS => []);
 AssignValue(VTEXT_MODE_BINDINGS => []);
-PushValue(HTEXT_MODE_BINDINGS => [T_MATH, T_CS('\@dollar@in@textmode')]);
-PushValue(VTEXT_MODE_BINDINGS => [T_MATH, T_CS('\@dollar@in@normalmode')]);
+PushValue(HTEXT_MODE_BINDINGS => [T_MATH, T_CS('\lx@dollar@in@textmode')]);
+PushValue(VTEXT_MODE_BINDINGS => [T_MATH, T_CS('\lx@dollar@in@normalmode')]);
 ###PushValue(TEXT_MODE_BINDINGS => [T_CS('\centerline'), T_CS('\relax')]);
 
 sub reenterTextMode {

--- a/lib/LaTeXML/Engine/TeX_Fonts.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Fonts.pool.ltxml
@@ -112,9 +112,7 @@ DefPrimitiveI('\/', undef, sub {
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Font encoding and FontMaps
 
-DefMacro('\fontencoding{}', '\@@@fontencoding{#1}');
-
-DefPrimitive('\@@@fontencoding{}', sub {
+DefPrimitive('\lx@fontencoding{}', sub {
     my ($stomach, $encoding) = @_;
     $encoding = ToString(Expand($encoding));
     if (LoadFontMap($encoding)) {
@@ -122,9 +120,6 @@ DefPrimitive('\@@@fontencoding{}', sub {
     else {
       MergeFont(encoding => 'OT1'); }    # Default to OT1 encoding if no map found
     return; });
-
-DefMacroI('\f@encoding',  undef, sub { ExplodeText(LookupValue('font')->getEncoding); });
-DefMacroI('\cf@encoding', undef, sub { ExplodeText(LookupValue('font')->getEncoding); });
 
 # Used for SemiVerbatim text
 DeclareFontMap('ASCII',

--- a/lib/LaTeXML/Engine/TeX_Logic.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Logic.pool.ltxml
@@ -45,7 +45,7 @@ DefParameterType('ExpandedIfToken', sub {
     if (!$token) {
       Error('expected', 'ExpandedIfToken', $gullet,
         "conditional expected a token argument, readXToken came back empty. Falling back to \\\@empty");
-      $token = T_CS('\@empty'); }
+      $token = T_CS('\lx@empty'); }
     return $token; });
 
 DefConditional('\if ExpandedIfToken ExpandedIfToken', sub { $_[1]->getCharcode == $_[2]->getCharcode; });

--- a/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
@@ -39,16 +39,16 @@ use LaTeXML::Package;
 Tag('ltx:XMText', autoOpen => 1, autoClose => 1);
 # This really should be T_MATH
 # and it should (or not) check for a second $ only if not in restricted horizontal mode!
-# (and then all the \@dollar@in@(text|math|normal)mode defns would not be needed.
-DefPrimitiveI('\@dollar@in@normalmode', undef, sub {
+# (and then all the \lx@dollar@in@(text|math|normal)mode defns would not be needed.
+DefPrimitiveI('\lx@dollar@in@normalmode', undef, sub {
     my ($stomach) = @_;
     my $gullet    = $stomach->getGullet;
     my $mode      = LookupValue('MODE');
-    my $op        = '\@@BEGININLINEMATH';
+    my $op        = '\lx@begin@inline@math';
     if ($mode eq 'display_math') {
       if ($gullet->ifNext(T_MATH)) {
         $gullet->readToken;
-        $op = '\@@ENDDISPLAYMATH'; }
+        $op = '\lx@end@display@math'; }
       else {
         # Avoid a Fatal, but we're likely in trouble.
         # Should we switch to text mode? (LaTeX normally wouldn't)
@@ -59,17 +59,70 @@ DefPrimitiveI('\@dollar@in@normalmode', undef, sub {
           "Ignoring; expect to be in wrong math/text mode.");
         $op = undef; } }
     elsif ($mode eq 'inline_math') {
-      $op = '\@@ENDINLINEMATH'; }
+      $op = '\\lx@end@inline@math'; }
     #  elsif(!LookupValue('Alignment') && $gullet->ifNext(T_MATH)){
     elsif ($gullet->ifNext(T_MATH)) {
       $gullet->readToken;
-      $op = '\@@BEGINDISPLAYMATH'; }
+      $op = '\lx@begin@display@math'; }
     $stomach->invokeToken(T_CS($op)) if $op; });
 # Let this be the default, conventional $
-Let(T_MATH, T_CS('\@dollar@in@normalmode'));
+Let(T_MATH, T_CS('\lx@dollar@in@normalmode'));
 
+#======================================================================
+# Math mode in alignment
+# Special forms for $ appearing within alignments.
+# Note that $ within a math alignment (eg array environment),
+# switches to text mode! There's no $$ for display math.
+
+# This is the "normal" case: $ appearing with an alignment that is in text mode.
+# It's just like regular $, except it doesn't look for $$ (no display math).
+DefPrimitiveI('\lx@dollar@in@textmode', undef, sub {
+    no warnings 'recursion';
+    $_[0]->invokeToken(T_CS((LookupValue('IN_MATH') ? '\\lx@end@inline@math' : '\lx@begin@inline@math'))); });
+
+# This one is for $ appearing within an alignment that's already math.
+# This should switch to text mode (because it's balancing the hidden $
+# wrapping each alignment cell!!!!!!)
+# However, it should be like a normal $ if it's inside something like \mbox
+# that itself makes a text box!!!!!!
+# Thus, we need to know at what boxing level we started the last math or text.
+# This is all complicated by the need to know _how_ we got into or out of math mode!
+# Gawd, this is awful!
+# NOTE: Probably the most "Right" thing to do would be to process
+# alignments in text mode only (like TeX), sneaking $'s in where needed,
+# but then afterwards, morph them into math arrays?
+# This would be complicated by the need to hide these $ from untex.
+DefPrimitiveI('\lx@dollar@in@mathmode', undef, sub {
+    my ($stomach) = @_;
+    my $level = $stomach->getBoxingLevel;
+    if ((LookupValue('MATH_ALIGN_$_BEGUN') || 0) == $level) { # If we're begun making _something_ with $.
+      my @l = ();
+      if (LookupValue('IN_MATH')) {                           # But we're somehow in math?
+        @l = $stomach->invokeToken(T_CS('\\lx@end@inline@math')); }
+      else {
+        @l = $stomach->invokeToken(T_CS('\lx@end@inmath@text')); }
+      AssignValue('MATH_ALIGN_$_BEGUN' => 0);                 # Reset this AFTER finishing the something
+      @l; }
+    else {
+      AssignValue('MATH_ALIGN_$_BEGUN' => $level + 1);        # Note that we've begun something
+      if (LookupValue('IN_MATH')) {                           # If we're "still" in math
+        $stomach->invokeToken(T_CS('\lx@begin@inmath@text')); }
+      else {
+        $stomach->invokeToken(T_CS('\lx@begin@inline@math')); } } });
+
+#======================================================================
+# For inserting (non-trivial?) text while in math mode
+DefConstructorI('\lx@begin@inmath@text', undef,
+  "<ltx:XMText>"
+    . "#body"
+    . "</ltx:XMText>",
+  alias => T_MATH, beforeDigest => sub { $_[0]->beginMode('text'); }, captureBody => 1);
+DefConstructorI('\lx@end@inmath@text', undef, "", alias => T_MATH,
+  beforeDigest => sub { $_[0]->endMode('text'); });
+
+#======================================================================
 # Effectively these are the math hooks, redefine these to do what you want with math?
-DefConstructorI('\@@BEGINDISPLAYMATH', undef,
+DefConstructorI('\lx@begin@display@math', undef,
   "<ltx:equation>"
     . "<ltx:Math mode='display'>"
     . "<ltx:XMath>"
@@ -85,11 +138,11 @@ DefConstructorI('\@@BEGINDISPLAYMATH', undef,
     if (my @everydisplay_toks = $STATE->lookupDefinition(T_CS('\everydisplay'))->valueOf->unlist()) {
       $_[0]->getGullet->unread(@everydisplay_toks); }
     return; }, captureBody => 1);
-DefConstructorI('\@@ENDDISPLAYMATH', undef, "",
+DefConstructorI('\lx@end@display@math', undef, "",
   reversion    => Tokens(T_MATH, T_MATH),
   beforeDigest => sub { $_[0]->endMode('display_math'); });
 
-DefConstructorI('\@@BEGININLINEMATH', undef,
+DefConstructorI('\lx@begin@inline@math', undef,
   "<ltx:Math mode='inline'>"
     . "<ltx:XMath>"
     . "#body"
@@ -101,10 +154,11 @@ DefConstructorI('\@@BEGININLINEMATH', undef,
     if (my @everymath_toks = $STATE->lookupDefinition(T_CS('\everymath'))->valueOf->unlist()) {
       $_[0]->getGullet->unread(@everymath_toks); }
     return; }, captureBody => 1);
-DefConstructorI('\@@ENDINLINEMATH', undef, "",
+DefConstructorI('\\lx@end@inline@math', undef, "",
   reversion    => Tokens(T_MATH),
   beforeDigest => sub { $_[0]->endMode('inline_math'); });
 
+#======================================================================
 # Add the TeX code from the object that created this node,
 # unless it has already been recorded on another node.
 sub add_TeX {
@@ -289,8 +343,8 @@ sub IsScript {
   if (ref $object eq 'LaTeXML::Core::List') {
     $object = [$object->unlist]->[-1]; }
   if ((ref $object eq 'LaTeXML::Core::Whatsit')    # careful w/alias in getCSName!
-    && ($object->getDefinition->getCS->getCSName =~ /^\\@@(FLOATING|POST)(SUBSCRIPT|SUPERSCRIPT)$/)) {
-    return [$1, $2]; }
+    && ($object->getDefinition->getCS->getCSName =~ /^\\lx@(floating|post)@(subscript|superscript)$/)) {
+    return [uc($1), uc($2)]; }
   return; }
 
 sub scriptHandler {
@@ -304,7 +358,7 @@ sub scriptHandler {
   my $nscripts = 0;
 
   if (defined $style) {
-    my $cs = '\@@FLOATING' . $op;
+    my $cs = '\lx@floating@' . lc($op);
     my ($prevscript, $prevspace, $base);
     # Check preceding boxes to determine possible attachment (floating vs post),
     # Note that this analysis has to be done now (or sometime like it) before grouping lists go away;
@@ -327,8 +381,8 @@ sub scriptHandler {
           $cs = '\@@FLOATING' . $op;
           last; }
         else {                       # Else, is OK (so far) assume POST (it will stack previous script)
-          $prevscript = $prev;               # we'll overlap the width of the previous.
-          $cs         = '\@@POST' . $op; }
+          $prevscript = $prev;                     # we'll overlap the width of the previous.
+          $cs         = '\lx@post@' . lc($op); }
         # if we hit a FLOATING script, terminate, as the floating empty group avoids double scripts
         last if ($$prevop[0] eq 'FLOATING');
         last if ++$nscripts > 1; }
@@ -336,7 +390,7 @@ sub scriptHandler {
         # We found something "normal", so assume we'll attach to it, and we're done.
         $base = $prev;
         unshift(@putback, $prev);
-        $cs = '\@@POST' . $op;
+        $cs = '\lx@post@' . lc($op);
         last; } }
     push(@LaTeXML::LIST, @putback);
 
@@ -374,7 +428,7 @@ DefPrimitiveI(T_SUB,   undef, sub { scriptHandler($_[0], 'SUBSCRIPT'); });
 # and either has braces, or is something that results in a single box.
 # When we revert these, we DON'T want to wrap extra braces around, because they'll accumulate;
 # at the least they're ugly; in some applications they affect "round trip" processing.
-# OTOH, direct use of \@@POSTSUPERSCRIPT, etal, MAY need to have extra braces around them.
+# OTOH, direct use of \lx@post@superscript, etal, MAY need to have extra braces around them.
 # So, when reverting, we're going to a bit of extra trouble to make sure we have ONE set
 # of braces, but no extras!!
 sub revertScript {
@@ -427,14 +481,14 @@ sub scriptSizer {
   return ($w, $h, $d); }
 
 # NOTE: The When reverting these, the
-DefConstructor('\@@POSTSUPERSCRIPT InScriptStyle',
+DefConstructor('\lx@post@superscript InScriptStyle',
   "<ltx:XMApp role='POSTSUPERSCRIPT' scriptpos='?#scriptpos(#scriptpos)(#scriptlevel)'>"
     . "<ltx:XMArg rule='Superscript'>#1</ltx:XMArg>"
     . "</ltx:XMApp>",
   reversion => sub { (T_SUPER, revertScript($_[1])); },
   sizer     => sub { scriptSizer($_[0]->getArg(1), $_[0]->getProperty('base'),
       $_[0]->getProperty('prevscript'), 'SUPERSCRIPT', 'post'); });
-DefConstructor('\@@POSTSUBSCRIPT InScriptStyle',
+DefConstructor('\lx@post@subscript InScriptStyle',
   "<ltx:XMApp role='POSTSUBSCRIPT' scriptpos='?#scriptpos(#scriptpos)(#scriptlevel)'>"
     . "<ltx:XMArg rule='Subscript'>#1</ltx:XMArg>"
     . "</ltx:XMApp>",
@@ -442,36 +496,18 @@ DefConstructor('\@@POSTSUBSCRIPT InScriptStyle',
   sizer     => sub { scriptSizer($_[0]->getArg(1), $_[0]->getProperty('base'),
       $_[0]->getProperty('prevscript'),
       'SUBSCRIPT', 'post'); });
-DefConstructor('\@@FLOATINGSUPERSCRIPT InScriptStyle',
+DefConstructor('\lx@floating@superscript InScriptStyle',
   "<ltx:XMApp role='FLOATSUPERSCRIPT' scriptpos='?#scriptpos(#scriptpos)(#scriptlevel)'>"
     . "<ltx:XMArg rule='Superscript'>#1</ltx:XMArg>"
     . "</ltx:XMApp>",
   reversion => sub { (T_BEGIN, T_END, T_SUPER, revertScript($_[1])); },
   sizer     => sub { scriptSizer($_[0]->getArg(1), undef, undef, 'SUPERSCRIPT', 'post'); });
-DefConstructor('\@@FLOATINGSUBSCRIPT InScriptStyle',
+DefConstructor('\lx@floating@subscript InScriptStyle',
   "<ltx:XMApp role='FLOATSUBSCRIPT' scriptpos='?#scriptpos(#scriptpos)(#scriptlevel)'>"
     . "<ltx:XMArg rule='Subscript'>#1</ltx:XMArg>"
     . "</ltx:XMApp>",
   reversion => sub { (T_BEGIN, T_END, T_SUB, revertScript($_[1])); },
   sizer     => sub { scriptSizer($_[0]->getArg(1), undef, undef, 'SUBSCRIPT', 'post'); });
-
-DefMacroI('\active@math@prime', undef, sub {
-    my ($gullet) = @_;
-    my @sup = (T_CS('\prime'));
-    # Collect up all ', convering to \prime
-    while ($gullet->ifNext(T_OTHER('\''))) {
-      $gullet->readToken;
-      push(@sup, T_CS('\prime')); }
-    # Combine with any following superscript!
-    # However, this is semantically screwed up!
-    # We really need to set up separate superscripts, but at same level!
-    if ($gullet->ifNext(T_SUPER)) {
-      $gullet->readToken;
-      push(@sup, $gullet->readArg->unlist); }
-    (T_SUPER, T_BEGIN, @sup, T_END); },
-  locked => 1);    # Only in math!
-AssignMathcode("'" => 0x8000);
-Let("'", '\active@math@prime');
 
 # Experiment: When we detect a math element containing solely a floating superscript in the
 #             *Frontmatter* of a document, assume it is a note mark, and normalize it down to
@@ -676,12 +712,12 @@ sub lookup_delimiter {
 # And this also gives us a single list of things to parse separately.
 # Since \left,\right are TeX, primitives and must be paired up,
 # we use a bit of macro trickery to simulate.
-# [The \@hidden@bgroup/egroup keep from putting a {} into the UnTeX]
+# [The \lx@hidden@bgroup/egroup keep from putting a {} into the UnTeX]
 # HOWEVER, an additional complication is that it is a common mistake to omit the balancing \right!
 # Using an \egroup (or hidden) makes it hard to recover, so use a special egroup
-DefMacro('\left XToken', '\@left #1\@hidden@bgroup');
-# Like \@hidden@egroup, but softer about missing \left
-DefConstructor('\right@hidden@egroup', '',
+DefMacro('\left XToken', '\lx@left #1\lx@hidden@bgroup');
+# Like \lx@hidden@egroup, but softer about missing \left
+DefConstructor('\lx@hidden@egroup@right', '',
   afterDigest => sub {
     my ($stomach) = @_;
     if ($STATE->isValueBound('MODE', 0)    # Last stack frame was a mode switch!?!?!
@@ -691,9 +727,9 @@ DefConstructor('\right@hidden@egroup', '',
       $stomach->egroup; } },
   reversion => '');
 
-DefMacro('\right XToken', '\right@hidden@egroup\@right #1');
+DefMacro('\right XToken', '\lx@hidden@egroup@right\lx@right #1');
 
-DefConstructor('\@left Token',
+DefConstructor('\lx@left Token',
   "?#char(<ltx:XMTok role='#role' name='#name' stretchy='#stretchy'>#char</ltx:XMTok>)"
     . "(?#hint(<ltx:XMHint/>)(#1))",
   afterDigest => sub { my ($stomach, $whatsit) = @_;
@@ -714,7 +750,7 @@ DefConstructor('\@left Token',
         "Missing delimiter; '.' inserted"); }
     return; },
   alias => '\left');
-DefConstructor('\@right Token',
+DefConstructor('\lx@right Token',
   "?#char(<ltx:XMTok role='#role' name='#name' stretchy='#stretchy'>#char</ltx:XMTok>)"
     . "(?#hint(<ltx:XMHint/>)(#1))",
   afterDigest => sub { my ($stomach, $whatsit) = @_;
@@ -848,17 +884,18 @@ Let('\vcenter', '\vbox');
 # \underline              c  puts a line under the following character or subformula.
 
 DefMath('\overline Digested', UTF(0xAF), operator_role => 'OVERACCENT');    # MACRON
-DefMath('\math@underline{}', UTF(0xAF), operator_role => 'UNDERACCENT',
+DefMath('\lx@math@underline{}', UTF(0xAF), operator_role => 'UNDERACCENT',
   name => 'underline', alias => '\underline');
-DefConstructor('\text@underline{}', "<ltx:text framed='underline' _noautoclose='1'>#1</ltx:text>");
-DefMath('\math@overrightarrow{}', "\x{2192}", operator_role => 'OVERACCENT',
+DefConstructor('\lx@text@underline{}',
+  "<ltx:text framed='underline' _noautoclose='1'>#1</ltx:text>");
+DefMath('\lx@math@overrightarrow{}', "\x{2192}", operator_role => 'OVERACCENT',
   name => 'overrightarrow', alias => '\overrightarrow');
-DefMath('\math@overleftarrow{}', "\x{2190}", operator_role => 'OVERACCENT',
+DefMath('\lx@math@overleftarrow{}', "\x{2190}", operator_role => 'OVERACCENT',
   name => 'overleftarrow', alias => '\overleftarrow');
 
 # Careful: Use \protect so that it doesn't expand too early in alignments, etc.
 # [Really shouldn't use \protect, since this is a TeX primitive and \protect is LaTeX]
-DefMacro('\underline{}', '\protect\ifmmode\math@underline{#1}\else\text@underline{#1}\fi');
+DefMacro('\underline{}', '\protect\ifmmode\lx@math@underline{#1}\else\lx@text@underline{#1}\fi');
 
 #======================================================================
 # fraction-like things
@@ -1002,15 +1039,15 @@ DefConstructor('\lx@generalized@over Undigested RequiredKeyVals',
 DefMacro('\above Dimension',
   '\lx@generalized@over{\above #1}{meaning=divide,thickness=#1}');
 DefMacro('\abovewithdelims Token Token Dimension',
-'\lx@generalized@over{\abovewithdelims #1 #2 #3}{left={\@left#1},right={\@right#2},meaning=divide,thickness=#3}');
+'\lx@generalized@over{\abovewithdelims #1 #2 #3}{left={\lx@left#1},right={\lx@right#2},meaning=divide,thickness=#3}');
 DefMacro('\atop',
   '\lx@generalized@over{\atop}{thickness=0pt}');
 DefMacro('\atopwithdelims Token Token',
-  '\lx@generalized@over{\atopwithdelims #1 #2}{thickness=0pt,left={\@left#1},right={\@right#2}}');
+  '\lx@generalized@over{\atopwithdelims #1 #2}{thickness=0pt,left={\lx@left#1},right={\lx@right#2}}');
 DefMacro('\over',
   '\lx@generalized@over{\over}{meaning=divide}');
 DefMacro('\overwithdelims Token Token',
-  '\lx@generalized@over{\overwithdelims #1 #2}{left={\@left#1},right={\@right#2},meaning=divide}');
+'\lx@generalized@over{\overwithdelims #1 #2}{left={\lx@left#1},right={\lx@right#2},meaning=divide}');
 # My thinking was that this is a "fraction" providing the dimension is > 0!
 
 #======================================================================
@@ -1122,13 +1159,13 @@ DefMacroI('\eqno', undef, sub {
         # UGH from 2022: also don't jump over rows
         || $t->defined_as(T_CS('\cr'))
         # see arXiv:math/0001062, for one example
-        || $t->defined_as(T_CS('\hidden@cr'))
-        || $t->defined_as(T_CS('\@@ENDDISPLAYMATH'))
+        || $t->defined_as(T_CS('\lx@hidden@cr'))
+        || $t->defined_as(T_CS('\lx@end@display@math'))
         || $t->defined_as(T_CS('\begingroup'))       # Totally wrong, but to catch expanded environments
         || (ToString($t) =~ /^\\(?:begin|end)\{/)    # any sort of environ begin or end???
                                                      # This seems needed within AmSTeX environs
       ) {
-        return (Invocation(T_CS('\@@eqno'), Tokens(@stuff)), $t); }
+        return (Invocation(T_CS('\lx@eqno'), Tokens(@stuff)), $t); }
       else {
         push(@stuff, $t); } }
     Error('unexpected', '\eqno', $gullet, "Fell of the end reading tag for \\eqno!",
@@ -1137,7 +1174,7 @@ DefMacroI('\eqno', undef, sub {
 
 Let('\leqno', '\eqno');
 # Revert to nothing, since it really doesn't belong in the TeX string(?)
-DefConstructor('\@@eqno{}',
+DefConstructor('\lx@eqno{}',
   "^ <ltx:tags><ltx:tag><ltx:Math><ltx:XMath>#1</ltx:XMath></ltx:Math></ltx:tag></ltx:tags>",
   reversion => '');
 

--- a/lib/LaTeXML/Engine/TeX_Tables.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Tables.pool.ltxml
@@ -24,7 +24,7 @@ use LaTeXML::Package;
 #----------------------------------------------------------------------
 # This is where ALL alignments start & finish
 # This creates the object representing the entire alignment!
-DefConstructor('\@start@alignment',
+DefConstructor('\lx@begin@alignment',
   "#alignment",
   reversion => sub { Revert($_[0]->getProperty('alignment')); },
   sizer     => '#alignment',
@@ -40,9 +40,9 @@ DefConstructor('\@start@alignment',
     return; });
 
 # Seems odd to need both end markers here...
-DefMacroI('\@finish@alignment', undef,
-  '\hidden@crcr\@close@alignment');
-DefPrimitive('\@close@alignment', sub { });
+DefMacroI('\lx@end@alignment', undef,
+  '\lx@hidden@crcr\lx@close@alignment');
+DefPrimitive('\lx@close@alignment', sub { });
 
 # & gives an error except within the right context
 # (which should redefine it!)
@@ -53,6 +53,7 @@ Tag('ltx:td', afterClose => \&trimNodeWhitespace);
 #----------------------------------------------------------------------
 # Primitive column types;
 # This is really LaTeX, but the mechanisms are used behind-the-scenes here, too.
+# Presumably is save to include, even at pure TeX/plain level processing.
 DefColumnType('|', sub {
     $LaTeXML::BUILD_TEMPLATE->addBetweenColumn(T_CS('\vrule'), T_CS('\relax')); return; });
 DefColumnType('l', sub {
@@ -96,9 +97,9 @@ DefConstructorI('\cr',   undef, "\n");
 DefConstructorI('\crcr', undef, "\n");
 # These are useful for reversion of higher-level macros that use alignment
 # internally, but don't use explicit &,\cr in the user markup
-DefConstructorI('\hidden@cr',    undef, "\n", alias => '');
-DefConstructorI('\hidden@crcr',  undef, "\n", alias => '');
-DefConstructorI('\hidden@align', undef, "",   alias => '');
+DefConstructorI('\lx@hidden@cr',    undef, "\n", alias => '');
+DefConstructorI('\lx@hidden@crcr',  undef, "\n", alias => '');
+DefConstructorI('\lx@hidden@align', undef, "",   alias => '');
 
 DefRegister('\everycr' => Tokens());
 DefRegister('\tabskip' => Glue(0));
@@ -144,8 +145,8 @@ DefPrimitiveI('\span', undef, sub {
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Now, for \halign itself
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-# See \@@LTX@noalign for some \noalign cases
-# See \@multicolumn for cases of \span,\omit
+# See \lxX@noalign for some \noalign cases
+# See \lx@alignment@multicolumn for cases of \span,\omit
 # See alignmentBindings for default bindings
 # But also see others for different handling of (eg) open@row, etc.
 # Probably we have to handle these cases by more generic default code
@@ -258,13 +259,13 @@ sub alignmentBindings {
     properties     => {%properties});
   AssignValue(Alignment => $alignment);
   Debug("Halign $alignment: New " . $template->show) if $LaTeXML::DEBUG{halign};
-  Let(T_MATH, ($ismath ? '\@dollar@in@mathmode' : '\@dollar@in@textmode'));
+  Let(T_MATH, ($ismath ? '\lx@dollar@in@mathmode' : '\lx@dollar@in@textmode'));
   return; }
 
-DefMacroI('\@row@before',    undef, undef);
-DefMacroI('\@row@after',     undef, undef);
-DefMacroI('\@column@before', undef, undef);
-DefMacroI('\@column@after',  undef, undef);
+DefMacroI('\lx@alignment@row@before',    undef, undef);
+DefMacroI('\lx@alignment@row@after',     undef, undef);
+DefMacroI('\lx@alignment@column@before', undef, undef);
+DefMacroI('\lx@alignment@column@after',  undef, undef);
 
 sub pRevert {
   my ($arg) = @_;
@@ -276,7 +277,7 @@ sub cRevert {
   local $LaTeXML::DUAL_BRANCH = 'content';
   return Revert($arg); }
 
-use constant T_close_alignment => T_CS('\@close@alignment');
+use constant T_close_alignment => T_CS('\lx@close@alignment');
 
 sub digestAlignmentBody {
   my ($stomach, $whatsit) = @_;
@@ -342,10 +343,10 @@ sub digestAlignmentBody {
   return; }
 
 use constant T_crcr           => T_CS('\crcr');
-use constant T_hidden_crcr    => T_CS('\hidden@crcr');
+use constant T_hidden_crcr    => T_CS('\lx@hidden@crcr');
 use constant T_omit           => T_CS('\omit');
 use constant T_noalign        => T_CS('\noalign');
-use constant T_hidden_noalign => T_CS('\hidden@noalign');
+use constant T_hidden_noalign => T_CS('\lx@hidden@noalign');
 
 # Read & digest an alignment column's data,
 # accommodating the current template and any special cs's
@@ -544,7 +545,7 @@ DefMacro('\valign', '');
 #########
 # Support for \\[dim] .... TO BE WORKED OUT!
 # NOTE that this does NOT skip spaces before * or []!!!!!
-#  As if: \@alignment@newline OptionalMatch:* [Dimension]
+#  As if: \lx@alignment@newline OptionalMatch:* [Dimension]
 # Read arguments for \\, namely * and/or [Dimension]
 # BUT optionally do it while skipping spaces (latex style) or not (ams style)
 sub readNewlineArgs {
@@ -575,40 +576,38 @@ sub readNewlineArgs {
 # But we're not there (yet)
 
 # This is the internal macro for \\[dim] used by LaTeX for various arrays, tabular, etc
-DefMacroI('\@alignment@newline', undef, sub {
+DefMacroI('\lx@alignment@newline', undef, sub {
     my ($gullet) = @_;
     my ($star, $optional) = readNewlineArgs($gullet, 1);
-    return (T_CS('\hidden@cr'), T_BEGIN,
+    return (T_CS('\lx@hidden@cr'), T_BEGIN,
       ($optional
-        ? (T_CS('\@alignment@newline@markertall'), T_BEGIN, $optional, T_END)
-        : T_CS('\@alignment@newline@marker')),
+        ? (T_CS('\lx@alignment@newline@markertall'), T_BEGIN, $optional, T_END)
+        : T_CS('\lx@alignment@newline@marker')),
       T_END); });
 # However, the above will skip spaces --AND a newline! -- looking for [],
 # which is kinda weird in math, since there may be a reasonable math [ in the 1st column!
 # AMS kindly avoids that, by using a special version of \\
-DefMacroI('\@alignment@newline@noskip', undef, sub {
+DefMacroI('\lx@alignment@newline@noskip', undef, sub {
     my ($gullet) = @_;
     my ($star, $optional) = readNewlineArgs($gullet);
-    return (T_CS('\hidden@cr'), T_BEGIN,
+    return (T_CS('\lx@hidden@cr'), T_BEGIN,
       ($optional
-        ? (T_CS('\@alignment@newline@markertall'), T_BEGIN, $optional, T_END)
-        : T_CS('\@alignment@newline@marker')),
+        ? (T_CS('\lx@alignment@newline@markertall'), T_BEGIN, $optional, T_END)
+        : T_CS('\lx@alignment@newline@marker')),
       T_END); });
 
 # These are the markers that produce \\ in the reversion,
 # and (eventually will) add vertical space to the row!
-DefConstructor('\@alignment@newline@marker', '',
+DefConstructor('\lx@alignment@newline@marker', '',
   reversion => Tokens(T_CS("\\\\"), T_CR));
 # AND add the spacing to the alignment!!!
-DefConstructor('\@alignment@newline@markertall {Dimension}', '',
+DefConstructor('\lx@alignment@newline@markertall {Dimension}', '',
   afterDigest => sub {
     if (my $alignment = LookupValue('Alignment')) {
       $alignment->currentRow->{padding} = $_[1]->getArg(1); }
     return; },
   reversion => sub {
     Tokens(T_CS("\\\\"), T_OTHER('['), Revert($_[1]), T_OTHER(']'), T_CR); });
-
-DefMacroI('\tabularnewline', undef, '\cr');    # ???
 
 # \lx@intercol is our replacement for LaTeX's \@acol which places intercolumn space in tabular
 # (but NOT used by TeX's \halign!)
@@ -638,7 +637,7 @@ DefConstructor('\lx@math@intercol', "",    # mspace ???
 
 # Like \noalign, takes an arg; handled within alignment processing.
 # But doesn't create a pseudo-row (??? Or does it?; is it still needed?)
-DefConstructor('\hidden@noalign{}', '#1',
+DefConstructor('\lx@hidden@noalign{}', '#1',
   reversion  => '',
   properties => sub {
     # Sometimes, we're smuggling stuff that needs to be carried into the XML.
@@ -654,88 +653,29 @@ DefConstructorI('\@@alignment@hline', undef, '',
   properties => { isHorizontalRule => 1 },
   sizer      => 0, alias => '\hline');
 
-DefMacroI('\@tabular@begin@heading', undef, sub {
+DefMacroI('\lx@alignment@begin@heading', undef, sub {
     my $alignment = LookupValue('Alignment');
     $$alignment{in_tabular_head} = 1;
     return; });
-DefMacroI('\@tabular@end@heading', undef, sub {
+DefMacroI('\lx@alignment@end@heading', undef, sub {
     my $alignment = LookupValue('Alignment');
     $$alignment{in_tabular_head} = 0;
     return; });
 
 #======================================================================
-# Math mode in alignment
-# Special forms for $ appearing within alignments.
-# Note that $ within a math alignment (eg array environment),
-# switches to text mode! There's no $$ for display math.
-
-# This is the "normal" case: $ appearing with an alignment that is in text mode.
-# It's just like regular $, except it doesn't look for $$ (no display math).
-DefPrimitiveI('\@dollar@in@textmode', undef, sub {
-    no warnings 'recursion';
-    $_[0]->invokeToken(T_CS((LookupValue('IN_MATH') ? '\@@ENDINLINEMATH' : '\@@BEGININLINEMATH'))); });
-
-# This one is for $ appearing within an alignment that's already math.
-# This should switch to text mode (because it's balancing the hidden $
-# wrapping each alignment cell!!!!!!)
-# However, it should be like a normal $ if it's inside something like \mbox
-# that itself makes a text box!!!!!!
-# Thus, we need to know at what boxing level we started the last math or text.
-# This is all complicated by the need to know _how_ we got into or out of math mode!
-# Gawd, this is awful!
-# NOTE: Probably the most "Right" thing to do would be to process
-# alignments in text mode only (like TeX), sneaking $'s in where needed,
-# but then afterwards, morph them into math arrays?
-# This would be complicated by the need to hide these $ from untex.
-DefPrimitiveI('\@dollar@in@mathmode', undef, sub {
-    my ($stomach) = @_;
-    my $level = $stomach->getBoxingLevel;
-    if ((LookupValue('MATH_ALIGN_$_BEGUN') || 0) == $level) { # If we're begun making _something_ with $.
-      my @l = ();
-      if (LookupValue('IN_MATH')) {                           # But we're somehow in math?
-        @l = $stomach->invokeToken(T_CS('\@@ENDINLINEMATH')); }
-      else {
-        @l = $stomach->invokeToken(T_CS('\@@ENDINLINETEXT')); }
-      AssignValue('MATH_ALIGN_$_BEGUN' => 0);                 # Reset this AFTER finishing the something
-      @l; }
-    else {
-      AssignValue('MATH_ALIGN_$_BEGUN' => $level + 1);        # Note that we've begun something
-      if (LookupValue('IN_MATH')) {                           # If we're "still" in math
-        $stomach->invokeToken(T_CS('\@@BEGININLINETEXT')); }
-      else {
-        $stomach->invokeToken(T_CS('\@@BEGININLINEMATH')); } } });
-
-DefConstructorI('\@@BEGININLINETEXT', undef,
-  "<ltx:XMText>"
-    . "#body"
-    . "</ltx:XMText>",
-  alias => T_MATH, beforeDigest => sub { $_[0]->beginMode('text'); }, captureBody => 1);
-DefConstructorI('\@@ENDINLINETEXT', undef, "", alias => T_MATH,
-  beforeDigest => sub { $_[0]->endMode('text'); });
-
-DefPrimitiveI('\@LTX@nonumber', undef, sub { AssignValue(EQUATIONROW_NUMBER => 0, 'global'); });
-
-DefMacroI('\hidewidth', undef, Tokens());
-
-#======================================================================
 # Multicolumn support
-DefMacro('\multispan{Number}', sub {
-    my ($gullet, $span) = @_;
-    $span = $span->valueOf;
-    (T_CS('\omit'), map { (T_CS('\span'), T_CS('\omit')) } 1 .. $span - 1); });
-
-DefRegisterI('\@alignment@ncolumns', undef, Dimension(0),
+DefRegisterI('\lx@alignment@ncolumns', undef, Dimension(0),
   getter => sub {
     if (my $alignment = LookupValue('Alignment')) {
       Number(scalar($alignment->getTemplate->columns)); }
     else { Number(0); } });
-DefRegisterI('\@alignment@column', undef, Dimension(0),
+DefRegisterI('\lx@alignment@column', undef, Dimension(0),
   getter => sub {
     if (my $alignment = LookupValue('Alignment')) {
       Number($alignment->currentColumnNumber); }
     else { Number(0); } });
 
-DefMacro('\@multicolumn {Number}  AlignmentTemplate {}', sub {
+DefMacro('\lx@alignment@multicolumn {Number}  AlignmentTemplate {}', sub {
     my ($gullet, $span, $template, $tokens) = @_;
     my $column = $template->column(1);
     $span = $span->valueOf;
@@ -746,9 +686,9 @@ DefMacro('\@multicolumn {Number}  AlignmentTemplate {}', sub {
       $tokens->unlist,
       ($column ? afterCellUnlist($$column{after}) : ())); });
 
-DefConditionalI('\if@in@alignment', undef, sub { LookupValue('Alignment'); });
+DefConditionalI('\if@in@lx@alignment', undef, sub { LookupValue('Alignment'); });
 
-DefPrimitive('\@alignment@bindings AlignmentTemplate []', sub {
+DefPrimitive('\lx@alignment@bindings AlignmentTemplate []', sub {
     my ($stomach, $template, $mode) = @_;
     alignmentBindings($template, $mode); });
 

--- a/lib/LaTeXML/Engine/plain.pool.ltxml
+++ b/lib/LaTeXML/Engine/plain.pool.ltxml
@@ -44,11 +44,11 @@ DefMacroI('\hideoutput',  undef, Tokens());
 # \choose & friends, also need VERY special argument handling
 
 DefMacro('\choose',
-  '\lx@generalized@over{\choose}{meaning=binomial,thickness=0pt,left=\@left(,right=\@right)}');
+  '\lx@generalized@over{\choose}{meaning=binomial,thickness=0pt,left=\lx@left(,right=\lx@right)}');
 DefMacro('\brace',
-  '\lx@generalized@over{\brace}{thickness=0pt,left=\@left\{,right=\@right\}}');
+  '\lx@generalized@over{\brace}{thickness=0pt,left=\lx@left\{,right=\lx@right\}}');
 DefMacro('\brack',
-  '\lx@generalized@over{\brack}{thickness=0pt,left=\@left[,right=\@right]}');
+  '\lx@generalized@over{\brack}{thickness=0pt,left=\lx@left[,right=\lx@right]}');
 
 #======================================================================
 # Special Characters.
@@ -156,7 +156,7 @@ Let('\ialign', '\halign');
 
 # Overlapping alignments ???
 DefMacro('\oalign{}',
-  '\@@oalign{\@start@alignment#1\@finish@alignment}');
+  '\@@oalign{\lx@begin@alignment#1\lx@end@alignment}');
 DefConstructor('\@@oalign{}',
   '#1',
   reversion    => '\oalign{#1}', bounded => 1, mode => 'text',
@@ -165,7 +165,7 @@ DefConstructor('\@@oalign{}',
 # This is actually different; the lines should lie ontop of each other.
 # How should this be represented?
 DefMacro('\ooalign{}',
-  '\@@ooalign{\@start@alignment#1\@finish@alignment}');
+  '\@@ooalign{\lx@begin@alignment#1\lx@end@alignment}');
 DefConstructor('\@@ooalign{}',
   '#1',
   reversion    => '\ooalign{#1}', bounded => 1, mode => 'text',
@@ -178,6 +178,13 @@ DefConstructor('\buildrel Until:\over {}',
     . "<ltx:XMArg>#1</ltx:XMArg>"
     . "</ltx:XMApp>",
   properties => { scriptpos => sub { "mid" . $_[0]->getScriptLevel; } });
+
+DefMacroI('\hidewidth', undef, Tokens());
+
+DefMacro('\multispan{Number}', sub {
+    my ($gullet, $span) = @_;
+    $span = $span->valueOf;
+    (T_CS('\omit'), map { (T_CS('\span'), T_CS('\omit')) } 1 .. $span - 1); });
 
 #======================================================================
 # TeX Book, Appendix B, p. 344
@@ -420,7 +427,7 @@ DefMacroI('\normalbaselines', undef,
 DefMacroI('\space', undef, Tokens(T_SPACE));
 DefMacroI('\lq',    undef, "`");
 DefMacroI('\rq',    undef, "'");
-Let('\empty', '\@empty');
+Let('\empty', '\lx@empty');
 DefMacroI('\null', undef, '\hbox{}');
 Let('\bgroup',  T_BEGIN);
 Let('\egroup',  T_END);
@@ -834,6 +841,24 @@ DefMathI('\clubsuit',    undef, "\x{2663}");
 DefMathI('\diamondsuit', undef, "\x{2662}");
 DefMathI('\heartsuit',   undef, "\x{2661}");
 DefMathI('\spadesuit',   undef, "\x{2660}");
+
+DefMacroI('\active@math@prime', undef, sub {
+    my ($gullet) = @_;
+    my @sup = (T_CS('\prime'));
+    # Collect up all ', convering to \prime
+    while ($gullet->ifNext(T_OTHER('\''))) {
+      $gullet->readToken;
+      push(@sup, T_CS('\prime')); }
+    # Combine with any following superscript!
+    # However, this is semantically screwed up!
+    # We really need to set up separate superscripts, but at same level!
+    if ($gullet->ifNext(T_SUPER)) {
+      $gullet->readToken;
+      push(@sup, $gullet->readArg->unlist); }
+    (T_SUPER, T_BEGIN, @sup, T_END); },
+  locked => 1);    # Only in math!
+AssignMathcode("'" => 0x8000);
+Let("'", '\active@math@prime');
 
 #----------------------------------------------------------------------
 DefMath('\smallint', "\x{222B}", meaning => 'integral', role => 'INTOP',
@@ -1253,8 +1278,8 @@ DefMath('\underbrace {}', "\x{23DF}", operator_role => 'UNDERACCENT',     # BOTT
 
 Let('\underbar', '\underline');    # Will anyone notice?
 
-DefMacro('\overrightarrow{}', '\protect\ifmmode\math@overrightarrow{#1}\else$\math@overrightarrow{#1}$\fi');
-DefMacro('\overleftarrow{}', '\protect\ifmmode\math@overleftarrow{#1}\else$\math@overleftarrow{#1}$\fi');
+DefMacro('\overrightarrow{}', '\protect\ifmmode\lx@math@overrightarrow{#1}\else$\lx@math@overrightarrow{#1}$\fi');
+DefMacro('\overleftarrow{}', '\protect\ifmmode\lx@math@overleftarrow{#1}\else$\lx@math@overleftarrow{#1}$\fi');
 
 DefMacro('\skew{}{}{}', '{#2{#3\mkern#1mu}\mkern-#1mu}{}');    # ignore the subtle spacing for now?
 #----------------------------------------------------------------------
@@ -1531,11 +1556,11 @@ DefConstructor('\lx@hack@bordermatrix{}', sub {
   reversion => '#1');
 
 DefMacro('\pmatrix{}',
-  '\lx@gen@plain@matrix{name=pmatrix,datameaning=matrix,left=\@left(,right=\@right)}{#1}');
+  '\lx@gen@plain@matrix{name=pmatrix,datameaning=matrix,left=\lx@left(,right=\lx@right)}{#1}');
 
 # Note that 2nd column in \cases is in text mode!
 DefMacro('\cases{}',
-  '\lx@gen@plain@cases{meaning=cases,left=\@left\{,conditionmode=text,style=\textstyle}{#1}');
+  '\lx@gen@plain@cases{meaning=cases,left=\lx@left\{,conditionmode=text,style=\textstyle}{#1}');
 
 DefPrimitive('\openup Dimension', undef);
 
@@ -1545,7 +1570,7 @@ DefPrimitive('\openup Dimension', undef);
 DefMacro('\displaylines{}', '\halign{\hbox to\displaywidth{$\hfil\displaystyle##\hfil$}\crcr#1\crcr}');
 
 DefMacro('\eqalign{}',
-  '\@@eqalign{\@start@alignment#1\@finish@alignment}');
+  '\@@eqalign{\lx@begin@alignment#1\lx@end@alignment}');
 DefConstructor('\@@eqalign{}',
   '#1',
   reversion    => '\eqalign{#1}', bounded => 1,
@@ -1553,7 +1578,7 @@ DefConstructor('\@@eqalign{}',
       attributes => { vattach => 'baseline' }); });
 
 DefMacro('\eqalignno{}',
-  '\@@eqalignno{\@start@alignment#1\@finish@alignment}');
+  '\@@eqalignno{\lx@begin@alignment#1\lx@end@alignment}');
 DefConstructor('\@@eqalignno{}',
   '#1',
   reversion    => '\eqalignno{#1}', bounded => 1,
@@ -1561,7 +1586,7 @@ DefConstructor('\@@eqalignno{}',
       attributes => { vattach => 'baseline' }); });
 
 DefMacro('\leqalignno{}',
-  '\@@leqalignno{\@start@alignment#1\@finish@alignment}');
+  '\@@leqalignno{\lx@begin@alignment#1\lx@end@alignment}');
 DefConstructor('\@@leqalignno{}',
   '#1',
   reversion    => '\leqalignno{#1}', bounded => 1,

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -662,7 +662,7 @@ sub NewCounter {
   if (defined $prefix) {
     if (my $idwithin = $options{idwithin} || $within) {
       DefMacroI(T_CS("\\the$ctr\@ID"), undef,
-        "\\expandafter\\ifx\\csname the$idwithin\@ID\\endcsname\\\@empty"
+        "\\expandafter\\ifx\\csname the$idwithin\@ID\\endcsname\\lx\@empty"
           . "\\else\\csname the$idwithin\@ID\\endcsname.\\fi"
           . " $prefix\\csname \@$ctr\@ID\\endcsname",
         scope => 'global'); }
@@ -1418,10 +1418,10 @@ sub DefConstructorI {
 # Perhaps it would be better to use a label(-like) indirection here,
 # so all ID's can stay in the desired format?
 sub getXMArgID {
-  StepCounter('@XMARG');
-  DefMacroI(T_CS('\@@XMARG@ID'), undef, Tokens(Explode(LookupRegister('\c@@XMARG')->valueOf)),
+  StepCounter('@lx@xmarg');
+  DefMacroI(T_CS('\@@lx@xmarg@ID'), undef, Tokens(Explode(LookupRegister('\c@@lx@xmarg')->valueOf)),
     scope => 'global');
-  return Expand(T_CS('\the@XMARG@ID')); }
+  return Expand(T_CS('\the@lx@xmarg@ID')); }
 
 # Given a list of Tokens (to be expanded into mathematical objects)
 # return two lists:

--- a/lib/LaTeXML/Package/IEEEtran.cls.ltxml
+++ b/lib/LaTeXML/Package/IEEEtran.cls.ltxml
@@ -317,13 +317,13 @@ DefMacro('\IEEEeqnarraybox',
     . '\else\def\@tempa{\let\endIEEEeqnarraybox\endIEEEeqnarrayboxt\IEEEeqnarrayboxt}\fi'
     . '\@tempa');
 DefMacro('\IEEEeqnarrayboxm OptionalMatch:* {}',
-  '\@array@bindings{#2}\@@IEEE@array{#2}\@start@alignment');
+  '\@array@bindings{#2}\@@IEEE@array{#2}\lx@begin@alignment');
 DefMacroI('\endIEEEeqnarrayboxm', undef,
-  '\@finish@alignment\@end@array');
+  '\lx@end@alignment\@end@array');
 DefMacro('\IEEEeqnarrayboxt OptionalMatch:* {}',
-  '\@@BEGININLINEMATH\@array@bindings{#2}\@@IEEE@array{#2}\@start@alignment');
+  '\lx@begin@inline@math\@array@bindings{#2}\@@IEEE@array{#2}\lx@begin@alignment');
 DefMacroI('\endIEEEeqnarrayboxt', undef,
-  '\@finish@alignment\@end@array\@@ENDINLINEMATH');
+  '\lx@end@alignment\@end@array\\lx@end@inline@math');
 
 DefConstructor('\@@IEEE@array[] Undigested DigestedBody',
   '#3',

--- a/lib/LaTeXML/Package/aa.cls.ltxml
+++ b/lib/LaTeXML/Package/aa.cls.ltxml
@@ -49,10 +49,10 @@ RequirePackage('aa_support');
 # see arXiv:astro-ph/0002145 for an example.
 # just use the one from TeX.pool, copied here:
 DefMacro('\pmatrix{}',
-  '\lx@gen@plain@matrix{name=pmatrix,datameaning=matrix,left=\@left(,right=\@right)}{#1}');
+  '\lx@gen@plain@matrix{name=pmatrix,datameaning=matrix,left=\lx@left(,right=\lx@right)}{#1}');
 # also don't use the amsmath cases
 DefMacro('\cases{}',
-  '\lx@gen@plain@cases{meaning=cases,left=\@left\{,conditionmode=text,style=\textstyle}{#1}');
+  '\lx@gen@plain@cases{meaning=cases,left=\lx@left\{,conditionmode=text,style=\textstyle}{#1}');
 # but allow reloading amsmath.sty if {cases} was really needed (arXiv:astro-ph/0203101)
 AssignValue('amsmath.sty.ltxml_loaded', undef, 'global');
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/LaTeXML/Package/aa_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aa_support.sty.ltxml
@@ -77,13 +77,13 @@ DefMacro('\abstract@old{}',
 
 # Apparently args #2--#4 are required non-empty.
 DefMacro('\abstract@new{}{}{}{}{}',
-         '\@add@frontmatter{ltx:abstract}[name={\abstractname}]{'
-         .'\ifx.#1.\else\textit{Context. }#1\par\fi'
-         .'\textit{Aims. }#2\par'
-         .'\textit{Methods. }#3\par'
-         .'\textit{Results. }#4\par'
-         .'\ifx.#5.\else\textit{Conclusions. }#5\fi'
-         .'}');
+  '\@add@frontmatter{ltx:abstract}[name={\abstractname}]{'
+    . '\ifx.#1.\else\textit{Context. }#1\par\fi'
+    . '\textit{Aims. }#2\par'
+    . '\textit{Methods. }#3\par'
+    . '\textit{Results. }#4\par'
+    . '\ifx.#5.\else\textit{Conclusions. }#5\fi'
+    . '}');
 
 DefMacro('\abstract{}', sub {
     my ($gullet, $arg1) = @_;
@@ -175,7 +175,7 @@ DefEnvironment('{equation}',
   beforeDigest => sub {
     prepareEquationCounter(numbered => 1, preset => 1);
     beforeEquation();
-    Let(T_MATH, T_CS('\@dollar@in@mathmode')); },
+    Let(T_MATH, T_CS('\lx@dollar@in@mathmode')); },
   afterDigestBody => sub {
     afterEquation($_[1]); },
   locked => 1);
@@ -194,7 +194,7 @@ DefEnvironment('{equation*}',
   beforeDigest => sub {
     prepareEquationCounter(numbered => undef, preset => 1);
     beforeEquation();
-    Let(T_MATH, T_CS('\@dollar@in@mathmode')); },
+    Let(T_MATH, T_CS('\lx@dollar@in@mathmode')); },
   afterDigestBody => sub {
     afterEquation($_[1]); },
   locked => 1);

--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -354,12 +354,12 @@ DefMacro('\aas@start@D@column XUntil:\aas@end@D@column', sub {
     my ($m,      $f) = SplitTokens($n, T_OTHER('.'));
     return ($f ? (@$m,
         T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_norightpad'), T_END,
-        T_CS('\@alignment@align'),
+        T_CS('\lx@alignment@align'),
         T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_noleftpad'), T_END,
         T_OTHER('.'),       @$f)
       : ($n,
         T_CS('\@ADDCLASS'), T_BEGIN, T_OTHER('ltx_norightpad'), T_END,
-        T_CS('\@alignment@align')));
+        T_CS('\lx@alignment@align')));
 });
 DefPrimitive('\aas@end@D@column', '');
 

--- a/lib/LaTeXML/Package/amscd.sty.ltxml
+++ b/lib/LaTeXML/Package/amscd.sty.ltxml
@@ -32,10 +32,10 @@ RequirePackage('amsgen');
 
 DefMacro('\CD', '\lx@ams@CD{name=CD,datameaning=commutative-diagram}');
 DefMacro('\lx@ams@CD RequiredKeyVals:lx@GEN',
-  '\lx@gen@matrix@bindings{#1}\lx@ams@CD@bindings\lx@ams@matrix@{#1}\@start@alignment');
-DefMacro('\endCD', '\@finish@alignment\lx@end@gen@matrix');
+  '\lx@gen@matrix@bindings{#1}\lx@ams@CD@bindings\lx@ams@matrix@{#1}\lx@begin@alignment');
+DefMacro('\endCD', '\lx@end@alignment\lx@end@gen@matrix');
 DefPrimitive('\lx@ams@CD@bindings', sub {
-    Let("\\\\", '\@alignment@newline@noskip');
+    Let("\\\\", '\lx@alignment@newline@noskip');
     $STATE->assignMathcode('@' => 0x8000);
     Let('@', '\cd@'); });
 
@@ -44,27 +44,27 @@ DefMacro('\cd@ Token', sub {
     (T_CS('@' . ToString($token))); });
 
 DefMacroI(T_CS('@>'), 'Until:> Until:>',
-  '\hidden@align\cd@stack{>}{\rightarrowfill@}{#1}{#2}\hidden@align');
+  '\lx@hidden@align\cd@stack{>}{\rightarrowfill@}{#1}{#2}\lx@hidden@align');
 DefMacroI(T_CS('@)'), 'Until:) Until:)',
-  '\hidden@align\cd@stack{)}{\rightarrowfill@}{#1}{#2}\hidden@align');
+  '\lx@hidden@align\cd@stack{)}{\rightarrowfill@}{#1}{#2}\lx@hidden@align');
 DefMacroI(T_CS('@<'), 'Until:< Until:<',
-  '\hidden@align\cd@stack{<}{\leftarrowfill@}{#1}{#2}\hidden@align');
+  '\lx@hidden@align\cd@stack{<}{\leftarrowfill@}{#1}{#2}\lx@hidden@align');
 DefMacroI(T_CS('@('), 'Until:( Until:(',
-  '\hidden@align\cd@stack{(}{\leftarrowfill@}{#1}{#2}\hidden@align');
+  '\lx@hidden@align\cd@stack{(}{\leftarrowfill@}{#1}{#2}\lx@hidden@align');
 
 DefMacroI(T_CS('@A'), 'Until:A Until:A',
-  '\cd@adjacent{A}{\Big\uparrow}{#1}{#2}\hidden@align\hidden@align');
+  '\cd@adjacent{A}{\Big\uparrow}{#1}{#2}\lx@hidden@align\lx@hidden@align');
 DefMacroI(T_CS('@V'), 'Until:V Until:V',
-  '\cd@adjacent{V}{\Big\downarrow}{#1}{#2}\hidden@align\hidden@align');
+  '\cd@adjacent{V}{\Big\downarrow}{#1}{#2}\lx@hidden@align\lx@hidden@align');
 
 DefMacroI(T_CS('@='), undef,
-  '\hidden@align\@cd@equals@\hidden@align');
+  '\lx@hidden@align\@cd@equals@\lx@hidden@align');
 DefMacroI(T_CS('@|'), undef,
-  '\Big\Vert\hidden@align\hidden@align');
+  '\Big\Vert\lx@hidden@align\lx@hidden@align');
 DefMacroI(T_CS('@\vert'), undef,
-  '\Big\Vert\hidden@align\hidden@align');
+  '\Big\Vert\lx@hidden@align\lx@hidden@align');
 DefMacroI(T_CS('@.'), undef,
-  '\hidden@align\hidden@align');
+  '\lx@hidden@align\lx@hidden@align');
 
 # Horizontal
 DefMath('\@cd@equals@', "=", role => 'ARROW', stretchy => 'true', reversion => '@=');

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -94,14 +94,14 @@ DefMacro('\tag OptionalMatch:* {}',
 # latexml, however, can end up with 2, which end up incrementing coutners twice!
 # Of course, that means we're doing something quite wrong, but we've at least got to recover the effect!!!
 DefMacro('\@ams@intertext{}',
-  '\hidden@crcr\noalign{\@@ams@intertext{#1}}');
+  '\lx@hidden@crcr\noalign{\@@ams@intertext{#1}}');
 
 DefConstructor('\@@ams@intertext{}',
   "<ltx:p class='ltx_intertext'>#1</ltx:p>", mode => 'text');
 
 # Note that most of ams's alignment environments originate in AmSTeX.
 # To make \begin{foo}...\end{foo} also work as \foo...\endfoo within AmSTeX.pool,
-# we're wrapping an extra \@hidden@bgroup ... \@hidden@egroup around the
+# we're wrapping an extra \lx@hidden@bgroup ... \lx@hidden@egroup around the
 # code imlementing these.
 
 # A utility for handling different alignment strategies centrally
@@ -112,7 +112,7 @@ sub amsAlignmentBindings {
   if ($cur_jot && ($cur_jot->valueOf != LookupDimension('\lx@default@jot')->valueOf)) {
     $properties{rowsep} = $cur_jot; }
   alignmentBindings($template, 'math', attributes => {%properties});
-  Let("\\\\", '\@alignment@newline@noskip');
+  Let("\\\\", '\lx@alignment@newline@noskip');
   return; }
 
 # This one is for alignment environments that can (and need to be) "rearranged"
@@ -140,14 +140,14 @@ sub amsRearrangeableBindings {
       openColumn  => sub { $_[0]->openElement('ltx:_Capture_', @_[1 .. $#_]); },
       closeColumn => sub { $_[0]->closeElement('ltx:_Capture_'); },
       properties  => {%properties}));
-  Let("\\\\",         '\@alignment@newline@noskip');
-  Let('\@row@before', '\eqnarray@row@before');
-  Let('\@row@after',  '\eqnarray@row@after');
-  Let('\intertext',   '\@ams@intertext');
+  Let("\\\\",                     '\lx@alignment@newline@noskip');
+  Let('\lx@alignment@row@before', '\eqnarray@row@before');
+  Let('\lx@alignment@row@after',  '\eqnarray@row@after');
+  Let('\intertext',               '\@ams@intertext');
   return; }
 
 DefPrimitive('\lx@ams@cr@binding', sub {
-    Let("\\\\", '\@alignment@newline@noskip'); });
+    Let("\\\\", '\lx@alignment@newline@noskip'); });
 
 #======================================================================
 # Section 3.1 introduction
@@ -223,14 +223,14 @@ DefPrimitiveI('\@ams@multirow@bindings', 'RequiredKeyVals:multirow OptionalKeyVa
     return; });
 
 DefMacro('\multline',
-  '\ifmmode\@hidden@bgroup\@ams@multirow@bindings{name=multline}\@@AmS@multline\@start@alignment'
-    . '\else\@hidden@bgroup\@ams@multirow@bindings{name=multline}\@@multline\@start@alignment\fi');
+  '\ifmmode\lx@hidden@bgroup\@ams@multirow@bindings{name=multline}\@@AmS@multline\lx@begin@alignment'
+    . '\else\lx@hidden@bgroup\@ams@multirow@bindings{name=multline}\@@multline\lx@begin@alignment\fi');
 DefMacro('\endmultline',
-  '\hidden@cr{}\@finish@alignment\@end@multline\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\@end@multline\lx@hidden@egroup');
 DefMacro('\csname multline*\endcsname',
-  '\@hidden@bgroup\@ams@multirow@bindings{name=multline}\@@multlinestar\@start@alignment');
+  '\lx@hidden@bgroup\@ams@multirow@bindings{name=multline}\@@multlinestar\lx@begin@alignment');
 DefMacro('\csname endmultline*\endcsname',
-  '\hidden@cr{}\@finish@alignment\@end@multline\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\@end@multline\lx@hidden@egroup');
 DefPrimitive('\@end@multline', sub { $_[0]->egroup; });
 
 DefConstructor('\@@multline DigestedBody',
@@ -345,9 +345,9 @@ DefConstructor('\lx@ams@marksplitinalign', sub {
 
 DefMacro('\split',
   '\if@in@ams@align\lx@ams@marksplitinalign\fi'
-    . '\@hidden@bgroup\@ams@aligned@bindings\@@split\@start@alignment');
+    . '\lx@hidden@bgroup\@ams@aligned@bindings\@@split\lx@begin@alignment');
 
-DefMacro('\endsplit', '\hidden@cr{}\@finish@alignment\@end@split\@hidden@egroup');
+DefMacro('\endsplit', '\lx@hidden@cr{}\lx@end@alignment\@end@split\lx@hidden@egroup');
 
 DefPrimitive('\@end@split', sub { $_[0]->egroup; });
 DefConstructor('\@@split DigestedBody',
@@ -418,18 +418,18 @@ sub rearrangeAMSGather {
 # So, we'll treat align as aligned in such cases.
 DefMacro('\gather',
   '\ifmmode\let\endgather\endgathered\gathered\else'
-    . '\@hidden@bgroup\@ams@gather@bindings\@@amsgather'
+    . '\lx@hidden@bgroup\@ams@gather@bindings\@@amsgather'
     . '\@equationgroup@numbering{numbered=1,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi');
+    . '\lx@begin@alignment\fi');
 DefMacro('\endgather',
-  '\hidden@cr{}\@finish@alignment\end@amsgather\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsgather\lx@hidden@egroup');
 DefMacro('\csname gather*\endcsname',
   '\ifmmode\expandafter\let\csname endgather*\endcsname\endgathered\gathered\else'
-    . '\@hidden@bgroup\@ams@gather@bindings\@@amsgather'
+    . '\lx@hidden@bgroup\@ams@gather@bindings\@@amsgather'
     . '\@equationgroup@numbering{numbered=0,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi');
+    . '\lx@begin@alignment\fi');
 DefMacro('\csname endgather*\endcsname',
-  '\hidden@cr{}\@finish@alignment\end@amsgather\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsgather\lx@hidden@egroup');
 
 #======================================================================
 # Section 3.6 Equation groups with mutual alignment
@@ -478,77 +478,77 @@ sub rearrangeAMSAlign {
 # So, we'll treat align as aligned in such cases.
 DefMacro('\align',
   '\ifmmode\let\endalign\endaligned\aligned\else'
-    . '\@hidden@bgroup\@ams@align@bindings\@@amsalign'
+    . '\lx@hidden@bgroup\@ams@align@bindings\@@amsalign'
     . '\@equationgroup@numbering{numbered=1,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi', locked => 1);
-# Note the included \hidden@cr
+    . '\lx@begin@alignment\fi', locked => 1);
+# Note the included \lx@hidden@cr
 DefMacro('\endalign',
-  '\hidden@cr{}\@finish@alignment\end@amsalign\@hidden@egroup', locked => 1);
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsalign\lx@hidden@egroup', locked => 1);
 DefMacro('\csname align*\endcsname',
   '\ifmmode\expandafter\let\csname endalign*\endcsname\endaligned\aligned\else'
-    . '\@hidden@bgroup\@ams@align@bindings\@@amsalign'
+    . '\lx@hidden@bgroup\@ams@align@bindings\@@amsalign'
     . '\@equationgroup@numbering{numbered=0,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi', locked => 1);
+    . '\lx@begin@alignment\fi', locked => 1);
 DefMacro('\csname endalign*\endcsname',
-  '\hidden@cr{}\@finish@alignment\end@amsalign\@hidden@egroup', locked => 1);
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsalign\lx@hidden@egroup', locked => 1);
 
 # flalign typesets in the full column width (seems perverse to me).
 # So, for the time being, it's treated exactly like align.
 DefMacro('\flalign',
   '\ifmmode\let\endfalign\endaligned\aligned\else'
-    . '\@hidden@bgroup\@ams@align@bindings\@@amsalign'
+    . '\lx@hidden@bgroup\@ams@align@bindings\@@amsalign'
     . '\@equationgroup@numbering{numbered=1,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi');
+    . '\lx@begin@alignment\fi');
 DefMacro('\endflalign',
-  '\hidden@cr{}\@finish@alignment\end@amsalign\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsalign\lx@hidden@egroup');
 DefMacro('\csname flalign*\endcsname',
   '\ifmmode\expandafter\let\csname endfalign*\endcsname\endaligned\aligned\else'
-    . '\@hidden@bgroup\@ams@align@bindings\@@amsalign'
+    . '\lx@hidden@bgroup\@ams@align@bindings\@@amsalign'
     . '\@equationgroup@numbering{numbered=0,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi');
+    . '\lx@begin@alignment\fi');
 DefMacro('\csname endflalign*\endcsname',
-  '\hidden@cr{}\@finish@alignment\end@amsalign\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsalign\lx@hidden@egroup');
 
 # alignat doesn't stretch the columns out as much (?)
 # and takes the number of column pairs (which we don't need?)
 # We'll ignore these distinctions for now.
 DefMacro('\alignat{}',
   '\ifmmode\let\endalignat\endalignedat\alignedat{#1}\else'
-    . '\@hidden@bgroup\@ams@align@bindings\@@amsalign'
+    . '\lx@hidden@bgroup\@ams@align@bindings\@@amsalign'
     . '\@equationgroup@numbering{numbered=1,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi');
+    . '\lx@begin@alignment\fi');
 DefMacro('\endalignat',
-  '\hidden@cr{}\@finish@alignment\end@amsalign\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsalign\lx@hidden@egroup');
 DefMacro('\csname alignat*\endcsname{}',
   '\ifmmode\expandafter\let\csname endalignat*\endcsname\endalignedat\alignedat{#1}\else'
-    . '\@hidden@bgroup\@ams@align@bindings\@@amsalign'
+    . '\lx@hidden@bgroup\@ams@align@bindings\@@amsalign'
     . '\@equationgroup@numbering{numbered=0,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi');
+    . '\lx@begin@alignment\fi');
 DefMacro('\csname endalignat*\endcsname',
-  '\hidden@cr{}\@finish@alignment\end@amsalign\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsalign\lx@hidden@egroup');
 
 DefMacro('\xalignat{}',
   '\ifmmode\let\endalignat\endalignedat\alignedat{#1}\else'
-    . '\@hidden@bgroup\@ams@align@bindings\@@amsalign'
+    . '\lx@hidden@bgroup\@ams@align@bindings\@@amsalign'
     . '\@equationgroup@numbering{numbered=1,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi');
+    . '\lx@begin@alignment\fi');
 DefMacro('\endxalignat',
-  '\hidden@cr{}\@finish@alignment\end@amsalign\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsalign\lx@hidden@egroup');
 DefMacro('\csname xalignat*\endcsname{}',
   '\ifmmode\expandafter\let\csname endalignat*\endcsname\endalignedat\alignedat{#1}\else'
-    . '\@hidden@bgroup\@ams@align@bindings\@@amsalign'
+    . '\lx@hidden@bgroup\@ams@align@bindings\@@amsalign'
     . '\@equationgroup@numbering{numbered=0,postset=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi');
+    . '\lx@begin@alignment\fi');
 DefMacro('\csname endxalignat*\endcsname',
-  '\hidden@cr{}\@finish@alignment\end@amsalign\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsalign\lx@hidden@egroup');
 
 DefMacro('\xxalignat{}',
   '\ifmmode\let\endalignat\endalignedat\alignedat{#1}\else'
-    . '\@hidden@bgroup\@ams@align@bindings\@@amsalign'
+    . '\lx@hidden@bgroup\@ams@align@bindings\@@amsalign'
     . '\@equationgroup@numbering{numbered=1,post=1,grouped=1,aligned=1}'
-    . '\@start@alignment\fi');
+    . '\lx@begin@alignment\fi');
 DefMacro('\endxxalignat',
-  '\hidden@cr{}\@finish@alignment\end@amsalign\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\end@amsalign\lx@hidden@egroup');
 
 #======================================================================
 # Section 3.7. Alignment building blocks
@@ -563,9 +563,9 @@ DefMacro('\endxxalignat',
 # these potentially separate equations will be awkward anyway!
 # We'll just create an XMDual to contain the whole results, and the aligned structure.
 DefMacro('\gathered[]',
-  '\@hidden@bgroup\@ams@multirow@bindings{name=gathered,vattach=#1}\@@gathered\@start@alignment');
+  '\lx@hidden@bgroup\@ams@multirow@bindings{name=gathered,vattach=#1}\@@gathered\lx@begin@alignment');
 DefMacro('\endgathered',
-  '\hidden@cr{}\@finish@alignment\@end@gathered\@hidden@egroup');
+  '\lx@hidden@cr{}\lx@end@alignment\@end@gathered\lx@hidden@egroup');
 DefPrimitive('\@end@gathered', sub { $_[0]->egroup; });
 DefConstructor('\@@gathered DigestedBody',
   '#1',
@@ -581,8 +581,8 @@ DefPrimitive('\@ams@aligned@bindings', sub {
       after => Tokens(T_CS('\hfil')) };
     my $template = LaTeXML::Core::Alignment::Template->new(repeated => [$col1, $col2]);
     amsAlignmentBindings($template, (name => 'aligned', colsep => '0pt'));
-    DefMacro('\@row@before', '');
-    DefMacro('\@row@after',  '');
+    DefMacro('\lx@alignment@row@before', '');
+    DefMacro('\lx@alignment@row@after',  '');
     return; });
 
 # Perverse, but See amsmath's \alignsafe@tesetopt
@@ -612,11 +612,11 @@ DefParameterType('alignsafeOptional', sub {
     else { (); } });
 
 DefMacro('\aligned alignsafeOptional',
-  '\@hidden@bgroup\@ams@aligned@bindings\@@amsaligned\@start@alignment', locked => 1);
-DefMacro('\endaligned', '\hidden@cr{}\@finish@alignment\@end@amsaligned\@hidden@egroup', locked => 1);
+  '\lx@hidden@bgroup\@ams@aligned@bindings\@@amsaligned\lx@begin@alignment', locked => 1);
+DefMacro('\endaligned', '\lx@hidden@cr{}\lx@end@alignment\@end@amsaligned\lx@hidden@egroup', locked => 1);
 DefMacro('\alignedat{} alignsafeOptional',
-  '\@hidden@bgroup\@ams@aligned@bindings\@@amsaligned\@start@alignment', locked => 1);
-DefMacro('\endalignedat', '\hidden@cr{}\@finish@alignment\@end@amsaligned\@hidden@egroup', locked => 1);
+  '\lx@hidden@bgroup\@ams@aligned@bindings\@@amsaligned\lx@begin@alignment', locked => 1);
+DefMacro('\endalignedat', '\lx@hidden@cr{}\lx@end@alignment\@end@amsaligned\lx@hidden@egroup', locked => 1);
 
 DefPrimitive('\@end@amsaligned', sub { $_[0]->egroup; });
 DefConstructor('\@@amsaligned DigestedBody',
@@ -685,9 +685,9 @@ sub rearrangeLoneAMSAligned {
 #  style : \textstyle or \displaystyle
 #  conditionmode : mode of 2nd column, text or math
 DefMacro('\lx@ams@cases{}',
-  '\lx@gen@cases@bindings{#1}\lx@ams@cr@binding\lx@ams@cases@{#1}\@start@alignment');
+  '\lx@gen@cases@bindings{#1}\lx@ams@cr@binding\lx@ams@cases@{#1}\lx@begin@alignment');
 DefMacro('\lx@end@ams@cases',
-  '\hidden@cr{}\@finish@alignment\lx@end@gen@cases');
+  '\lx@hidden@cr{}\lx@end@alignment\lx@end@gen@cases');
 
 # The logical structure for cases extracts the columns of the alignment
 # to give alternating value,condition (an empty condition is replaced by "otherwise" !?!?!)
@@ -714,9 +714,9 @@ DefConstructor('\lx@ams@cases@ RequiredKeyVals:lx@GEN DigestedBody',
       Revert($body),
       T_CS('\end'), T_BEGIN, Revert($name), T_END); });
 
-# NOTE: Use \@left,\@right here, to avoid the hidden grouping (see TeX.pool, \@hidden@bgroup)
+# NOTE: Use \lx@left,\lx@right here, to avoid the hidden grouping (see TeX.pool, \lx@hidden@bgroup)
 # NOTE: These defns have an  column spec [] (omit that for mathtools)
-DefMacro('\cases',    '\lx@ams@cases{name=cases,meaning=cases,left=\@left\{}');
+DefMacro('\cases',    '\lx@ams@cases{name=cases,meaning=cases,left=\lx@left\{}');
 DefMacro('\endcases', '\lx@end@ams@cases');
 
 #======================================================================
@@ -774,9 +774,9 @@ SetCounter('MaxMatrixCols' => Number(10));
 #  right  : TeX code for right
 #  alignment: the alignment of the columnns (default "c")
 DefMacro('\lx@ams@matrix {}',
-  '\lx@gen@matrix@bindings{#1}\lx@ams@cr@binding\lx@ams@matrix@{#1}\@start@alignment');
+  '\lx@gen@matrix@bindings{#1}\lx@ams@cr@binding\lx@ams@matrix@{#1}\lx@begin@alignment');
 DefMacro('\lx@end@ams@matrix',
-  '\@finish@alignment\lx@end@gen@matrix');
+  '\lx@end@alignment\lx@end@gen@matrix');
 
 # The delimiters around a matrix may simply be notational, or for readability,
 # and don't affect the "meaning" of the array structure as a matrix.
@@ -826,19 +826,19 @@ DefConstructor('\lx@ams@matrix@ RequiredKeyVals:lx@GEN DigestedBody',
       ($name ? (T_CS('\end'), T_BEGIN, Revert($name), T_END) : ())); }
 );
 
-# NOTE: Use \@left,\@right here, to avoid the hidden grouping (see TeX.pool, \@hidden@bgroup)
+# NOTE: Use \lx@left,\lx@right here, to avoid the hidden grouping (see TeX.pool, \lx@hidden@bgroup)
 # NOTE: These defns have an  column spec [] (omit that for mathtools)
 DefMacro('\matrix',    '\lx@ams@matrix{name=matrix,datameaning=matrix}');
 DefMacro('\endmatrix', '\lx@end@ams@matrix');
-DefMacro('\pmatrix', '\lx@ams@matrix{name=pmatrix,datameaning=matrix,left=\@left(,right=\@right)}');
+DefMacro('\pmatrix', '\lx@ams@matrix{name=pmatrix,datameaning=matrix,left=\lx@left(,right=\lx@right)}');
 DefMacro('\endpmatrix', '\lx@end@ams@matrix');
-DefMacro('\bmatrix', '\lx@ams@matrix{name=bmatrix,datameaning=matrix,left=\@left[,right=\@right]}');
+DefMacro('\bmatrix', '\lx@ams@matrix{name=bmatrix,datameaning=matrix,left=\lx@left[,right=\lx@right]}');
 DefMacro('\endbmatrix', '\lx@end@ams@matrix');
-DefMacro('\Bmatrix', '\lx@ams@matrix{name=Bmatrix,datameaning=matrix,left=\@left\{,right=\@right\}}');
+DefMacro('\Bmatrix', '\lx@ams@matrix{name=Bmatrix,datameaning=matrix,left=\lx@left\{,right=\lx@right\}}');
 DefMacro('\endBmatrix', '\lx@end@ams@matrix');
-DefMacro('\vmatrix', '\lx@ams@matrix{name=vmatrix,delimitermeaning=determinant,datameaning=matrix,left=\@left|,right=\@right|}');
+DefMacro('\vmatrix', '\lx@ams@matrix{name=vmatrix,delimitermeaning=determinant,datameaning=matrix,left=\lx@left|,right=\lx@right|}');
 DefMacro('\endvmatrix', '\lx@end@ams@matrix');
-DefMacro('\Vmatrix', '\lx@ams@matrix{name=Vmatrix,delimitermeaning=norm,datameaning=matrix,left=\@left\|,right=\@right\|}');
+DefMacro('\Vmatrix', '\lx@ams@matrix{name=Vmatrix,delimitermeaning=norm,datameaning=matrix,left=\lx@left\|,right=\lx@right\|}');
 DefMacro('\endVmatrix', '\lx@end@ams@matrix');
 #DefMacro('\smallmatrix',    '\lx@ams@matrix{name=smallmatrix,atameaning=matrix,left=\scriptsize}');
 DefMacro('\smallmatrix',    '\lx@ams@matrix{name=smallmatrix,atameaning=matrix,style=\scriptsize}');
@@ -1040,7 +1040,7 @@ DefMath('\dbinom{}{}', '{\displaystyle\left({{#1}\atop{#2}}\right)}',
 # if style is empty, it is the current mathstyle.
 # (to disambiguate the optional's, shuffle the order)
 DefMacro('\genfrac{}{}{}{}{}{}',
-  '\lx@genfrac{\if.#1.\else\@left#1\fi}{\if.#2.\else\@right#2\fi}{#3}{#4}{#5}{#6}');
+  '\lx@genfrac{\if.#1.\else\lx@left#1\fi}{\if.#2.\else\lx@right#2\fi}{#3}{#4}{#5}{#6}');
 DefMacro('\lx@genfrac{}{}{}{}{}{}',
   '\if @#3@'
     . '\if.#4.\lx@@genfrac{#1}{#2}{#5}{#6}\else\lx@@genfrac{#1}{#2}[#4]{#5}{#6}\fi'
@@ -1071,7 +1071,7 @@ DefConstructor('\lx@@genfrac{}[Dimension]{}[Number]',
     $open  = $open->getArg(1)  if ref $open eq 'LaTeXML::Core::Whatsit';
     $close = $close->getArg(1) if ref $close eq 'LaTeXML::Core::Whatsit';
     (T_CS('\genfrac'),
-      T_BEGIN, Revert($open),  T_END,    # Assumes wrapped in \@left/\@right!
+      T_BEGIN, Revert($open),  T_END,    # Assumes wrapped in \lx@left/\lx@right!
       T_BEGIN, Revert($close), T_END,
       T_BEGIN, ($thickness ? Revert($thickness) : ()), T_END,
       T_BEGIN, ($stylecode ? Revert($stylecode) : ()), T_END,

--- a/lib/LaTeXML/Package/cases.sty.ltxml
+++ b/lib/LaTeXML/Package/cases.sty.ltxml
@@ -37,20 +37,20 @@ use LaTeXML::Package;
 DefMacro('\numcases{}',
   '\@numcases@bindings{#1}\@@numcases'
     . '\@equationgroup@numbering{numbered=1,preset=1,deferretract=1,grouped=1,aligned=1}'
-    . '\@start@alignment\@numcases@LHS',
+    . '\lx@begin@alignment\@numcases@LHS',
   locked => 1);
 DefMacroI('\endnumcases', undef,
-  '\@finish@alignment\end@numcases',
+  '\lx@end@alignment\end@numcases',
   locked => 1);
 
 # Needs sub-numbering turned on!
 DefMacro('\subnumcases{}',
   '\@numcases@bindings{#1}\lx@numcases@subnumbering@begin\@@numcases'
     . '\@equationgroup@numbering{numbered=1,preset=1,deferretract=1,grouped=1,aligned=1}'
-    . '\@start@alignment\@numcases@LHS',
+    . '\lx@begin@alignment\@numcases@LHS',
   locked => 1);
 DefMacroI('\endsubnumcases', undef,
-  '\@finish@alignment\end@numcases\lx@numcases@subnumbering@end',
+  '\lx@end@alignment\end@numcases\lx@numcases@subnumbering@end',
   locked => 1);
 
 # Somehow, I haven't generalized equation numbering setup enough???
@@ -70,12 +70,12 @@ DefPrimitive('\@numcases@bindings{}', sub {
 sub numcasesBindings {
   my ($lhs) = @_;
   # 3 columns: math right, math left, text left
-  my $col1 = { before => Tokens(T_CS('\hfil'), T_MATH, T_CS('\@hidden@bgroup'), T_CS('\displaystyle')),
-    after => Tokens(T_CS('\@hidden@egroup'), T_MATH) };
-  my $col2 = { before => Tokens(T_MATH, T_CS('\@hidden@bgroup'), T_CS('\displaystyle')),
-    after => Tokens(T_CS('\@hidden@egroup'), T_MATH, T_CS('\hfil')) };
-  my $col3 = { before => Tokens(T_CS('\@hidden@bgroup')),
-    after => Tokens(T_CS('\@hidden@egroup'), T_CS('\hfil')) };
+  my $col1 = { before => Tokens(T_CS('\hfil'), T_MATH, T_CS('\lx@hidden@bgroup'), T_CS('\displaystyle')),
+    after => Tokens(T_CS('\lx@hidden@egroup'), T_MATH) };
+  my $col2 = { before => Tokens(T_MATH, T_CS('\lx@hidden@bgroup'), T_CS('\displaystyle')),
+    after => Tokens(T_CS('\lx@hidden@egroup'), T_MATH, T_CS('\hfil')) };
+  my $col3 = { before => Tokens(T_CS('\lx@hidden@bgroup')),
+    after => Tokens(T_CS('\lx@hidden@egroup'), T_CS('\hfil')) };
 
   my %attributes = (
     'class'  => 'ltx_eqn_numcases',
@@ -102,15 +102,15 @@ sub numcasesBindings {
       properties  => { preserve_structure => 1, attributes => {%attributes} }));
 
   DefMacroI('\@numcases@LHS', undef, Tokens($lhs, T_ALIGN));
-  #  Let(T_ALIGN,        '\@alignment@align');
-  Let("\\\\",         '\@numcases@newline');
-  Let('\@row@before', '\eqnarray@row@before');
-  Let('\@row@after',  '\eqnarray@row@after');
+  #  Let(T_ALIGN,        '\lx@alignment@align');
+  Let("\\\\",                     '\@numcases@newline');
+  Let('\lx@alignment@row@before', '\eqnarray@row@before');
+  Let('\lx@alignment@row@after',  '\eqnarray@row@after');
   return; }
 
 DefMacro('\@numcases@newline[]',
-  '\ifx.#1.\@alignment@newline\else\@alignment@newline[#1]\fi\@numcases@LHS');
-DefMacro('\@numcases@cr', '\@alignment@cr\@numcases@LHS');
+  '\ifx.#1.\lx@alignment@newline\else\lx@alignment@newline[#1]\fi\@numcases@LHS');
+DefMacro('\@numcases@cr', '\lx@alignment@cr\@numcases@LHS');
 
 DefConstructor('\@@numcases SkipSpaces DigestedBody',
   '#1',

--- a/lib/LaTeXML/Package/colortbl.sty.ltxml
+++ b/lib/LaTeXML/Package/colortbl.sty.ltxml
@@ -35,7 +35,7 @@ DefConditional('\if@@rowcolored', sub { LookupValue('tabular_row_color'); });
 DefPrimitive('\@clearrowcolor', sub {
     MergeFont(background => undef);
     AssignValue(tabular_row_color => undef, 'global'); });
-AddToMacro('\@tabular@row@after', '\hidden@noalign{\@clearrowcolor}');
+AddToMacro('\@tabular@row@after', '\lx@hidden@noalign{\@clearrowcolor}');
 
 AddToMacro('\@tabular@column@before', '\@userowcolor');
 
@@ -53,7 +53,7 @@ DefMacro('\columncolor[]{}[][]',
 # \rowcolor[<model>]{<color>}
 # Set the background color, and arrange for it to attach to the ltx:td
 DefMacro('\rowcolor[]{}',
-  '\hidden@noalign{\ifx.#1.\pagecolor{#2}\else\pagecolor[#1]{#2}\fi\@setrowcolor}');
+  '\lx@hidden@noalign{\ifx.#1.\pagecolor{#2}\else\pagecolor[#1]{#2}\fi\@setrowcolor}');
 
 # \cellcolor[<model>]{<color>}
 # Set the background color (we should already be in a cell),

--- a/lib/LaTeXML/Package/dcolumn.sty.ltxml
+++ b/lib/LaTeXML/Package/dcolumn.sty.ltxml
@@ -18,9 +18,9 @@ use LaTeXML::Package;
 RequirePackage('array');
 
 sub absorbedString {
-  my ($tokens) = @_;
+  my ($tokens)    = @_;
   my $capdocument = LaTeXML::Core::Document->new($STATE->getModel);
-  my $capture = $capdocument->openElement('ltx:_Capture_', font => LaTeXML::Common::Font->new());
+  my $capture     = $capdocument->openElement('ltx:_Capture_', font => LaTeXML::Common::Font->new());
   $capdocument->absorb(Digest($tokens));
   if (my @nodes = $capdocument->findnodes("//ltx:XMath/*", $capture)) {
     return $nodes[0]->textContent; }
@@ -36,19 +36,19 @@ DefMacro('\DC@{}{}{}', sub {
     $delim = ToString($delim);
     if ($delim ne ToString($todelim)) {
       $STATE->assignMathcode($delim => 0x8000);
-      DefMacroI(T_CS($delim), undef, '\@hidden@bgroup\lx@unactivate{' . $delim . '}\lx@wrap[role=PERIOD]{' . UnTeX($todelim) . '}\@hidden@egroup');
+      DefMacroI(T_CS($delim), undef, '\lx@hidden@bgroup\lx@unactivate{' . $delim . '}\lx@wrap[role=PERIOD]{' . UnTeX($todelim) . '}\lx@hidden@egroup');
     }
     # We need to temporarily deactivate '$'
     Let(T_CS('\DC@saved@dollar'), T_MATH);
     Let(T_MATH,                   T_CS('\relax'));
-    return Tokens(LookupValue('IN_MATH') ? () : T_CS('\@@BEGININLINEMATH'));
+    return Tokens(LookupValue('IN_MATH') ? () : T_CS('\lx@begin@inline@math'));
 });
 # NOTE: We should be making arrangements for this funny thing to still
 # be considered a number!
 
 DefMacro('\DC@end', sub {
     Let(T_MATH, T_CS('\DC@saved@dollar'));
-    return (T_CS('\@@ENDINLINEMATH'));
+    return (T_CS('\\lx@end@inline@math'));
 });
 
 DefColumnType('D{}{}{}', sub {

--- a/lib/LaTeXML/Package/deluxetable.sty.ltxml
+++ b/lib/LaTeXML/Package/deluxetable.sty.ltxml
@@ -40,8 +40,8 @@ DefMacro('\csname enddeluxetable*\endcsname', '\spew@tblnotes\end{table}');
 DefMacro('\set@deluxetable@template AlignmentTemplate', sub {
     AssignValue('@deluxetable@template', $_[1]); });
 
-DefMacro('\startdata', '\bgroup\@deluxetable@bindings\@@deluxetabular\@start@alignment\hline\hline\@deluxetable@header');
-DefMacro('\enddata', '\\\\\hline\@finish@alignment\@end@deluxetabular\egroup');
+DefMacro('\startdata', '\bgroup\@deluxetable@bindings\@@deluxetabular\lx@begin@alignment\hline\hline\@deluxetable@header');
+DefMacro('\enddata', '\\\\\hline\lx@end@alignment\@end@deluxetabular\egroup');
 
 DefPrimitive('\@deluxetable@bindings', sub {
     tabularBindings(LookupValue('@deluxetable@template')); });
@@ -77,7 +77,7 @@ DefMacro('\tablecolumns{Number}', '');                       # Ignorable ???
 Let('\tablecaption', '\caption');
 
 DefMacro('\tablehead{}',
-  '\def\@deluxetable@header{\@tabular@begin@heading#1\\\\\hline\@tabular@end@heading}');
+  '\def\@deluxetable@header{\lx@alignment@begin@heading#1\\\\\hline\lx@alignment@end@heading}');
 DefMacro('\colhead{}',    '\multicolumn{1}{c}{#1}');
 DefMacro('\twocolhead{}', '\multicolumn{2}{c}{\hss #1 \hss}');
 DefMacro('\nocolhead{}',  '\multicolumn{1}{h}{#1}');
@@ -94,8 +94,8 @@ DefMacro('\tablebreak',    '\\\\[0pt]');                     # Obsolete form
 DefMacro('\tablebreak', '');    # Ignorable; we're not splitting tables.
 DefMacro('\nodata',     '');    # Ignorable
 
-DefMacro('\cutinhead{}', '\hline\multicolumn{\@alignment@ncolumns}{c}{#1}\\\\\hline');
-DefMacro('\sidehead{}',  '\hline\multicolumn{\@alignment@ncolumns}{l}{#1}\\\\\hline');
+DefMacro('\cutinhead{}', '\hline\multicolumn{\lx@alignment@ncolumns}{c}{#1}\\\\\hline');
+DefMacro('\sidehead{}',  '\hline\multicolumn{\lx@alignment@ncolumns}{l}{#1}\\\\\hline');
 
 DefMacro('\tableline', '\hline');
 

--- a/lib/LaTeXML/Package/iopart_support.sty.ltxml
+++ b/lib/LaTeXML/Package/iopart_support.sty.ltxml
@@ -170,15 +170,15 @@ Let('\pmit', '\mathnormal');
 DefMacro('\eqnalign{}',
   '\@eqnarray@bindings\@@eqnarray'
     . '\@equationgroup@numbering{numbered=1,stepped=post,grouped=1,aligned=1}'
-    . '\@start@alignment'
+    . '\lx@begin@alignment'
     . '#1'
-    . '\@finish@alignment\end@eqnarray');
+    . '\lx@end@alignment\end@eqnarray');
 DefMacro('\eqnalignno{}',
   '\@eqnarray@bindings\@@eqnarray'
     . '\@equationgroup@numbering{numbered=1,stepped=post,grouped=1,aligned=1}'
-    . '\@start@alignment'
+    . '\lx@begin@alignment'
     . '#1'
-    . '\@finish@alignment\end@eqnarray');
+    . '\lx@end@alignment\end@eqnarray');
 
 #======================================================================
 

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -290,14 +290,14 @@ DefEnvironment('{lxFooter}', sub { },
 
 # To mark the table head/foot (table column headers)
 # Put this before first table heading row
-DefMacroI('\lxBeginTableHead', undef, '\@tabular@begin@heading');
+DefMacroI('\lxBeginTableHead', undef, '\lx@alignment@begin@heading');
 # put this after the \\ ending the table heading.
-DefMacroI('\lxEndTableHead', undef, '\@tabular@end@heading');
+DefMacroI('\lxEndTableHead', undef, '\lx@alignment@end@heading');
 
 # Ditto for table foot (last rows in table)
-DefMacroI('\lxBeginTableFoot', undef, '\@tabular@begin@heading');
+DefMacroI('\lxBeginTableFoot', undef, '\lx@alignment@begin@heading');
 # put this after the \\ ending the table heading.
-DefMacroI('\lxEndTableFoot', undef, '\@tabular@end@heading');
+DefMacroI('\lxEndTableFoot', undef, '\lx@alignment@end@heading');
 
 # To mark an individual cell as a column header
 DefMacroI('\lxTableColumnHead', undef, sub {

--- a/lib/LaTeXML/Package/longtable.sty.ltxml
+++ b/lib/LaTeXML/Package/longtable.sty.ltxml
@@ -21,14 +21,14 @@ use LaTeXML::Package;
 #======================================================================
 # Environment \begin{longtable}[align]{pattern} ... \end{longtable}
 DefMacro('\longtable[]{}',
-  '\lx@longtable@bindings{#2}\@@longtable[#1]{#2}\@start@alignment');
+  '\lx@longtable@bindings{#2}\@@longtable[#1]{#2}\lx@begin@alignment');
 DefMacro('\endlongtable',
-  '\@finish@alignment\@end@tabular');
+  '\lx@end@alignment\@end@tabular');
 # {longtable*} is defined in revtex4-1 to be able to span a two column document
 DefMacro('\csname longtable*\endcsname []{}',
-  '\lx@longtable@bindings{#2}\@@longtable[#1]{#2}\@start@alignment');
+  '\lx@longtable@bindings{#2}\@@longtable[#1]{#2}\lx@begin@alignment');
 DefMacro('\csname endlongtable*\endcsname',
-  '\@finish@alignment\@end@tabular');
+  '\lx@end@alignment\@end@tabular');
 
 DefMacro('\@gobble@optional[]', Tokens());
 

--- a/lib/LaTeXML/Package/mathtools.sty.ltxml
+++ b/lib/LaTeXML/Package/mathtools.sty.ltxml
@@ -482,19 +482,19 @@ Let('\LaTeXoverbrace',  '\overbrace');
 DefMacro('\csname matrix*\endcsname []', '\lx@ams@matrix{name=matrix,datameaning=matrix,alignment=#1}');
 DefMacro('\csname endmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname pmatrix*\endcsname []', '\lx@ams@matrix{name=pmatrix,datameaning=matrix,alignment=#1,left=\@left(,right=\@right)}');
+DefMacro('\csname pmatrix*\endcsname []', '\lx@ams@matrix{name=pmatrix,datameaning=matrix,alignment=#1,left=\lx@left(,right=\lx@right)}');
 DefMacro('\csname endpmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname bmatrix*\endcsname []', '\lx@ams@matrix{name=bmatrix,datameaning=matrix,alignment=#1,left=\@left[,right=\@right]}');
+DefMacro('\csname bmatrix*\endcsname []', '\lx@ams@matrix{name=bmatrix,datameaning=matrix,alignment=#1,left=\lx@left[,right=\lx@right]}');
 DefMacro('\csname endbmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname Bmatrix*\endcsname []', '\lx@ams@matrix{name=Bmatrix,datameaning=matrix,alignment=#1,left=\@left\{,right=\@right\}}');
+DefMacro('\csname Bmatrix*\endcsname []', '\lx@ams@matrix{name=Bmatrix,datameaning=matrix,alignment=#1,left=\lx@left\{,right=\lx@right\}}');
 DefMacro('\csname endBmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname vmatrix*\endcsname []', '\lx@ams@matrix{name=vmatrix,delimitermeaning=determinant,datameaning=matrix,alignment=#1,left=\@left|,right=\@right|}');
+DefMacro('\csname vmatrix*\endcsname []', '\lx@ams@matrix{name=vmatrix,delimitermeaning=determinant,datameaning=matrix,alignment=#1,left=\lx@left|,right=\lx@right|}');
 DefMacro('\csname endvmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname Vmatrix*\endcsname []', '\lx@ams@matrix{name=Vmatrix,delimitermeaning=norm,datameaning=matrix,alignment=#1,left=\@left\|,right=\@right\|}');
+DefMacro('\csname Vmatrix*\endcsname []', '\lx@ams@matrix{name=Vmatrix,delimitermeaning=norm,datameaning=matrix,alignment=#1,left=\lx@left\|,right=\lx@right\|}');
 DefMacro('\csname endVmatrix*\endcsname', '\lx@end@ams@matrix');
 
 # starred small matrices
@@ -521,35 +521,35 @@ DefMacroI('\@smallmatrix@star@tmp', 'RequiredKeyVals', sub {
 DefMacro('\csname smallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=matrix,datameaning=matrix,style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
 DefMacro('\csname endsmallmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname psmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=pmatrix,datameaning=matrix,left=\@left(,right=\@right),style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
+DefMacro('\csname psmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=pmatrix,datameaning=matrix,left=\lx@left(,right=\lx@right),style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
 DefMacro('\csname endpsmallmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname bsmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=bmatrix,datameaning=matrix,left=\@left[,right=\@right],style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
+DefMacro('\csname bsmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=bmatrix,datameaning=matrix,left=\lx@left[,right=\lx@right],style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
 DefMacro('\csname endbsmallmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname Bsmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=Bmatrix,datameaning=matrix,left=\@left\{,right=\@right\},style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
+DefMacro('\csname Bsmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=Bmatrix,datameaning=matrix,left=\lx@left\{,right=\lx@right\},style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
 DefMacro('\csname endBsmallmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname vsmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=vmatrix,delimitermeaning=determinant,datameaning=matrix,left=\@left|,right=\@right|,style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
+DefMacro('\csname vsmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=vmatrix,delimitermeaning=determinant,datameaning=matrix,left=\lx@left|,right=\lx@right|,style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
 DefMacro('\csname endvsmallmatrix*\endcsname', '\lx@end@ams@matrix');
 
-DefMacro('\csname Vsmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=Vmatrix,delimitermeaning=norm,datameaning=matrix,left=\@left\|,right=\@right\|,style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
+DefMacro('\csname Vsmallmatrix*\endcsname []', '\@smallmatrix@star@tmp{name=Vmatrix,delimitermeaning=norm,datameaning=matrix,left=\lx@left\|,right=\lx@right\|,style=\scriptsize,\ifx/#1/\else alignment=#1,\fi}');
 DefMacro('\csname endVsmallmatrix*\endcsname', '\lx@end@ams@matrix');
 
 # non-starred small matrices
-DefMacro('\psmallmatrix', '\lx@ams@matrix{name=pmatrix,datameaning=matrix,left=\@left(,right=\@right),style=\scriptsize}');
+DefMacro('\psmallmatrix', '\lx@ams@matrix{name=pmatrix,datameaning=matrix,left=\lx@left(,right=\lx@right),style=\scriptsize}');
 DefMacro('\endpsmallmatrix', '\lx@end@ams@matrix');
 
-DefMacro('\bsmallmatrix', '\lx@ams@matrix{name=bmatrix,datameaning=matrix,left=\@left[,right=\@right],style=\scriptsize}');
+DefMacro('\bsmallmatrix', '\lx@ams@matrix{name=bmatrix,datameaning=matrix,left=\lx@left[,right=\lx@right],style=\scriptsize}');
 DefMacro('\endbsmallmatrix', '\lx@end@ams@matrix');
 
-DefMacro('\Bsmallmatrix', '\lx@ams@matrix{name=Bmatrix,datameaning=matrix,left=\@left\{,right=\@right\},style=\scriptsize}');
+DefMacro('\Bsmallmatrix', '\lx@ams@matrix{name=Bmatrix,datameaning=matrix,left=\lx@left\{,right=\lx@right\},style=\scriptsize}');
 DefMacro('\endBsmallmatrix', '\lx@end@ams@matrix');
 
-DefMacro('\vsmallmatrix', '\lx@ams@matrix{name=vmatrix,delimitermeaning=determinant,datameaning=matrix,left=\@left|,right=\@right|,style=\scriptsize}');
+DefMacro('\vsmallmatrix', '\lx@ams@matrix{name=vmatrix,delimitermeaning=determinant,datameaning=matrix,left=\lx@left|,right=\lx@right|,style=\scriptsize}');
 DefMacro('\endvsmallmatrix', '\lx@end@ams@matrix');
 
-DefMacro('\Vsmallmatrix', '\lx@ams@matrix{name=Vmatrix,delimitermeaning=norm,datameaning=matrix,left=\@left\|,right=\@right\|,style=\scriptsize}');
+DefMacro('\Vsmallmatrix', '\lx@ams@matrix{name=Vmatrix,delimitermeaning=norm,datameaning=matrix,left=\lx@left\|,right=\lx@right\|,style=\scriptsize}');
 DefMacro('\endVsmallmatrix', '\lx@end@ams@matrix');
 
 # {multlined}
@@ -581,8 +581,8 @@ DefMacroI('\multlined', '[][]', '\@multlined@tmp{'
     . 'name=multlined,'
     . '\ifx/#1/\else vattach=#1,\fi'
     . '\ifx/#2/\else width=#2,\fi'
-    . '}\@@multlined\@start@alignment');
-DefMacroI('\endmultlined', undef, '\@finish@alignment\@end@multlined');
+    . '}\@@multlined\lx@begin@alignment');
+DefMacroI('\endmultlined', undef, '\lx@end@alignment\@end@multlined');
 DefPrimitiveI('\@end@multlined', undef, sub { $_[0]->egroup; });
 
 # Is currently ignore the shoving dimension
@@ -599,37 +599,37 @@ DefMacro('\shoveleft[]{}',  '\@MT@shove{left}#2');
 
 # cases
 DefMacro('\dcases',
-  '\lx@ams@cases{name=dcases,meaning=cases,left=\@left\{,style=\displaystyle,conditionmode=math}');
+  '\lx@ams@cases{name=dcases,meaning=cases,left=\lx@left\{,style=\displaystyle,conditionmode=math}');
 DefMacro('\enddcases',
   '\lx@end@ams@cases');
 
 DefMacro('\csname dcases*\endcsname',
-  '\lx@ams@cases{name=dcases*,meaning=cases,left=\@left\{,style=\displaystyle,conditionmode=text}');
+  '\lx@ams@cases{name=dcases*,meaning=cases,left=\lx@left\{,style=\displaystyle,conditionmode=text}');
 DefMacro('\csname enddcases*\endcsname',
   '\lx@end@ams@cases');
 
 DefMacro('\csname rcases\endcsname',
-  '\lx@ams@cases{name=rcases,meaning=cases,right=\@right\},style=\textstyle,conditionmode=math}');
+  '\lx@ams@cases{name=rcases,meaning=cases,right=\lx@right\},style=\textstyle,conditionmode=math}');
 DefMacro('\csname endrcases\endcsname',
   '\lx@end@ams@cases');
 
 DefMacro('\csname rcases*\endcsname',
-  '\lx@ams@cases{name=rcases*,meaning=cases,right=\@right\},style=\textstyle,conditionmode=text}');
+  '\lx@ams@cases{name=rcases*,meaning=cases,right=\lx@right\},style=\textstyle,conditionmode=text}');
 DefMacro('\csname endrcases*\endcsname',
   '\lx@end@ams@cases');
 
 DefMacro('\csname drcases\endcsname',
-  '\lx@ams@cases{name=drcases,meaning=cases,right=\@right\},style=\displaystyle,conditionmode=math}');
+'\lx@ams@cases{name=drcases,meaning=cases,right=\lx@right\},style=\displaystyle,conditionmode=math}');
 DefMacro('\csname enddrcases\endcsname',
   '\lx@end@ams@cases');
 
 DefMacro('\csname drcases*\endcsname',
-'\lx@ams@cases{name=drcases*,meaning=cases,right=\@right\},style=\displaystyle,conditionmode=text}');
+'\lx@ams@cases{name=drcases*,meaning=cases,right=\lx@right\},style=\displaystyle,conditionmode=text}');
 DefMacro('\csname enddrcases*\endcsname',
   '\lx@end@ams@cases');
 
 DefMacro('\csname cases*\endcsname',
-  '\lx@ams@cases{name=cases*,meaning=cases,left=\@left\{,style=\textstyle,conditionmode=text}');
+  '\lx@ams@cases{name=cases*,meaning=cases,left=\lx@left\{,style=\textstyle,conditionmode=text}');
 DefMacro('\csname endcases*\endcsname',
   '\lx@end@ams@cases');
 
@@ -773,8 +773,8 @@ DefConstructor('\@@lgathered DigestedBody',
     rearrangeAMSMultirow($_[0], $_[1], $_[0]->getNode->lastChild); },
   reversion => '\begin{lgathered}#1\end{lgathered}');
 
-DefMacroI('\lgathered', '[]', '\@ams@multirow@bindings{name=lgathered,vattach=#1}\@@lgathered\@start@alignment');
-DefMacroI('\endlgathered', undef, '\@finish@alignment\@end@gathered');
+DefMacroI('\lgathered', '[]', '\@ams@multirow@bindings{name=lgathered,vattach=#1}\@@lgathered\lx@begin@alignment');
+DefMacroI('\endlgathered', undef, '\lx@end@alignment\@end@gathered');
 
 DefConstructor('\@@rgathered DigestedBody',
   "#1",
@@ -786,8 +786,8 @@ DefConstructor('\@@rgathered DigestedBody',
     rearrangeAMSMultirow($_[0], $_[1], $_[0]->getNode->lastChild); },
   reversion => '\begin{rgathered}#1\end{rgathered}');
 
-DefMacroI('\rgathered', '[]', '\@ams@multirow@bindings{name=rgathered,vattach=#1}\@@rgathered\@start@alignment');
-DefMacroI('\endrgathered', undef, '\@finish@alignment\@end@gathered');
+DefMacroI('\rgathered', '[]', '\@ams@multirow@bindings{name=rgathered,vattach=#1}\@@rgathered\lx@begin@alignment');
+DefMacroI('\endrgathered', undef, '\lx@end@alignment\@end@gathered');
 
 DefConstructor('\@@newgathered@dummy DigestedBody',
   '#1',
@@ -811,19 +811,19 @@ DefMacro('\newgathered{}{}{}{}', sub {
     # Really should be making the pre/post_line into separate columns!!!
     DefMacroI('\\' . $name, undef,
       '\@ams@multirow@bindings{name=' . $name . '}['
-        . 'before_row=\hidden@noalign{' . UnTeX($pre_line) . '},'
-        . 'after_row=\hidden@noalign{' . UnTeX($post_line) . '}'
-        . ']\@@newgathered@dummy\@start@alignment');
+        . 'before_row=\lx@hidden@noalign{' . UnTeX($pre_line) . '},'
+        . 'after_row=\lx@hidden@noalign{' . UnTeX($post_line) . '}'
+        . ']\@@newgathered@dummy\lx@begin@alignment');
     DefMacroI('\end' . $name, undef,
-      Tokens(T_CS('\@finish@alignment'), T_CS('\@end@gathered'), $after)); });
+      Tokens(T_CS('\lx@end@alignment'), T_CS('\@end@gathered'), $after)); });
 Let('\renewgathered', '\newgathered');
 
 ## 4.6
 
 DefMacro('\splitfrac{}{}',
-'\@ams@multirow@bindings{name=splitfrac}\@@multlined\@start@alignment #1 \\\\ #2 \@finish@alignment\@end@multline');
+'\@ams@multirow@bindings{name=splitfrac}\@@multlined\lx@begin@alignment #1 \\\\ #2 \lx@end@alignment\@end@multline');
 DefMacro('\splitdfrac{}{}',
-'\displaystyle\@ams@multirow@bindings{name=splitdfrac}\@@multlined\@start@alignment #1 \\\\ #2 \@finish@alignment\@end@multline');
+'\displaystyle\@ams@multirow@bindings{name=splitdfrac}\@@multlined\lx@begin@alignment #1 \\\\ #2 \lx@end@alignment\@end@multline');
 
 ######################################################
 

--- a/lib/LaTeXML/Package/mn2e_support.sty.ltxml
+++ b/lib/LaTeXML/Package/mn2e_support.sty.ltxml
@@ -223,7 +223,7 @@ DefEnvironment('{equation}',
   beforeDigest => sub {
     prepareEquationCounter(numbered => 1, preset => 1);
     beforeEquation();
-    Let(T_MATH, T_CS('\@dollar@in@mathmode')); },
+    Let(T_MATH, T_CS('\lx@dollar@in@mathmode')); },
   afterDigestBody => sub {
     afterEquation($_[1]); },
   locked => 1);
@@ -242,7 +242,7 @@ DefEnvironment('{equation*}',
   beforeDigest => sub {
     prepareEquationCounter(numbered => undef, preset => 1);
     beforeEquation();
-    Let(T_MATH, T_CS('\@dollar@in@mathmode')); },
+    Let(T_MATH, T_CS('\lx@dollar@in@mathmode')); },
   afterDigestBody => sub {
     afterEquation($_[1]); },
   locked => 1);

--- a/lib/LaTeXML/Package/moderncv.cls.ltxml
+++ b/lib/LaTeXML/Package/moderncv.cls.ltxml
@@ -66,9 +66,9 @@ DefConstructor('\@@cv@section{} Undigested OptionalUndigested Undigested', sub {
   properties => sub {
     my ($stomach, $type, $inlist, $toctitle, $title) = @_;
     my %props = RefStepID(ToString($type));
-    $props{title} = Digest(T_CS('\@hidden@bgroup'), $title, T_CS('\@hidden@egroup'));
+    $props{title}    = Digest(T_CS('\lx@hidden@bgroup'), $title, T_CS('\lx@hidden@egroup'));
     $props{toctitle} = $toctitle
-      && Digest(T_CS('\@hidden@bgroup'), $toctitle, T_CS('\@hidden@egroup'));
+      && Digest(T_CS('\lx@hidden@bgroup'), $toctitle, T_CS('\lx@hidden@egroup'));
     return %props; },
   locked => 1);
 Let(T_CS('\\@@numbered@section'),   T_CS('\\@@cv@section'));
@@ -98,13 +98,13 @@ DefMacro('\moderncvstyle',     Tokens());
 #
 # TODO: should we use them in the final HTML style? Feedback from professionals welcome.
 #       for now just adding the macro support, but omitting them from the final output
-DefMacro('\marvosymbol {}',    '');
-DefMacro('\addresssymbol',     '');
-DefMacro('\mobilephonesymbol', '📱');
-DefMacro('\fixedphonesymbol',  '☎');
-DefMacro('\faxphonesymbol',    '📠');
-DefMacro('\emailsymbol',       '✉');
-DefMacro('\homepagesymbol',    '🖰');
+DefMacro('\marvosymbol {}',       '');
+DefMacro('\addresssymbol',        '');
+DefMacro('\mobilephonesymbol',    '📱');
+DefMacro('\fixedphonesymbol',     '☎');
+DefMacro('\faxphonesymbol',       '📠');
+DefMacro('\emailsymbol',          '✉');
+DefMacro('\homepagesymbol',       '🖰');
 DefMacro('\linkedinsocialsymbol', '');  # Tikz image, needs a smart workaround (font awesome maybe?)
 DefMacro('\twittersocialsymbol',  '');  # Tikz image, needs a smart workaround (font awesome maybe?)
 DefMacro('\githubsocialsymbol',   '');  # Tikz image, needs a smart workaround (font awesome maybe?)

--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -305,8 +305,8 @@ our $PGFMathFunctions;
 # NOTE: need to handle \ifpgfmathunitsdeclared
 # Version issue?
 RawTeX(<<'EoTeX');
-\@ifundefined{pgfmathunitsdeclaredtrue}{\newif\ifpgfmathunitsdeclared}{}
-\@ifundefined{pgfmathmathunitsdeclaredtrue}{\newif\ifpgfmathmathunitsdeclared}{}
+\lx@ifundefined{pgfmathunitsdeclaredtrue}{\newif\ifpgfmathunitsdeclared}{}
+\lx@ifundefined{pgfmathmathunitsdeclaredtrue}{\newif\ifpgfmathmathunitsdeclared}{}
 EoTeX
 
 our $PGMATH_UNITS_REGEXP = undef;

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -927,7 +927,7 @@ sub tikzAlignmentBindings {
     isMath         => $ismath,
     properties     => { preserve_structure => 1, %properties });
   AssignValue(Alignment => $alignment);
-  Let(T_MATH, ($ismath ? '\@dollar@in@mathmode' : '\@dollar@in@textmode'));
+  Let(T_MATH, ($ismath ? '\lx@dollar@in@mathmode' : '\lx@dollar@in@textmode'));
   return; }
 
 # Note that pgf *seems* to have set the coordinate system to the center(?) (w/ \pgfsys@transformcm)

--- a/lib/LaTeXML/Package/physics.sty.ltxml
+++ b/lib/LaTeXML/Package/physics.sty.ltxml
@@ -232,7 +232,7 @@ DefConstructor('\lx@physics@mathbfit{}', '#1', bounded => 1, requireMath => 1,
 DefMacro('\vectorbold OptionalMatch:* {}',
   '\lx@wrap[role=ID]{\ifx.#1.\mathbf{#2}\else\lx@physics@mathbfit{#2}\fi}');
 DefMacro('\vectorarrow OptionalMatch:* {}',
-  '\lx@wrap[role=ID]{\math@overrightarrow{\ifx.#1.\mathbf{#2}\else\lx@physics@mathbfit{#2}\fi}}');
+  '\lx@wrap[role=ID]{\lx@math@overrightarrow{\ifx.#1.\mathbf{#2}\else\lx@physics@mathbfit{#2}\fi}}');
 DefMacro('\vectorunit OptionalMatch:* {}',
   '\lx@wrap[role=ID]{\hat{\ifx.#1.\mathbf{#2}\else\lx@physics@mathbfit{#2}\fi}}');
 Let('\vb', '\vectorbold');
@@ -608,7 +608,7 @@ DefMacro('\xmatrix OptionalMatch:* {}{}{}', sub {
         push(@tokens, ($j > 0 ? T_ALIGN : ()),
           $item,
           ($star
-            ? Invocation(T_CS('\@@POSTSUBSCRIPT'),
+            ? Invocation(T_CS('\lx@post@subscript'),
               ($n == 1 ? T_OTHER($j + 1)
                 : ($m == 1 ? T_OTHER($i + 1)
                   : Tokens(T_OTHER($i + 1), T_CS('\lx@InvisibleComma'), T_OTHER($j + 1)))))    # one based

--- a/lib/LaTeXML/Package/revtex3_support.sty.ltxml
+++ b/lib/LaTeXML/Package/revtex3_support.sty.ltxml
@@ -46,8 +46,8 @@ DefMacro('\endmathletters', '\lx@equationgroup@subnumbering@end');
 #======================================================================
 # Apparently, you can use single $ within equations to switch back to text
 
-DefMacro('\@dollar@in@oldrevtex', '\bgroup\hbox\bgroup\let$\@eegroup');
-DefMacro('\@eegroup',             '\egroup\egroup');
+DefMacro('\lx@dollar@in@oldrevtex', '\bgroup\hbox\bgroup\let$\@eegroup');
+DefMacro('\@eegroup',               '\egroup\egroup');
 DefEnvironment('{equation}',
   "<ltx:equation xml:id='#id'>"
     . "#tags"
@@ -58,7 +58,7 @@ DefEnvironment('{equation}',
     . "</ltx:Math>"
     . "</ltx:equation>",
   mode         => 'display_math',
-  beforeDigest => sub { Let(T_MATH, '\@dollar@in@oldrevtex'); },
+  beforeDigest => sub { Let(T_MATH, '\lx@dollar@in@oldrevtex'); },
   properties   => sub { RefStepCounter('equation'); },
   locked       => 1);
 DefEnvironment('{equation*}',
@@ -70,7 +70,7 @@ DefEnvironment('{equation*}',
     . "</ltx:Math>"
     . "</ltx:equation>",
   mode         => 'display_math',
-  beforeDigest => sub { Let(T_MATH, '\@dollar@in@oldrevtex'); },
+  beforeDigest => sub { Let(T_MATH, '\lx@dollar@in@oldrevtex'); },
   properties   => sub { RefStepID('equation') },
   locked       => 1);
 DefConstructorI('\[', undef,
@@ -82,9 +82,9 @@ DefConstructorI('\[', undef,
     . "</ltx:Math>"
     . "</ltx:equation>",
   beforeDigest => sub { $_[0]->beginMode('display_math');
-    Let(T_MATH, '\@dollar@in@oldrevtex'); },
+    Let(T_MATH, '\lx@dollar@in@oldrevtex'); },
   captureBody => 1,
-  properties => sub { RefStepID('equation') });
+  properties  => sub { RefStepID('equation') });
 
 #**********************************************************************
 

--- a/lib/LaTeXML/Package/siunitx.sty.ltxml
+++ b/lib/LaTeXML/Package/siunitx.sty.ltxml
@@ -752,9 +752,9 @@ sub six_wrap {
   my $color = six_get('color');
   return Tokens(
     ($color ? (T_BEGIN, T_CS('\color'), T_BEGIN, $color, T_END) : ()),
-    T_CS('\@@BEGININLINEMATH'),
+    T_CS('\lx@begin@inline@math'),
     (grep { $_; } @stuff),
-    T_CS('\@@ENDINLINEMATH'),
+    T_CS('\\lx@end@inline@math'),
     ($color ? (T_END) : ())); }
 
 # \num[options]{number}

--- a/lib/LaTeXML/Package/subeqnarray.sty.ltxml
+++ b/lib/LaTeXML/Package/subeqnarray.sty.ltxml
@@ -18,8 +18,8 @@ use LaTeXML::Package;
 #**********************************************************************
 
 # see example use at arXiv:hep-th/0002165
-DefMacroI('\subeqnarray', undef, '\lx@equationgroup@subnumbering@begin\bgroup\@@BEGINDISPLAYMATH', locked => 1);
-DefMacroI('\endsubeqnarray', undef, '\@@ENDDISPLAYMATH\egroup\lx@equationgroup@subnumbering@end', locked => 1);
+DefMacroI('\subeqnarray', undef, '\lx@equationgroup@subnumbering@begin\bgroup\lx@begin@display@math', locked => 1);
+DefMacroI('\endsubeqnarray', undef, '\lx@end@display@math\egroup\lx@equationgroup@subnumbering@end', locked => 1);
 
 InputDefinitions('subeqnarray', type => 'sty', noltxml => 1);
 

--- a/lib/LaTeXML/Package/supertabular.sty.ltxml
+++ b/lib/LaTeXML/Package/supertabular.sty.ltxml
@@ -23,11 +23,11 @@ DefPrimitive('\@supertabular@bindings [Dimension] AlignmentTemplate', sub {
 # Environment \begin{supertabular}{pattern} ... \end{supertabular}
 DefMacro('\supertabular{}',
   '\@supertabular@start'
-    . '\@supertabular@bindings{#1}\@@supertabular{#1}\@start@alignment'
+    . '\@supertabular@bindings{#1}\@@supertabular{#1}\lx@begin@alignment'
     . '\@supertabular@head');
 DefMacro('\endsupertabular',
   '\@supertabular@tail'
-    . '\@finish@alignment\@end@tabular'
+    . '\lx@end@alignment\@end@tabular'
     . '\@supertabular@finish');
 
 DefConstructor('\@@supertabular Undigested DigestedBody',
@@ -39,11 +39,11 @@ DefConstructor('\@@supertabular Undigested DigestedBody',
 # Environment \begin{supertabular*}{width}{pattern} ... \end{supertabular*}
 DefMacro('\csname supertabular*\endcsname{Dimension}{}',
   '\@supertabular@start'
-    . '\@supertabular@bindings[#1]{#2}\@@supertabular@{#1}{#2}\@start@alignment'
+    . '\@supertabular@bindings[#1]{#2}\@@supertabular@{#1}{#2}\lx@begin@alignment'
     . '\@supertabular@head');
 DefMacro('\csname endsupertabular*\endcsname',
   '\@supertabular@tail'
-    . '\@finish@alignment\@end@tabular'
+    . '\lx@end@alignment\@end@tabular'
     . '\@supertabular@finish');
 
 DefConstructor('\@@supertabular@ {Dimension} Undigested DigestedBody',
@@ -59,21 +59,21 @@ DefConstructor('\@@supertabular@ {Dimension} Undigested DigestedBody',
 # Environment \begin{mpsupertabular}{pattern} ... \end{mpsupertabular}
 DefMacro('\mpsupertabular{}',
   '\@supertabular@start'
-    . '\@supertabular@bindings{#1}\@@supertabular{#1}\@start@alignment'
+    . '\@supertabular@bindings{#1}\@@supertabular{#1}\lx@begin@alignment'
     . '\@supertabular@head');
 DefMacro('\endmpsupertabular',
   '\@supertabular@tail'
-    . '\@finish@alignment\@end@tabular'
+    . '\lx@end@alignment\@end@tabular'
     . '\@supertabular@finish');
 
 # Environment \begin{mpsupertabular*}{width}{pattern} ... \end{mpsupertabular*}
 DefMacro('\csname mpsupertabular*\endcsname{Dimension}{}',
   '\@supertabular@start'
-    . '\@supertabular@bindings[#1]{#2}\@@supertabular@{#1}{#2}\@start@alignment'
+    . '\@supertabular@bindings[#1]{#2}\@@supertabular@{#1}{#2}\lx@begin@alignment'
     . '\@supertabular@head');
 DefMacro('\csname endmpsupertabular*\endcsname',
   '\@supertabular@tail'
-    . '\@finish@alignment\@end@tabular'
+    . '\lx@end@alignment\@end@tabular'
     . '\@supertabular@finish');
 
 #======================================================================
@@ -90,11 +90,11 @@ DefPrimitive('\tablelasttail{}',  sub { AssignValue(SUPERTABULAR_LASTTAIL  => $_
 # instead of head, if it was given.  Analogously for tail
 DefMacro('\@supertabular@head', sub {
     my $head = LookupValue('SUPERTABULAR_FIRSTHEAD') || LookupValue('SUPERTABULAR_HEAD');
-    ($head ? (T_CS('\@tabular@begin@heading'), $head->unlist, T_CS('\@tabular@end@heading')) : ()); });
+    ($head ? (T_CS('\lx@alignment@begin@heading'), $head->unlist, T_CS('\lx@alignment@end@heading')) : ()); });
 
 DefMacro('\@supertabular@tail', sub {
     my $tail = LookupValue('SUPERTABULAR_LASTTAIL') || LookupValue('SUPERTABULAR_TAIL');
-    ($tail ? (T_CS('\@tabular@begin@heading'), $tail->unlist, T_CS('\@tabular@end@heading')) : ()); });
+    ($tail ? (T_CS('\lx@alignment@begin@heading'), $tail->unlist, T_CS('\lx@alignment@end@heading')) : ()); });
 
 #======================================================================
 # Captions

--- a/lib/LaTeXML/Package/tabularx.sty.ltxml
+++ b/lib/LaTeXML/Package/tabularx.sty.ltxml
@@ -19,9 +19,9 @@ RequirePackage('array');
 
 # \tabularx{Dimension}[]{}
 DefMacro('\tabularx{}[]{}',
-  '\@tabular@bindings{#3}[vattach=#2,width=#1]\@@tabularx{#1}[#2]{#3}\@start@alignment');
+  '\@tabular@bindings{#3}[vattach=#2,width=#1]\@@tabularx{#1}[#2]{#3}\lx@begin@alignment');
 DefMacro('\endtabularx',
-  '\@finish@alignment\@end@tabularx');
+  '\lx@end@alignment\@end@tabularx');
 DefPrimitive('\@end@tabularx', sub { $_[0]->egroup; });
 DefConstructor('\@@tabularx{Dimension}[] Undigested DigestedBody',
   '#4',

--- a/lib/LaTeXML/Package/tabulary.sty.ltxml
+++ b/lib/LaTeXML/Package/tabulary.sty.ltxml
@@ -19,9 +19,9 @@ RequirePackage('array');
 
 # \tabularx{Dimension}[]{}
 DefMacro('\tabulary{}[]{}',
-  '\@tabular@bindings{#3}[vattach=#2,width=#1]\@@tabulary{#1}[#2]{#3}\@start@alignment', locked => 1);
+'\@tabular@bindings{#3}[vattach=#2,width=#1]\@@tabulary{#1}[#2]{#3}\lx@begin@alignment', locked => 1);
 DefMacro('\endtabulary',
-  '\@finish@alignment\@end@tabulary', locked => 1);
+  '\lx@end@alignment\@end@tabulary', locked => 1);
 DefPrimitive('\@end@tabulary', sub { $_[0]->egroup; });
 DefConstructor('\@@tabulary{Dimension}[] Undigested DigestedBody',
   '#4',

--- a/lib/LaTeXML/Package/xcolor.sty.ltxml
+++ b/lib/LaTeXML/Package/xcolor.sty.ltxml
@@ -726,8 +726,8 @@ DefConditional('\if@rowcolors', undef);
 RawTeX('\@rowcolorstrue');
 #DefMacroI('\showrowcolors', undef, '\global\@rowcolorstrue');
 #DefMacroI('\hiderowcolors', undef, '\global\@rowcolorsfalse');
-DefMacroI('\showrowcolors', undef, '\hidden@noalign{\global\@rowcolorstrue}');
-DefMacroI('\hiderowcolors', undef, '\hidden@noalign{\global\@rowcolorsfalse}');
+DefMacroI('\showrowcolors', undef, '\lx@hidden@noalign{\global\@rowcolorstrue}');
+DefMacroI('\hiderowcolors', undef, '\lx@hidden@noalign{\global\@rowcolorsfalse}');
 
 DefMacro('\rownum', sub {
     my $alignment = LookupValue('Alignment');


### PR DESCRIPTION
…l-sequences.

They usually should start with \lx@, to avoid conflicts with external styles, classes, formats, etc.

To assist in updating any user bindings, a warning is issued when the old names are used (but the new name will be executed).
For reference (and tool building) The old and new names are listed here: 
```
\@ERROR \lx@ERROR
\@@eqno \lx@eqno
\LTX@nonumber \lx@equation@nonumber
\normnal@par \lx@normal@par
\inner@par \lx@normal@par
\hidden@bgroup \lx@hidden@bgroup
\hidden@egroup \lx@hidden@egroup
\right@hidden@egroup \lx@hidden@egroup@right
\hidden@align \lx@hidden@align
\hidden@noalign \lx@hidden@noalign
\hidden@cr \lx@hidden@cr
\hidden@crcr \lx@hidden@crcr
\@start@alignment \lx@start@alignment
\@finish@alignment \lx@finish@alignment
\@close@alignment \lx@close@alignment
\if@in@alignment \if@in@lx@alignment
\@alignment@hline \lx@alignment@hline
\@alignment@newline \lx@alignment@newline
\@alignment@newline@noskip \lx@alignment@newline@noskip \@alignment@newline@marker \lx@alignment@newline@marker \@alignment@newline@markertall \lx@alignment@newline@markertall \@alignment@column \lx@alignment@column
\@alignment@ncolumns \lx@alignment@ncolumns
\@alignment@bindings \lx@alignment@bindings
\@row@before \lx@alignment@row@before
\@row@after \lx@alignment@row@after
\@column@before \lx@alignment@column@before
\@column@after \lx@alignment@column@after
\@tabular@begin@heading \lx@alignment@begin@heading \@tabular@end@heading \lx@alignment@end@heading
\@multicolumn \lx@alignment@multicolumn
\@dollar@in@normalmode \lx@dollar@in@normalmode
\@dollar@in@mathmode \lx@dollar@in@mathmode
\@dollar@in@textmode \lx@dollar@in@textmode
\math@underline \lx@math@underline
\text@underline \lx@text@underline
\math@overleftarrow \lx@math@overleftarrow
\math@overrightarrow \lx@math@overrightarrow
\@@BEGININLINEMATH \lx@begin@inline@math
\@@ENDINLINEMATH \lx@end@inline@math
\@@BEGINDISPLAYMATH \lx@begin@display@math
\@@ENDDISPLAYMATH \lx@end@display@math
\@@BEGININLINETEXT \lx@begin@inmath@text
\@@ENDINLINETEXT \lx@end@inmath@text
\@@FLOATINGSUBSCRIPT \lx@floating@subscript
\@@FLOATINGSUPERSCRIPT \lx@floating@superscript
\@@POSTSUBSCRIPT \lx@post@subscript
\@@POSTSUPERSCRIPT \lx@post@superscript
\@ASSERT@MEANING \lx@assert@meaning
```

DG: Updating with code block to avoid @-tagging github users