### PR TITLE
more detailed warning for toAttribute in Document::setAttribute

### DIFF
--- a/lib/LaTeXML/Core/Document.pm
+++ b/lib/LaTeXML/Core/Document.pm
@@ -20,6 +20,7 @@ use LaTeXML::Common::Error;
 use LaTeXML::Common::XML;
 use LaTeXML::Util::Radix;
 use Unicode::Normalize;
+use Data::Dumper;
 use Scalar::Util qw(blessed);
 use base         qw(LaTeXML::Common::Object);
 
@@ -1383,7 +1384,7 @@ sub setAttribute {
       return $self->setNodeFont($node, $value); }
     elsif ((!blessed($value)) || !$value->can('toAttribute')) {
       Warn('unexpected', (ref $value), $self,
-        "Don't know how to encode $value as an attribute value");
+        "While setting \"$key\", don't know how to encode $value as an attribute value.", Dumper($value));
       return; }
     else {
       $value = $value->toAttribute; } }


### PR DESCRIPTION
Follow-up to #2465 , adding a little more detail to the warning message.

I encountered the warning while diagnozing something independent, on the example:
```tex
\documentclass{article}
\usepackage{amsmath}
\begin{document}
$$\begin{aligned}A \end{aligned}$$
\end{document}
```

Which with this PR will now print to the `.latexml.log` file the following.

@brucemiller if you have any suggestions how to handle the array-reference attribute, I can add that here if you prefer.

```
Warning:unexpected:ARRAY While setting "columnwidths", don't know how to encode ARRAY(0x5728582ae2f8) as an attribute value.
	at test.tex; line 5 col 2 - line 5 col 34
	$VAR1 = [
	          bless( [
	                   491521
	                 ], 'LaTeXML::Common::Dimension' )
	        ];
	In Core::Document[@0x572857366e40] /tmp/test.tex; from line 5 col 2 to line 5 col 34
	 <= Alignment[] <= Core::Document[@0x572857366e40] <= Core::Definition::Constructor[\lx@beg... <= ...
Warning:unexpected:ARRAY While setting "rowheights", don't know how to encode ARRAY(0x5728582ae4f0) as an attribute value.
	at test.tex; line 5 col 2 - line 5 col 34
	$VAR1 = [
	          bless( [
	                   447828
	                 ], 'LaTeXML::Common::Dimension' )
	        ];
	In Core::Document[@0x572857366e40] /tmp/test.tex; from line 5 col 2 to line 5 col 34
	 <= Alignment[] <= Core::Document[@0x572857366e40] <= Core::Definition::Constructor[\lx@beg... <= ...
 0.02 sec)
```