### PR TITLE
Leaders

### DIFF
--- a/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
@@ -708,11 +708,54 @@ DefConstructor('\hrule RuleSpecification',
     return; });
 
 # ======================================================================
-# Various leaders, ignored for now...
-DefPrimitiveI('\leaders',  undef, undef);
-DefPrimitiveI('\cleaders', undef, undef);
-DefPrimitiveI('\xleaders', undef, undef);
+# Various leaders, mostly faking it for now...
 
+# \leaders <box or rule><glue>  fills the space specified by <glue> (which may be \hfill)
+#  with copies of the <box or glue>
+# \cleaders similarly, but centers the result, if it doesn't completely fill <glue>
+# \xleaders similarly, but stretches the result, if it doesn't completely fill <glue>
+# Note that the <glue> is NOT a Glue (eg a glue specification), but something like \hfill
+
+# Normally, these are used in a TOC, with a variable width (reflow),
+# so you'd hope for some adaptive CSS approach.
+# But the CSS is tricky, and you need CSS to control the leader's container as well.
+# However, occasionally, leaders appear within an object with an explicitly requested width,
+# so maybe it's reasonable to set the width (or duplicate the filler) to fill that width?
+# Alternatively, you may wish to simply hide ltx_leaders
+DefConstructor('\leaders Digested Digested', sub {
+    my ($document, $filler, $glue) = @_;
+    my $fw = $filler->getWidth;
+    #    my $context = $document->getNode;
+    my $context = $document->getElement;
+    Debug("LEADERS of " . Stringify($filler) . " to fill " . Stringify($glue));
+    my $cbox      = $document->getNodeBox($context);
+    my $container = $document->openElement('ltx:text', _noautoclose => 1);
+    my ($fnode)   = $document->absorb($filler);
+    my ($unwrap, $fillw, $reqw);
+    # EXPLICITLY requested width?
+    if ($fnode && $cbox && ($reqw = $cbox->getProperty('width'))) {
+      if ($document->getNodeQName($fnode) eq 'ltx:rule') {    # Or other stretchable element?
+        Debug("   extend to " . ToString($reqw));
+        $document->setAttribute($fnode, width => $reqw->toAttribute);
+        $document->addClass($fnode, 'ltx_filled_leader');
+        $unwrap = 1; }
+      elsif (($fillw = $filler->getWidth) && ($fillw = $fillw->valueOf)) {
+        my $n = int($reqw->valueOf / $fillw);
+        Debug("  duplicate $n times");
+        $document->addClass($container, 'ltx_filled_leader');
+        for (my $i = 2 ; $i < $n ; $i++) {
+          $document->absorb($filler); } } }
+    else {
+      $document->addClass($container, 'ltx_leader'); }
+    $document->closeElement('ltx:text');
+    $document->unwrapNodes($container) if $unwrap;    # avoid redundant <ltx:text><ltx:rule>
+    return; },
+  ## Hide the rule argument from contributing cell borders to any containing Alignment
+  bounded => 1, beforeDigest => sub { $STATE->assignValue(Alignment => undef); }
+);
+
+Let('\cleaders', '\leaders');
+Let('\xleaders', '\leaders');
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 1;
 

--- a/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
@@ -908,18 +908,34 @@ Let('\vcenter', '\vbox');
 # \overline               c  puts a line over the following character or subformula.
 # \underline              c  puts a line under the following character or subformula.
 
-DefMath('\lx@math@overline{}', UTF(0xAF), operator_role => 'OVERACCENT',
-  name => 'overline', alias => '\overline');
+DefMath('\lx@math@overline{}', UTF(0xAF),
+  operator_role => 'OVERACCENT', scriptpos => 'mid', operator_stretchy => 'true',
+  name          => 'overline',   alias     => '\overline');
 DefConstructor('\lx@text@overline{}',
   "<ltx:text framed='overline' _noautoclose='1'>#1</ltx:text>");
-DefMath('\lx@math@underline{}', UTF(0xAF), operator_role => 'UNDERACCENT',
-  name => 'underline', alias => '\underline');
+DefMath('\lx@math@underline{}', UTF(0xAF),
+  operator_role => 'UNDERACCENT', scriptpos => 'mid', operator_stretchy => 'true',
+  name          => 'underline',   alias     => '\underline');
 DefConstructor('\lx@text@underline{}',
   "<ltx:text framed='underline' _noautoclose='1'>#1</ltx:text>");
-DefMath('\lx@math@overrightarrow{}', "\x{2192}", operator_role => 'OVERACCENT',
-  name => 'overrightarrow', alias => '\overrightarrow');
-DefMath('\lx@math@overleftarrow{}', "\x{2190}", operator_role => 'OVERACCENT',
-  name => 'overleftarrow', alias => '\overleftarrow');
+DefMath('\lx@math@overrightarrow{}', "\x{2192}",
+  operator_role => 'OVERACCENT',     scriptpos => 'mid', operator_stretchy => 'true',
+  name          => 'overrightarrow', alias     => '\overrightarrow');
+DefMath('\lx@math@overleftarrow{}', "\x{2190}",
+  operator_role => 'OVERACCENT',    scriptpos => 'mid', operator_stretchy => 'true',
+  name          => 'overleftarrow', alias     => '\overleftarrow');
+DefMath('\lx@math@underrightarrow{}', "\x{2192}",
+  operator_role => 'UNDERACCENT',     scriptpos => 'mid', operator_stretchy => 'true',
+  name          => 'underrightarrow', alias     => '\underrightarrow');
+DefMath('\lx@math@underleftarrow{}', "\x{2190}",
+  operator_role => 'UNDERACCENT',    scriptpos => 'mid', operator_stretchy => 'true',
+  name          => 'underleftarrow', alias     => '\underleftarrow');
+DefMath('\lx@math@overbrace{}', "\x{23DE}",
+  operator_role => 'OVERACCENT', scriptpos => 'mid',        operator_stretchy => 'true',
+  name          => 'overbrace',  alias     => '\overbrace', robust            => 1);
+DefMath('\lx@math@underbrace{}', "\x{23DF}",
+  operator_role => 'UNDERACCENT', scriptpos => 'mid',         operator_stretchy => 'true',
+  name          => 'underbrace',  alias     => '\underbrace', robust            => 1);
 
 # Careful: Use \protect so that it doesn't expand too early in alignments, etc.
 # [Really shouldn't use \protect, since this is a TeX primitive and \protect is LaTeX]

--- a/lib/LaTeXML/Engine/plain.pool.ltxml
+++ b/lib/LaTeXML/Engine/plain.pool.ltxml
@@ -736,9 +736,12 @@ DefConstructor('\@math@baccent {}',
 
 DefMathI('\to', undef, "\x{2192}", role => 'ARROW'); # RIGHTWARDS ARROW??? a bit more explicitly relation-like?
 
-foreach my $op ('\hrulefill', '\dotfill', '\rightarrowfill', '\leftarrowfill',
-  '\upbracefill', '\downbracefill') {
-  DefPrimitiveI($op, undef, undef); }
+DefMacro('\hrulefill', '\leaders\hrule\hfill');
+DefMacro('\dotfill',   '\leaders\hbox{.}\hfill');    # Not exactly, but...
+DefMath('\leftarrowfill',  "\x{2190}", role => 'ARROW', stretchy => 'true');
+DefMath('\rightarrowfill', "\x{2192}", role => 'ARROW', stretchy => 'true');
+DefMath('\upbracefill',    "\x{23DF}", role => 'ARROW', stretchy => 'true');    # for \underbrace
+DefMath('\downbracefill',  "\x{23DE}", role => 'ARROW', stretchy => 'true');    # for \overbrace
 
 Let('\sp', T_SUPER);
 Let('\sb', T_SUB);
@@ -1218,11 +1221,9 @@ DefMath('\dot Digested',  "\x{02D9}", operator_role => 'OVERACCENT');     # DOT 
 DefMath('\ddot Digested', UTF(0xA8),  operator_role => 'OVERACCENT');     # DIAERESIS
 DefMath('\widehat Digested', UTF(0x5E), operator_role => 'OVERACCENT'); # CIRCUMFLEX ACCENT [plain? also amsfonts]
 DefMath('\widetilde Digested', UTF(0x7E), operator_role => 'OVERACCENT'); # TILDE [plain? also amsfonts]
-# These aren't handled as simple accents by TeX, so no Digested
-DefMath('\overbrace {}', "\x{23DE}", operator_role => 'OVERACCENT',       # TOP CURLY BRACKET
-  scriptpos => 'mid', robust => 1);
-DefMath('\underbrace {}', "\x{23DF}", operator_role => 'UNDERACCENT',     # BOTTOM CURLY BRACKET
-  scriptpos => 'mid', robust => 1);
+
+Let('\overbrace',  '\lx@math@overbrace');
+Let('\underbrace', '\lx@math@underbrace');
 
 # NOTE that all the above accents REQUIRE math mode
 # EXCEPT underline, overrightarrow and overleftarrow!

--- a/t/alignment/tabbing.xml
+++ b/t/alignment/tabbing.xml
@@ -35,17 +35,17 @@
       <tr>
         <td align="left">pc</td>
         <td align="left">Pica = 12pt</td>
-        <td align="left"><text width="12.0pt"><rule height="4.0pt" width="0.4pt"/><rule height="4.0pt" width="0.4pt"/></text></td>
+        <td align="left"><text width="12.0pt"><rule height="4.0pt" width="0.4pt"/><rule class="ltx_filled_leader" height="1px" width="12.0pt"/><rule height="4.0pt" width="0.4pt"/></text></td>
       </tr>
       <tr>
         <td align="left">cc</td>
         <td align="left">Cicero = 12dd</td>
-        <td align="left"><text width="12.8pt"><rule height="4.0pt" width="0.4pt"/><rule height="4.0pt" width="0.4pt"/></text></td>
+        <td align="left"><text width="12.8pt"><rule height="4.0pt" width="0.4pt"/><rule class="ltx_filled_leader" height="1px" width="12.8pt"/><rule height="4.0pt" width="0.4pt"/></text></td>
       </tr>
       <tr>
         <td align="left">cm</td>
         <td align="left">Centimeter = 10mm</td>
-        <td align="left"><text width="28.5pt"><rule height="4.0pt" width="0.4pt"/><rule height="4.0pt" width="0.4pt"/></text></td>
+        <td align="left"><text width="28.5pt"><rule height="4.0pt" width="0.4pt"/><rule class="ltx_filled_leader" height="1px" width="28.5pt"/><rule height="4.0pt" width="0.4pt"/></text></td>
       </tr>
     </tabular>
   </para>

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -1461,7 +1461,7 @@ Then a switch of tag forms.</p>
                   <XMApp xml:id="S3.Ex22.m1.1">
                     <XMTok role="SUPERSCRIPTOP" scriptpos="mid1"/>
                     <XMApp scriptpos="mid">
-                      <XMTok name="overbrace" role="OVERACCENT">⏞</XMTok>
+                      <XMTok name="overbrace" role="OVERACCENT" stretchy="true">⏞</XMTok>
                       <XMApp>
                         <XMTok meaning="plus" role="ADDOP">+</XMTok>
                         <XMApp>
@@ -1492,7 +1492,7 @@ Then a switch of tag forms.</p>
                   <XMApp xml:id="S3.Ex22.m1.2">
                     <XMTok role="SUBSCRIPTOP" scriptpos="mid1"/>
                     <XMApp scriptpos="mid">
-                      <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                      <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                       <XMApp>
                         <XMTok meaning="plus" role="ADDOP">+</XMTok>
                         <XMTok meaning="1" role="NUMBER">1</XMTok>

--- a/t/complex/physics.xml
+++ b/t/complex/physics.xml
@@ -661,13 +661,13 @@
                   <XMHint name="qquad" role="PUNCT" width="20pt"/>
                   <XMTok font="bold italic" role="ID" xml:id="S1.Ex7.m1.2">a</XMTok>
                   <XMHint name="qquad" role="PUNCT" width="20pt"/>
-                  <XMApp role="ID" xml:id="S1.Ex7.m1.3">
-                    <XMTok name="overrightarrow" role="OVERACCENT">→</XMTok>
+                  <XMApp role="ID" scriptpos="mid" xml:id="S1.Ex7.m1.3">
+                    <XMTok name="overrightarrow" role="OVERACCENT" stretchy="true">→</XMTok>
                     <XMTok font="bold" role="UNKNOWN">a</XMTok>
                   </XMApp>
                   <XMHint name="qquad" role="PUNCT" width="20pt"/>
-                  <XMApp role="ID" xml:id="S1.Ex7.m1.4">
-                    <XMTok name="overrightarrow" role="OVERACCENT">→</XMTok>
+                  <XMApp role="ID" scriptpos="mid" xml:id="S1.Ex7.m1.4">
+                    <XMTok name="overrightarrow" role="OVERACCENT" stretchy="true">→</XMTok>
                     <XMTok font="bold italic" role="UNKNOWN">a</XMTok>
                   </XMApp>
                   <XMHint name="qquad" role="PUNCT" width="20pt"/>

--- a/t/fonts/abxtest.xml
+++ b/t/fonts/abxtest.xml
@@ -4696,7 +4696,7 @@
             <td align="left" thead="row"><Math mode="inline" tex="\overbrace{ABC\ldots XYZ}" text="overbrace@(A * B * C * ldots * X * Y * Z)" xml:id="S0.SS0.SSS0.Px29.p2.m5">
                 <XMath>
                   <XMApp scriptpos="mid">
-                    <XMTok name="overbrace" role="OVERACCENT">⏞</XMTok>
+                    <XMTok name="overbrace" role="OVERACCENT" stretchy="true">⏞</XMTok>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok font="italic" role="UNKNOWN">A</XMTok>
@@ -4716,7 +4716,7 @@
             <td align="left" thead="row"><Math mode="inline" tex="\underbrace{ABC\ldots XYZ}" text="underbrace@(A * B * C * ldots * X * Y * Z)" xml:id="S0.SS0.SSS0.Px29.p2.m6">
                 <XMath>
                   <XMApp scriptpos="mid">
-                    <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                    <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok font="italic" role="UNKNOWN">A</XMTok>
@@ -5022,8 +5022,8 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="\overrightarrow{ABC\ldots XYZ}" text="overrightarrow@(A * B * C * ldots * X * Y * Z)" xml:id="S0.SS0.SSS0.Px30.p2.m12">
                 <XMath>
-                  <XMApp>
-                    <XMTok name="overrightarrow" role="OVERACCENT">→</XMTok>
+                  <XMApp scriptpos="mid">
+                    <XMTok name="overrightarrow" role="OVERACCENT" stretchy="true">→</XMTok>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok font="italic" role="UNKNOWN">A</XMTok>
@@ -5042,8 +5042,8 @@
           <tr>
             <td align="left" thead="row"><Math mode="inline" tex="\overleftarrow{ABC\ldots XYZ}" text="overleftarrow@(A * B * C * ldots * X * Y * Z)" xml:id="S0.SS0.SSS0.Px30.p2.m13">
                 <XMath>
-                  <XMApp>
-                    <XMTok name="overleftarrow" role="OVERACCENT">←</XMTok>
+                  <XMApp scriptpos="mid">
+                    <XMTok name="overleftarrow" role="OVERACCENT" stretchy="true">←</XMTok>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok font="italic" role="UNKNOWN">A</XMTok>

--- a/t/fonts/mathaccents.xml
+++ b/t/fonts/mathaccents.xml
@@ -639,7 +639,7 @@ dot, ddot, overline, widehat, widetilde)</p>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">[</XMTok>
                   <XMApp scriptpos="mid" xml:id="S0.Ex3.m1.1">
-                    <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                    <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                     <XMTok font="italic" role="UNKNOWN">A</XMTok>
                   </XMApp>
                   <XMTok role="CLOSE" stretchy="false">]</XMTok>
@@ -654,7 +654,7 @@ dot, ddot, overline, widehat, widetilde)</p>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">[</XMTok>
                   <XMApp scriptpos="mid" xml:id="S0.Ex3.m1.2">
-                    <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                    <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                     <XMTok meaning="absent"/>
                   </XMApp>
                   <XMTok role="CLOSE" stretchy="false">]</XMTok>
@@ -669,7 +669,7 @@ dot, ddot, overline, widehat, widetilde)</p>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">[</XMTok>
                   <XMApp scriptpos="mid" xml:id="S0.Ex3.m1.3">
-                    <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                    <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                     <XMTok font="italic" role="UNKNOWN">A</XMTok>
                   </XMApp>
                   <XMTok role="CLOSE" stretchy="false">]</XMTok>
@@ -684,7 +684,7 @@ dot, ddot, overline, widehat, widetilde)</p>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">[</XMTok>
                   <XMApp scriptpos="mid" xml:id="S0.Ex3.m1.4">
-                    <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                    <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok font="italic" role="UNKNOWN">A</XMTok>
@@ -704,7 +704,7 @@ dot, ddot, overline, widehat, widetilde)</p>
                 <XMWrap>
                   <XMTok role="OPEN" stretchy="false">[</XMTok>
                   <XMApp scriptpos="mid" xml:id="S0.Ex3.m1.5">
-                    <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                    <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                     <XMApp>
                       <XMTok meaning="times" role="MULOP">⁢</XMTok>
                       <XMTok font="italic" role="UNKNOWN">A</XMTok>
@@ -743,7 +743,7 @@ dot, ddot, overline, widehat, widetilde)</p>
                   <XMApp xml:id="S0.Ex4.m1.1.1">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMApp scriptpos="mid">
-                      <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                      <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                       <XMTok meaning="absent"/>
                     </XMApp>
                     <XMTok font="italic" role="UNKNOWN">A</XMTok>
@@ -762,7 +762,7 @@ dot, ddot, overline, widehat, widetilde)</p>
                   <XMApp xml:id="S0.Ex4.m1.2.1">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMApp scriptpos="mid">
-                      <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                      <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                       <XMTok meaning="absent"/>
                     </XMApp>
                     <XMTok font="italic" role="UNKNOWN">A</XMTok>
@@ -781,7 +781,7 @@ dot, ddot, overline, widehat, widetilde)</p>
                   <XMApp xml:id="S0.Ex4.m1.3.1">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMApp scriptpos="mid">
-                      <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                      <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                       <XMTok meaning="absent"/>
                     </XMApp>
                     <XMTok font="italic" role="UNKNOWN">A</XMTok>
@@ -800,7 +800,7 @@ dot, ddot, overline, widehat, widetilde)</p>
                   <XMApp xml:id="S0.Ex4.m1.4.1">
                     <XMTok meaning="times" role="MULOP">⁢</XMTok>
                     <XMApp scriptpos="mid">
-                      <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+                      <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
                       <XMTok meaning="absent"/>
                     </XMApp>
                     <XMTok font="italic" role="UNKNOWN">A</XMTok>
@@ -820,11 +820,11 @@ dot, ddot, overline, widehat, widetilde)</p>
           <XMApp>
             <XMTok meaning="times" role="MULOP">⁢</XMTok>
             <XMApp scriptpos="mid">
-              <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+              <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
               <XMTok meaning="absent"/>
             </XMApp>
             <XMApp scriptpos="mid">
-              <XMTok name="underbrace" role="UNDERACCENT">⏟</XMTok>
+              <XMTok name="underbrace" role="UNDERACCENT" stretchy="true">⏟</XMTok>
               <XMTok font="italic" role="UNKNOWN">f</XMTok>
             </XMApp>
             <XMTok font="italic" role="UNKNOWN">o</XMTok>

--- a/t/math/sampler.xml
+++ b/t/math/sampler.xml
@@ -1239,8 +1239,8 @@ some as accents, and pre-scripts (<text font="typewriter">m:multiscripts</text>,
                 <XMApp xml:id="S3.E20.m1.3">
                   <XMTok meaning="times" role="MULOP">⁢</XMTok>
                   <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                  <XMApp>
-                    <XMTok name="overrightarrow" role="OVERACCENT">→</XMTok>
+                  <XMApp scriptpos="mid">
+                    <XMTok name="overrightarrow" role="OVERACCENT" stretchy="true">→</XMTok>
                     <XMTok role="UNKNOWN">def</XMTok>
                   </XMApp>
                   <XMTok font="italic" role="UNKNOWN">b</XMTok>


### PR DESCRIPTION
A slightly hacky implementation of `\leaders`, at least with the correct parameters, and some refinement to stretchy accents (that TeX deals with internally with leaders).