### PR TITLE
prune an empty \bibitem when auto-opened without need

### DIFF
--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -4263,11 +4263,22 @@ DefConstructor('\lx@bibitem[] Semiverbatim',
     . "#tags"
     . "<ltx:bibblock>",
   afterDigest => sub {
+    # check if the previous bibitem had an empty body,
+    # in which case prune it and reuse its ID and counters.
+    # this happens due to auto-open being a bit fragile (see issue #2403)
+    my $pruned_prev = 0;
+    if (my $prev_item = $LaTeXML::LIST[-1]) {
+      if (ref $prev_item eq 'LaTeXML::Core::Whatsit' and
+        $prev_item->getDefinition->getCS->getCSName eq '\lx@bibitem' and
+        not($prev_item->getArg(1)) and IsEmpty($prev_item->getArg(2))) {
+        $pruned_prev = 1;
+        Info('empty', 'bibitem', $_[0], "Encountered an empty \\bibitem, likely auto-opened without need. Pruning and reusing its id.");
+        pop(@LaTeXML::LIST); } }
     my $tag = $_[1]->getArg(1);
     my $key = CleanBibKey($_[1]->getArg(2));
     if ($tag) {
       $_[1]->setProperties(key => $key,
-        RefStepID('@bibitem'),
+        ($pruned_prev ? RefCurrentID('@bibitem') : RefStepID('@bibitem')),
         tags => Digest(T_BEGIN,
           T_CS('\def'), T_CS('\the@bibitem'), T_BEGIN, Revert($tag), T_END,
           Invocation(T_CS('\lx@make@tags'), T_OTHER('@bibitem')),

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -67,7 +67,8 @@ our @EXPORT = (qw(&DefAutoload &DefExpandable
     &AddToMacro &AtBeginDocument &AtEndDocument),
 
   # Counter support
-  qw(&NewCounter &CounterValue &SetCounter &AddToCounter &StepCounter &RefStepCounter &RefStepID &ResetCounter
+  qw(&NewCounter &CounterValue &SetCounter &AddToCounter &StepCounter &RefStepCounter
+    &RefStepID &ResetCounter &RefCurrentID
     &GenerateID &AfterAssignment
     &MaybePeekLabel &MaybeNoteLabel),
 
@@ -835,6 +836,15 @@ sub RefStepID {
   DefMacroI(T_CS('\@currentID'), undef, T_CS("\\the$ctr\@ID"));
   my $id = CleanID(ToString(DigestLiteral(T_CS("\\the$ctr\@ID"))));
   return (id => $id); }
+
+# For UN-numbered units, recycle the last ID without incrementing
+# (useful if the last ID-ed box got pruned)
+sub RefCurrentID {
+  my ($type) = @_;
+  my $ctr    = LookupMapping('counter_for_type', $type) || $type;
+  my $id     = CleanID(ToString(DigestLiteral(T_CS("\\the$ctr\@ID"))));
+  return (id => $id);
+}
 
 sub ResetCounter {
   my ($ctr) = @_;
@@ -1776,7 +1786,7 @@ sub defmath_cons {
         ? $cs : $presentation->unlist); }; }
   $STATE->installDefinition(LaTeXML::Core::Definition::Constructor->new($defcs, $paramlist,
       ($nargs == 0
-          # If trivial presentation, allow it in Text
+        # If trivial presentation, allow it in Text
         ? ($presentation !~ /(?:\(|\)|\\)/
           ? "?#isMath(<ltx:XMTok role='#role' scriptpos='#scriptpos' stretchy='#stretchy'"
             . " font='#font' $cons_attr$end_tok)"
@@ -2453,7 +2463,7 @@ sub AddToMacro {
   else {
     local $LaTeXML::Core::State::UNLOCKED = 1;    # ALLOW redefinitions that only adding to the macro
     DefMacroI($cs, undef, Tokens(map { $_->unlist }
-          map { (blessed $_ ? $_ : TokenizeInternal($_)) } ($defn->getExpansion, @tokens)),
+        map { (blessed $_ ? $_ : TokenizeInternal($_)) } ($defn->getExpansion, @tokens)),
       nopackParameters => 1, scope => 'global', locked => $$defn{locked}); }
   return; }
 


### PR DESCRIPTION
Fixes #2403 

With Bruce's help, I zeroed in on the cause of the issue, namely `\par@in@bibliography`. That code, which defensively auto-opens a `\bibitem`, recognizes too few of the legitimate cases with macro use (as described in the issue).

Since it is rather high difficulty to both handle "sloppy" uses of `{thebibliography}` as well as the advanced macro uses before a real `\bibitem`, this PR resigns to undoing the error after it is caused.

Namely, this first stab suggests to check in the `afterDigest` hook of `\lx@bibitem` whether the previous recorded box was an _empty_ use of `\bibitem`. In the case it was, the assembled previous box is pruned from the digested list, and its `RefStepID` is reused.

Seems to work well on the few cases I tried, open to adjustments.