### PR TITLE
sum of my PGF, SVG, XY patches

### DIFF
--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -311,6 +311,7 @@ sub beAbsorbed {
   &{ $$self{openContainer} }($document, ($attr ? %$attr : ()),
     cwidth       => $$self{cwidth}, cheight => $$self{cheight}, cdepth => $$self{cdepth},
     rowheights   => $$self{rowheights},
+    rowdepths    => $$self{rowdepths},
     columnwidths => $$self{columnwidths},
   );
   foreach my $row (@rows) {
@@ -513,6 +514,7 @@ sub showSize {
 sub normalize_sum_sizes {
   my ($self)     = @_;
   my @rowheights = ();
+  my @rowdepths  = ();
   my @colwidths  = ();
   my @colrights  = ();
   my @collefts   = ();
@@ -564,6 +566,7 @@ sub normalize_sum_sizes {
     $$row{tpadding} = Dimension($rowt);
     $$row{bpadding} = Dimension($rowb);
     # NOTE: Should be storing column widths to; individually, as well as per-column!
+    push(@rowdepths,  $rowd);
     push(@rowheights, $rowh + $rowd); }    # somehow our heights are way too short????
   ## Now compute the positions
   my @rowpos = ();
@@ -588,8 +591,10 @@ sub normalize_sum_sizes {
   $$self{cdepth}       = Dimension(0);
   @colwidths           = map { Dimension($_); } @colwidths;
   @rowheights          = map { Dimension($_); } @rowheights;
+  @rowdepths           = map { Dimension($_); } @rowdepths;
   $$self{columnwidths} = [@colwidths];
   $$self{rowheights}   = [@rowheights];
+  $$self{rowdepths}    = [@rowdepths];
 
   for (my $i = 0 ; $i < scalar(@rowheights) ; $i++) {
     my $row   = $rows[$i];

--- a/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
@@ -337,11 +337,12 @@ Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
     # Make sure we get a size, in case autoOpen'd
     if ($whatsit) {
       my ($w, $h, $d) = $whatsit->getSize;
-      my $y  = $STATE->lookupDefinition(T_CS('\baselineskip'))->valueOf->pxValue;
-      my $ht = $h->add($d);
-      $node->setAttribute(width     => $w->pxValue)  unless $node->hasAttribute('width');
-      $node->setAttribute(height    => $ht->pxValue) unless $node->hasAttribute('height');
-      $node->setAttribute(transform => "matrix(1 0 0 -1 0 $y)");
+      my $ht = $node->getAttribute('height') // $h->add($d)->pxValue;
+      $h = $h->pxValue;
+      $node->setAttribute(style     => "line-height:${h}px");
+      $node->setAttribute(width     => $w->pxValue) unless $node->hasAttribute('width');
+      $node->setAttribute(height    => $ht)         unless $node->hasAttribute('height');
+      $node->setAttribute(transform => "matrix(1 0 0 -1 0 $h)");
       $node->setAttribute(overflow  => 'visible'); } });
 
 # This attempts to be a generalize vbox construction;

--- a/lib/LaTeXML/Engine/TeX_Kern.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Kern.pool.ltxml
@@ -27,16 +27,40 @@ use LaTeXML::Package;
 # \lastkern         iq is 0.0 pt or the last kern on the current list.
 
 # \kern is heavily used by xy.
-# Completely HACK version for the moment
 # Note that \kern should add vertical spacing in vertical modes!
 DefConstructor('\kern Dimension', sub {
     my ($document, $length, %props) = @_;
     my $parent = $document->getNode;
     if ($document->getNodeQName($parent) eq 'svg:g') {
       if (my $x = $length->pxValue) {
-        # HACK HACK HACK
         my $transform = $parent->getAttribute('transform');
         $parent->setAttribute(transform => ($transform ? $transform . ' ' : '') . "translate($x,0)");
+        if (my @nodes = $parent->childNodes) {
+          # nodes have already been deposited, wrap those in svg:g to avoid shifting them
+          # the code below is essentially Document::wrapNodes, but we add the transform attribute
+          # *before* running afterClose, or collapseSVGGroup will immediately remove the wrapper
+
+          # Check if any of @nodes, or any of it's children, are the current node, and thus still "open"
+          my $leave_open = 0;
+          foreach my $n (@nodes) {
+            if ($document->isOpen($n)) {
+              $leave_open = 1;
+              last; } }
+
+          my $model = $document->getModel;
+          my ($ns, $tag) = $model->decodeQName('svg:g');
+          my $new = $document->openElement_internal($parent, $ns, $tag);
+          $new->setAttribute(transform => 'translate(' . -$x . ',0)');
+          $document->afterOpen($new);
+          $parent->replaceChild($new, $nodes[0]);
+
+          if (my $font = $document->getNodeFont($parent)) {
+            $document->setNodeFont($new, $font); }
+          if (my $box = $document->getNodeBox($parent)) {
+            $document->setNodeBox($new, $box); }
+          foreach my $node (@nodes) {
+            $new->appendChild($node); }
+          $document->afterClose($new) unless $leave_open; }
     } }
     elsif (inSVG()) {
       Warn('unexpected', 'kern', $_[0], "Lost kern in SVG " . ToString($length)); }

--- a/lib/LaTeXML/Package/pgf.sty.ltxml
+++ b/lib/LaTeXML/Package/pgf.sty.ltxml
@@ -52,13 +52,6 @@ AtBeginDocument(
   '\expandafter\def\expandafter\pgfpicture\expandafter{\expandafter\lxSVG@picture\pgfpicture}'
     . '\expandafter\def\expandafter\endpgfpicture\expandafter{\endpgfpicture\endlxSVG@picture}');
 
-# define "q" forms of some commands??
-DefMacro('\pgfpathqmoveto{}{}', '\pgfpathmoveto{\pgfqpoint{#1}{#2}}');
-DefMacro('\pgfpathqlineto{}{}', '\pgfpathlineto{\pgfqpoint{#1}{#2}}');
-DefMacro('\pgfpathqcircle{}',   '\pgfpathcircle{\pgfpointorigin}{#1}');
-DefMacro('\pgfpathqcurveto{}{}{}{}{}{}',
-  '\pgfpathcurveto{\pgfqpoint{#1}{#2}}{\pgfqpoint{#3}{#4}}{\pgfqpoint{#5}{#6}}');
-
 # Wrap tikzpicture?
 #RawTeX('\expandafter\def\expandafter\tikzpicture\expandafter{\expandafter\lxSVG@picture\tikzpicture}');
 #RawTeX('\expandafter\def\expandafter\endtikzpicture\expandafter{\endtikzpicture\endlxSVG@picture}');

--- a/lib/LaTeXML/Package/pgf.sty.ltxml
+++ b/lib/LaTeXML/Package/pgf.sty.ltxml
@@ -43,9 +43,9 @@ if (XEquals(T_CS('\XC@mcolor'), T_CS('\relax'))) {
 AddToMacro('\XC@mcolor', '\pgfsetcolor{.}');
 
 # This makes this conditional always true;  Why???
-DefConditionalI('\ifpgf@relevantforpicturesize', undef, sub { 1; });
-DefMacroI('\pgf@relevantforpicturesizefalse', undef, '');
-DefMacroI('\pgf@relevantforpicturesizetrue',  undef, '');
+# DefConditionalI('\ifpgf@relevantforpicturesize', undef, sub { 1; });
+# DefMacroI('\pgf@relevantforpicturesizefalse', undef, '');
+# DefMacroI('\pgf@relevantforpicturesizetrue',  undef, '');
 
 # These wrap pgfpicture with lxSVG@picture (but wait till everything loaded!)
 AtBeginDocument(

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -85,9 +85,9 @@ DefConstructor('\lxSVG@insertpicture{}', sub {
     else {
       $document->openElement('ltx:picture');
       $document->openElement('svg:svg',
-        version => "1.1",
-        width   => $props{pxwidth}, height => $props{pxheight},
-####        viewBox  => "$props{minx} $props{miny} $props{pxwidth} $props{pxheight}",
+        version  => "1.1",
+        width    => $props{pxwidth}, height => $props{pxheight},
+        viewBox  => "$props{minx} $props{miny} $props{pxwidth} $props{pxheight}",
         overflow => "visible");
       my $x0 = -(0 + $props{minx});
       my $y0 = $props{pxheight} + $props{miny};

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -77,13 +77,15 @@ DefConstructor('\lxSVG@insertpicture{}', sub {
     if ($document->getNodeQName($current) =~ /^svg:/) {    # Already in svg:svg ?
           # Seemingly this positioning is correct; otherwise inherit from context
       my ($x, $y) = (-$props{minx}, -$props{miny});
+      $y -= $props{depth}->pxValue if $props{depth}->pxValue;
       my $gnode = $document->openElement('svg:g',
         transform   => "matrix(1 0 0 1 $x $y)",
         _scopebegin => 1, class => 'ltx_nestedsvg');
       $document->absorb($content);
       $document->closeElement('svg:g'); }
     else {
-      $document->openElement('ltx:picture');
+      my $picture = $document->openElement('ltx:picture');
+      $document->setAttribute($picture, 'imagedepth', $props{depth}->pxValue) if $props{depth}->pxValue;
       $document->openElement('svg:svg',
         version  => "1.1",
         width    => $props{pxwidth}, height => $props{pxheight},
@@ -114,12 +116,13 @@ DefConstructor('\lxSVG@insertpicture{}', sub {
     my $miny    = LookupRegister('\pgf@picminy');
     my $width   = LookupRegister('\pgf@picmaxx');
     my $height  = LookupRegister('\pgf@picmaxy');
+    my $depth   = Dimension(Expand(T_CS('\pgf@shift@baseline')));
     my $w       = max($width->pxValue,  1);
     my $h       = max($height->pxValue, 1);
     my $content = $whatsit->getArg(1);
     my ($cwidth, $cheight, $cdepth) = $content->getSize;
-    Debug("TIKZ size: " . ToString($width) . " x " . ToString($height)) if $LaTeXML::DEBUG{pgf};
-    Debug("TIKZ pos: " . ToString($minx) . " x " . ToString($miny))     if $LaTeXML::DEBUG{pgf};
+    Debug("TIKZ size: " . ToString($width) . " x " . ToString($height) . " + " . ToString($depth)) if $LaTeXML::DEBUG{pgf};
+    Debug("TIKZ pos: " . ToString($minx) . " x " . ToString($miny)) if $LaTeXML::DEBUG{pgf};
     Debug("TIKZ BODY: " . ToString($cwidth) . " x " . ToString($cheight)
         . " + " . ToString($cdepth)) if $LaTeXML::DEBUG{pgf};
     Debug("BODY is " . ToString($content)) if $LaTeXML::DEBUG{pgf};
@@ -130,7 +133,7 @@ DefConstructor('\lxSVG@insertpicture{}', sub {
     $whatsit->setProperty(miny     => 0);
     $whatsit->setProperty(width    => $width);
     $whatsit->setProperty(height   => $height);
-    $whatsit->setProperty(depth    => Dimension(0));
+    $whatsit->setProperty(depth    => $depth->add($miny->negate));
     $whatsit->setProperty(pxwidth  => $w);
     $whatsit->setProperty(pxheight => $h);
     # or tikz macro (see corescopes)
@@ -754,6 +757,7 @@ DefMacro('\pgfsys@shadingoutsidepgfpicture{}', <<'EoTeX');
     \pgf@picminy=0pt%
     \pgf@picmaxx=\pgf@x%
     \pgf@picmaxy=\pgf@y%
+    \def\pgf@shift@baseline{0pt}%
     \pgfsys@typesetpicturebox{\pgfpic}%
   \endgroup
 EoTeX

--- a/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
+++ b/lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
@@ -934,7 +934,7 @@ sub tikzAlignmentBindings {
 
 # Note that pgf *seems* to have set the coordinate system to the center(?) (w/ \pgfsys@transformcm)
 # Additionally, there's a svg:g outside the alignment (w/ ltx_svg_fog)
-# The following tweaks (heuristically) the transform to position the alignment object
+# The following tweaks the transform to position the alignment object
 #
 # Coordinates are currently pgf: y moves UP
 # Coordinates of alignment are : y moves DOWN
@@ -944,14 +944,14 @@ sub openTikzAlignment {
   my $h          = ($props{cheight} && $props{cheight}->pxValue) || 0;
   my $d          = ($props{cdepth}  && $props{cdepth}->pxValue)  || 0;
   my @rowheights = ($props{rowheights}   ? @{ $props{rowheights} }   : (Dimension(0)));
+  my @rowdepths  = ($props{rowdepths}    ? @{ $props{rowdepths} }    : (Dimension(0)));
   my @colwidths  = ($props{columnwidths} ? @{ $props{columnwidths} } : (Dimension(0)));
   my $x          = 0;
-  # This SHOULD be just $h+$d, but the shift is necessary to align
-  # w/additional material outside the \halign ( arrows & such)
-  my $y = ($h + $d) - $rowheights[-1]->pxValue / 2;    # HEURISTIC adjustment! half of LAST row!?
+  my $y          = ($h + $d) - $rowdepths[-1]->pxValue;    # set baseline to baseline of last row
   Debug("TIKZ Alignment size $w x $h + $d"
-      . "  rows: " . join(',', map { $_->pxValue; } @rowheights)
-      . "  cols: " . join(',', map { $_->pxValue; } @colwidths)
+      . "    rows: " . join(',', map { $_->pxValue; } @rowheights)
+      . "    cols: " . join(',', map { $_->pxValue; } @colwidths)
+      . "  depths: " . join(',', map { $_->pxValue; } @rowdepths)
       . " => alignment adjustment = $x, $y") if $LaTeXML::DEBUG{pgf};
   my $array = $doc->openElement($tag, class => 'ltx_tikzmatrix',
     _scopebegin => 1,

--- a/lib/LaTeXML/Package/xy.tex.ltxml
+++ b/lib/LaTeXML/Package/xy.tex.ltxml
@@ -90,7 +90,7 @@ DefConstructor('\lx@xy@svgnested Digested',
     return (width => $w, height => $y1, depth => $y0->negate, transform => $transform); });
 
 DefConstructor('\lx@xy@svg Digested',
-  "<ltx:picture><svg:svg overflow='visible' version='1.1' width='#pxwidth' height='#pxheight'>"
+"<ltx:picture imagedepth='#imagedepth'><svg:svg overflow='visible' version='1.1' width='#pxwidth' height='#pxheight' viewBox='#minx #miny #pxwidth #pxheight'>"
     . "<svg:g transform='#transform'>#1</svg:g>"
     . "</svg:svg></ltx:picture>",
   properties => sub {
@@ -101,14 +101,16 @@ DefConstructor('\lx@xy@svg Digested',
       if $LaTeXML::DEBUG{xy};
     my $w         = $x1->subtract($x0);
     my $h         = $y1->subtract($y0);
-    my $x         = $x0->negate->larger(Dimension(0));
+    my $x         = $x0->negate;
     my $yma       = Dimension(LookupValue('IN_MATH') ? '2.5pt' : 0);           # math-axis; fontdimen 22
-    my $y         = $y1->add($yma->subtract($y0->larger(Dimension(0))));
+    my $miny      = $yma->subtract($y0);
+    my $y         = $y1->add($yma->subtract($y0));
     my $transform = "matrix(1 0 0 -1 " . $x->pxValue . ' ' . $y->pxValue . ')';
     Debug("XY size: " . ToString($w) . ' x ' . ToString($h) . ' + ' . 0 . ' @ ' . ToString($x) . ' x ' . ToString($y))
 
       if $LaTeXML::DEBUG{xy};
     return (width => $w, height => $h, pxwidth => $w->pxValue, pxheight => $h->pxValue,
+      minx      => $x->pxValue, miny => $miny->pxValue, imagedepth => int($miny->pxValue + 0.5),
       transform => $transform); });
 
 DefPrimitive('\lx@xy@capturerange', sub {

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -443,6 +443,8 @@ span.ltx_framed       { display:inline-block; text-indent:0; } /* avoid padding/
 .ltx_svg_fog foreignObject > p { margin:0; padding:0; display:block; }
 /*.ltx_svg_fog foreignObject > p { margin:0; padding:0; display:block; white-space:nowrap; }*/
 
+.ltx_foreignobject_container { display:flex; width:100%; height:100%; align-items:end; justify-items:center; justify-content:center; }
+
 /*======================================================================
  Low-level Basics */
 /* Note that LaTeX(ML)'s font model doesn't map quite exactly to CSS's */

--- a/lib/LaTeXML/resources/RelaxNG/LaTeXML-common.rnc
+++ b/lib/LaTeXML/resources/RelaxNG/LaTeXML-common.rnc
@@ -273,7 +273,7 @@ Imageable.attributes =
   ## baseline of the content shown in the image.
   ## When displayed inilne, an image with a positive \attr{depth}
   ## should be shifted down relative to the baseline of neighboring material.
-  attribute imagedepth { xsd:integer }?,
+  attribute imagedepth { xsd:float }?,
 
   ## a description of the image
   attribute description { text }?

--- a/lib/LaTeXML/resources/RelaxNG/LaTeXML-common.rng
+++ b/lib/LaTeXML/resources/RelaxNG/LaTeXML-common.rng
@@ -408,7 +408,7 @@ Note that, unlike \TeX, this is the total height, including the depth (if any).<
 baseline of the content shown in the image.
 When displayed inilne, an image with a positive \attr{depth}
 should be shifted down relative to the baseline of neighboring material.</a:documentation>
-        <data type="integer"/>
+        <data type="float"/>
       </attribute>
     </optional>
     <optional>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
@@ -95,8 +95,17 @@
       <xsl:call-template name="add_classes"/>
       <xsl:call-template name="copy_foreign_attributes"/>
       <xsl:apply-templates select="." mode="add_RDFa"/>
+      <xsl:if test="@imagedepth | svg:svg/@style">
+        <xsl:attribute name="style">
+          <xsl:if test="@imagedepth">
+            <xsl:value-of select="concat('vertical-align:',-@imagedepth,'px')"/>
+            <xsl:if test="svg:svg/@style">;</xsl:if>
+          </xsl:if>
+          <xsl:value-of select="svg:svg/@style"/>
+        </xsl:attribute>
+      </xsl:if>
       <!-- but copy other svg:svg attributes -->
-      <xsl:for-each select="svg:svg/@*">
+      <xsl:for-each select="svg:svg/@*[name() != 'style']">
         <xsl:apply-templates select="." mode="copy-attribute"/>
       </xsl:for-each>
       <xsl:apply-templates select="svg:svg/*"/>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-picture-xhtml.xsl
@@ -148,10 +148,23 @@
         </xsl:choose>
       </xsl:for-each>
       <xsl:choose>
-        <!-- If foreignObject in a DIFFERENT namespace, copy as foreign markup -->
-        <xsl:when test="local-name()='foreignObject'
-                        and not(namespace-uri(child::*) = $SVG_NAMESPACE)">
-          <xsl:apply-templates mode='copy-foreign'/>
+        <xsl:when test="local-name()='foreignObject'">
+          <!-- center the content within foreignObject (note that display:flex does not work on foreignObject so we use two wrappers) -->
+          <xsl:element name="div" namespace="{$html_ns}">
+            <xsl:attribute name="class">ltx_foreignobject_container</xsl:attribute>
+            <xsl:element name="div" namespace="{$html_ns}">
+              <xsl:attribute name="class">ltx_foreignobject_content</xsl:attribute>
+              <!-- If foreignObject in a DIFFERENT namespace, copy as foreign markup -->
+              <xsl:choose>
+                <xsl:when test="not(namespace-uri(child::*) = $SVG_NAMESPACE)">
+                  <xsl:apply-templates mode='copy-foreign'/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:apply-templates/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:element>
+          </xsl:element>
         </xsl:when>
         <xsl:otherwise>
           <xsl:apply-templates/>


### PR DESCRIPTION
This includes #2502 (better horizontal alignment, mostly for XY), #2488 (better overall alignment of foreignObject, with TikZ matrix improvements), #2477 (PGF baseline), #2401 #2490 (respect PGF bounding boxes), #2397 #2396 (add SVG viewBox in both PGF and XY).

I didn't add `\pgfmathparse` because, ahem, it fails badly.

Edit: the document I have been using as reference
```latex
\documentclass{article}
\usepackage[all,cmtip]{xypic}
\usepackage{tikz}
\usetikzlibrary{cd}
\newcommand\tikzname{Ti\emph{k}Z}
\begin{document}

\xymatrix{A \ar[d]^q \\ B }

\noindent Inline \Xy-matrix: $\xymatrix{
  A \ar[rd] \ar^\phi[r] & B \\
                        & C }$.

\xymatrix{
A \ar@{->>}[rd] \ar@{^{(}->}[r]
&B \ar@{.>}[d]
&C \ar@{_{(}->}[l]\ar@{->>}[ld]\\
&D}

\[
\xymatrix{
T \ar@/_/[ddr]_y \ar@/^/[drr]^x \ar@{.>}[dr]|-{(x,y)}\\
&X \times_Z Y \ar[d]^q \ar[r]_p & X\ar[d]_f \\
&Y \ar[r]^g &Z}
\]

\noindent Inline \tikzname-picture: \begin{tikzpicture}
  \draw (0.5,0.5) node {$2$};
  \draw (1.5,0.5) node {$+$};
  \draw (3,0.5) node {$3$};
  \draw (4.5,0.5) node {$=$};
  \draw (7,0.5) node {$5$};
  \draw (0,0) node [below] {$0$} -- (1,0) node [below] {$1$};
  \draw (1.5,0) node {$+$};
  \draw (2,0) node [below] {$0$} -- (3,0) node [below] {$1$} -- (4,0) node [below] {$2$};
  \draw (4.5,0) node {$=$};
  \draw (5,0) node [below] {$0$} -- (6,0) node [below] {$1$};
  \draw [dashed] (6,0) -- (7,0);
  \draw (7,0) node [below] {$2$} -- (8,0) node [below] {$3$} -- (9,0) node [below] {$4$};
  \foreach \x in {0,1,2,3,4,5,6,7,8,9} {
      \fill (\x,0) circle (0.05);
    }
\end{tikzpicture}

\noindent Inline \tikzname-cd: \begin{tikzcd}
A \arrow[r, "\phi"] \arrow[d, red]
& B \arrow[d, "\psi" red] \\
C \arrow[r, red, "\eta" blue]
& |[blue, rotate=-15]| D
\end{tikzcd}

\noindent Another one: \begin{tikzcd}
  A \arrow[r, "\phi\eta" near start, "\psi"', "\eta" near end] & {\hbox{\large B}}
\end{tikzcd}

\end{document}
```