### PR TITLE
implement TikZ/PGF baseline support

### DIFF
--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -77,13 +77,15 @@ DefConstructor('\lxSVG@insertpicture{}', sub {
     if ($document->getNodeQName($current) =~ /^svg:/) {    # Already in svg:svg ?
           # Seemingly this positioning is correct; otherwise inherit from context
       my ($x, $y) = (-$props{minx}, -$props{miny});
+      $y -= $props{depth}->pxValue if $props{depth}->pxValue;
       my $gnode = $document->openElement('svg:g',
         transform   => "matrix(1 0 0 1 $x $y)",
         _scopebegin => 1, class => 'ltx_nestedsvg');
       $document->absorb($content);
       $document->closeElement('svg:g'); }
     else {
-      $document->openElement('ltx:picture');
+      my $picture = $document->openElement('ltx:picture');
+      $document->setAttribute($picture, 'imagedepth', $props{depth}->pxValue) if $props{depth}->pxValue;
       $document->openElement('svg:svg',
         version => "1.1",
         width   => $props{pxwidth}, height => $props{pxheight},
@@ -114,12 +116,13 @@ DefConstructor('\lxSVG@insertpicture{}', sub {
     my $miny    = LookupRegister('\pgf@picminy');
     my $width   = LookupRegister('\pgf@picmaxx');
     my $height  = LookupRegister('\pgf@picmaxy');
+    my $depth   = Dimension(Expand(T_CS('\pgf@shift@baseline')));
     my $w       = max($width->pxValue,  1);
     my $h       = max($height->pxValue, 1);
     my $content = $whatsit->getArg(1);
     my ($cwidth, $cheight, $cdepth) = $content->getSize;
-    Debug("TIKZ size: " . ToString($width) . " x " . ToString($height)) if $LaTeXML::DEBUG{pgf};
-    Debug("TIKZ pos: " . ToString($minx) . " x " . ToString($miny))     if $LaTeXML::DEBUG{pgf};
+    Debug("TIKZ size: " . ToString($width) . " x " . ToString($height) . " + " . ToString($depth)) if $LaTeXML::DEBUG{pgf};
+    Debug("TIKZ pos: " . ToString($minx) . " x " . ToString($miny)) if $LaTeXML::DEBUG{pgf};
     Debug("TIKZ BODY: " . ToString($cwidth) . " x " . ToString($cheight)
         . " + " . ToString($cdepth)) if $LaTeXML::DEBUG{pgf};
     Debug("BODY is " . ToString($content)) if $LaTeXML::DEBUG{pgf};
@@ -130,7 +133,7 @@ DefConstructor('\lxSVG@insertpicture{}', sub {
     $whatsit->setProperty(miny     => 0);
     $whatsit->setProperty(width    => $width);
     $whatsit->setProperty(height   => $height);
-    $whatsit->setProperty(depth    => Dimension(0));
+    $whatsit->setProperty(depth    => $depth->add($miny->negate));
     $whatsit->setProperty(pxwidth  => $w);
     $whatsit->setProperty(pxheight => $h);
     # or tikz macro (see corescopes)
@@ -756,6 +759,7 @@ DefMacro('\pgfsys@shadingoutsidepgfpicture{}', <<'EoTeX');
     \pgf@picminy=0pt%
     \pgf@picmaxx=\pgf@x%
     \pgf@picmaxy=\pgf@y%
+    \def\pgf@shift@baseline{0pt}%
     \pgfsys@typesetpicturebox{\pgfpic}%
   \endgroup
 EoTeX

--- a/lib/LaTeXML/resources/RelaxNG/LaTeXML-common.rnc
+++ b/lib/LaTeXML/resources/RelaxNG/LaTeXML-common.rnc
@@ -273,7 +273,7 @@ Imageable.attributes =
   ## baseline of the content shown in the image.
   ## When displayed inilne, an image with a positive \attr{depth}
   ## should be shifted down relative to the baseline of neighboring material.
-  attribute imagedepth { xsd:integer }?,
+  attribute imagedepth { xsd:float }?,
 
   ## a description of the image
   attribute description { text }?

--- a/lib/LaTeXML/resources/RelaxNG/LaTeXML-common.rng
+++ b/lib/LaTeXML/resources/RelaxNG/LaTeXML-common.rng
@@ -408,7 +408,7 @@ Note that, unlike \TeX, this is the total height, including the depth (if any).<
 baseline of the content shown in the image.
 When displayed inilne, an image with a positive \attr{depth}
 should be shifted down relative to the baseline of neighboring material.</a:documentation>
-        <data type="integer"/>
+        <data type="float"/>
       </attribute>
     </optional>
     <optional>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
@@ -95,8 +95,17 @@
       <xsl:call-template name="add_classes"/>
       <xsl:call-template name="copy_foreign_attributes"/>
       <xsl:apply-templates select="." mode="add_RDFa"/>
+      <xsl:if test="@imagedepth | svg:svg/@style">
+        <xsl:attribute name="style">
+          <xsl:if test="@imagedepth">
+            <xsl:value-of select="concat('vertical-align:',-@imagedepth,'px')"/>
+            <xsl:if test="svg:svg/@style">;</xsl:if>
+          </xsl:if>
+          <xsl:value-of select="svg:svg/@style"/>
+        </xsl:attribute>
+      </xsl:if>
       <!-- but copy other svg:svg attributes -->
-      <xsl:for-each select="svg:svg/@*">
+      <xsl:for-each select="svg:svg/@*[name() != 'style']">
         <xsl:apply-templates select="." mode="copy-attribute"/>
       </xsl:for-each>
       <xsl:apply-templates select="svg:svg/*"/>


### PR DESCRIPTION
Fix #2462. Note that it does not fix the baseline issues in the 'unit tests by Silviu'. This is a good sign, because those tests do not modify the baseline, ever; they are broken for a different minx/miny related reason.