### PR TITLE
add viewBox in xy pictures

### DIFF
--- a/lib/LaTeXML/Package/xy.tex.ltxml
+++ b/lib/LaTeXML/Package/xy.tex.ltxml
@@ -90,7 +90,7 @@ DefConstructor('\lx@xy@svgnested Digested',
     return (width => $w, height => $y1, depth => $y0->negate, transform => $transform); });
 
 DefConstructor('\lx@xy@svg Digested',
-  "<ltx:picture><svg:svg overflow='visible' version='1.1' width='#pxwidth' height='#pxheight'>"
+"<ltx:picture imagedepth='#imagedepth'><svg:svg overflow='visible' version='1.1' width='#pxwidth' height='#pxheight' viewBox='#minx #miny #pxwidth #pxheight'>"
     . "<svg:g transform='#transform'>#1</svg:g>"
     . "</svg:svg></ltx:picture>",
   properties => sub {
@@ -101,14 +101,16 @@ DefConstructor('\lx@xy@svg Digested',
       if $LaTeXML::DEBUG{xy};
     my $w         = $x1->subtract($x0);
     my $h         = $y1->subtract($y0);
-    my $x         = $x0->negate->larger(Dimension(0));
+    my $x         = $x0->negate;
     my $yma       = Dimension(LookupValue('IN_MATH') ? '2.5pt' : 0);           # math-axis; fontdimen 22
-    my $y         = $y1->add($yma->subtract($y0->larger(Dimension(0))));
+    my $miny      = $yma->subtract($y0);
+    my $y         = $y1->add($yma->subtract($y0));
     my $transform = "matrix(1 0 0 -1 " . $x->pxValue . ' ' . $y->pxValue . ')';
     Debug("XY size: " . ToString($w) . ' x ' . ToString($h) . ' + ' . 0 . ' @ ' . ToString($x) . ' x ' . ToString($y))
 
       if $LaTeXML::DEBUG{xy};
     return (width => $w, height => $h, pxwidth => $w->pxValue, pxheight => $h->pxValue,
+      minx      => $x->pxValue, miny => $miny->pxValue, imagedepth => int($miny->pxValue + 0.5),
       transform => $transform); });
 
 DefPrimitive('\lx@xy@capturerange', sub {

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
@@ -96,9 +96,29 @@
       <xsl:call-template name="copy_foreign_attributes"/>
       <xsl:apply-templates select="." mode="add_RDFa"/>
       <!-- but copy other svg:svg attributes -->
-      <xsl:for-each select="svg:svg/@*">
+      <xsl:for-each select="svg:svg/@*[name() != 'style']">
         <xsl:apply-templates select="." mode="copy-attribute"/>
       </xsl:for-each>
+      <xsl:choose>
+        <xsl:when test="svg:svg/@style">
+          <xsl:for-each select="svg:svg/@style">
+            <xsl:call-template name="add_style">
+              <xsl:with-param name="extra_style">
+                <xsl:if test="@imagedepth">
+                  <xsl:value-of select="concat('vertical-align:-',@imagedepth,'px')"/>
+                </xsl:if>
+              </xsl:with-param>
+            </xsl:call-template>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:if test="@imagedepth">
+            <xsl:attribute name="style">
+              <xsl:value-of select="concat('vertical-align:-',@imagedepth,'px')"/>
+            </xsl:attribute>
+          </xsl:if>
+        </xsl:otherwise>
+      </xsl:choose>
       <xsl:apply-templates select="svg:svg/*"/>
     </xsl:element>
   </xsl:template>


### PR DESCRIPTION
Fix #2376 for xy pictures. This requires XSLT changes because setting the correct `@viewBox` implies that vertical alignment must be done in CSS (as it should, so that text is placed correctly), hence we need to handle `@imagedepth`.

The change looks ok in very simple tests but it makes me a little nervous, because I don't quite understand the reasoning behind the original code and I might be breaking something. If you have a xy corpus, I can check it properly.

Source:
```latex
\documentclass{article}
\usepackage[all]{xy}
\begin{document}
\[ x = \xymatrix{A \ar[r] \ar[d] \ar[rd] & B \\ C & D} \]
Followed by more text.
\end{document}
```

Before:

![image](https://github.com/user-attachments/assets/b6c64133-e6c4-4681-8d80-73f34abcd50f)

After (correctly mimicking LaTeX):

![image](https://github.com/user-attachments/assets/b468382a-61b3-48ae-949a-0586004fef88)

Vertical alignment is hit and miss when the SVG is nested inside MathML:
- Safari: works out of the box
- Chrome: one must add `display: inline-block` or `display: block` to `<mtext>`
- Firefox: `vertical-align` is completely ignored in MathML and I couldn't find a way to make it look right

@dginev does the MathML spec say anything about `vertical-align`?