### PR TITLE
encode and decode paths in Util::Pathname

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,6 +59,7 @@ WriteMakefile(NAME => 'LaTeXML',
   PREREQ_PM => {
     'Archive::Zip'      => 0,
     'DB_File'           => 0,
+    'Encode::Locale'    => 0,
     'File::Which'       => 0,
     'Getopt::Long'      => 2.37,
     'Image::Size'       => 0,

--- a/bin/latexml
+++ b/bin/latexml
@@ -22,6 +22,10 @@ use LaTeXML::Util::Pathname;
 use LaTeXML::Common::Error;
 use Encode;
 
+# decode @ARGV before further processing
+use Encode::Locale;
+Encode::Locale::decode_argv(Encode::FB_CROAK);
+
 #**********************************************************************
 # Parse command line
 my ($verbosity, $strict, $comments, $noparse, $includestyles) = (0, 0, 1, 0, 0);

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -41,6 +41,10 @@ use HTTP::Response;
 use HTTP::Request;
 use JSON::XS qw(decode_json);
 
+# decode @ARGV before further processing
+use Encode::Locale;
+Encode::Locale::decode_argv(Encode::FB_CROAK);
+
 # Determine if a socket server is installed locally and obtain its pathname:
 my $latexmls;
 $latexmls = catfile($RealBin_safe, 'latexmls') if (-e catfile($RealBin_safe, 'latexmls'));

--- a/bin/latexmlfind
+++ b/bin/latexmlfind
@@ -20,6 +20,10 @@ use LaTeXML::Common::XML;
 use Text::Wrap;
 use LaTeXML;    # Currently, just for version information.
 
+# decode @ARGV before further processing
+use Encode::Locale;
+Encode::Locale::decode_argv(Encode::FB_CROAK);
+
 #**********************************************************************
 # Parse command line
 my ($verbosity) = (0);
@@ -125,7 +129,7 @@ sub collect_matches {
   my ($description, $xpath) = @_;
   my @nodes = $XPATH->findnodes($xpath, $DOC);
   print "Query $description appears in " . scalar(@nodes) . " places\n" if $verbosity > -1;
-  print "  [XPath = \"$xpath\"]\n" if $verbosity > 0;
+  print "  [XPath = \"$xpath\"]\n"                                      if $verbosity > 0;
   foreach my $node (@nodes) {
     my $object = id_object($node);
     push(@{ $$object{items} }, $node); }
@@ -144,9 +148,9 @@ sub id_object {
     my $parent_object = id_object($node);
     my $type          = $node->localname;
     my $labels        = $node->getAttribute('labels');
-    my ($refnum) = $XPATH->findnodes("child::ltx:tags/ltx:tag[\@refnum]/text()", $node);
-    my ($title)  = $XPATH->findnodes("child::ltx:toctitle | child::ltx:title",   $node);
-    my $desc = ($refnum ? ($title ? "$refnum. " . $title->textContent : $refnum)
+    my ($refnum)      = $XPATH->findnodes("child::ltx:tags/ltx:tag[\@refnum]/text()", $node);
+    my ($title)       = $XPATH->findnodes("child::ltx:toctitle | child::ltx:title",   $node);
+    my $desc          = ($refnum ? ($title ? "$refnum. " . $title->textContent : $refnum)
       : ($title ? $title->textContent : ''));
     $desc =~ s/\s+/ /g;
     $OBJECTS{$id} = $object

--- a/bin/latexmlmath
+++ b/bin/latexmlmath
@@ -27,6 +27,10 @@ use LaTeXML::Post::CrossRef;
 use LaTeXML::Util::ObjectDB;
 use LaTeXML::Common::Error;
 
+# decode @ARGV before further processing
+use Encode::Locale;
+Encode::Locale::decode_argv(Encode::FB_CROAK);
+
 #**********************************************************************
 # Parse command line
 

--- a/bin/latexmlpost
+++ b/bin/latexmlpost
@@ -25,6 +25,10 @@ use LaTeXML::Post::Scan;
 use LaTeXML::Util::Pathname;
 use LaTeXML::Util::ObjectDB;
 
+# decode @ARGV before further processing
+use Encode::Locale;
+Encode::Locale::decode_argv(Encode::FB_CROAK);
+
 #======================================================================
 # Parse command line.
 #======================================================================


### PR DESCRIPTION
Fix #2413 and various straightforward file name encoding issues that can be addressed directly in Util::Pathname. It is stacked on top of #2544 because it also uses Encode::Locale, and of course it is easier to test if I can pass non-ASCII characters to latexmlpost.

This is not yet a complete fix for all encoding issues, such as #2336, because I still need to replace *every* call to `open`, `readdir`, `-r`, `-f`, and so on with suitable calls to `pathname_open` and similar. That's going to be a lot more invasive.