### PR TITLE
ensure \Big and variants use TeXDelimiter parameters

### DIFF
--- a/lib/LaTeXML/Engine/Base_ParameterTypes.pool.ltxml
+++ b/lib/LaTeXML/Engine/Base_ParameterTypes.pool.ltxml
@@ -360,19 +360,23 @@ sub readDigested {
   no warnings 'recursion';
   my ($gullet) = @_;
   $gullet->skipSpaces;
-  my $ismath = $STATE->lookupValue('IN_MATH');
-  my @list   = ();
+  my $ismath  = $STATE->lookupValue('IN_MATH');
+  my @list    = ();
+  my $grouped = 0;
   my $token;
   do { $token = $gullet->readXToken(0);
   } while (defined $token && (($token->getCatcode == CC_SPACE) || $token->equals(T_CS('\relax'))));
   if    (!defined $token) { }
   elsif ($token->getCatcode == CC_BEGIN) {
+    $grouped = 1;
     Digest($token);
     push(@list, $STATE->getStomach->digestNextBody()); pop(@list); }    # content w/o the braces
   else {
     push(@list, $STATE->getStomach->invokeToken($token)); }
   @list = grep { ref $_ ne 'LaTeXML::Core::Comment' } @list;
-  return List(@list, mode => ($ismath ? 'math' : 'text')); }
+  my $list = List(@list, mode => ($ismath ? 'math' : 'text'));
+  $list->setProperty('grouped', $grouped) if $grouped;
+  return $list; }
 
 DefParameterType('Digested', \&readDigested,
   undigested => 1,                                           # since _already_ digested.
@@ -383,8 +387,11 @@ DefParameterType('Digested', \&readDigested,
 # but we don't actually restrict to those.
 # Here, we just read a single Digested thing, but reversion gets no braces
 DefParameterType('TeXDelimiter', \&readDigested,
-  undigested => 1,                         # since _already_ digested.
-  reversion  => sub { Revert($_[0]); });
+  undigested => 1,      # since _already_ digested.
+  reversion  => sub {
+    return $_[0]->getProperty('grouped') ?
+      (T_BEGIN, Revert($_[0]), T_END) :
+      Revert($_[0]); });
 
 # A variation: Digest until we encounter a given token!
 DefParameterType('DigestUntil', sub {

--- a/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
@@ -458,9 +458,9 @@ sub revertScript {
 #  * should italic correction be omitted in deep subscripts?
 sub scriptSizer {
   my ($script, $base, $prev, $op, $pos) = @_;
-  my $bfont  = $base   && $base->getFont;
-  my $style  = $base   && $bfont->getMathstyle || 'text';
-  my $syfont = 'cmsy'.($bfont && $bfont->getSize || 10);
+  my $bfont  = $base && $base->getFont;
+  my $style  = $base && $bfont->getMathstyle || 'text';
+  my $syfont = 'cmsy' . ($bfont && $bfont->getSize || 10);
   my ($ws, $hs, $ds) = map { $_->valueOf } $script->getSize;
   my ($wb, $hb, $db) = map { $_->valueOf } ($base ? $base->getSize
     : LookupValue('font')->getNominalSize);
@@ -475,18 +475,18 @@ sub scriptSizer {
     else {
       $d = $db + $hs + $ds; } }
   else {
-    my $wp = ($prev && $prev->getWidth) || 0;    # as if max of width & prev script's width
-    my $xheight  = getFontDimen($syfont, 5);
-    my $space    = LookupRegister('\scriptspace')->valueOf;
+    my $wp      = ($prev && $prev->getWidth) || 0;           # as if max of width & prev script's width
+    my $xheight = getFontDimen($syfont, 5);
+    my $space   = LookupRegister('\scriptspace')->valueOf;
     $ws += $space;
     $w = max(0, $ws - $wp);
     if ($op eq 'SUPERSCRIPT') {
-      my $supshift = getFontDimen($syfont, # displaystyle:13, cramped:15, else 14;
+      my $supshift = getFontDimen($syfont,                   # displaystyle:13, cramped:15, else 14;
         ($style eq 'display' ? 13 : ($style eq 'scriptscript' ? 15 : 14)));
-      $h = max($hb, $hs + max($ds + $xheight/4, $supshift)); }
+      $h = max($hb, $hs + max($ds + $xheight / 4, $supshift)); }
     else {
       my $subshift = getFontDimen($syfont, 16);
-      $d = max($db, $ds + max($hs - $xheight*0.8, $subshift)); } }
+      $d = max($db, $ds + max($hs - $xheight * 0.8, $subshift)); } }
   $w = Dimension($w); $h = Dimension($h); $d = Dimension($d);
   return ($w, $h, $d); }
 
@@ -732,20 +732,21 @@ our %DELIMITER_MAP =
   "\x{21D5}" => { lrole => 'OPEN',    rrole => 'CLOSE', name => 'Updownarrow' },    # ??
   );
 
+sub checkDelimiterHints {
+  my ($stomach, $whatsit) = @_;
+  $whatsit->setProperty(hint => 1) if ToString($whatsit->getArg(1)) eq '.';
+  return; }
+
 # The \lx@left, \lx@right versions are like \left,\right but without any extra grouping
 DefConstructor('\lx@left TeXDelimiter',
   "?#hint(<ltx:XMHint/>)(#1)",
-  afterDigest => sub { my ($stomach, $whatsit) = @_;
-    $whatsit->setProperty(hint => 1) if ToString($whatsit->getArg(1)) eq '.';
-    return; },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { augmentDelimiterProperties($_[0], $_[1], 'OPEN'); },
   alias          => '\left');
 
 DefConstructor('\lx@right TeXDelimiter',
   "?#hint(<ltx:XMHint/>)(#1)",
-  afterDigest => sub { my ($stomach, $whatsit) = @_;
-    $whatsit->setProperty(hint => 1) if ToString($whatsit->getArg(1)) eq '.';
-    return; },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { augmentDelimiterProperties($_[0], $_[1], 'CLOSE'); },
   alias          => '\right');
 
@@ -755,7 +756,7 @@ DefConstructor('\lx@right TeXDelimiter',
 DefConstructor('\left TeXDelimiter',
   "?#hint(<ltx:XMHint/>)(#1)",
   afterDigest => sub { my ($stomach, $whatsit) = @_;
-    $whatsit->setProperty(hint => 1) if ToString($whatsit->getArg(1)) eq '.';
+    checkDelimiterHints($stomach, $whatsit);
     $stomach->getGullet->unread(T_CS('\lx@hidden@bgroup'));
     return; },
   afterConstruct => sub { augmentDelimiterProperties($_[0], $_[1], 'OPEN'); });

--- a/lib/LaTeXML/Engine/plain.pool.ltxml
+++ b/lib/LaTeXML/Engine/plain.pool.ltxml
@@ -1272,10 +1272,14 @@ DefMathI('\bracevert', undef, "|", font => { series => 'bold' }, role => 'VERTBA
 
 # These originally had Token as parameter, rather than {}..... Why?
 # Note that in TeX, \big{((} will only enlarge the 1st paren!!!
-DefConstructor('\big {}',  '#1', bounded => 1, font => { size => 'big' });
-DefConstructor('\Big {}',  '#1', bounded => 1, font => { size => 'Big' });
-DefConstructor('\bigg {}', '#1', bounded => 1, font => { size => 'bigg' });
-DefConstructor('\Bigg {}', '#1', bounded => 1, font => { size => 'Bigg' });
+DefConstructor('\big TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'big' },
+  afterDigest => \&checkDelimiterHints);
+DefConstructor('\Big TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'Big' },
+  afterDigest => \&checkDelimiterHints);
+DefConstructor('\bigg TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'bigg' },
+  afterDigest => \&checkDelimiterHints);
+DefConstructor('\Bigg TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'Bigg' },
+  afterDigest => \&checkDelimiterHints);
 
 sub addDelimiterRole {
   my ($document, $role) = @_;
@@ -1291,32 +1295,44 @@ sub addDelimiterRole {
   return; }
 
 # The "m" versions are defined in e-Tex and other places.
-DefConstructor('\bigl {}', '#1', bounded => 1, font => { size => 'big' },
+DefConstructor('\bigl TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'big' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'OPEN'); });
-DefConstructor('\bigm {}', '#1', bounded => 1, font => { size => 'big' },
+DefConstructor('\bigm TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'big' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'MIDDLE'); });
-DefConstructor('\bigr {}', '#1', bounded => 1, font => { size => 'big' },
+DefConstructor('\bigr TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'big' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'CLOSE'); });
 
-DefConstructor('\Bigl {}', '#1', bounded => 1, font => { size => 'Big' },
+DefConstructor('\Bigl TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'Big' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'OPEN'); });
-DefConstructor('\Bigm {}', '#1', bounded => 1, font => { size => 'Big' },
+DefConstructor('\Bigm TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'Big' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'MIDDLE'); });
-DefConstructor('\Bigr {}', '#1', bounded => 1, font => { size => 'Big' },
+DefConstructor('\Bigr TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'Big' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'CLOSE'); });
 
-DefConstructor('\biggl {}', '#1', bounded => 1, font => { size => 'bigg' },
+DefConstructor('\biggl TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'bigg' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'OPEN'); });
-DefConstructor('\biggm {}', '#1', bounded => 1, font => { size => 'bigg' },
+DefConstructor('\biggm TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'bigg' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'MIDDLE'); });
-DefConstructor('\biggr {}', '#1', bounded => 1, font => { size => 'bigg' },
+DefConstructor('\biggr TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'bigg' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'CLOSE'); });
 
-DefConstructor('\Biggl {}', '#1', bounded => 1, font => { size => 'Bigg' },
+DefConstructor('\Biggl TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'Bigg' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'OPEN'); });
-DefConstructor('\Biggm {}', '#1', bounded => 1, font => { size => 'Bigg' },
+DefConstructor('\Biggm TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'Bigg' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'MIDDLE'); });
-DefConstructor('\Biggr {}', '#1', bounded => 1, font => { size => 'Bigg' },
+DefConstructor('\Biggr TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)', bounded => 1, font => { size => 'Bigg' },
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'CLOSE'); });
 
 Let('\vert', T_OTHER('|'));

--- a/lib/LaTeXML/Package/revsymb.sty.ltxml
+++ b/lib/LaTeXML/Package/revsymb.sty.ltxml
@@ -28,28 +28,36 @@ DefMacro('\Bbb{}', '\mathbb{#1}');
 # These constructors DO create Tokens with the appropriate series & size font attributes;
 # However, the way delimiters are stored in the parsed math representation (as attributes)
 # loses that font information, so that these tokens will appear as normal delimiters in the mathml.
-DefConstructor('\biglb Token', '#1',
+DefConstructor('\biglb TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)',
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'OPEN'); },
   font           => { size => 'big', series => 'bold', forcebold => 1 }, bounded => 1);
-DefConstructor('\bigrb Token', '#1',
+DefConstructor('\bigrb TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)',
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'CLOSE'); },
   font           => { size => 'big', series => 'bold', forcebold => 1 }, bounded => 1);
-DefConstructor('\Biglb Token', '#1',
+DefConstructor('\Biglb TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)',
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'OPEN'); },
   font           => { size => 'Big', series => 'bold', forcebold => 1 }, bounded => 1);
-DefConstructor('\Bigrb Token', '#1',
+DefConstructor('\Bigrb TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)',
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'CLOSE'); },
   font           => { size => 'Big', series => 'bold', forcebold => 1 }, bounded => 1);
-DefConstructor('\bigglb Token', '#1',
+DefConstructor('\bigglb TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)',
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'OPEN'); },
   font           => { size => 'bigg', series => 'bold', forcebold => 1 }, bounded => 1);
-DefConstructor('\biggrb Token', '#1',
+DefConstructor('\biggrb TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)',
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'CLOSE'); },
   font           => { size => 'bigg', series => 'bold', forcebold => 1 }, bounded => 1);
-DefConstructor('\Bigglb Token', '#1',
+DefConstructor('\Bigglb TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)',
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'OPEN'); },
   font           => { size => 'Bigg', series => 'bold', forcebold => 1 }, bounded => 1);
-DefConstructor('\Biggrb Token', '#1',
+DefConstructor('\Biggrb TeXDelimiter', '?#hint(<ltx:XMHint/>)(#1)',
+  afterDigest    => \&checkDelimiterHints,
   afterConstruct => sub { addDelimiterRole($_[0], 'CLOSE'); },
   font           => { size => 'Bigg', series => 'bold', forcebold => 1 }, bounded => 1);
 

--- a/t/ams/cd.xml
+++ b/t/ams/cd.xml
@@ -116,7 +116,7 @@
         <tag>(2)</tag>
         <tag role="refnum">2</tag>
       </tags>
-      <Math mode="display" tex="\begin{CD}\operatorname{cov}(\mathcal{L})@&gt;{i}&gt;{j}&gt;\operatorname{non}(\mathcal%&#10;{K})@){i}){})\operatorname{cf}(\mathcal{K})@&gt;{}&gt;{j}&gt;\operatorname{cf}(\mathcal%&#10;{L})\\&#10;@V{}V{}V\Big{\|}\Big{\|}@A{}A{}A\\&#10;\operatorname{add}(\mathcal{L})@&lt;{}&lt;{}&lt;\operatorname{add}(\mathcal{K})@({}({}(%&#10;\operatorname{cov}(\mathcal{K})@&lt;{}&lt;{}&lt;\operatorname{non}(\mathcal{L})\end{CD}" text="commutative-diagram@(Array[[cov@(L), (rightarrow ^ i) _ j, non@(K), rightarrow ^ i, cf@(K), rightarrow _ j, cf@(L)], [downarrow, , ||, , ||, , uparrow, , ], [add@(L), leftarrow, add@(K), leftarrow, cov@(K), leftarrow, non@(L)]])" xml:id="S0.E2.m1">
+      <Math mode="display" tex="\begin{CD}\operatorname{cov}(\mathcal{L})@&gt;{i}&gt;{j}&gt;\operatorname{non}(\mathcal%&#10;{K})@){i}){})\operatorname{cf}(\mathcal{K})@&gt;{}&gt;{j}&gt;\operatorname{cf}(\mathcal%&#10;{L})\\&#10;@V{}V{}V\Big\|\Big\|@A{}A{}A\\&#10;\operatorname{add}(\mathcal{L})@&lt;{}&lt;{}&lt;\operatorname{add}(\mathcal{K})@({}({}(%&#10;\operatorname{cov}(\mathcal{K})@&lt;{}&lt;{}&lt;\operatorname{non}(\mathcal{L})\end{CD}" text="commutative-diagram@(Array[[cov@(L), (rightarrow ^ i) _ j, non@(K), rightarrow ^ i, cf@(K), rightarrow _ j, cf@(L)], [downarrow, , ||, , ||, , uparrow, , ], [add@(L), leftarrow, add@(K), leftarrow, cov@(K), leftarrow, non@(L)]])" xml:id="S0.E2.m1">
         <XMath>
           <XMDual>
             <XMApp>

--- a/t/ams/mathtools.xml
+++ b/t/ams/mathtools.xml
@@ -3499,7 +3499,7 @@ Then a switch of tag forms.</p>
     <title><tag close=" ">7</tag>Delimiters</title>
     <para xml:id="S7.p1">
       <equation xml:id="S7.Ex51">
-        <Math mode="display" tex="\lvert\frac{a}{c}\rvert\quad\left\lvert\frac{a}{c}\right\rvert\quad\Bigg{%&#10;\lvert}\frac{a}{b}\Bigg{\rvert}" text="list@(absolute-value@(a / c), absolute-value@(a / c), absolute-value@(a / b))" xml:id="S7.Ex51.m1">
+        <Math mode="display" tex="\lvert\frac{a}{c}\rvert\quad\left\lvert\frac{a}{c}\right\rvert\quad\Bigg\lvert%&#10;\frac{a}{b}\Bigg\rvert" text="list@(absolute-value@(a / c), absolute-value@(a / c), absolute-value@(a / b))" xml:id="S7.Ex51.m1">
           <XMath>
             <XMDual>
               <XMApp>
@@ -3564,7 +3564,7 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S7.p2">
       <equation xml:id="S7.Ex52">
-        <Math mode="display" tex="\lvert\frac{a}{b}\rvert\quad\left\lvert\frac{a}{b}\right\rvert\quad\big{\lvert%&#10;}\frac{a}{b}\big{\rvert}\quad\Bigg{\lvert}\frac{a}{b}\Bigg{\rvert}" text="list@(absolute-value@(a / b), absolute-value@(a / b), absolute-value@(a / b), absolute-value@(a / b))" xml:id="S7.Ex52.m1">
+        <Math mode="display" tex="\lvert\frac{a}{b}\rvert\quad\left\lvert\frac{a}{b}\right\rvert\quad\big\lvert%&#10;\frac{a}{b}\big\rvert\quad\Bigg\lvert\frac{a}{b}\Bigg\rvert" text="list@(absolute-value@(a / b), absolute-value@(a / b), absolute-value@(a / b), absolute-value@(a / b))" xml:id="S7.Ex52.m1">
           <XMath>
             <XMDual>
               <XMApp>
@@ -3694,7 +3694,7 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S7.p3">
       <equation xml:id="S7.Ex54">
-        <Math mode="display" tex="\left\langle A,\frac{1}{2}\right\rangle\quad\Big{\langle}B\,\Big{|}\,\sum_{k}f%&#10;_{k}\,\Big{|}\,C\Big{\rangle}" text="list@(list@(A, 1 / 2), quantum-operator-product@(B, (sum _ k)@(f _ k), C))" xml:id="S7.Ex54.m1">
+        <Math mode="display" tex="\left\langle A,\frac{1}{2}\right\rangle\quad\Big\langle B\,\Big|\,\sum_{k}f_{k%&#10;}\,\Big|\,C\Big\rangle" text="list@(list@(A, 1 / 2), quantum-operator-product@(B, (sum _ k)@(f _ k), C))" xml:id="S7.Ex54.m1">
           <XMath>
             <XMDual>
               <XMApp>
@@ -3860,7 +3860,7 @@ Then a switch of tag forms.</p>
             </XMDual>
           </XMath>
         </Math>
-<Math mode="inline" tex="\big{\langle}1\,\big{|}\,\frac{8}{\frac{4}{1}}\,\big{|}\,3\big{\rangle}" text="quantum-operator-product@(1, 8 / 4 / 1, 3)" xml:id="S7.p5.m3">
+<Math mode="inline" tex="\big\langle 1\,\big|\,\frac{8}{\frac{4}{1}}\,\big|\,3\big\rangle" text="quantum-operator-product@(1, 8 / 4 / 1, 3)" xml:id="S7.p5.m3">
           <XMath>
             <XMDual>
               <XMApp>
@@ -6652,7 +6652,7 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S10.p12">
       <equation xml:id="S10.Ex77">
-        <Math mode="display" tex="\bigl{(}\begin{smallmatrix}a&amp;b\\&#10;c&amp;d\end{smallmatrix}\bigr{)}" text="Array[[a, b], [c, d]]" xml:id="S10.Ex77.m1">
+        <Math mode="display" tex="\bigl(\begin{smallmatrix}a&amp;b\\&#10;c&amp;d\end{smallmatrix}\bigr)" text="Array[[a, b], [c, d]]" xml:id="S10.Ex77.m1">
           <XMath>
             <XMDual>
               <XMRef idref="S10.Ex77.m1.1"/>
@@ -6685,7 +6685,7 @@ Then a switch of tag forms.</p>
     </para>
     <para xml:id="S10.p13">
       <equation xml:id="S10.Ex78">
-        <Math mode="display" tex="\bigl{(}\begin{matrix}[l]a&amp;b\\&#10;c&amp;d\end{matrix}\bigr{)}" text="matrix@(Array[[a, b], [c, d]])" xml:id="S10.Ex78.m1">
+        <Math mode="display" tex="\bigl(\begin{matrix}[l]a&amp;b\\&#10;c&amp;d\end{matrix}\bigr)" text="matrix@(Array[[a, b], [c, d]])" xml:id="S10.Ex78.m1">
           <XMath>
             <XMDual>
               <XMRef idref="S10.Ex78.m1.2"/>

--- a/t/math/sampler.xml
+++ b/t/math/sampler.xml
@@ -213,7 +213,7 @@ attributes <text font="typewriter">@mathvariant</text>, <text font="typewriter">
           <tag>(5)</tag>
           <tag role="refnum">5</tag>
         </tags>
-        <Math class="ltx_math_unparsed" mode="display" tex="(a|b),\qquad\bigl{(}a\bigm{|}b\bigr{)},\qquad\Bigl{(}a\Bigm{|}b\Bigr{)},\qquad%&#10;\biggl{(}a\biggm{|}b\biggr{)},\qquad\Biggl{(}a\Biggm{|}b\Biggr{)}" xml:id="S1.E5.m1">
+        <Math class="ltx_math_unparsed" mode="display" tex="(a|b),\qquad\bigl(a\bigm|b\bigr),\qquad\Bigl(a\Bigm|b\Bigr),\qquad\biggl(a%&#10;\biggm|b\biggr),\qquad\Biggl(a\Biggm|b\Biggr)" xml:id="S1.E5.m1">
           <XMath>
             <XMWrap>
               <XMTok role="OPEN" stretchy="false">(</XMTok>


### PR DESCRIPTION
Fixes #2507. Review most welcome, just my first idea for an approach.

The premise of the PR is that \Big (and its variants) and \left should really take the same parameter types - currently called `TeXDelimiter`.

That requires a slight adjustment to use the `#hint` property check for `.` and a little more care to group reversions only when a T_BEGIN was encountered in the argument.

Seems to work? My test file was derived from the issue and one comment:
```tex
\documentclass[11pt]{amsart}
\begin{document}
$\left[ \Big. x+y \right]$

$\left. \Big. x+y \right.$

$ \Big{((} x-z \Big{))} $
\end{document}
```

The advanced care for `\Big{((}` successfuly reading both parens but only modifying the first hasn't been added here - so both of those parens will continue to have their sizes modified.