### PR TITLE
Stray comments

### DIFF
--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -1383,8 +1383,11 @@ sub applyAligningContext {
   if (my $container = LookupValue('ALIGNING_NODE')) {
     my ($node, $previous) = @$container;
     my @children = $node->childNodes;
-    while (my $skip = shift(@children)) {
-      last if !$previous || $previous->isSameNode($skip); }
+    while (@children) {
+      my $skip = $children[0];
+      last if !$previous;
+      shift(@children);
+      last if $previous->isSameNode($skip); }
     while (my $child = shift(@children)) {
       setAlignOrClass($document, $child, $align, $class) if $child->nodeType == XML_ELEMENT_NODE; } }
   return; }

--- a/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
@@ -368,8 +368,8 @@ sub insertBlock {
   my $inline    = $is_svg || $document->canContain($context_tag, '#PCDATA');
   my $container = $document->openElement('ltx:_CaptureBlock_', '_vertical_mode_' => 1, %blockattr);
   $document->absorb($contents);
-  my @nodes     = $container->childNodes;
-  my @node_tags = map { $document->getNodeQName($_); } @nodes;
+  my @nodes     = grep { $_->nodeType != XML_COMMENT_NODE; } $container->childNodes;
+  my @node_tags = map  { $document->getNodeQName($_); } @nodes;
   my $nnodes    = scalar(@nodes);
   $document->closeToNode($container, 1);
   $document->closeNode($container);

--- a/t/alignment/colortbls.xml
+++ b/t/alignment/colortbls.xml
@@ -95,10 +95,10 @@ p{3cm}}"?>
         <tbody>
           <tr>
             <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" color="#FFFFFF">P-column</text></p>
+                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">P-column</text></p>
               </inline-block></td>
             <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" color="#FFFF00">and another one</text></p>
+                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">and another one</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}12\cdot 34" text="12.34" xml:id="S2.T1.m1">
                 <XMath>
@@ -117,10 +117,10 @@ p{3cm}}"?>
           </tr>
           <tr>
             <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" color="#FFFFFF">Some long text in the first column</text></p>
+                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">Some long text in the first column</text></p>
               </inline-block></td>
             <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
+                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 2" text="1.2" xml:id="S2.T1.m3">
                 <XMath>
@@ -130,10 +130,10 @@ p{3cm}}"?>
           </tr>
           <tr>
             <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
+                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
             <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" color="#FFFF00">and some long text in the second column</text></p>
+                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">and some long text in the second column</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m4">
                 <XMath>
@@ -152,10 +152,10 @@ p{3cm}}"?>
           </tr>
           <tr>
             <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
+                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
             <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
+                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m6">
                 <XMath>
@@ -165,11 +165,11 @@ p{3cm}}"?>
           </tr>
           <tr>
             <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" color="#FFFFFF">Note that the coloured rules in all columns stretch to accomodate
+                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">Note that the coloured rules in all columns stretch to accomodate
 large entries in one column.</text></p>
               </inline-block></td>
             <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
+                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m7">
                 <XMath>
@@ -179,10 +179,10 @@ large entries in one column.</text></p>
           </tr>
           <tr>
             <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
+                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
             <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
+                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}100" text="100" xml:id="S2.T1.m8">
                 <XMath>
@@ -192,10 +192,10 @@ large entries in one column.</text></p>
           </tr>
           <tr>
             <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
+                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
             <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" color="#FFFF00">Depending on your driver you may get unsightly gaps or lines
+                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">Depending on your driver you may get unsightly gaps or lines
 where the ‘screens’ used to produce different shapes interact
 badly. You may want to cause adjacent panels of the same colour by
 specifying a larger overhang
@@ -209,10 +209,10 @@ or by adding some negative space (in a ”“noalign” between rows.</text></p>
           </tr>
           <tr>
             <td align="justify" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top">
-                <p width="56.9pt"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
+                <p width="56.9pt"><text backgroundcolor="#FF0000" class="ltx_align_left" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
             <td align="justify" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top">
-                <p width="85.4pt"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
+                <p width="85.4pt"><text backgroundcolor="#0000FF" class="ltx_align_left" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}45\cdot 3" text="45.3" xml:id="S2.T1.m10">
                 <XMath>

--- a/t/complex/figure_dual_caption.xml
+++ b/t/complex/figure_dual_caption.xml
@@ -12,12 +12,12 @@
       <tag role="typerefnum">Figure 2</tag>
     </tags>
     <figure align="center" class="ltx_figure_panel ltx_minipage" vattach="middle" width="216.8pt" xml:id="S0.F2.fig1">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=411.93767pt,keepaspectratio=true" xml:id="S0.F2.g1"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=411.93767pt,keepaspectratio=true" xml:id="S0.F2.g1"/>
       <toccaption class="ltx_centering"><tag close=" ">1</tag>Left figure.</toccaption>
       <caption class="ltx_centering"><tag close=": ">Figure 1</tag>Left figure.</caption>
     </figure>
     <figure align="center" class="ltx_figure_panel ltx_minipage" vattach="middle" width="216.8pt" xml:id="S0.F2.fig2">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=411.93767pt,keepaspectratio=true" xml:id="S0.F2.g2"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=411.93767pt,keepaspectratio=true" xml:id="S0.F2.g2"/>
       <toccaption class="ltx_centering"><tag close=" ">2</tag>Right figure.</toccaption>
       <caption class="ltx_centering"><tag close=": ">Figure 2</tag>Right figure.</caption>
     </figure>
@@ -29,7 +29,7 @@
       <tag role="typerefnum">Table 2</tag>
     </tags>
     <figure align="center" class="ltx_figure_panel ltx_minipage" vattach="middle" width="216.8pt" xml:id="S0.T2.fig1">
-      <tabular vattach="middle">
+      <tabular class="ltx_centering" vattach="middle">
         <tbody>
           <tr>
             <td align="center">a</td>
@@ -47,7 +47,7 @@
       <caption class="ltx_centering"><tag close=": ">Table 1</tag>Left table.</caption>
     </figure>
     <figure align="center" class="ltx_figure_panel ltx_minipage" vattach="middle" width="216.8pt" xml:id="S0.T2.fig2">
-      <tabular vattach="middle">
+      <tabular class="ltx_centering" vattach="middle">
         <tbody>
           <tr>
             <td align="center">1</td>

--- a/t/complex/figure_mixed_content.xml
+++ b/t/complex/figure_mixed_content.xml
@@ -101,7 +101,7 @@
     <pagination role="newpage"/>
   </para>
   <figure float="right" xml:id="fig1">
-    <float class="ltx_minipage" framed="top" inlist="loa" placement="H" vattach="middle" width="433.6pt" xml:id="alg1">
+    <float align="center" class="ltx_minipage" framed="top" inlist="loa" placement="H" vattach="middle" width="433.6pt" xml:id="alg1">
       <tags>
         <tag><text font="bold">Algorithm 1</text></tag>
         <tag role="refnum">1</tag>

--- a/t/structure/figure_grids.xml
+++ b/t/structure/figure_grids.xml
@@ -8,20 +8,20 @@
   <resource src="LaTeXML.css" type="text/css"/>
   <resource src="ltx-article.css" type="text/css"/>
   <figure xml:id="fig1">
-    <graphics candidates="../graphics/none.png" class="ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g1"/>
+    <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g1"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g2"/>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig2">
-    <graphics candidates="../graphics/none.png" class="ltx_figure_panel" graphic="../graphics/none.png" options="width=430.77473pt,keepaspectratio=true" xml:id="g3"/>
+    <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=430.77473pt,keepaspectratio=true" xml:id="g3"/>
     <break class="ltx_centering"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=430.77473pt,keepaspectratio=true" xml:id="g4"/>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig3">
-    <graphics candidates="../graphics/none.png" class="ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g5"/>
+    <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g5"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g6"/>
     <break class="ltx_centering"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g7"/>
@@ -30,7 +30,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig4">
-    <graphics candidates="../graphics/none.png" class="ltx_figure_panel" graphic="../graphics/none.png" options="width=141.69473pt,keepaspectratio=true" xml:id="g9"/>
+    <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=141.69473pt,keepaspectratio=true" xml:id="g9"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=141.69473pt,keepaspectratio=true" xml:id="g10"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=141.69473pt,keepaspectratio=true" xml:id="g11"/>
     <break class="ltx_centering"/>
@@ -45,7 +45,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig5">
-    <graphics candidates="../graphics/none.png" class="ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g18"/>
+    <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g18"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g19"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g20"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g21"/>
@@ -68,7 +68,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig6">
-    <graphics candidates="../graphics/none.png" class="ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g34"/>
+    <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g34"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g35"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g36"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=105.55974pt,keepaspectratio=true" xml:id="g37"/>
@@ -81,7 +81,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig7">
-    <graphics candidates="../graphics/none.png" class="ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g42"/>
+    <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g42"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g43"/>
     <break class="ltx_centering"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=213.96474pt,keepaspectratio=true" xml:id="g44"/>
@@ -96,7 +96,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig8">
-    <graphics candidates="../graphics/none.png" class="ltx_figure_panel" graphic="../graphics/none.png" options="width=83.87874pt,keepaspectratio=true" xml:id="g50"/>
+    <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=83.87874pt,keepaspectratio=true" xml:id="g50"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=83.87874pt,keepaspectratio=true" xml:id="g51"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=83.87874pt,keepaspectratio=true" xml:id="g52"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=83.87874pt,keepaspectratio=true" xml:id="g53"/>
@@ -129,7 +129,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig9">
-    <graphics candidates="../graphics/none.png" class="ltx_figure_panel" graphic="../graphics/none.png" options="width=69.42474pt,keepaspectratio=true" xml:id="g75"/>
+    <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=69.42474pt,keepaspectratio=true" xml:id="g75"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=69.42474pt,keepaspectratio=true" xml:id="g76"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=69.42474pt,keepaspectratio=true" xml:id="g77"/>
     <graphics candidates="../graphics/none.png" class="ltx_centering ltx_figure_panel" graphic="../graphics/none.png" options="width=69.42474pt,keepaspectratio=true" xml:id="g78"/>
@@ -174,7 +174,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig10">
-    <figure class="ltx_figure_panel" inlist="lof" xml:id="S0.F1.sf1">
+    <figure align="center" class="ltx_figure_panel" inlist="lof" xml:id="S0.F1.sf1">
       <tags>
         <tag><text fontsize="90%">(a)</text></tag>
         <tag role="refnum">1(a)</tag>
@@ -196,7 +196,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig11">
-    <figure class="ltx_figure_panel" inlist="lof" xml:id="S0.F2.sf1">
+    <figure align="center" class="ltx_figure_panel" inlist="lof" xml:id="S0.F2.sf1">
       <tags>
         <tag><text fontsize="90%">(a)</text></tag>
         <tag role="refnum">2(a)</tag>
@@ -219,7 +219,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig12">
-    <figure class="ltx_figure_panel" inlist="lof" xml:id="S0.F3.sf1">
+    <figure align="center" class="ltx_figure_panel" inlist="lof" xml:id="S0.F3.sf1">
       <tags>
         <tag><text fontsize="90%">(a)</text></tag>
         <tag role="refnum">3(a)</tag>
@@ -260,7 +260,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig13">
-    <figure class="ltx_figure_panel" inlist="lof" xml:id="S0.F4.sf1">
+    <figure align="center" class="ltx_figure_panel" inlist="lof" xml:id="S0.F4.sf1">
       <tags>
         <tag><text fontsize="90%">(a)</text></tag>
         <tag role="refnum">4(a)</tag>
@@ -347,7 +347,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig14">
-    <figure class="ltx_figure_panel" inlist="lof" xml:id="S0.F5.sf1">
+    <figure align="center" class="ltx_figure_panel" inlist="lof" xml:id="S0.F5.sf1">
       <tags>
         <tag><text fontsize="90%">(a)</text></tag>
         <tag role="refnum">5(a)</tag>
@@ -498,7 +498,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig15">
-    <figure class="ltx_figure_panel" inlist="lof" xml:id="S0.F6.sf1">
+    <figure align="center" class="ltx_figure_panel" inlist="lof" xml:id="S0.F6.sf1">
       <tags>
         <tag><text fontsize="90%">(a)</text></tag>
         <tag role="refnum">6(a)</tag>
@@ -575,7 +575,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig16">
-    <figure class="ltx_figure_panel" inlist="lof" xml:id="S0.F7.sf1">
+    <figure align="center" class="ltx_figure_panel" inlist="lof" xml:id="S0.F7.sf1">
       <tags>
         <tag><text fontsize="90%">(a)</text></tag>
         <tag role="refnum">7(a)</tag>
@@ -654,7 +654,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig17">
-    <figure class="ltx_figure_panel" inlist="lof" xml:id="S0.F8.sf1">
+    <figure align="center" class="ltx_figure_panel" inlist="lof" xml:id="S0.F8.sf1">
       <tags>
         <tag><text fontsize="90%">(a)</text></tag>
         <tag role="refnum">8(a)</tag>
@@ -887,7 +887,7 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig18">
-    <figure class="ltx_figure_panel" inlist="lof" xml:id="S0.F9.sf1">
+    <figure align="center" class="ltx_figure_panel" inlist="lof" xml:id="S0.F9.sf1">
       <tags>
         <tag><text fontsize="90%">(a)</text></tag>
         <tag role="refnum">9(a)</tag>
@@ -1220,387 +1220,387 @@
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig19">
-    <block class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g111"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g111"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g112"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g112"/>
     </block>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig20">
-    <block class="ltx_figure_panel ltx_minipage" vattach="top" width="430.8pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g113"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="430.8pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g113"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="430.8pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g114"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g114"/>
     </block>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig21">
-    <block class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g115"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g115"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g116"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g116"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g117"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g117"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g118"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g118"/>
     </block>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig22">
-    <block class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g119"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g119"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g120"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g120"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g121"/>
-    </block>
-    <break class="ltx_centering"/>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g122"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g123"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g124"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g121"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g125"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g122"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g126"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g123"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g127"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g124"/>
+    </block>
+    <break class="ltx_centering"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g125"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g126"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="141.7pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g127"/>
     </block>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig23">
-    <block class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g128"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g128"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g129"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g129"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g130"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g130"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g131"/>
-    </block>
-    <break class="ltx_centering"/>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g132"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g133"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g134"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g135"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g131"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g136"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g132"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g137"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g133"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g138"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g134"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g139"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g135"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g140"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g136"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g141"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g137"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g142"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g138"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g143"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g139"/>
+    </block>
+    <break class="ltx_centering"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g140"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g141"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g142"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g143"/>
     </block>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig24">
-    <block class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g144"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g144"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g145"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g145"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g146"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g146"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g147"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g147"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g148"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g148"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g149"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g149"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g150"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g150"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="105.6pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g151"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g151"/>
     </block>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig25">
-    <block class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g152"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g152"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g153"/>
-    </block>
-    <break class="ltx_centering"/>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g154"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g155"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g153"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g156"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g154"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g157"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g155"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g158"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g156"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g159"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g157"/>
+    </block>
+    <break class="ltx_centering"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g158"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="214.0pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g159"/>
     </block>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig26">
-    <block class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g160"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g160"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g161"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g161"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g162"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g162"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g163"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g163"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g164"/>
-    </block>
-    <break class="ltx_centering"/>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g165"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g166"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g167"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g168"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g169"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g164"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g170"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g165"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g171"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g166"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g172"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g167"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g173"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g168"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g174"/>
-    </block>
-    <break class="ltx_centering"/>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g175"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g176"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g177"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g178"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g179"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g169"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g180"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g170"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g181"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g171"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g182"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g172"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g183"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g173"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g184"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g174"/>
+    </block>
+    <break class="ltx_centering"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g175"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g176"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g177"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g178"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g179"/>
+    </block>
+    <break class="ltx_centering"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g180"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g181"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g182"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g183"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="83.9pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g184"/>
     </block>
     <break class="ltx_centering"/>
   </figure>
   <pagination role="newpage"/>
   <figure xml:id="fig27">
-    <block class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g185"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g185"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g186"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g186"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g187"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g187"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g188"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g188"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g189"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g189"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g190"/>
-    </block>
-    <break class="ltx_centering"/>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g191"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g192"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g193"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g194"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g195"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g196"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g190"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g197"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g191"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g198"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g192"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g199"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g193"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g200"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g194"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g201"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g195"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g202"/>
-    </block>
-    <break class="ltx_centering"/>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g203"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g204"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g205"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g206"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g207"/>
-    </block>
-    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g208"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g196"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g209"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g197"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g210"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g198"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g211"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g199"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g212"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g200"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g213"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g201"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g214"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g202"/>
     </block>
     <break class="ltx_centering"/>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g215"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g203"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g216"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g204"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g217"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g205"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g218"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g206"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g219"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g207"/>
     </block>
     <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
-      <graphics candidates="../graphics/none.png" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g220"/>
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g208"/>
+    </block>
+    <break class="ltx_centering"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g209"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g210"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g211"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g212"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g213"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g214"/>
+    </block>
+    <break class="ltx_centering"/>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g215"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g216"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g217"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g218"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g219"/>
+    </block>
+    <block align="center" class="ltx_figure_panel ltx_minipage" vattach="top" width="69.4pt">
+      <graphics candidates="../graphics/none.png" class="ltx_centering" graphic="../graphics/none.png" options="width=346.89731pt,keepaspectratio=true" xml:id="g220"/>
     </block>
     <break class="ltx_centering"/>
   </figure>


### PR DESCRIPTION
When characterizing certain blocks of XML, we need to be careful of unexpected comment nodes, since the exact order of appearance can be affected by other code changes. For example, this can affect marking nodes due to `\centering` or similar.  This PR fixes a couple of such cases, and updates some test cases which seem to have been missing `ltx_centering` (or similar).