### PR TITLE
Allocate

### DIFF
--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -36,6 +36,10 @@ Let('\magnification', '\@undefined');
 Let('\@empty',        '\lx@empty');
 Let('\@ifundefined',  '\lx@ifundefined');
 
+# Use Package's register allocation to avoid allocating same slot twice; and ALWAYS have room!
+DefMacro('\e@alloc{}{}{}{}{}{}', '\lx@alloc@{#1}{#3}{#2}{#6}', locked => 1);
+DefMacro('\e@ch@ck{}{}{}{}',     '',                           locked => 1);
+
 #**********************************************************************
 # Basic \documentclass & \documentstyle
 
@@ -771,6 +775,7 @@ sub beginAppendices {
   else {
     NewCounter($counter, 'document', idprefix => 'A');
     DefMacroI('\the' . $counter, undef, '\Alph{' . $counter . '}', scope => 'global'); }
+  SetCounter($counter => Number(0));          # In case register was already defined
   AssignMapping('counter_for_type', appendix => $counter);
   Let(T_CS('\\' . $counter), T_CS('\@@appendix'), 'global');
   Let(T_CS('\@appendix'),    T_CS('\relax'),      'global');

--- a/lib/LaTeXML/Engine/TeX_Registers.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Registers.pool.ltxml
@@ -70,6 +70,29 @@ DefPrimitive('\muskipdef SkipSpaces Token SkipSpaces SkipMatch:=', sub {
 DefPrimitive('\toksdef SkipSpaces Token SkipSpaces SkipMatch:=', sub {
     shorthandDef($_[0], $_[1], '\toks', Tokens()); });
 
+# Candidate for use defining plain's \alloc@ and latex's \e@alloc
+our %stored_registers = (
+  '\countdef' => 1, '\dimendef' => 1, '\skipdef' => 1, '\muskipdef' => 1, '\toksdef' => 1);
+DefMacro('\lx@alloc@ DefToken {} {} DefToken', sub {
+    my ($gullet, $type, $tracker, $allocator, $cs) = @_;
+    $type    = ToString($type);
+    $tracker = ToString($tracker);
+    my $next;
+    if ($stored_registers{ ToString($allocator) }) {
+      $next = LaTeXML::Package::allocateRegister($type);
+      $next =~ s/^\Q$type\E//; }
+    else {
+      my $xnext = $STATE->lookupValue($tracker) || Number(0);
+      $next = $xnext->valueOf + 1; }
+    my $value = Number($next);
+    $STATE->assignValue($tracker => Number($next), 'global');
+    return Tokens(T_CS('\allocationnumber'), Explode($next), T_CS('\relax'),
+      T_CS('\global'), $allocator, $cs, T_OTHER('='), T_CS('\allocationnumber')); });
+
+# Out of place, but utility for LaTeX-style \the<ctr>; used by Package's NewCounter
+DefMacro('\lx@counter@arabic{}', sub {
+    ExplodeText(CounterValue(ToString(Expand($_[1])))->valueOf); });
+
 #======================================================================
 # Numeric Registers
 #----------------------------------------------------------------------

--- a/lib/LaTeXML/Engine/TeX_Registers.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Registers.pool.ltxml
@@ -84,7 +84,6 @@ DefMacro('\lx@alloc@ DefToken {} {} DefToken', sub {
     else {
       my $xnext = $STATE->lookupValue($tracker) || Number(0);
       $next = $xnext->valueOf + 1; }
-    my $value = Number($next);
     $STATE->assignValue($tracker => Number($next), 'global');
     return Tokens(T_CS('\allocationnumber'), Explode($next), T_CS('\relax'),
       T_CS('\global'), $allocator, $cs, T_OTHER('='), T_CS('\allocationnumber')); });

--- a/lib/LaTeXML/Engine/plain.pool.ltxml
+++ b/lib/LaTeXML/Engine/plain.pool.ltxml
@@ -196,6 +196,10 @@ DefPrimitive('\wlog{}', sub {
     NoteLog(ToString(Expand($_[1])));
     return; },
   locked => 1);
+
+# Use Package's register allocation to avoid allocating same slot twice; and ALWAYS have room!
+DefMacro('\alloc@{}{}{}{}{}', '\lx@alloc@{#2}{\count1#1}{#3}{#5}', locked => 1);
+DefMacro('\ch@ck{}{}{}',      '',                                  locked => 1);
 # From plain.tex
 RawTeX(<<'EoTeX');
 \outer\def\newcount{\alloc@0\count\countdef\insc@unt}
@@ -211,18 +215,9 @@ RawTeX(<<'EoTeX');
 \outer\def\newfam{\alloc@8\fam\chardef\sixt@@n}
 \outer\def\newlanguage{\alloc@9\language\chardef\@cclvi}
 EoTeX
-DefMacro('\e@alloc{}{}{}{}{}{}',
-  '\global\advance#3\@ne
-%  \e@ch@ck{#3}{#4}{#5}#1%
-  \allocationnumber#3\relax
-  \global#2#6\allocationnumber
-%  \wlog{\string#6=\string#1\the\allocationnumber}
-');
-DefMacro('\alloc@{}{}{}{}', '\e@alloc#2#3{\count1#1}#4\float@count');
 
 # This implementation is quite wrong
 DefPrimitive('\newinsert Token', sub { DefRegisterI($_[1], undef, Number(0)); });
-# \alloc@, \ch@ck
 
 # TeX plain uses \newdimen, etc. for these.
 # Is there any advantage to that?


### PR DESCRIPTION
This PR makes register allocation (eg `\newcount` and friends) a bit safer against load order or accidental redefinitions. A new utility `\lx@alloc@` useful for plain's `\alloc@` and LaTeX's `\e@alloc` avoids allocating a `\count` (etc) slot if it has already been assigned to a register. `NewCounter(...)` avoids redefining counters. 