### PR TITLE
omit \lxSVG@closescope in reversion

### DIFF
--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -565,7 +565,8 @@ DefConstructor('\lxSVG@closescope', sub {
       $n++;
       last if $node->getAttribute('_scopebegin'); }
     return; },
-  sizer => 0);
+  sizer     => 0,
+  reversion => '');
 
 DefConstructor('\lxSVG@beginscope', '',
   afterDigest => sub {


### PR DESCRIPTION
Fix #2476. It doesn't fix `--pictureimages` in general: it only makes it compile *something* successfully. Unfortunately, the output is cropped the wrong way, but that's a different issue altogether.