### PR TITLE
treat Cygwin as Unix, do not use ShellQuote on NetWare

### DIFF
--- a/lib/LaTeXML/Util/Pathname.pm
+++ b/lib/LaTeXML/Util/Pathname.pm
@@ -46,10 +46,11 @@ our @EXPORT = qw( &pathname_find &pathname_findall &pathname_kpsewhich
   &pathname_cwd &pathname_chdir &pathname_mkdir &pathname_copy
   &pathname_installation);
 
-my $ISWINDOWS;
+my ($DOSPATHS, $ISWINDOWS);
 
 BEGIN {
-  $ISWINDOWS = $^O =~ /^(MSWin|NetWare|cygwin)/i;
+  $DOSPATHS  = $^O =~ /^(MSWin|NetWare)/i;
+  $ISWINDOWS = $^O eq 'MSWin32';
   require Win32::ShellQuote if $ISWINDOWS;
 }
 
@@ -61,7 +62,7 @@ BEGIN {
 ### my $SEP         = '/';                          # [CONSTANT]
 # Some indicators that this is not sufficient? (calls to libraries/externals???)
 # PRELIMINARY test, probably need to be even more careful
-my $SEP         = ($ISWINDOWS ? '\\' : '/');    # [CONSTANT]
+my $SEP         = ($DOSPATHS  ? '\\' : '/');    # [CONSTANT]
 my $KPATHSEP    = ($ISWINDOWS ? ';'  : ':');    # [CONSTANT]
 my $LITERAL_RE  = '(?:literal)(?=:)';           # [CONSTANT]
 my $PROTOCOL_RE = '(?:https|http|ftp)(?=:)';    # [CONSTANT]


### PR DESCRIPTION
While I was looking at Windows things, I remember that LaTeXML is currently broken on Cygwin. This PR unbreaks it, although it comes with a big caveat: it assumes that kpsewhich is also a Cygwin binary.

Also, I was wrong to use Win32::ShellQuote on NetWare. Not that anybody was complaining.