### PR TITLE
Have math rewrite patterns NOT distinguish between text and display style

### DIFF
--- a/lib/LaTeXML/Core/Rewrite.pm
+++ b/lib/LaTeXML/Core/Rewrite.pm
@@ -420,7 +420,9 @@ sub domToXPath {
   return ($xpath, $nnodes, @wilds); }
 
 # May need some work here;
-my %EXCLUDED_MATCH_ATTRIBUTES = (scriptpos => 1, 'xml:id' => 1, fontsize => 1);    # [CONSTANT]
+my %EXCLUDED_MATCH_ATTRIBUTES = (
+    scriptpos => 1, mathstyle => 1,
+    'xml:id' => 1, fontsize => 1);    # [CONSTANT]
 
 sub domToXPath_rec {
   my ($document, $node, $axis, $pos) = @_;


### PR DESCRIPTION
That is, `\lxDeclare[...]{$\sum_x$}` shouldn't match the pattern whether it is in textstyle or displaystyle. Seems safe and useful.