### PR TITLE
convert ltx:graphics candidates to file URIs

### DIFF
--- a/lib/LaTeXML/Engine/TeX_FileIO.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_FileIO.pool.ltxml
@@ -17,6 +17,7 @@ use LaTeXML::Package;
 #use Unicode::Normalize;
 use LaTeXML::Util::Pathname;
 #use List::Util qw(min max);
+use URI::file;
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # File I/O Family of primitive control sequences
@@ -182,7 +183,7 @@ DefConstructor('\ltx@special@graphics OptionalKeyVals:SpecialPS Semiverbatim',
     my $searchpaths = LookupValue('GRAPHICSPATHS');
     my @candidates  = pathname_findall($path, types => ['*'], paths => $searchpaths);
     if (my $base = LookupValue('SOURCEDIRECTORY')) {
-      @candidates = map { pathname_relative($_, $base) } @candidates; }
+      @candidates = map { URI::file->new(pathname_relative($_, $base)) } @candidates; }
     my $options = '';
     if ($kv) {    # remap psfile options to includegraphics options:
       if (my $hscale = $kv->getValue('hscale')) {

--- a/lib/LaTeXML/Package/epsf.sty.ltxml
+++ b/lib/LaTeXML/Package/epsf.sty.ltxml
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 use LaTeXML::Util::Image;
+use URI::file;
 
 #**********************************************************************
 # (See  LaTeXML::Post::Graphics for suggested postprocessing)
@@ -50,6 +51,7 @@ DefConstructor('\epsfbox[] Semiverbatim',
     my $clip    = LookupValue('epsf_clip');
     my $options = ($clip ? ($bb ? "viewport=" . ToString($bb) . ", clip" : "clip") : '');
     my ($file, @candidates) = image_candidates(ToString($graphic));
+    @candidates = map { URI::file->new($_) } @candidates;
     my $w = LookupRegister('\epsfxsize');
     my $h = LookupRegister('\epsfysize');
     if ($w->valueOf > 0) {

--- a/lib/LaTeXML/Package/epsfig.sty.ltxml
+++ b/lib/LaTeXML/Package/epsfig.sty.ltxml
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 use LaTeXML::Util::Image;
+use URI::file;
 
 #**********************************************************************
 # (See  LaTeXML::Post::Graphics for suggested postprocessing)
@@ -44,11 +45,11 @@ DefConstructor('\psfig RequiredKeyVals:epsGin',
     $kv->setValue(clip   => 'true') if LookupValue('epsfclip');
     my @candidates = pathname_findall($file, types => ['*'], paths => LookupValue('GRAPHICSPATHS'));
     if (my $base = LookupValue('SOURCEDIRECTORY')) {
-      @candidates = map { pathname_relative($_, $base) } @candidates; }
+      @candidates = map { URI::file->new(pathname_relative($_, $base)) } @candidates; }
     my $options = ToString($kv);
     (graphic => $file,
       candidates => join(',', @candidates),
-      options => $options); });
+      options    => $options); });
 
 Let('\epsfig', '\psfig');
 
@@ -79,4 +80,3 @@ DefRegister('\epsfysize' => Dimension(0));
 DefPrimitive('\epsfsize{}{}', undef);
 #**********************************************************************
 1;
-

--- a/lib/LaTeXML/Package/graphics.sty.ltxml
+++ b/lib/LaTeXML/Package/graphics.sty.ltxml
@@ -17,6 +17,7 @@ use warnings;
 use LaTeXML::Package;
 use LaTeXML::Util::Pathname;
 use LaTeXML::Util::Image;
+use URI::file;
 
 #======================================================================
 # (See  LaTeXML::Post::Graphics for suggested postprocessing)
@@ -295,6 +296,7 @@ DefConstructor('\@includegraphics OptionalMatch:* [][] Semiverbatim',
     my ($stomach, $starred, $op1, $op2, $graphic) = @_;
     my $options = graphicS_options($starred, $op1, $op2);
     my ($path, @candidates) = image_candidates(ToString($graphic));
+    @candidates = map { URI::file->new($_) } @candidates;
     (graphic => $path,
       candidates => join(',', @candidates),
       options    => $options); },

--- a/lib/LaTeXML/Package/graphicx.sty.ltxml
+++ b/lib/LaTeXML/Package/graphicx.sty.ltxml
@@ -64,6 +64,7 @@ DefConstructor('\@includegraphicx OptionalMatch:* OptionalKeyVals:Gin Semiverbat
     my ($stomach, $starred, $kv, $graphic) = @_;
     my $options = graphicX_options($starred, $kv);
     my ($path, @candidates) = image_candidates(ToString($graphic));
+    @candidates = map { URI::file->new($_) } @candidates;
     my $alt = $kv && $kv->getValue('alt');
     (path => $path,
       candidates => join(',', @candidates),

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -22,6 +22,7 @@ use warnings;
 use LaTeXML::Package;
 use LaTeXML::Util::Image;
 use List::Util qw(min max);
+use URI::file;
 
 DebuggableFeature('pgf', "Debug pgf processing");
 
@@ -615,7 +616,7 @@ DefConstructor('\lxSVG@includegraphics{}{} Semiverbatim',
     my @candidates = pathname_findall($graphic, types => ['*'],
       paths => LookupValue('GRAPHICSPATHS'));
     if (my $base = LookupValue('SOURCEDIRECTORY')) {
-      @candidates = map { pathname_relative($_, $base) } @candidates; }
+      @candidates = map { URI::file->new(pathname_relative($_, $base)) } @candidates; }
     (graphic => $graphic,
       candidates => join(',', @candidates),
       options    => $options); },

--- a/lib/LaTeXML/Package/psfrag.sty.ltxml
+++ b/lib/LaTeXML/Package/psfrag.sty.ltxml
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 use LaTeXML::Util::Image;
+use URI::file;
 
 #======================================================================
 # Would be lovely to overlay SVG, MathML, Images etc
@@ -87,6 +88,7 @@ DefConstructor('\lx@psfrag@includegraphics OptionalMatch:* [][] Semiverbatim',
     my $options = graphicS_options($starred, $op1, $op2);
     my ($path, @candidates) = image_candidates(ToString($graphic));
     my $ifpicture = psfrag_requirepicture(@candidates);
+    @candidates = map { URI::file->new($_) } @candidates;
     (graphic => $path,
       candidates => join(',', @candidates),
       options    => $options,
@@ -110,6 +112,7 @@ DefConstructor('\lx@psfrag@includegraphicx OptionalMatch:* OptionalKeyVals:Gin S
     my $options = graphicX_options($starred, $kv);
     my ($path, @candidates) = image_candidates(ToString($graphic));
     my $ifpicture = psfrag_requirepicture(@candidates);
+    @candidates = map { URI::file->new($_) } @candidates;
     (path => $path,
       candidates => join(',', @candidates),
       options    => $options,
@@ -133,6 +136,7 @@ DefConstructor('\lx@psfrag@epsfbox[] Semiverbatim',
     my $options = ($clip ? ($bb ? "viewport=$bb, clip" : "clip") : '');
     my ($path, @candidates) = image_candidates(ToString($graphic));
     my $ifpicture = psfrag_requirepicture(@candidates);
+    @candidates = map { URI::file->new($_) } @candidates;
     (graphic => $path,
       candidates => join(',', @candidates),
       options    => $options,

--- a/lib/LaTeXML/Post/Graphics.pm
+++ b/lib/LaTeXML/Post/Graphics.pm
@@ -18,6 +18,7 @@ use warnings;
 use LaTeXML::Util::Pathname;
 use LaTeXML::Util::Image;
 use LaTeXML::Post;
+use URI::file;
 use base qw(LaTeXML::Post::Processor);
 
 #======================================================================
@@ -53,7 +54,7 @@ sub new {
   $$self{trivial_scaling} = $options{trivial_scaling} || 1;
   $$self{graphics_types}  = $options{graphics_types}
     || [qw(svg png gif jpg jpeg
-      eps ps postscript ai pdf)];
+    eps ps postscript ai pdf)];
   $$self{type_properties} = $options{type_properties}
     || {
     ai => { destination_type => 'png',
@@ -135,7 +136,7 @@ sub findGraphicFile {
   my ($self, $doc, $node) = @_;
   if (my $source = $node->getAttribute('graphic')) {
     # if we already have a usable candidate, save ourselves the work
-    my @paths = grep { -e $_ } split(',', $node->getAttribute('candidates') || '');
+    my @paths = grep { -e $_ } (map { URI->new($_, 'file')->file } split(',', $node->getAttribute('candidates') || ''));
     if (!scalar(@paths)) {
       # Find all acceptable image files, in order of search paths
       my ($dir, $name, $reqtype) = pathname_split($source);

--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -18,6 +18,7 @@ use LaTeXML::Common::Dimension;
 use LaTeXML::Util::Pathname;
 use List::Util qw(min max);
 use Image::Size;
+use URI::file;
 use POSIX;
 use base qw(Exporter);
 our @EXPORT = (
@@ -251,7 +252,7 @@ sub image_graphicx_sizer {
   my ($whatsit) = @_;
   if (my $candidates = $whatsit->getProperty('candidates')) {
     my $dpi = ($STATE && $STATE->lookupValue('DPI')) || $DPI;
-    foreach my $source (split(/,/, $candidates)) {
+    foreach my $source (map { URI->new($_, 'file')->file } split(/,/, $candidates)) {
       if (!pathname_is_absolute($source)) {
         if (my $base = $STATE->lookupValue('SOURCEDIRECTORY')) {
           $source = pathname_concat($base, $source); } }


### PR DESCRIPTION
Fix #2355 (allegedly) by making `candidates` a comma-separated list of URIs instead of plain file names.

I do not have conclusive proof about Windows, because the relevant tests seem to require a minimum texlive version, and I am using MikTeX. This would explain why CI did not catch the issue.

I suggest taking this PR further: make `candidates` a *space* separated list (since now spaces are %-encoded), and add this restriction to the schema (with something like `list(anyURI)`).