### PR TITLE
Lift \tikz@align@temp and define \pgfmathresult as 0.0

### DIFF
--- a/lib/LaTeXML/Package/tikz.sty.ltxml
+++ b/lib/LaTeXML/Package/tikz.sty.ltxml
@@ -21,6 +21,10 @@ use strict;
 use warnings;
 use LaTeXML::Package;
 
+# TODO: What do we need to do to get the native emulation working?
+DefMacro('\pgfmathresult',   '0.0');
+DefMacro('\tikz@align@temp', '\pgfmathresult');
+
 InputDefinitions('tikz', type => 'sty', noltxml => 1);
 
 # Not absolutely necessary to redefine this, but it makes sure
@@ -46,9 +50,6 @@ DefPrimitive('\use@@tikzlibrary{}', sub {
         AssignCatcode('|', $barcc);
     } }
     return; });
-
-# TODO: What do we need to do to get the native emulation working?
-DefMacro('\tikz@align@temp', '\pgfmathresult');
 
 # TODO: Why is this macro failing to get picked up?
 DefMacro('\tikzcdset', '\pgfqkeys{/tikz/commutative diagrams}');


### PR DESCRIPTION
This is an oddball PR in need of extra eyes+feedback. It is motivated by [arXiv/html_feedback#3723](https://github.com/arXiv/html_feedback/issues/3723), which discusses arXiv:2203.00837v4.

The exact technical issue reduces to:
```tex
\documentclass{article}
\usepackage{tikz}
\begin{document}
\begin{tikzpicture}[align=center]
\node (1) {example};
\end{tikzpicture}
\end{document}
```

which throws an error in latexml (and is fine in pdflatex):
```
latexml (LaTeXML version 0.8.8; revision a23fe9af) processing test.tex
Error:undefined:\pgfmathresult The token T_CS[\pgfmathresult] is not defined. at test.tex; line 5 col 0
Warning:expected:<number> Missing number (Dimension), treated as zero. at test.tex; line 5 col 0
```

The code that deals with this curious macro is in `frontendlayer/tikz/tikz.code.tex`.

As you can see from the current PR diff, this was somewhat violently patched on top of `tikz.sty.ltxml` as the `\tikz@align@temp` macro never seemed to be getting picked up in our tests. Clearly the `\tikz@align@...` emulation is partial and somehow skips over various bits - and it is clearly used as this error is only produced when the `[align=center]` option is set in the source.

Thoughts? This may or may not be of interest for @xworld21, I am just tagging for visibility - but no expectation for feedback.

Edit: Oh, and about this PR - simply defining a default zero value for `\pgfmathresult` fixes the issue, and I lifted the two macros up before the load raw for visibility. But it definitely feels like I patched a symptom.