### PR TITLE
restore native PGF quick commands

### DIFF
--- a/lib/LaTeXML/Package/pgf.sty.ltxml
+++ b/lib/LaTeXML/Package/pgf.sty.ltxml
@@ -47,13 +47,6 @@ AtBeginDocument(
   '\expandafter\def\expandafter\pgfpicture\expandafter{\expandafter\lxSVG@picture\pgfpicture}'
     . '\expandafter\def\expandafter\endpgfpicture\expandafter{\endpgfpicture\endlxSVG@picture}');
 
-# define "q" forms of some commands??
-DefMacro('\pgfpathqmoveto{}{}', '\pgfpathmoveto{\pgfqpoint{#1}{#2}}');
-DefMacro('\pgfpathqlineto{}{}', '\pgfpathlineto{\pgfqpoint{#1}{#2}}');
-DefMacro('\pgfpathqcircle{}',   '\pgfpathcircle{\pgfpointorigin}{#1}');
-DefMacro('\pgfpathqcurveto{}{}{}{}{}{}',
-  '\pgfpathcurveto{\pgfqpoint{#1}{#2}}{\pgfqpoint{#3}{#4}}{\pgfqpoint{#5}{#6}}');
-
 # Wrap tikzpicture?
 #RawTeX('\expandafter\def\expandafter\tikzpicture\expandafter{\expandafter\lxSVG@picture\tikzpicture}');
 #RawTeX('\expandafter\def\expandafter\endtikzpicture\expandafter{\endtikzpicture\endlxSVG@picture}');


### PR DESCRIPTION
Part two of #2401 (to fully fix #2399): the quick commands *by definition* must not alter the bounding box. They do this by altering `relevantforpicturesize`, so this depends on the other PR to actually have an effect. This changes how some of Silviu's test are rendered (for the better) although plenty of stuff is still broken.

As far as I can tell, the initial implementation of PGF was extremely conservative about stuff being drawn outside of the SVG bounding box, hence the disabling of `relevantforpicturesize` and the redefinition of the quick commands. I don't think this is necessary anymore.