### PR TITLE
Simplify \lastskip,\lastkern (suggested by D.Ginev)

### DIFF
--- a/lib/LaTeXML/Engine/TeX_Glue.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Glue.pool.ltxml
@@ -137,8 +137,13 @@ DefPrimitiveI('\vfilneg', undef, undef);
 #----------------------------------------------------------------------
 # \lastskip         iq is 0.0 pt or the last glue or muglue on the current list.
 DefRegister('\lastskip' => Dimension(0), readonly => 1, getter => sub {
-    my $box = $LaTeXML::LIST[-1];
-    return ($box && $box->getProperty('isSkip') ? $box->getProperty('width') : Dimension(0)); });
+    for (my $i = $#LaTeXML::LIST ; $i > 0 ; $i--) {
+      my $box = $LaTeXML::LIST[$i];
+      last if !$box;
+      next if ref $box eq 'LaTeXML::Core::Comment';
+      last if !$box->getProperty('isSkip');
+      return $box->getProperty('width'); }
+    return Dimension(0); });
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;

--- a/lib/LaTeXML/Engine/TeX_Glue.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Glue.pool.ltxml
@@ -137,12 +137,8 @@ DefPrimitiveI('\vfilneg', undef, undef);
 #----------------------------------------------------------------------
 # \lastskip         iq is 0.0 pt or the last glue or muglue on the current list.
 DefRegister('\lastskip' => Dimension(0), readonly => 1, getter => sub {
-    my $box;
-    for (my $i = $#LaTeXML::LIST ; $i > 0 ; $i--) {
-      my $box = $LaTeXML::LIST[$i];
-      last if !$box || !$box->getProperty('isSkip');
-      return $box->getProperty('width'); }
-    return Dimension(0); });
+    my $box = $LaTeXML::LIST[-1];
+    return ($box && $box->getProperty('isSkip') ? $box->getProperty('width') : Dimension(0)); });
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;

--- a/lib/LaTeXML/Engine/TeX_Kern.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Kern.pool.ltxml
@@ -65,8 +65,13 @@ DefPrimitiveI('\unkern', undef, sub {
 
 # Get kern, if last on LIST
 DefRegister('\lastkern' => Dimension(0), readonly => 1, getter => sub {
-    my $box = $LaTeXML::LIST[-1];
-    return ($box && $box->getProperty('isKern') ? $box->getProperty('width') : Dimension(0)); });
+    for (my $i = $#LaTeXML::LIST ; $i > 0 ; $i--) {
+      my $box = $LaTeXML::LIST[$i];
+      last if !$box;
+      next if ref $box eq 'LaTeXML::Core::Comment';
+      last if !$box->getProperty('isKern');
+      return $box->getProperty('width'); }
+    return Dimension(0); });
 
 #======================================================================
 # Moving Vertically

--- a/lib/LaTeXML/Engine/TeX_Kern.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Kern.pool.ltxml
@@ -65,12 +65,8 @@ DefPrimitiveI('\unkern', undef, sub {
 
 # Get kern, if last on LIST
 DefRegister('\lastkern' => Dimension(0), readonly => 1, getter => sub {
-    my $box;
-    for (my $i = $#LaTeXML::LIST ; $i > 0 ; $i--) {
-      my $box = $LaTeXML::LIST[$i];
-      last if !$box || !$box->getProperty('isKern');
-      return $box->getProperty('width'); }
-    return Dimension(0); });
+    my $box = $LaTeXML::LIST[-1];
+    return ($box && $box->getProperty('isKern') ? $box->getProperty('width') : Dimension(0)); });
 
 #======================================================================
 # Moving Vertically


### PR DESCRIPTION
Simplify `\lastskip` (and also simlar `\lastkern`); as mentioned in last comment in #2423. The code was correct but hadn't been cleaned up after development.