### PR TITLE
Limit length of captions in wrapfigures using CSS

### DIFF
--- a/lib/LaTeXML/resources/CSS/ltx-article.css
+++ b/lib/LaTeXML/resources/CSS/ltx-article.css
@@ -52,6 +52,10 @@
 /* experimental: flex model, to center short captions, justify long ones */
 .ltx_table,
 .ltx_figure { display:flex; flex-direction:column; align-items:center; }
+.ltx_table.ltx_align_floatright,
+.ltx_table.ltx_align_floatleft,
+.ltx_figure.ltx_align_floatright, 
+.ltx_figure.ltx_align_floatleft { width:min-content; }
 .ltx_table .ltx_caption,
 .ltx_figure .ltx_caption { text-align:justify; }
 

--- a/lib/LaTeXML/resources/CSS/ltx-book.css
+++ b/lib/LaTeXML/resources/CSS/ltx-book.css
@@ -50,6 +50,10 @@
 /* experimental: flex model, to center short captions, justify long ones */
 .ltx_table,
 .ltx_figure { display:flex; flex-direction:column; align-items:center; }
+.ltx_table.ltx_align_floatright,
+.ltx_table.ltx_align_floatleft,
+.ltx_figure.ltx_align_floatright, 
+.ltx_figure.ltx_align_floatleft { width:min-content; }
 .ltx_table .ltx_caption,
 .ltx_figure .ltx_caption { text-align:justify; }
 

--- a/lib/LaTeXML/resources/CSS/ltx-report.css
+++ b/lib/LaTeXML/resources/CSS/ltx-report.css
@@ -50,6 +50,10 @@
 /* experimental: flex model, to center short captions, justify long ones */
 .ltx_table,
 .ltx_figure { display:flex; flex-direction:column; align-items:center; }
+.ltx_table.ltx_align_floatright,
+.ltx_table.ltx_align_floatleft,
+.ltx_figure.ltx_align_floatright, 
+.ltx_figure.ltx_align_floatleft { width:min-content; }
 .ltx_table .ltx_caption,
 .ltx_figure .ltx_caption { text-align:justify; }
 


### PR DESCRIPTION
The [current bindings](https://github.com/brucemiller/LaTeXML/blob/f75b0c6b06ff9191178a008c62a95f2b9c1dd087/lib/LaTeXML/Package/wrapfig.sty.ltxml#L21) for the `wrapfig` package ignore the author-specified width. Together with the standard css, this leads to a bad presentation of wrapfigures with long captions. This pull request adds CSS (setting [`width: min-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-content) on the `<figure>` element) to limit the length of the caption of a wrapfigure to the length of the image. (Probably the more elegant solution is to take into account the width parameter of the `wrapfigure` environment, but this is a simple fix for the moment.)

Example:
```latex
\documentclass{article}
\usepackage{wrapfig,tikz}
\begin{document}
    \begin{wrapfigure}{r}{0.4\textwidth}
        \centering
        \tikz{\fill[purple] (0,0) rectangle (4,2);}
        \caption{A red rectangle deserving a long caption.}
    \end{wrapfigure}
    This is a\foreach \wordnum in {0,...,300} { test}.
\end{document}
```

PDF:
<img width="580" alt="image" src="https://github.com/brucemiller/LaTeXML/assets/3543224/81805899-5c8b-4366-8dda-2c636ef7269d">

LaTeXML (note that if the caption gets longer, the figure can take up up to 100% of the width of the page):
<img width="579" alt="image" src="https://github.com/brucemiller/LaTeXML/assets/3543224/d3417228-8b49-4395-8fa6-104ea315c8e5">

LaTeXML with this pull request:
<img width="586" alt="image" src="https://github.com/brucemiller/LaTeXML/assets/3543224/fb824355-43b5-480b-89fe-bbc3fcf7a452">
