### PR TITLE
restore viewBox in pgf pictures

### DIFF
--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -85,9 +85,9 @@ DefConstructor('\lxSVG@insertpicture{}', sub {
     else {
       $document->openElement('ltx:picture');
       $document->openElement('svg:svg',
-        version => "1.1",
-        width   => $props{pxwidth}, height => $props{pxheight},
-####        viewBox  => "$props{minx} $props{miny} $props{pxwidth} $props{pxheight}",
+        version  => "1.1",
+        width    => $props{pxwidth}, height => $props{pxheight},
+        viewBox  => "$props{minx} $props{miny} $props{pxwidth} $props{pxheight}",
         overflow => "visible");
       my $x0 = -(0 + $props{minx});
       my $y0 = $props{pxheight} + $props{miny};


### PR DESCRIPTION
Fix #2376 for PGF/TikZ.

The [commit that removed `@viewBox`](https://github.com/brucemiller/LaTeXML/commit/b1d4af1958c1e1e0f222b3e3deb933e04a6e3b92 ) said 'AVOID scaling, in particular viewBox so that text size matches containing document'. I can't quite tell what issue was being addressed: if `@viewBox` and `@width`, `@height` agree, no scaling happens. Rather, having the correct `@viewBox` *enables* CSS to change width and height, and that can only happen intentionally. So I am guessing this PR is fine.