### PR TITLE
robust path join in import.sty.ltxml

### DIFF
--- a/lib/LaTeXML/Package/import.sty.ltxml
+++ b/lib/LaTeXML/Package/import.sty.ltxml
@@ -13,7 +13,6 @@
 package LaTeXML::Package::Pool;
 use strict;
 use warnings;
-use Config;
 use LaTeXML::Package;
 use LaTeXML::Util::Pathname;
 #======================================================================
@@ -35,12 +34,11 @@ DefPrimitive('\lx@append@path OptionalMatch:* {}', sub {
     return unless $path;
     if (my @paths = @{ LookupValue('SEARCHPATHS') }) {
       my $lead_path = shift(@paths);
-      $lead_path =~ s/\/+$//;
-      my $newpath = join($Config::Config{'path_sep'}, ($lead_path, $path));
+      my $newpath   = pathname_concat($lead_path, $path);
       if ($star) {    # * omits TEXINPUTS!
-        AssignValue(SEARCHPATHS => [pathname_canonical($newpath)]); }
+        AssignValue(SEARCHPATHS => [$newpath]); }
       else {
-        AssignValue(SEARCHPATHS => [pathname_canonical($newpath), @paths]); } }
+        AssignValue(SEARCHPATHS => [$newpath, @paths]); } }
     return; });
 
 DefMacro('\import OptionalMatch:* {}{}',       '{\lx@set@path #1{#2} \input{#3}}');

--- a/lib/LaTeXML/Package/import.sty.ltxml
+++ b/lib/LaTeXML/Package/import.sty.ltxml
@@ -13,6 +13,7 @@
 package LaTeXML::Package::Pool;
 use strict;
 use warnings;
+use Config;
 use LaTeXML::Package;
 use LaTeXML::Util::Pathname;
 #======================================================================
@@ -31,8 +32,11 @@ DefPrimitive('\lx@set@path OptionalMatch:* {}', sub {
 DefPrimitive('\lx@append@path OptionalMatch:* {}', sub {
     my ($stomach, $star, $path) = @_;
     $path = ToString(Expand($path));
+    return unless $path;
     if (my @paths = @{ LookupValue('SEARCHPATHS') }) {
-      my $newpath = shift(@paths) . $path;
+      my $lead_path = shift(@paths);
+      $lead_path =~ s/\/+$//;
+      my $newpath = join($Config::Config{'path_sep'}, ($lead_path, $path));
       if ($star) {    # * omits TEXINPUTS!
         AssignValue(SEARCHPATHS => [pathname_canonical($newpath)]); }
       else {


### PR DESCRIPTION
Fixes [arXiv:2103.14899](https://ar5iv.labs.arxiv.org/html/2103.14899), reported in [ar5iv:535](https://github.com/dginev/ar5iv/issues/535).

The concrete use example was:
```tex
\subimport{./}{Main/Tex/01_introduction}
\subimport{./}{Main/Tex/02_related_works}
\subimport{./}{Main/Tex/03_proposed}
```

The issue was particularly visible when using the `.zip` input to latexml (appending the raw `.` char was invalidating the unpacked sandbox path, hence all relative imports were failing).

A bit of care to always use a path separator improves the arXiv article to Warning status.