### PR TITLE
minor: \bibsep is a glue register

### DIFF
--- a/lib/LaTeXML/Package/natbib.sty.ltxml
+++ b/lib/LaTeXML/Package/natbib.sty.ltxml
@@ -455,7 +455,7 @@ DefMacro('\bibfont',     '');
 DefMacro('\citenumfont', '');
 DefMacro('\bibnumfmt{}', '#1');
 DefRegister('\bibhang', Dimension(0));
-DefRegister('\bibsep',  Dimension(0));
+DefRegister('\bibsep',  Glue(0));
 
 #======================================================================
 # 2.13 Automatic Indexing of Citations


### PR DESCRIPTION
Very minimal, fixes  https://github.com/arXiv/html_feedback/issues/2651

The scarier question is "how do we catch all of these DefRegister subtleties in general, in all bindings?"

Minimal snippet:
```tex
\documentclass{article}
\usepackage{natbib}
\begin{document}
\bibsep.9ex plus.1ex minus.05ex
\end{document}
```