### PR TITLE
More precise expansion for \typeout

### DIFF
--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -4714,9 +4714,9 @@ DefPrimitiveI('\makeglossary', undef, undef);
 # C.11.6 Terminal Input and Output
 #======================================================================
 
-DefPrimitive('\typeout{}', sub {
+DefPrimitive('\typeout ExpandedPartially', sub {
     my ($stomach, $stuff) = @_;
-    Note(ToString(Expand($stuff)));
+    Note(ToString($stuff));
     return; });
 
 DefPrimitive('\typein[]{}', undef);


### PR DESCRIPTION
Fixes #2221 .

The unfortunate aspect is that the example reported in the issue identifies only a surface symptom problem, where `\typeout` was being too eager with expanding its argument before printing. But isn't otherwise related to the deeper issues related to changes.sty loads.

Although I suspect the main work of improving core interpretation will improve that front. 