### PR TITLE
update xsl rule for moderncv personal position/title

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -504,9 +504,11 @@
           <xsl:text> </xsl:text>
           <xsl:value-of select="ltx:contact[@role='familyname']" />
         </h1>
-        <h3 class="author-title">
-          <xsl:apply-templates select="ltx:contact[@role='position']/ltx:inline-block" />
-        </h3>
+        <xsl:if test="ltx:contact[@role='position']">
+          <h3 class="author-title">
+            <xsl:apply-templates select="ltx:contact[@role='position']" />
+          </h3>
+        </xsl:if>
       </div>
       <div class="col-25">
       </div>


### PR DESCRIPTION
A bit of a minor tweak that makes the moderncv.cls output capable of handling a simple plain-text position (originating in the `\title` macro). The previous version was expecting a multiline construct in a `\vbox`, which is a bit too specific.

Funny story how I stumbled on it...