### PR TITLE
Be careful to inhibit-linebreaks in UnTeX 

### DIFF
--- a/lib/LaTeXML/Engine/BibTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/BibTeX.pool.ltxml
@@ -274,7 +274,7 @@ DefMacro('\bib@@names{}{}', sub {
     (T_CS('\bib@@@names'), T_BEGIN,
       (map { Invocation(T_CS('\bib@@@name'), $field, $_) }
 ##          processBibNameList(currentBibEntryField(ToString($field)))),
-          processBibNameList(UnTeX($names))),
+          processBibNameList(UnTeX($names, 1))),
       T_END); });
 
 # Now, we define

--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -2292,8 +2292,8 @@ DefConstructor('\lx@equationgroup@subnumbering@begin',
     AssignValue(SAVED_EQUATION_NUMBER => LookupRegister('\c@equation'));
     $whatsit->setProperties(%eqn);
     ResetCounter('equation');
-    DefMacroI('\theequation',    undef, UnTeX($eqnum) . '\alph{equation}');
-    DefMacroI('\theequation@ID', undef, UnTeX($eqn{id}) . '.\@equation@ID'); });
+    DefMacroI('\theequation',    undef, UnTeX($eqnum, 1) . '\alph{equation}');
+    DefMacroI('\theequation@ID', undef, UnTeX($eqn{id}, 1) . '.\@equation@ID'); });
 Tag('ltx:equationgroup', autoClose => 1);
 DefConstructor('\lx@equationgroup@subnumbering@end', sub {
     $_[0]->maybeCloseElement('ltx:equationgroup'); },
@@ -3122,7 +3122,7 @@ sub defineNewTheorem {
     afterDigestBegin => sub {
       my $name = $_[1]->getArg(1);
       Digest('\the\thm@bodyfont\the\thm@styling'
-          . '\def\lx@thistheorem{' . ($name ? UnTeX($name) : '') . '}'); },
+          . '\def\lx@thistheorem{' . ($name ? UnTeX($name, 1) : '') . '}'); },
     beforeDigestEnd => sub { Digest('\thm@doendmark\the\thm@postwork'); },
     properties      => sub {
       my %ctr = ();
@@ -4549,7 +4549,7 @@ DefParameterType('SanitizedVerbatim', sub {
     # the strangeness comes from the original TeX workflow requiring multiple conversion calls,
     # alongside a call to the `makeidx` binary, which we don't do in latexml. This parameter type
     # emulates one important aspect implied by those steps.
-    $arg = TokenizeInternal(UnTeX($arg));
+    $arg = TokenizeInternal(UnTeX($arg, 1));
     return $arg; },
   reversion => sub { (T_BEGIN, Revert($_[0]), T_END); });
 
@@ -6481,7 +6481,7 @@ DefPrimitive('\protected@write Number {}{}', sub {
     if (my $filename = LookupValue('output_file:' . $port)) {
       my $handle   = $filename . '_contents';
       my $contents = LookupValue($handle);
-      AssignValue($handle => $contents . UnTeX($tokens) . "\n", 'global'); }
+      AssignValue($handle => $contents . UnTeX($tokens, 1) . "\n", 'global'); }
     else {
       Note(UnTeX($tokens)); }
     $stomach->egroup;

--- a/lib/LaTeXML/Package/amsrefs.sty.ltxml
+++ b/lib/LaTeXML/Package/amsrefs.sty.ltxml
@@ -45,7 +45,7 @@ DefMacro('\bib{}{} RequiredKeyVals:amsrefs', sub {
     my @rawpairs = $keyvals->getPairs;
     my @fields;
     while (@rawpairs) {
-      push(@fields, [lc(shift(@rawpairs)), UnTeX(shift(@rawpairs))]); }
+      push(@fields, [lc(shift(@rawpairs)), UnTeX(shift(@rawpairs), 1)]); }
     AssignValue('BIBENTRY@' . NormalizeBibKey($key)
         => LaTeXML::Pre::BibTeX::Entry->new(ToString($type), $key, [@fields], [@fields]));
     Invocation(T_CS('\ProcessBibTeXEntry'), T_OTHER($key)); });

--- a/lib/LaTeXML/Package/cases.sty.ltxml
+++ b/lib/LaTeXML/Package/cases.sty.ltxml
@@ -59,8 +59,8 @@ DefPrimitive('\lx@numcases@subnumbering@begin', sub {
     my $eqnum = Expand(T_CS('\theequation'));
     AssignValue(SAVED_EQUATION_NUMBER => LookupRegister('\c@equation'));
     ResetCounter('equation');
-    DefMacro('\theequation',    UnTeX($eqnum) . '\alph{equation}');
-    DefMacro('\theequation@ID', UnTeX($eqn{id}) . '.\@equation@ID'); });
+    DefMacro('\theequation',    UnTeX($eqnum, 1) . '\alph{equation}');
+    DefMacro('\theequation@ID', UnTeX($eqn{id}, 1) . '.\@equation@ID'); });
 DefPrimitive('\lx@numcases@subnumbering@end', sub {
     AssignRegister('\c@equation', LookupValue('SAVED_EQUATION_NUMBER'), 'global'); });
 

--- a/lib/LaTeXML/Package/dcolumn.sty.ltxml
+++ b/lib/LaTeXML/Package/dcolumn.sty.ltxml
@@ -36,7 +36,7 @@ DefMacro('\DC@{}{}{}', sub {
     $delim = ToString($delim);
     if ($delim ne ToString($todelim)) {
       $STATE->assignMathcode($delim => 0x8000);
-      DefMacroI(T_CS($delim), undef, '\lx@hidden@bgroup\lx@unactivate{' . $delim . '}\lx@wrap[role=PERIOD]{' . UnTeX($todelim) . '}\lx@hidden@egroup');
+      DefMacroI(T_CS($delim), undef, '\lx@hidden@bgroup\lx@unactivate{' . $delim . '}\lx@wrap[role=PERIOD]{' . UnTeX($todelim, 1) . '}\lx@hidden@egroup');
     }
     # We need to temporarily deactivate '$'
     Let(T_CS('\DC@saved@dollar'), T_MATH);

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -300,7 +300,7 @@ sub listingsReadRawString {
         push(@tokens, $token); } }
     while (@tokens && $tokens[-1]->getCatcode == CC_SPACE) {    # Remove trailing space
       pop(@tokens); } }
-  return UnTeX(Tokens(@tokens)); }
+  return UnTeX(Tokens(@tokens), 1); }
 
 # Read raw strings for environment, until matching \end{$environment}
 sub listingsReadRawLines {

--- a/lib/LaTeXML/Package/mathtools.sty.ltxml
+++ b/lib/LaTeXML/Package/mathtools.sty.ltxml
@@ -819,8 +819,8 @@ DefMacro('\newgathered{}{}{}{}', sub {
     # Really should be making the pre/post_line into separate columns!!!
     DefMacroI('\\' . $name, undef,
       '\@ams@multirow@bindings{name=' . $name . '}['
-        . 'before_row=\lx@hidden@noalign{' . UnTeX($pre_line) . '},'
-        . 'after_row=\lx@hidden@noalign{' . UnTeX($post_line) . '}'
+        . 'before_row=\lx@hidden@noalign{' . UnTeX($pre_line, 1) . '},'
+        . 'after_row=\lx@hidden@noalign{' . UnTeX($post_line, 1) . '}'
         . ']\@@newgathered@dummy\lx@begin@alignment');
     DefMacroI('\end' . $name, undef,
       Tokens(T_CS('\lx@end@alignment'), T_CS('\@end@gathered'), $after)); });


### PR DESCRIPTION
This PR adjusts calls to `UnTeX` to  inhibit-linebreaks when used to create Tokens for further TeX processing; particularly when used in a context where `%` might not even trigger a comment, like `listings`. (A perhaps unfortunate API design, requires an extra flag in such cases).

Fixes #2553