### PR TITLE
Explicit test requirements of figure_mixed_content 

### DIFF
--- a/t/80_complex.t
+++ b/t/80_complex.t
@@ -8,7 +8,9 @@ latexml_tests("t/complex",
   requires => {
     cleveref_minimal => 'cleveref.sty',
     figure_dual_caption => {packages => 'graphicx.sty', texlive_min => 2021},
-    figure_mixed_content => {packages => 'graphicx.sty', texlive_min => 2021},
-    si               => {
+    figure_mixed_content => {
+      packages => ['algorithm.sty','algorithmic.sty','graphicx.sty','ifthen.sty','keyval.sty'], 
+      texlive_min => 2021},
+    si => {
       env=>'CI', # only runs in continuous integration
       packages => 'siunitx.sty', texlive_min => 2015 } });


### PR DESCRIPTION
Fixes #2427 

This may be a change in the packaging of texlive, I am unsure. I would have assumed our texlive 2021 CI would also fail due to the various `.sty` dependencies not being present, but it succeeds?

To reproduce the reported error on Ubuntu (with texlive 2023), it takes:
```bash
$ sudo apt remove texlive-science
```

With this PR the test is gracefully skipped:

```
$ make test TEST_FILES=t/80_complex.t 
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/80_complex.t
t/80_complex.t .. 5/15 # Skip: Missing requirement algorithm.sty for t/complex/figure_mixed_content
t/80_complex.t .. 11/15 # Skip: Missing requirement siunitx.sty for t/complex/si
t/80_complex.t .. ok     
All tests successful.
```