### PR TITLE
To attribute

### DIFF
--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -498,10 +498,10 @@ sub serialize_aux {
       (map { $_ . '="' . $atnodes{$_} . '"' } sort keys %atnodes)
     );
     my $noindent_children = ($heuristic
-        # This emulates libxml2's heuristic
-        #     ? $noindent || grep { $_->nodeType != XML_ELEMENT_NODE } @children
+      # This emulates libxml2's heuristic
+      #     ? $noindent || grep { $_->nodeType != XML_ELEMENT_NODE } @children
       ? $noindent || grep { $_->nodeType == XML_TEXT_NODE } @children
-        # This is the "Correct" way to determine whether to add indentation
+      # This is the "Correct" way to determine whether to add indentation
       : $model->canContain(getNodeQName($self, $node), '#PCDATA'));
     return join('',
       ($noindent ? '' : $indent), $start,
@@ -1376,12 +1376,15 @@ sub makeError {
 # [xml:id and namespaced attributes are always allowed]
 sub setAttribute {
   my ($self, $node, $key, $value) = @_;
-  return if (ref $value) && ((!blessed($value)) || !$value->can('toAttribute'));
   if (ref $value) {
     if ($key eq '_box') {
       return $self->setNodeBox($node, $value); }
     elsif ($key eq '_font') {
       return $self->setNodeFont($node, $value); }
+    elsif ((!blessed($value)) || !$value->can('toAttribute')) {
+      Warn('unexpected', (ref $value), $self,
+        "Don't know how to encode $value as an attribute value");
+      return; }
     else {
       $value = $value->toAttribute; } }
   if ((defined $value) && ($value ne '')) {    # Skip if `empty'; but 0 is OK!

--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -1376,8 +1376,14 @@ sub makeError {
 # [xml:id and namespaced attributes are always allowed]
 sub setAttribute {
   my ($self, $node, $key, $value) = @_;
-  return                       if (ref $value) && ((!blessed($value)) || !$value->can('toAttribute'));
-  $value = $value->toAttribute if ref $value;
+  return if (ref $value) && ((!blessed($value)) || !$value->can('toAttribute'));
+  if (ref $value) {
+    if ($key eq '_box') {
+      return $self->setNodeBox($node, $value); }
+    elsif ($key eq '_font') {
+      return $self->setNodeFont($node, $value); }
+    else {
+      $value = $value->toAttribute; } }
   if ((defined $value) && ($value ne '')) {    # Skip if `empty'; but 0 is OK!
     if ($key eq 'xml:id') {                    # If it's an ID attribute
       $value = recordID($self, $value, $node);                                 # Do id book keeping

--- a/lib/LaTeXML/Core/List.pm
+++ b/lib/LaTeXML/Core/List.pm
@@ -17,7 +17,7 @@ use LaTeXML::Common::Object;
 use LaTeXML::Common::Error;
 use LaTeXML::Common::Dimension;
 use List::Util qw(min max);
-use base qw(Exporter LaTeXML::Core::Box);
+use base       qw(Exporter LaTeXML::Core::Box);
 our @EXPORT = (qw(&List));
 
 # Tricky; don't really want a separate constructor for a Math List,
@@ -70,6 +70,10 @@ sub revert {
 sub toString {
   my ($self) = @_;
   return join('', grep { defined $_ } map { $_->toString } $self->unlist); }
+
+sub toAttribute {
+  my ($self) = @_;
+  return join('', grep { defined $_ } map { $_->toAttribute } $self->unlist); }
 
 # Methods for overloaded operators
 sub stringify {

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -218,6 +218,31 @@ sub beAbsorbed {
   LaTeXML::Core::Definition::stopProfiling($profiled, 'absorb') if $profiled;
   return @result; }
 
+# Similar to ->revert, but converts to pure string for use in an attribute value
+sub toAttribute {
+  my ($self) = @_;
+  my $props  = $$self{properties};
+  my $defn   = $self->getDefinition;
+  my $spec   = $$props{toAttribute} || $$defn{toAttribute};
+  if (!defined $spec) {
+    return $self->toString; }    # Default
+  elsif (ref $spec eq 'CODE') {    # If handled by CODE, call it
+    $spec = &$spec($self, $self->getArgs); }
+  # Now, similar to substituteParameters, but creating a string.
+  $spec =~ s/#(#|[1-9]|\w+)/ toAttribute_aux($self,$1)/eg;
+  return $spec; }
+
+sub toAttribute_aux {
+  my ($self, $code) = @_;
+  my $value;
+  if    ($code eq '#') { return $code; }
+  elsif ((ord($code) > ord('0')) && (ord($code) <= ord('9'))) {
+    $value = $self->getArg(ord($code) - ord('0')); }
+  else {
+    $value = $self->getProperty($code); }
+  $value = $value->toAttribute if (defined $value) && (ref $value);
+  return $value; }
+
 # See discussion in Box.pm
 sub computeSize {
   my ($self, %options) = @_;

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -223,7 +223,7 @@ sub toAttribute {
   my ($self) = @_;
   my $props  = $$self{properties};
   my $defn   = $self->getDefinition;
-  my $spec   = $$props{toAttribute} || $$defn{toAttribute};
+  my $spec   = $$props{attributeForm} || $$defn{attributeForm};
   if (!defined $spec) {
     return $self->toString; }    # Default
   elsif (ref $spec eq 'CODE') {    # If handled by CODE, call it
@@ -240,7 +240,7 @@ sub toAttribute_aux {
     $value = $self->getArg(ord($code) - ord('0')); }
   else {
     $value = $self->getProperty($code); }
-  $value = $value->toAttribute if (defined $value) && (ref $value);
+  $value = $value->toAttribute if ref $value;
   return $value; }
 
 # See discussion in Box.pm

--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -1211,9 +1211,9 @@ DefConstructor('\lx@author@prefix', sub {
     my $i          = scalar(@{ $document->findnodes('//ltx:creator[@role="author"]') });
     if    ($i <= 1) { }
     elsif ($i == $nauthors) {
-      $document->setAttribute($node, before => ToString(Digest(T_CS('\lx@author@conj')))); }
+      $document->setAttribute($node, before => Digest(T_CS('\lx@author@conj'))); }
     else {
-      $document->setAttribute($node, before => ToString(Digest(T_CS('\lx@author@sep')))); }
+      $document->setAttribute($node, before => Digest(T_CS('\lx@author@sep'))); }
 });
 
 DefMacro('\@author',                 '\@empty');
@@ -4376,8 +4376,8 @@ DefConstructor('\@@bibref Semiverbatim Semiverbatim {}{}',
   "<ltx:bibref show='#1' bibrefs='#bibrefs' inlist='#bibunit'"
     . " separator='#separator' yyseparator='#yyseparator'>#3#4</ltx:bibref>",
   properties => sub { (bibrefs => CleanBibKey($_[2]),
-      separator   => ToString(Digest(LookupValue('CITE_SEPARATOR'))),
-      yyseparator => ToString(Digest(LookupValue('CITE_YY_SEPARATOR'))),
+      separator   => Digest(LookupValue('CITE_SEPARATOR')),
+      yyseparator => Digest(LookupValue('CITE_YY_SEPARATOR')),
       bibunit     => LookupValue('CITE_UNIT')); });
 
 # Simple container for any phrases used in the bibref

--- a/lib/LaTeXML/Engine/TeX_Glue.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Glue.pool.ltxml
@@ -79,9 +79,9 @@ DefConstructor('\hskip Glue', sub {
     else {
       #      $document->openText(DimensionToSpaces($length), $props{font}); } },
       $document->absorb(DimensionToSpaces($length)); } },
-  reversion   => sub { revertSkip(T_CS('\hskip'), $_[1]); },
-  toAttribute => sub { DimensionToSpaces($_[1]); },
-  properties  => sub {
+  reversion     => sub { revertSkip(T_CS('\hskip'), $_[1]); },
+  attributeForm => sub { DimensionToSpaces($_[1]); },
+  properties    => sub {
     my ($stomach, $length) = @_;
     (width => $length, isSpace => 1, isSkip => 1); });
 
@@ -96,7 +96,7 @@ DefConstructor('\vskip Glue', sub {
       elsif ($document->isOpenable('ltx:break')) {
         $document->insertElement('ltx:break'); } }
     return; },
-  properties => sub { (height => $_[1], isSpace => 1,, isSkip => 1, isVerticalSpace => 1, isBreak => 1); });
+  properties => sub { (height => $_[1], isSpace => 1, isSkip => 1, isVerticalSpace => 1, isBreak => 1); });
 
 # Remove skip, if last on LIST
 DefPrimitiveI('\unskip', undef, sub {

--- a/lib/LaTeXML/Engine/TeX_Glue.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Glue.pool.ltxml
@@ -79,8 +79,9 @@ DefConstructor('\hskip Glue', sub {
     else {
       #      $document->openText(DimensionToSpaces($length), $props{font}); } },
       $document->absorb(DimensionToSpaces($length)); } },
-  reversion  => sub { revertSkip(T_CS('\hskip'), $_[1]); },
-  properties => sub {
+  reversion   => sub { revertSkip(T_CS('\hskip'), $_[1]); },
+  toAttribute => sub { DimensionToSpaces($_[1]); },
+  properties  => sub {
     my ($stomach, $length) = @_;
     (width => $length, isSpace => 1, isSkip => 1); });
 

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -1383,7 +1383,7 @@ sub flatten {
 my $constructor_options = {    # [CONSTANT]
   mode         => 1, requireMath => 1, forbidMath => 1, font       => 1,
   alias        => 1, reversion   => 1, sizer      => 1, properties => 1,
-  nargs        => 1,
+  nargs        => 1, toAttribute => 1,
   beforeDigest => 1, afterDigest => 1, beforeConstruct => 1, afterConstruct => 1,
   captureBody  => 1, scope       => 1, bounded         => 1, locked         => 1,
   outer        => 1, long        => 1, robust          => 1 };
@@ -1425,6 +1425,7 @@ sub DefConstructorI {
       alias           => (defined $options{alias} ? $options{alias}
         : ($options{robust} ? $cs : undef)),
       reversion   => $options{reversion},
+      toAttribute => $options{toAttribute},
       sizer       => inferSizer($options{sizer}, $options{reversion}),
       captureBody => $options{captureBody},
       properties  => $options{properties} || {},
@@ -1827,7 +1828,8 @@ my $environment_options = {    # [CONSTANT]
   beforeDigest     => 1, afterDigest     => 1,
   afterDigestBegin => 1, beforeDigestEnd => 1, afterDigestBody => 1,
   beforeConstruct  => 1, afterConstruct  => 1,
-  reversion        => 1, sizer           => 1, scope => 1, locked => 1 };
+  reversion        => 1, sizer           => 1, scope => 1, locked => 1,
+  toAttribute      => 1 };
 
 sub DefEnvironment {
   my ($proto, $replacement, %options) = @_;
@@ -1873,8 +1875,9 @@ sub DefEnvironmentI {
       nargs          => $options{nargs},
       captureBody    => 1,
       properties     => $options{properties} || {},
-      (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
-      (defined $sizer              ? (sizer     => $sizer)              : ()),
+      (defined $options{reversion}   ? (reversion   => $options{reversion})   : ()),
+      (defined $options{toAttribute} ? (toAttribute => $options{toAttribute}) : ()),
+      (defined $sizer                ? (sizer       => $sizer)                : ()),
       ), $options{scope});
   $STATE->installDefinition(LaTeXML::Core::Definition::Constructor
       ->new(T_CS("\\end{$name}"), "", "",
@@ -1914,8 +1917,9 @@ sub DefEnvironmentI {
       nargs          => $options{nargs},
       captureBody    => T_CS("\\end$name"),           # Required to capture!!
       properties     => $options{properties} || {},
-      (defined $options{reversion} ? (reversion => $options{reversion}) : ()),
-      (defined $sizer              ? (sizer     => $sizer)              : ()),
+      (defined $options{reversion}   ? (reversion   => $options{reversion})   : ()),
+      (defined $options{toAttribute} ? (toAttribute => $options{toAttribute}) : ()),
+      (defined $sizer                ? (sizer       => $sizer)                : ()),
       ), $options{scope});
   $STATE->installDefinition(LaTeXML::Core::Definition::Constructor
       ->new(T_CS("\\end$name"), "", "",
@@ -3681,6 +3685,14 @@ provides a control sequence to be used in the C<reversion> instead of
 the one defined in the C<prototype>.  This is a convenient alternative for
 reversion when a 'public' command conditionally expands into
 an internal one, but the reversion should be for the public command.
+
+=item C<toAttribute=E<gt>I<texstring> | I<code>($whatsit,#1,#2,...)>
+
+specifies the conversion of the invocation back into plain text for an attribute value
+(the default is C<toString>).
+The I<textstring> string can include C<#1>, C<#2>...
+The I<code> is called with the C<$whatsit> and digested arguments
+and must return a string.
 
 =item C<sizer=E<gt>I<string> | I<code>($whatsit)>
 


### PR DESCRIPTION
This PR provides an option `toAttribute` to `DefConstructor,DefEnvironment` (and `Whatsit`s generally) to customize the conversion of a whatsit to an attribute value; its sytax is analogous to that of the `reversion` option, being a sub or string, possibly containing `#1..`. 
This is useful for objects which need the flexibility of a `Whatsit` (as opposed to simple `Box`) but which are sometimes placed in an attribute value that ends up in the text (or html) of the conversion; In those cases, the value should contain neither XML, nor the TeX reversion (as `toString` typically does). The motivating example is `\hskip`.
The `setAttribute` method of `Document`, when given an object reference as value, will use `toAttribute` to turn it into a string, but we need to be careful *not* to use `ToString` on such values before they get there.