### PR TITLE
allow setting a maximum number of warnings

### DIFF
--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -383,6 +383,10 @@ sub Warn {
   my $formatted = generateMessage("Warning:" . $category . ":" . ToString($object),
     $where, $message, 0, @details);
   _printline($formatted);
+  # Optional: practical guards for max warnings, (e.g. to avoid infinite loops overflowings disks)
+  if (my $maxwarnings = ($state && $state->lookupValue('MAX_WARNINGS'))) {
+    if (($state->getStatus('warning') || 0) > $maxwarnings) {
+      Fatal('too_many_warnings', $maxwarnings, $where, "Too many warnings (> $maxwarnings)!"); } }
   return; }
 
 # Informational message; results likely unaffected


### PR DESCRIPTION
Fixes #2308 - following the approach for maximum number of errors.

The cost is calling a `lookupValue` every time we emit a Warning, which is possibly OK?

If this seems acceptable, I plan on combining it with a run-specific binding, for example `ar5iv.sty.ltxml` can include the line:

```perl
AssignValue('MAX_WARNINGS', 10_000, 'global');
```

So it is meant as an internal capability for the moment.