### PR TITLE
update \XC@mcolor in pgf.sty rather than pgfsys-latexml.def

### DIFF
--- a/lib/LaTeXML/Package/pgf.sty.ltxml
+++ b/lib/LaTeXML/Package/pgf.sty.ltxml
@@ -37,6 +37,11 @@ DefMacro('\pgfsetcolor{}', '\pgfsetcolor@orig{#1}\lxSVG@set@color');
 DefPrimitive('\lxSVG@set@color', sub {
     MergeFont(color => LookupValue('color_pgfstrokecolor')); });
 
+# This seems to be needed to actually set colors (code similar to xxcolor.sty)
+if (XEquals(T_CS('\XC@mcolor'), T_CS('\relax'))) {
+  Let('\XC@mcolor', '\@empty'); }
+AddToMacro('\XC@mcolor', '\pgfsetcolor{.}');
+
 # This makes this conditional always true;  Why???
 DefConditionalI('\ifpgf@relevantforpicturesize', undef, sub { 1; });
 DefMacroI('\pgf@relevantforpicturesizefalse', undef, '');

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -439,9 +439,6 @@ DefConstructor('\lxSVG@eorulefalse',     '', alias => '\pgfsys@eorulefalse',   s
 
 DefMacro('\lxSVG@setcolor{}{}', '\ifpgfpicture\lxSVG@begingroup{#1={#2}}\fi');
 
-# Need to defer until after color/xcolor are loaded!
-AtBeginDocument('\def\XC@mcolor{\pgfsetcolor{.}}');
-
 #=====================================================================
 # Implementation
 


### PR DESCRIPTION
The change guarantees that `\XC@mcolor` is updated after color/xcolor are loaded, but also before finishing loading PGF, as opposed to at the end of the preamble. This also improves the usage of `\XC@mcolor`: in principle, other packages may be adding stuff to it, so it should be extended rather than redefined.

This fixes #2398, and hopefully does not break anything.