### PR TITLE
[site] switch to transitive dependency on libxml2 and libxslt1.1 for Debian

### DIFF
--- a/doc/site/index.tex
+++ b/doc/site/index.tex
@@ -451,7 +451,7 @@ sudo apt-get install   \
   libarchive-zip-perl libfile-which-perl libimage-size-perl  \
   libio-string-perl libjson-xs-perl libtext-unidecode-perl \
   libparse-recdescent-perl liburi-perl libuuid-tiny-perl libwww-perl \
-  libxml2 libxml-libxml-perl libxslt1.1 libxml-libxslt-perl  \
+  libxml-libxml-perl libxml-libxslt-perl  \
   texlive-latex-base imagemagick libimage-magick-perl
 \end{lstlisting}
 See note \ref{get.perl-doc} about optional installation of \texttt{perl-doc}.


### PR DESCRIPTION
Motivating discussion from the .deb maintainers here:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1106715

This would also need a live site rebuild (by @brucemiller )