### PR TITLE
Deactivate \keywords after \maketitle

### DIFF
--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -1243,6 +1243,7 @@ DefMacroI('\maketitle', undef,
     . '\global\let\title\relax'
     . '\global\let\author\relax'
     . '\global\let\date\relax'
+    . '\global\let\keywords\relax'
     . '\global\let\and\relax', locked => 1);
 
 DefMacro('\@thanks', '\@empty');

--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -1231,20 +1231,22 @@ DefMacro('\@add@conversion@date', '\@add@frontmatter{ltx:date}[role=creation]{\t
 # Doesn't produce anything (we're already inserting frontmatter),
 # But, it does make the various frontmatter macros into no-ops.
 DefMacroI('\maketitle', undef,
-  '\lx@frontmatterhere'
-    . '\@startsection@hook'
-    . '\global\let\thanks\relax'
-    . '\global\let\maketitle\relax'
-    . '\global\let\@maketitle\relax'
-    . '\global\let\@thanks\@empty'
-    . '\global\let\@author\@empty'
-    . '\global\let\@date\@empty'
-    . '\global\let\@title\@empty'
-    . '\global\let\title\relax'
-    . '\global\let\author\relax'
-    . '\global\let\date\relax'
-    . '\global\let\keywords\relax'
-    . '\global\let\and\relax', locked => 1);
+  '\lx@frontmatterhere\@startsection@hook\lx@deactivate@frontmatter');
+DefPrimitive('\lx@deactivate@frontmatter', sub {
+    Let('\maketitle',  '\relax',  'global');
+    Let('\@maketitle', '\relax',  'global');
+    Let('\@thanks',    '\@empty', 'global');
+    Let('\@author',    '\@empty', 'global');
+    Let('\@date',      '\@empty', 'global');
+    Let('\@title',     '\@empty', 'global');
+    DefMacro('\thanks[]{}', Tokens(), scope => 'global');
+    DefMacro('\title[]{}',  Tokens(), scope => 'global');
+    DefMacro('\author[]{}', Tokens(), scope => 'global');
+    DefMacro('\date{}',     Tokens(), scope => 'global');
+    DefMacro('\keywords{}', Tokens(), scope => 'global');
+    Let('\and', '\relax', scope => 'global');
+    return;
+});
 
 DefMacro('\@thanks', '\@empty');
 # make a throwaway optional argument available for OmniBus use

--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -1231,7 +1231,7 @@ DefMacro('\@add@conversion@date', '\@add@frontmatter{ltx:date}[role=creation]{\t
 # Doesn't produce anything (we're already inserting frontmatter),
 # But, it does make the various frontmatter macros into no-ops.
 DefMacroI('\maketitle', undef,
-  '\lx@frontmatterhere\@startsection@hook\lx@deactivate@frontmatter');
+  '\lx@frontmatterhere\@startsection@hook\lx@deactivate@frontmatter', locked => 1);
 DefPrimitive('\lx@deactivate@frontmatter', sub {
     Let('\maketitle',  '\relax',  'global');
     Let('\@maketitle', '\relax',  'global');


### PR DESCRIPTION
Fixes #2263 .

That issue could also be closed as wontfix, as it is not really a "healthy" use of LaTeX syntax, since using \keywords after \maketitle is asking for trouble.

But since trouble is often a part of life, and we have some idiosyncratic code that _caused_ the behavior, I took a pass ironing it out a little further.

Namely, after `\maketitle` executes in a document, we try to deactivate a number of frontmatter macros. This PR adds `\keywords` to that list of macros, but also redoes the deactivation as a subroutine, so that deactivated macros can _also_ consume their arguments. The guard in question seems to [have been around since 2007](https://github.com/dginev/LaTeXML/commit/e1a454b00e8ef28cf2f673559df0d782da361301#diff-75ceaa5c4d7a9cd00a7663c800339bf9eec6355a16d8931c6c03d155852c6ff6R414), so I am conservatively sticking with it here.