### PR TITLE
some MathML operator dictionary fixes and tests

### DIFF
--- a/lib/LaTeXML/Post/MathML/OperatorDictionary.pm
+++ b/lib/LaTeXML/Post/MathML/OperatorDictionary.pm
@@ -102,7 +102,7 @@ sub lookup_category {
   # Otherwise, if it has two characters:
   if ($len == 2) {
     my $code2 = ord(substr($content, 1, 1));
-    # [NOT YET HANDLED] If Content is the surrogate pairs corresponding to
+    # [ADDED TO $Content_form] If Content is the surrogate pairs corresponding to
     #   U+1EEF0 ARABIC MATHEMATICAL OPERATOR MEEM WITH HAH WITH TATWEEL
     #   or U+1EEF1 ARABIC MATHEMATICAL OPERATOR HAH WITH DAL and Form is postfix,
     #   exit with category I.
@@ -214,6 +214,8 @@ BEGIN {
       # 22 entries (13 Unicode ranges) in postfix form:
       decode_ranges(
 "[U+005E-U+005F], {U+007E}, {U+00AF}, [U+02C6-U+02C7], {U+02C9}, {U+02CD}, {U+02DC}, {U+02F7}, {U+0302}, {U+203E}, [U+2322-U+2323], [U+23B4-U+23B5], [U+23DC-U+23E1]", 'I'),
+      # additional range that the MathML Core spec handles in 'Step 2'
+      decode_ranges("[U+1EEF0-U+1EEF1]", 'I'),
     },
   };
 

--- a/lib/LaTeXML/Post/MathML/OperatorDictionary.pm
+++ b/lib/LaTeXML/Post/MathML/OperatorDictionary.pm
@@ -116,8 +116,8 @@ sub lookup_category {
     #   then replace Content with the Unicode character "U+0320
     #   plus the index of Content in Operators_2_ascii_chars"
     #   and move to step 3.
-    elsif (my ($p) = grep { $$Operators_2_ascii_chars[$_] ? ($_) : (); } 0 .. $#$Operators_2_ascii_chars) {
-      $code1 += $p;
+    elsif (my ($p) = grep { $$Operators_2_ascii_chars[$_] eq $content ? ($_) : (); } 0 .. $#$Operators_2_ascii_chars) {
+      $code1   = 0x320 + $p;
       $content = chr($code1); }
     # Otherwise exit with category Default.
     else {

--- a/lib/LaTeXML/Post/MathML/OperatorDictionary.pm
+++ b/lib/LaTeXML/Post/MathML/OperatorDictionary.pm
@@ -116,9 +116,8 @@ sub lookup_category {
     #   then replace Content with the Unicode character "U+0320
     #   plus the index of Content in Operators_2_ascii_chars"
     #   and move to step 3.
-    elsif (my ($p) = grep { $$Operators_2_ascii_chars[$_] eq $content ? ($_) : (); } 0 .. $#$Operators_2_ascii_chars) {
-      $code1   = 0x320 + $p;
-      $content = chr($code1); }
+    elsif (my $p = $$Operators_2_ascii_chars{$content}) {
+      $content = chr($p); }
     # Otherwise exit with category Default.
     else {
       return 'Default'; } }
@@ -158,8 +157,11 @@ BEGIN {
   #   Total size: 82 entries, 90 bytes
   #   (assuming characters are UTF-16 and 1-byte range lengths).
   # Operators_2_ascii_chars 18 entries (2-characters ASCII strings):
-  $Operators_2_ascii_chars = [
-'!!', '!=', '&&', '**', '*=', '++', '+=', '--', '-=', '->', '//', '/=', ':=', '<=', '<>', '==', '>=', '||'];
+  {
+    my @ops = ('!!', '!=', '&&', '**', '*=', '++', '+=', '--', '-=', '->', '//', '/=', ':=', '<=', '<>', '==', '>=', '||');
+    # precompute 'U+0320 + index' from 'Step 2'
+    foreach (0 .. $#ops) { $$Operators_2_ascii_chars{ $ops[$_] } = 0x320 + $_; }
+  }
   # Note that fence & separator properties have no visible effect, but are for semantics
   # Operators_fence 61 entries (16 Unicode ranges):
   $Operators_fence = { decode_ranges(

--- a/t/post/simplemath-post.xml
+++ b/t/post/simplemath-post.xml
@@ -126,6 +126,38 @@
         </XMath>
         <m:math alttext="\hat{f}a" display="block"><m:mrow><m:mover accent="true"><m:mi>f</m:mi><m:mo>^</m:mo></m:mover><m:mo>⁢</m:mo><m:mi>a</m:mi></m:mrow></m:math></Math>
     </equation>
+    <equation xml:id="S0.Ex6">
+      <Math mode="display" tex="a\mathbin{F}b" text="F@(a, b)" xml:id="S0.Ex6.m1">
+        <XMath>
+          <XMApp>
+            <XMTok meaning="plus" role="BINOP">F</XMTok>
+            <XMTok font="italic" role="ID">a</XMTok>
+            <XMTok font="italic" role="ID">b</XMTok>
+          </XMApp>
+        </XMath>
+        <m:math alttext="a\mathbin{F}b" display="block"><m:mrow><m:mi>a</m:mi><m:mo lspace="0.222em" rspace="0.222em">F</m:mo><m:mi>b</m:mi></m:mrow></m:math></Math>
+    </equation>
+    <equation xml:id="S0.Ex7">
+      <Math mode="display" tex="a\mathbin{&amp;&amp;}b" text="&amp;&amp;@(a, b)" xml:id="S0.Ex7.m1">
+        <XMath>
+          <XMApp>
+            <XMTok meaning="plus" role="BINOP">&amp;&amp;</XMTok>
+            <XMTok font="italic" role="ID">a</XMTok>
+            <XMTok font="italic" role="ID">b</XMTok>
+          </XMApp>
+        </XMath>
+        <m:math alttext="a\mathbin{&amp;&amp;}b" display="block"><m:mrow><m:mi>a</m:mi><m:mo>&amp;&amp;</m:mo><m:mi>b</m:mi></m:mrow></m:math></Math>
+    </equation>
+    <equation xml:id="S0.Ex8">
+      <Math mode="display" tex="a!!" text="adouble-factorial" xml:id="S0.Ex8.m1">
+        <XMath>
+          <XMApp>
+            <XMTok meaning="double-factorial" role="POSTFIX">!!</XMTok>
+            <XMTok font="italic" role="ID">a</XMTok>
+          </XMApp>
+        </XMath>
+        <m:math alttext="a!!" display="block"><m:mrow><m:mi>a</m:mi><m:mo>!!</m:mo></m:mrow></m:math></Math>
+    </equation>
   </para>
   <section labels="LABEL:sec:restricted" xml:id="S1">
     <tags>

--- a/t/post/simplemath.xml
+++ b/t/post/simplemath.xml
@@ -128,6 +128,38 @@
         </XMath>
       </Math>
     </equation>
+    <equation xml:id="S0.Ex6">
+      <Math mode="display" tex="a\mathbin{F}b" text="F@(a, b)" xml:id="S0.Ex6.m1">
+        <XMath>
+          <XMApp>
+            <XMTok meaning="plus" role="BINOP">F</XMTok>
+            <XMTok font="italic" role="ID">a</XMTok>
+            <XMTok font="italic" role="ID">b</XMTok>
+          </XMApp>
+        </XMath>
+      </Math>
+    </equation>
+    <equation xml:id="S0.Ex7">
+      <Math mode="display" tex="a\mathbin{&amp;&amp;}b" text="&amp;&amp;@(a, b)" xml:id="S0.Ex7.m1">
+        <XMath>
+          <XMApp>
+            <XMTok meaning="plus" role="BINOP">&amp;&amp;</XMTok>
+            <XMTok font="italic" role="ID">a</XMTok>
+            <XMTok font="italic" role="ID">b</XMTok>
+          </XMApp>
+        </XMath>
+      </Math>
+    </equation>
+    <equation xml:id="S0.Ex8">
+      <Math mode="display" tex="a!!" text="adouble-factorial" xml:id="S0.Ex8.m1">
+        <XMath>
+          <XMApp>
+            <XMTok meaning="double-factorial" role="POSTFIX">!!</XMTok>
+            <XMTok font="italic" role="ID">a</XMTok>
+          </XMApp>
+        </XMath>
+      </Math>
+    </equation>
   </para>
   <section labels="LABEL:sec:restricted" xml:id="S1">
     <tags>


### PR DESCRIPTION
I noticed some typos in the MathML operator dictionary code and fixed them.

To be sure, I added a couple of artificial tests in t/post/simplemath.xml to verify that the code is working as intended (e.g. now `&&` is correctly recognised as binary operator, so it does not get lspace/rspace attributes).