### PR TITLE
Rearrangements

### DIFF
--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -187,6 +187,8 @@ sub decodeFontname {
     if (my $fser = lookupFontSeries($ser)) { map { $props{$_} = $$fser{$_} } keys %$fser; }
     if (my $fsh  = lookupFontShape($shp))  { map { $props{$_} = $$fsh{$_} } keys %$fsh; }
     $size        = 1 unless $size;    # Yes, also if 0, "" (from regexp)
+    $size        = $at           if defined $at;
+    $size        = $at * $scaled if defined $scaled;
     $props{name} = $name;
     $props{size} = $size;
     # Experimental Hack !?!?!?
@@ -249,7 +251,7 @@ sub textDefault {
 sub mathDefault {
   my ($self) = @_;
   return $self->new_internal('math', $DEFSERIES, 'italic', DEFSIZE(),
-    $DEFCOLOR, $DEFBACKGROUND, $DEFOPACITY, 'OT1', $DEFLANGUAGE, 'text', 0); }
+    $DEFCOLOR, $DEFBACKGROUND, $DEFOPACITY, undef, $DEFLANGUAGE, 'text', 0); }
 
 # Accessors
 # Using an array here is getting ridiculous!

--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -187,8 +187,8 @@ sub decodeFontname {
     if (my $fser = lookupFontSeries($ser)) { map { $props{$_} = $$fser{$_} } keys %$fser; }
     if (my $fsh  = lookupFontShape($shp))  { map { $props{$_} = $$fsh{$_} } keys %$fsh; }
     $size        = 1 unless $size;    # Yes, also if 0, "" (from regexp)
-    $size        = $at           if defined $at;
-    $size        = $at * $scaled if defined $scaled;
+    $size        = $at             if defined $at;
+    $size        = $size * $scaled if defined $scaled;
     $props{name} = $name;
     $props{size} = $size;
     # Experimental Hack !?!?!?

--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -60,44 +60,53 @@ my $FLAG_EMPH         = 0x10;
 # NOTE: This probably doesn't really belong in here...
 
 my %font_family = (
-  cmr   => { family => 'serif' },      cmss  => { family => 'sansserif' },
-  cmtt  => { family => 'typewriter' }, cmvtt => { family => 'typewriter' },
-  cmt   => { family => 'serif' },    # for cmti "text italic"
-  cmfib => { family => 'serif' },      cmfr  => { family => 'serif' },
-  cmdh  => { family => 'serif' },      cm    => { family => 'serif' },
-  ptm   => { family => 'serif' },      ppl   => { family => 'serif' },
-  pnc   => { family => 'serif' },      pbk   => { family => 'serif' },
-  phv   => { family => 'sansserif' },  pag   => { family => 'serif' },
-  pcr   => { family => 'typewriter' }, pzc   => { family => 'script' },
-  put   => { family => 'serif' },      bch   => { family => 'serif' },
-  psy   => { family => 'symbol' },     pzd   => { family => 'dingbats' },
-  ccr   => { family => 'serif' },      ccy   => { family => 'symbol' },
-  cmbr  => { family => 'sansserif' },  cmtl  => { family => 'typewriter' },
-  cmbrs => { family => 'symbol' },     ul9   => { family => 'typewriter' },
-  txr   => { family => 'serif' },      txss  => { family => 'sansserif' },
-  txtt  => { family => 'typewriter' }, txms  => { family => 'symbol' },
-  txsya => { family => 'symbol' },     txsyb => { family => 'symbol' },
-  pxr   => { family => 'serif' },      pxms  => { family => 'symbol' },
-  pxsya => { family => 'symbol' },     pxsyb => { family => 'symbol' },
-  futs  => { family => 'serif' },
-  uaq   => { family => 'serif' },   ugq  => { family => 'sansserif' },
-  eur   => { family => 'serif' },   eus  => { family => 'script' },
-  euf   => { family => 'fraktur' }, euex => { family => 'symbol' },
+  cmr    => { family => 'serif' },
+  cmss   => { family => 'sansserif' },
+  cmssq  => { family => 'sansserif' },                       # quote style?
+  cmssqi => { family => 'sansserif', shape => 'italic' },    # quote style?
+  cmtt   => { family => 'typewriter' }, cmvtt => { family => 'typewriter' },
+  cmt    => { family => 'serif' },                           # for cmti "text italic"
+  cmfib  => { family => 'serif' },
+  cmfr   => { family => 'serif' },
+  cm     => { family => 'serif' },
+  cmdh   => { family => 'serif' },
+  cmr    => { family => 'serif' },
+  cmdunh => { family => 'serif' },                           # like cmr10 but with tall body heights
+  cmu    => { family => 'serif' },                           # unslanted italic ??
+  ptm    => { family => 'serif' },      ppl   => { family => 'serif' },
+  pnc    => { family => 'serif' },      pbk   => { family => 'serif' },
+  phv    => { family => 'sansserif' },  pag   => { family => 'serif' },
+  pcr    => { family => 'typewriter' }, pzc   => { family => 'script' },
+  put    => { family => 'serif' },      bch   => { family => 'serif' },
+  psy    => { family => 'symbol' },     pzd   => { family => 'dingbats' },
+  ccr    => { family => 'serif' },      ccy   => { family => 'symbol' },
+  cmbr   => { family => 'sansserif' },  cmtl  => { family => 'typewriter' },
+  cmbrs  => { family => 'symbol' },     ul9   => { family => 'typewriter' },
+  txr    => { family => 'serif' },      txss  => { family => 'sansserif' },
+  txtt   => { family => 'typewriter' }, txms  => { family => 'symbol' },
+  txsya  => { family => 'symbol' },     txsyb => { family => 'symbol' },
+  pxr    => { family => 'serif' },      pxms  => { family => 'symbol' },
+  pxsya  => { family => 'symbol' },     pxsyb => { family => 'symbol' },
+  futs   => { family => 'serif' },
+  uaq    => { family => 'serif' },   ugq  => { family => 'sansserif' },
+  eur    => { family => 'serif' },   eus  => { family => 'script' },
+  euf    => { family => 'fraktur' }, euex => { family => 'symbol' },
   # The following are actually math fonts.
-  ms    => { family => 'symbol' },
-  ccm   => { family => 'serif',      shape    => 'italic' },
-  cmm   => { family => 'italic',     encoding => 'OML' },
-  cmex  => { family => 'symbol',     encoding => 'OMX' },      # Not really symbol, but...
-  cmsy  => { family => 'symbol',     encoding => 'OMS' },
-  ccitt => { family => 'typewriter', shape    => 'italic' },
-  cmbrm => { family => 'sansserif',  shape    => 'italic' },
-  futm  => { family => 'serif',      shape    => 'italic' },
-  futmi => { family => 'serif',      shape    => 'italic' },
-  txmi  => { family => 'serif',      shape    => 'italic' },
-  pxmi  => { family => 'serif',      shape    => 'italic' },
-  bbm   => { family => 'blackboard' },
-  bbold => { family => 'blackboard' },
-  bbmss => { family => 'blackboard' },
+  ms     => { family => 'symbol' },
+  ccm    => { family => 'serif',      shape    => 'italic' },
+  cmm    => { family => 'math',       shape    => 'italic', encoding => 'OML' },
+  cmex   => { family => 'symbol',     encoding => 'OMX' },       # Not really symbol, but...
+  cmsy   => { family => 'symbol',     encoding => 'OMS' },
+  ccitt  => { family => 'typewriter', shape    => 'italic' },
+  cmsltt => { family => 'typewriter', shape    => 'slanted' },
+  cmbrm  => { family => 'sansserif',  shape    => 'italic' },
+  futm   => { family => 'serif',      shape    => 'italic' },
+  futmi  => { family => 'serif',      shape    => 'italic' },
+  txmi   => { family => 'serif',      shape    => 'italic' },
+  pxmi   => { family => 'serif',      shape    => 'italic' },
+  bbm    => { family => 'blackboard' },
+  bbold  => { family => 'blackboard' },
+  bbmss  => { family => 'blackboard' },
   # some ams fonts
   cmmib => { family => 'italic', series   => 'bold' },
   cmbsy => { family => 'symbol', series   => 'bold' },
@@ -177,16 +186,15 @@ sub decodeFontname {
     if (my $ffam = lookupFontFamily($fam)) { map { $props{$_} = $$ffam{$_} } keys %$ffam; }
     if (my $fser = lookupFontSeries($ser)) { map { $props{$_} = $$fser{$_} } keys %$fser; }
     if (my $fsh  = lookupFontShape($shp))  { map { $props{$_} = $$fsh{$_} } keys %$fsh; }
-    $size = 1 unless $size;    # Yes, also if 0, "" (from regexp)
-    $size = $at if defined $at;
-    $size *= $scaled if defined $scaled;
+    $size        = 1 unless $size;    # Yes, also if 0, "" (from regexp)
+    $props{name} = $name;
     $props{size} = $size;
     # Experimental Hack !?!?!?
     $props{encoding} = 'OT1' unless defined $props{encoding};
-    $props{at}       = $at . "pt" if defined $at;
     return %props; }
   else {
-    return; } }
+    Info('unrecognized', 'font', undef, "Unrecognized fontname '$name'");
+    return (family => $name, size => DEFSIZE()); } }
 
 sub lookupTeXFont {
   my ($fontname, $seriescode, $shapecode) = @_;
@@ -241,7 +249,7 @@ sub textDefault {
 sub mathDefault {
   my ($self) = @_;
   return $self->new_internal('math', $DEFSERIES, 'italic', DEFSIZE(),
-    $DEFCOLOR, $DEFBACKGROUND, $DEFOPACITY, undef, $DEFLANGUAGE, 'text', 0); }
+    $DEFCOLOR, $DEFBACKGROUND, $DEFOPACITY, 'OT1', $DEFLANGUAGE, 'text', 0); }
 
 # Accessors
 # Using an array here is getting ridiculous!
@@ -266,6 +274,7 @@ sub stringify {
   no warnings 'recursion';
   my ($self) = @_;
   my ($fam, $ser, $shp, $siz, $col, $bkg, $opa, $enc, $lang, $mstyle, $flags) = @$self;
+  # !!!!!
   $fam = 'serif' if $fam && ($fam eq 'math');
   return 'Font[' . join(',', map { Stringify($_) } grep { $_ }
       (isDiff($fam, $DEFFAMILY)   ? ($fam)    : ()),
@@ -279,6 +288,16 @@ sub stringify {
     ($flags                       ? ($flags)  : ()),
     )
     . ']'; }
+
+# Return a Fontinfo-like hash
+# Eventually a more integrated representation of Fonts that accommodates
+# both low-level TeX-like commands, and higher-level CSS-like ones.
+sub asFontinfo {
+  my ($self) = @_;
+  my ($fam, $ser, $shp, $siz, $col, $bkg, $opa, $enc, $lang, $mstyle, $flags) = @$self;
+  return { family => $fam, series => $ser, shape => $shp, size => $siz,
+    color    => $col,          background => $bkg,  opacity   => $opa,
+    encoding => $enc || 'OT1', language   => $lang, mathstyle => $mstyle }; }
 
 sub equals {
   my ($self, $other) = @_;
@@ -328,6 +347,7 @@ sub relativeTo {
   my ($self, $other) = @_;
   my ($fam,  $ser,  $shp,  $siz,  $col,  $bkg,  $opa,  $enc,  $lang,  $mstyle,  $flags)  = @$self;
   my ($ofam, $oser, $oshp, $osiz, $ocol, $obkg, $oopa, $oenc, $olang, $omstyle, $oflags) = @$other;
+  # !!!!
   $fam  = 'serif' if $fam  && ($fam eq 'math');
   $ofam = 'serif' if $ofam && ($ofam eq 'math');
 ##  my $emph = 0;
@@ -357,6 +377,9 @@ sub relativeTo {
       : ()),
     (isDiff($opa, $oopa)
       ? (opacity => { value => $opa, properties => { opacity => $opa } })
+      : ()),
+    (isDiff($enc, $oenc)
+      ? (encoding => { value => $enc, properties => { encoding => $enc } })
       : ()),
     (isDiff($lang, $olang)
       ? ('xml:lang' => { value => $lang, properties => { language => $lang } })

--- a/lib/LaTeXML/Common/Font/Metric.pm
+++ b/lib/LaTeXML/Common/Font/Metric.pm
@@ -101,7 +101,7 @@ sub read_tfm {
     my ($skip, $next, $op, $remainder);
     ($skip, $next) = unpack "CC", $lig_kern[0];
     if (($skip == 255) && (defined $$fontmap[$next])) {
-      $$self{boundary} = (ref $$fontmap[$next] ? $$fontmap[$next][0] : $$fontmap[$next]); }
+      $$self{boundary} = $$fontmap[$next]; }
     ($skip, $next, $op, $remainder) = unpack "CCCC", $lig_kern[-1];
     if ($skip == 255) {
       $self->process_lig_kern("boundary", \@lig_kern, 256 * $op + $remainder, $fontmap, \@kern); }
@@ -109,8 +109,7 @@ sub read_tfm {
   # Interpret char_info (for w,h,d,ital) and lig_kern program
   my $sizes = $$self{sizes};
   for (my $code = $bc ; $code <= $ec ; $code++) {
-    my $mapentry = $$fontmap[$code];
-    my $char     = (ref $mapentry ? $$mapentry[0] : $mapentry);
+    my $char = $$fontmap[$code];
     if (defined $char) {
       my ($wloc, $hdloc, $ixloc, $remainder) = unpack "C4", $char_info[$code];
       my ($hloc, $dloc, $iloc, $tag) = ($hdloc >> 4, $hdloc & 0x0F, $ixloc >> 2, $ixloc & 0x03);
@@ -153,15 +152,12 @@ sub process_lig_kern {
       $prognum = 256 * $op + $remainder; $firstinstr = 0;
       next; }
     $next = $$fontmap[$next];
-    $next = $$next[0] if ref $next;
     my $pair = $char . $next;
     if (($op >= 128) && !exists $$kerns{$pair}) {
       $$kerns{$pair} = $$kernref[256 * ($op - 128) + $remainder]; }
     if (($op < 128) && !exists $$ligs{$pair}) {
       my ($pass, $keepc, $keepn) = ($op >> 2, ($op >> 1) & 0x01, $op & 0x01);
-      my $rchar = $$fontmap[$remainder];
-      $rchar = $$rchar[0] if ref $rchar;
-      my $lig = ($keepc ? $char : "") . $rchar . ($keepn ? $next : '');
+      my $lig = ($keepc ? $char : "") . $$fontmap[$remainder] . ($keepn ? $next : '');
       $$ligs{$pair} = [$lig, $pass]; }    # ligature & number of chars to "passover" (always 0???)
     last if ($skip >= 128);
     $prognum += $skip + 1;

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -124,13 +124,12 @@ sub new {
   $$self{delcode}             = {};
   $$self{tracing_definitions} = {};
   # Initializations that INITEX would have set.
-  $$self{mathcode}{'.'} = [0];
   for (my $c = ord('0') ; $c <= ord('9') ; $c++) {
-    $$self{mathcode}{ chr($c) } = [0x7000]; }
+    $$self{mathcode}{ chr($c) } = [0x7000 + $c]; }
   for (my $c = ord('a') ; $c <= ord('z') ; $c++) {
     my $C = $c + ord('A') - ord('a');
-    $$self{mathcode}{ chr($c) } = [0x7100];
-    $$self{mathcode}{ chr($C) } = [0x7100];
+    $$self{mathcode}{ chr($c) } = [0x7100 + $c];
+    $$self{mathcode}{ chr($C) } = [0x7100 + $C];
     $$self{uccode}{ chr($c) }   = [$C];
     $$self{lccode}{ chr($C) }   = [$c];
     $$self{sfcode}{ chr($C) }   = [999]; }

--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -4889,7 +4889,7 @@ DefConstructor('\@framebox[Dimension][]{}',
           $document->setAttribute($c[0], $k => $v); } } } }
 );
 
-AssignValue(allocated_boxes => 0);
+AssignValue(allocated_boxes => 0, 'global');
 DefPrimitive('\newsavebox DefToken', sub {
     my $n = LookupValue('allocated_boxes') + 1;
     AssignValue(allocated_boxes => $n, 'global');

--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -4889,6 +4889,7 @@ DefConstructor('\@framebox[Dimension][]{}',
           $document->setAttribute($c[0], $k => $v); } } } }
 );
 
+AssignValue(allocated_boxes => 0);
 DefPrimitive('\newsavebox DefToken', sub {
     my $n = LookupValue('allocated_boxes') + 1;
     AssignValue(allocated_boxes => $n, 'global');

--- a/lib/LaTeXML/Engine/TeX_Character.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Character.pool.ltxml
@@ -185,7 +185,7 @@ DefRegister('\catcode Number', Number(0),
 # Not used anywhere (yet)
 DefRegister('\sfcode Number', Number(0),
   getter => sub { my $code = $STATE->lookupSFcode(chr($_[0]->valueOf));
-    Number(defined $code ? $code : 0); },
+    Number(defined $code ? $code : 1000); },
   setter => sub { $STATE->assignSFcode(chr($_[2]->valueOf) => $_[0]->valueOf, $_[1]); });
 DefRegister('\lccode Number', Number(0),
   getter => sub { my $code = $STATE->lookupLCcode(chr($_[0]->valueOf));

--- a/lib/LaTeXML/Engine/TeX_Fonts.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Fonts.pool.ltxml
@@ -286,4 +286,37 @@ DeclareFontMap('OMX',
     "\x{2191}", "\x{2193}", undef, undef, undef, undef, "\x{21D1}", "\x{21D3}"]);
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# TeX's ligatures handled by rewrite regexps.
+# Note: applied in reverse order of definition (latest defined applied first!)
+# Note also, these area only applied in text content, not in attributes!
+sub nonTypewriter {
+  my ($font) = @_;
+  return ($font->getFamily ne 'typewriter'); }
+
+sub nonTypewriterT1 {
+  my ($font) = @_;
+  return ($font->getFamily ne 'typewriter') && (($font->getEncoding || 'OT1') =~ /^(OT1|T1)$/); }
+
+# EN DASH (NOTE: With digits before & aft => \N{FIGURE DASH})
+DefLigature(qr{--},  "\x{2013}", fontTest => \&nonTypewriter);    # EN dash
+DefLigature(qr{---}, "\x{2014}", fontTest => \&nonTypewriter);    # EM dash
+
+# Ligatures for doubled single left & right quotes to convert to double quotes
+# [should ligatures be part of a font, in the first place? (it is in TeX!)
+DefLigature(qr{\x{2018}\x{2018}}, "\x{201C}", fontTest => \&nonTypewriterT1);   # double left quote
+DefLigature(qr{\x{2019}\x{2019}}, "\x{201D}", fontTest => \&nonTypewriterT1);   # double right quote
+DefLigature(qr{\?\x{2018}},       UTF(0xBF),  fontTest => \&nonTypewriterT1);   # ? backquote
+DefLigature(qr{!\x{2018}},        UTF(0xA1),  fontTest => \&nonTypewriterT1);   # ! backquote
+# These ligatures are also handled by TeX.
+# However, it appears that decent modern fonts in modern browsers handle these at that level.
+# So it's likely not worth doing it at the conversion level, possibly adversely affecting search.
+# DefLigature(qr{ff},               "\x{FB00}", fontTest => \&nonTypewriterT1);
+# DefLigature(qr{fi},               "\x{FB01}", fontTest => \&nonTypewriterT1);
+# DefLigature(qr{fl},               "\x{FB02}", fontTest => \&nonTypewriterT1);
+# DefLigature(qr{ffi},              "\x{FB03}", fontTest => \&nonTypewriterT1);
+# DefLigature(qr{ffl},              "\x{FB04}", fontTest => \&nonTypewriterT1);
+
+DefLigature(qr{\.\.\.}, "\x{2026}", fontTest => sub { $_[0]->getFamily ne 'typewriter'; });  # ldots
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;

--- a/lib/LaTeXML/Engine/TeX_Fonts.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Fonts.pool.ltxml
@@ -316,7 +316,7 @@ DefLigature(qr{!\x{2018}},        UTF(0xA1),  fontTest => \&nonTypewriterT1);   
 # DefLigature(qr{ffi},              "\x{FB03}", fontTest => \&nonTypewriterT1);
 # DefLigature(qr{ffl},              "\x{FB04}", fontTest => \&nonTypewriterT1);
 
-DefLigature(qr{\.\.\.}, "\x{2026}", fontTest => sub { $_[0]->getFamily ne 'typewriter'; });  # ldots
+DefLigature(qr{\.\.\.}, "\x{2026}", fontTest => \&nonTypewriter);    # ldots
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;

--- a/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
@@ -1193,5 +1193,14 @@ DefConstructor('\lx@eqno{}',
   "^ <ltx:tags><ltx:tag><ltx:Math><ltx:XMath>#1</ltx:XMath></ltx:Math></ltx:tag></ltx:tags>",
   reversion => '');
 
+#======================================================================
+# Pretest for XMath to keep from interpreting math that the DOM may not allow!!
+##DefMathRewrite(xpath=>'descendant-or-self::ltx:XMath',match=>'\cdot\cdot\cdot',replace=>'\cdots');
+
+DefMathLigature("\x{22C5}\x{22C5}\x{22C5}" => "\x{22EF}", role => 'ID', name => 'cdots');
+
+#DefMathRewrite(xpath=>'descendant-or-self::ltx:XMath',match=>'...',replace=>'\ldots');
+DefMathLigature("..." => "\x{2026}", role => 'ID', name => 'ldots');
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;

--- a/lib/LaTeXML/Engine/TeX_Paragraph.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Paragraph.pool.ltxml
@@ -68,6 +68,17 @@ DefConstructorI('\noindent', undef, sub {
     # Otherwise ignore.
     return; });
 
+sub alignLine {
+  my ($document, $line, $alignment) = @_;
+  if ($document->isOpenable('ltx:p')) {
+    $document->insertElement('ltx:p', $line, class => 'ltx_align_' . $alignment); }
+  elsif ($document->isOpenable('ltx:text')) {
+    $document->insertElement('ltx:text', $line, class => 'ltx_align_' . $alignment);
+    $document->insertElement('ltx:break'); }
+  else {
+    $document->absorb($line); }
+  return; }
+
 # <ltx:para> represents a Logical Paragraph, whereas <ltx:p> is a `physical paragraph'.
 # A para can contain both p and displayed equations and such.
 

--- a/lib/LaTeXML/Engine/TeX_Paragraph.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Paragraph.pool.ltxml
@@ -76,6 +76,8 @@ sub alignLine {
     $document->insertElement('ltx:text', $line, class => 'ltx_align_' . $alignment);
     $document->insertElement('ltx:break'); }
   else {
+    Info('unexpected', 'alignment', $document,
+      "Lost requested alignment '$alignment'; no suitable element");
     $document->absorb($line); }
   return; }
 

--- a/lib/LaTeXML/Engine/plain.pool.ltxml
+++ b/lib/LaTeXML/Engine/plain.pool.ltxml
@@ -95,38 +95,8 @@ DefMathRewrite(xpath => 'descendant-or-self::ltx:XMWrap['
   });
 
 #======================================================================
-# TeX's ligatures handled by rewrite regexps.
-# Note: applied in reverse order of definition (latest defined applied first!)
-# Note also, these area only applied in text content, not in attributes!
 DefPrimitive('\@@endash', sub { Box("\x{2013}", undef, undef, T_CS('\@@endash')); });
 DefPrimitive('\@@emdash', sub { Box("\x{2014}", undef, undef, T_CS('\@@emdash')); });
-
-sub nonTypewriter {
-  my ($font) = @_;
-  return ($font->getFamily ne 'typewriter'); }
-
-sub nonTypewriterT1 {
-  my ($font) = @_;
-  return ($font->getFamily ne 'typewriter') && (($font->getEncoding || 'OT1') =~ /^(OT1|T1)$/); }
-
-# EN DASH (NOTE: With digits before & aft => \N{FIGURE DASH})
-DefLigature(qr{--},  "\x{2013}", fontTest => \&nonTypewriter);    # EN dash
-DefLigature(qr{---}, "\x{2014}", fontTest => \&nonTypewriter);    # EM dash
-
-# Ligatures for doubled single left & right quotes to convert to double quotes
-# [should ligatures be part of a font, in the first place? (it is in TeX!)
-DefLigature(qr{\x{2018}\x{2018}}, "\x{201C}", fontTest => \&nonTypewriterT1);   # double left quote
-DefLigature(qr{\x{2019}\x{2019}}, "\x{201D}", fontTest => \&nonTypewriterT1);   # double right quote
-DefLigature(qr{\?\x{2018}},       UTF(0xBF),  fontTest => \&nonTypewriterT1);   # ? backquote
-DefLigature(qr{!\x{2018}},        UTF(0xA1),  fontTest => \&nonTypewriterT1);   # ! backquote
-# These ligatures are also handled by TeX.
-# However, it appears that decent modern fonts in modern browsers handle these at that level.
-# So it's likely not worth doing it at the conversion level, possibly adversely affecting search.
-# DefLigature(qr{ff},               "\x{FB00}", fontTest => \&nonTypewriterT1);
-# DefLigature(qr{fi},               "\x{FB01}", fontTest => \&nonTypewriterT1);
-# DefLigature(qr{fl},               "\x{FB02}", fontTest => \&nonTypewriterT1);
-# DefLigature(qr{ffi},              "\x{FB03}", fontTest => \&nonTypewriterT1);
-# DefLigature(qr{ffl},              "\x{FB04}", fontTest => \&nonTypewriterT1);
 
 DefConstructor('\TeX',
   "<ltx:text class='ltx_TeX_logo' cssstyle='letter-spacing:-0.2em; margin-right:0.2em'>"
@@ -237,36 +207,20 @@ DefPrimitive('\wlog{}', sub {
     return; },
   locked => 1);
 # From plain.tex
-DefPrimitive('\newcount  DefToken', sub {
-    DefRegisterI($_[1], undef, Number(0), allocate => '\count'); });
-DefPrimitive('\newdimen  DefToken', sub {
-    DefRegisterI($_[1], undef, Dimension(0), allocate => '\dimen'); });
-DefPrimitive('\newskip   DefToken', sub {
-    DefRegisterI($_[1], undef, Glue(0), allocate => '\skip'); });
-DefPrimitive('\newmuskip DefToken', sub {
-    DefRegisterI($_[1], undef, MuGlue(0), allocate => '\muskip'); });
-AssignValue(allocated_boxes => 0);
-DefPrimitive('\newbox DefToken', sub {
-    my $n = LookupValue('allocated_boxes');
-    AssignValue(allocated_boxes => $n + 1, 'global');
-    AssignValue("box$n", List());
-    DefRegisterI($_[1], undef, Number($n), readonly => 1); });
-DefPrimitive('\newhelp DefToken {}', sub { AssignValue(ToString($_[1]) => $_[2]); });
-DefPrimitive('\newtoks DefToken',    sub { DefRegisterI($_[1], undef, Tokens()); });
-# the next 4 actually work by doing a \chardef instead of \countdef, etc.
-# which means they actually work quite differently
-DefPrimitive('\alloc@@ {}', sub {
-    my ($stomach, $type) = @_;
-    my $c = 'allocation @' . ToString($type);
-    my $n = LookupValue($c) || '0';
-    $n = $n->valueOf if ref $n;
-    AssignValue($c => $n + 1, 'global');
-    AssignRegister('\allocationnumber' => Number($n), 'global'); });
-DefMacro('\newread DefToken',     '\alloc@@{read}\global\chardef#1=\allocationnumber');
-DefMacro('\newwrite DefToken',    '\alloc@@{write}\global\chardef#1=\allocationnumber');
-DefMacro('\newfam DefToken',      '\alloc@@{fam}\global\chardef#1=\allocationnumber');
-DefMacro('\newlanguage DefToken', '\alloc@@{language}\global\chardef#1=\allocationnumber');
-
+RawTeX(<<'EoTeX');
+\outer\def\newcount{\alloc@0\count\countdef\insc@unt}
+\outer\def\newdimen{\alloc@1\dimen\dimendef\insc@unt}
+\outer\def\newskip{\alloc@2\skip\skipdef\insc@unt}
+\outer\def\newmuskip{\alloc@3\muskip\muskipdef\@cclv}
+\outer\def\newbox{\alloc@4\box\chardef\insc@unt}
+%%\let\newtoks=\relax % we do this to allow plain.tex to be read in twice
+\outer\def\newhelp#1#2{\newtoks#1#1\expandafter{\csname#2\endcsname}}
+\outer\def\newtoks{\alloc@5\toks\toksdef\@cclv}
+\outer\def\newread{\alloc@6\read\chardef\sixt@@n}
+\outer\def\newwrite{\alloc@7\write\chardef\sixt@@n}
+\outer\def\newfam{\alloc@8\fam\chardef\sixt@@n}
+\outer\def\newlanguage{\alloc@9\language\chardef\@cclvi}
+EoTeX
 DefMacro('\e@alloc{}{}{}{}{}{}',
   '\global\advance#3\@ne
 %  \e@ch@ck{#3}{#4}{#5}#1%
@@ -275,16 +229,6 @@ DefMacro('\e@alloc{}{}{}{}{}{}',
 %  \wlog{\string#6=\string#1\the\allocationnumber}
 ');
 DefMacro('\alloc@{}{}{}{}', '\e@alloc#2#3{\count1#1}#4\float@count');
-DefMacro('\newread',        '\e@alloc\read \chardef{\count16}\m@ne\sixt@@n');
-DefMacro('\newwrite', '\e@alloc\write
-                   {\ifnum\allocationnumber=18
-                     \advance\count17\@ne
-                     \allocationnumber\count17 %
-                    \fi
-                    \global\chardef}%
-                   {\count17}%
-                   \m@ne
-                   {128}');
 
 # This implementation is quite wrong
 DefPrimitive('\newinsert Token', sub { DefRegisterI($_[1], undef, Number(0)); });
@@ -366,6 +310,74 @@ RawTeX(<<'EoTeX');
 \textfont1=\teni\scriptfont1=\seveni\scriptscriptfont1=\fivei
 \textfont2=\tensy\scriptfont2=\sevensy\scriptscriptfont2=\fivesy
 \textfont3=\tenex
+\textfont\itfam=\tenit
+\textfont\slfam=\tensl
+\textfont\bffam=\tenbf
+\textfont\ttfam=\tentt
+%\textfont4=\tenit
+%\textfont5=\tensl
+%\textfont6=\tenbf
+%\textfont7=\tentt
+% More for latex?
+%%%\font\tensf=cmss10
+%%%\textfont8=\tensf
+\mathcode`\^^@="2201 % \cdot
+\mathcode`\^^A="3223 % \downarrow
+\mathcode`\^^B="010B % \alpha
+\mathcode`\^^C="010C % \beta
+\mathcode`\^^D="225E % \land
+\mathcode`\^^E="023A % \lnot
+\mathcode`\^^F="3232 % \in
+\mathcode`\^^G="0119 % \pi
+\mathcode`\^^H="0115 % \lambda
+\mathcode`\^^I="010D % \gamma
+\mathcode`\^^J="010E % \delta
+\mathcode`\^^K="3222 % \uparrow
+\mathcode`\^^L="2206 % \pm
+\mathcode`\^^M="2208 % \oplus
+\mathcode`\^^N="0231 % \infty
+\mathcode`\^^O="0140 % \partial
+\mathcode`\^^P="321A % \subset
+\mathcode`\^^Q="321B % \supset
+\mathcode`\^^R="225C % \cap
+\mathcode`\^^S="225B % \cup
+\mathcode`\^^T="0238 % \forall
+\mathcode`\^^U="0239 % \exists
+\mathcode`\^^V="220A % \otimes
+\mathcode`\^^W="3224 % \leftrightarrow
+\mathcode`\^^X="3220 % \leftarrow
+\mathcode`\^^Y="3221 % \rightarrow
+\mathcode`\^^Z="8000 % \ne
+\mathcode`\^^[="2205 % \diamond
+\mathcode`\^^\="3214 % \le
+\mathcode`\^^]="3215 % \ge
+\mathcode`\^^^="3211 % \equiv
+\mathcode`\^^_="225F % \lor
+\mathcode`\ ="8000 % \space
+\mathcode`\!="5021
+\mathcode`\'="8000 % ^\prime
+\mathcode`\(="4028
+\mathcode`\)="5029
+%%%%%\mathcode`\*="2203 % \ast
+\mathcode`\+="202B
+\mathcode`\,="613B
+\mathcode`\-="2200
+\mathcode`\.="013A
+\mathcode`\/="013D
+\mathcode`\:="303A
+\mathcode`\;="603B
+\mathcode`\<="313C
+\mathcode`\=="303D
+\mathcode`\>="313E
+%%%%\mathcode`\?="503F
+\mathcode`\[="405B
+\mathcode`\\="026E % \backslash
+\mathcode`\]="505D
+\mathcode`\_="8000 % \_
+\mathcode`\{="4266
+\mathcode`\|="026A
+\mathcode`\}="5267
+\mathcode`\^^?="1273 % \smallint
 EoTeX
 # Note: \newfam in math should be font switching(?)
 
@@ -545,17 +557,6 @@ DefConstructor('\ltx@centerline{}', sub {
     alignLine($_[0], $_[1], 'center'); },
   alias   => '\centerline',
   bounded => 1);
-
-sub alignLine {
-  my ($document, $line, $alignment) = @_;
-  if ($document->isOpenable('ltx:p')) {
-    $document->insertElement('ltx:p', $line, class => 'ltx_align_' . $alignment); }
-  elsif ($document->isOpenable('ltx:text')) {
-    $document->insertElement('ltx:text', $line, class => 'ltx_align_' . $alignment);
-    $document->insertElement('ltx:break'); }
-  else {
-    $document->absorb($line); }
-  return; }
 
 # These should be 0 width, but perhaps also shifted?
 DefMacro('\llap{}', '\hbox to 0pt{\hss#1}');
@@ -1221,16 +1222,6 @@ DefConstructorI('\dots', undef,
       : ()); });    # Since not DefMath!
 
 # And while we're at it...
-
-# Pretest for XMath to keep from interpreting math that the DOM may not allow!!
-##DefMathRewrite(xpath=>'descendant-or-self::ltx:XMath',match=>'\cdot\cdot\cdot',replace=>'\cdots');
-
-DefMathLigature("\x{22C5}\x{22C5}\x{22C5}" => "\x{22EF}", role => 'ID', name => 'cdots');
-
-DefLigature(qr{\.\.\.}, "\x{2026}", fontTest => sub { $_[0]->getFamily ne 'typewriter'; });  # ldots
-
-#DefMathRewrite(xpath=>'descendant-or-self::ltx:XMath',match=>'...',replace=>'\ldots');
-DefMathLigature("..." => "\x{2026}", role => 'ID', name => 'ldots');
 
 #----------------------------------------------------------------------
 # Math Accents.


### PR DESCRIPTION
This PR continues the previous TeX-pool reorg PR in preparation for more extensive refactoring.
* move several helper functions and ligature patterns to more appropriate "Engine" modules
* recognizes more font names
* more accurate initialization of various `\mathcode`, `\sfcode`
* simulate TeX-plain's register allocation better.