### PR TITLE
remove redundant \expandafter definition

### DIFF
--- a/lib/LaTeXML/Engine/TeX_Macro.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Macro.pool.ltxml
@@ -194,26 +194,6 @@ DefPrimitive('\futurelet Token Token Token', sub {
 # \expandafter      c  `<token1><token2>' is equivalent to `<token1> expansion of <token2>'.
 # \noexpand         c  prevents the expansion of the following token.
 
-DefMacro('\expandafter Token Token', sub {
-    no warnings 'recursion';
-    my ($gullet, $tok, $xtok) = @_;
-    my $defn;
-    if (defined($defn = $STATE->lookupExpandable($xtok))) {
-      my @x = ();
-      {
-        local $LaTeXML::CURRENT_TOKEN = $xtok;
-        @x = $defn->invoke($gullet, 1);    # Expand $xtok ONCE ONLY!
-      }
-      ($tok, @x); }
-    elsif (!$STATE->lookupMeaning($xtok)) {
-      # Undefined token is an error, as expansion is expected.
-      # BUT The unknown token is NOT consumed, (see TeX B book, item 367)
-      # since probably in a real TeX run it would have been defined.
-      $STATE->generateErrorStub($gullet, $xtok);
-      ($tok, $xtok); }
-    else {
-      ($tok, $xtok); } });
-
 use constant T_expandafter => T_CS('\expandafter');
 DefMacro('\expandafter Token Token', sub {
     no warnings 'recursion';

--- a/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
@@ -1106,7 +1106,6 @@ DefRegister('\belowdisplayshortskip' => Glue('0pt plus 3pt'));
 
 DefRegister('\binoppenalty'        => Number(700));
 DefRegister('\relpenalty'          => Number(500));
-DefRegister('\relpenalty'          => Number(700));
 DefRegister('\displaywidowpenalty' => Number(50));
 DefRegister('\predisplaypenalty'   => Number(10000));
 DefRegister('\postdisplaypenalty'  => Number(0));


### PR DESCRIPTION
Spotted while porting. There appear to be two \expandafter definitions following each other. 

As the first one wasn't getting used (immediately overwritten by the second), this PR removes it for clarity.