### PR TITLE
Extra safety when unreading alignment-related characters for \aligned

### DIFF
--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -590,8 +590,8 @@ DefPrimitive('\@ams@aligned@bindings', sub {
 DefParameterType('alignsafeOptional', sub {
     my ($gullet, $default, $inner) = @_;
     my ($tok, $value);
-    { local $LaTeXML::ALIGN_STATE = 1000000;
-      $tok = $gullet->readNonSpace; }
+    local $LaTeXML::ALIGN_STATE = 1000000;
+    $tok = $gullet->readNonSpace;
     if    (!defined $tok) { }
     elsif (($tok->equals(T_OTHER('[')))) {
       $value = $gullet->readUntil(T_OTHER(']')); }


### PR DESCRIPTION
Fixes #2383 . Quite subtle, but I think I got it - I can make the minimal example from the issue into a test if preferred.

Details: The key problem was that when the `->unread` of a `{` happened, the *actual* aligned state got modified, rather than the "safely neutralized" local state, which appears to be the primary purpose of this parameter type.