### PR TITLE
Fix authblk line breaks when font has been customized

### DIFF
--- a/lib/LaTeXML/Package/authblk.sty.ltxml
+++ b/lib/LaTeXML/Package/authblk.sty.ltxml
@@ -24,7 +24,7 @@ DefMacro('\Authfont',  '\normalfont');
 DefMacro('\Authsep',   ',');
 DefMacro('\Authand',   ' and ');
 DefMacro('\Authands',  ', and ');
-DefMacro('\authorcr',  '\\\\\Authfont');
+DefMacro('\authorcr',  '\\\\');
 
 # package bookkeeping
 DefConditional('\ifnewaffil');


### PR DESCRIPTION
Author lines typeset using the `authblk` package can have an unexpected behavior when the `\Authfont` has been set to a custom font size and a line break `\authorcr` is used to separate authors.

Example document:
```latex
\documentclass{article}
\usepackage{authblk}
\renewcommand\Authfont{\Large}
\title{Use of authblk}
\author[1]{Alice}
\author[1]{Bob}
\author[1]{\authorcr Charlie} % \authorcr = line break
\author[1]{Dominik}
\affil[1]{Example University}
\begin{document}
	\maketitle
\end{document}
```

| PDF | LaTeXML | LaTeXML with this pull request |
| --- | --- | --- |
| <img width="290" alt="image" src="https://github.com/brucemiller/LaTeXML/assets/3543224/0651a28e-1541-4385-a2dc-9f93d9787238"> | <img width="200" alt="image" src="https://github.com/brucemiller/LaTeXML/assets/3543224/6cd2f6e4-4f63-46de-ba0e-ba4a36f11ab1"> | <img width="200" alt="image" src="https://github.com/brucemiller/LaTeXML/assets/3543224/c7d3c0e5-9e31-4ace-933b-20d83ec664fd">
|  | `<br class="ltx_break"><span class="ltx_text" style="font-size:144%;">Charlie</span>` | `<br class="ltx_break">Charlie`

The reason for the difference is that the `authblk` binding does not actually apply the `\Authfont` to the author name text in its current version, except after `\authorcr`. 
https://github.com/brucemiller/LaTeXML/blob/f75b0c6b06ff9191178a008c62a95f2b9c1dd087/lib/LaTeXML/Package/authblk.sty.ltxml#L27
This pull request removes this:
https://github.com/brucemiller/LaTeXML/blob/ca7e2146e73b9e566b797992487cc8102f0fe14a/lib/LaTeXML/Package/authblk.sty.ltxml#L27

Example to make it clear that normally `\Authfont` is ignored: let's set
```latex
\renewcommand\Authfont{\bfseries}
```
Then LaTeXML outputs the following:
<img width="178" alt="image" src="https://github.com/brucemiller/LaTeXML/assets/3543224/050a4af5-1f4f-40a9-8e6f-d06dbec1b18b">

LaTeXML with this pull request gives the same output as in the above table, right-most cell.