### PR TITLE
Defer digesting frontmatter to \maketitle

### DIFF
--- a/lib/LaTeXML/Engine/Base_Utility.pool.ltxml
+++ b/lib/LaTeXML/Engine/Base_Utility.pool.ltxml
@@ -162,6 +162,14 @@ AssignValue(frontmatter => {}, 'global');
 
 DefConditionalI('\if@in@preamble', undef, sub { LookupValue('inPreamble'); });
 
+# Some frontmatter tags are replaceable by default, only one per document.
+our %ReplaceableFrontmatterTags = (
+  'ltx:title'    => 1,
+  'ltx:toctitle' => 1,
+  'ltx:subtitle' => 1,
+  'ltx:date'     => 1,
+  'ltx:abstract' => 1,
+  'ltx:keywords' => 1);
 # Add a new frontmatter item that will be enclosed in <$tag %attr>...</$tag>
 # The content is the result of digesting $tokens.
 # \@add@frontmatter[keys]{tag}[attributes]{content}
@@ -169,6 +177,12 @@ DefConditionalI('\if@in@preamble', undef, sub { LookupValue('inPreamble'); });
 #   replace (to replace the current entry, if any)
 #   ifnew   (only add if no previous entry)
 DefPrimitive('\@add@frontmatter OptionalKeyVals {} OptionalKeyVals {}', sub {
+    my ($stomach, $keys, $tag, $attr, $tokens) = @_;
+    AssignValue('@at@begin@maketitle', [], 'global') unless LookupValue('@at@begin@maketitle');
+    PushValue('@at@begin@maketitle',
+      Invocation(T_CS('\@add@frontmatter@now'), $keys, $tag, $attr, $tokens)->unlist);
+    return; });
+DefPrimitive('\@add@frontmatter@now OptionalKeyVals {} OptionalKeyVals {}', sub {
     my ($stomach, $keys, $tag, $attr, $tokens) = @_;
     # Digest this as if we're already in the document body!
     my $frontmatter = LookupValue('frontmatter');
@@ -178,10 +192,11 @@ DefPrimitive('\@add@frontmatter OptionalKeyVals {} OptionalKeyVals {}', sub {
     # (which should be inside or after this one!)
     # So, we append this entry before digesting
     $tag = ToString($tag);
-    if ($keys && $keys->hasKey('replace') && $$frontmatter{$tag}) {    # if replace and previous entries
-      $$frontmatter{$tag} = []; }                                      # Remove previous entries
-    if ($keys && $keys->hasKey('ifnew') && $$frontmatter{$tag}) {      # if ifnew and previous entries
-      return; }                                                        # Skip this one.
+    my $replaceable = $ReplaceableFrontmatterTags{$tag} || ($keys && $keys->hasKey('replace'));
+    if ($replaceable && exists $$frontmatter{$tag}) {    # if replace and previous entries
+      $$frontmatter{$tag} = []; }                        # Remove previous entries
+    if ($keys && $keys->hasKey('ifnew') && exists $$frontmatter{$tag}) { # if ifnew and previous entries
+      return; }                                                          # Skip this one.
     my $entry = [$tag, undef, 'to-be-filled-in'];
     push(@{ $$frontmatter{$tag} }, $entry);
     if ($attr) {
@@ -197,6 +212,12 @@ DefPrimitive('\@add@frontmatter OptionalKeyVals {} OptionalKeyVals {}', sub {
 
 # \@add@to@frontmatter{tag}[label]{content}
 DefPrimitive('\@add@to@frontmatter {} [] {}', sub {
+    my ($stomach, $tag, $label, $tokens) = @_;
+    AssignValue('@at@begin@maketitle', [], 'global') unless LookupValue('@at@begin@maketitle');
+    PushValue('@at@begin@maketitle',
+      Invocation(T_CS('\@add@to@frontmatter@now'), $tag, $label, $tokens)->unlist);
+    return; });
+DefPrimitive('\@add@to@frontmatter@now {} [] {}', sub {
     my ($stomach, $tag, $label, $tokens) = @_;
     $tag   = ToString($tag);
     $label = ToString($label) if $label;
@@ -274,7 +295,21 @@ Tag('ltx:document', 'afterOpen:late' => sub {
 # Request Frontmatter to appear HERE (if not already done),
 # deferring it from document begin.
 DefConstructor('\lx@frontmatterhere', sub { insertFrontMatter($_[0]); },
-  afterDigest => sub { AssignValue(frontmatter_deferred => 1, 'global'); });
+  afterDigest => sub {
+    my ($stomach) = @_;
+    my @boxes = ();
+    if (my $frontmatter_tks = LookupValue('@at@begin@maketitle')) {
+      push(@boxes, $stomach->digest(Tokens(@$frontmatter_tks)));
+      AssignValue('@at@begin@maketitle', undef, 'global'); }
+    AssignValue(frontmatter_deferred => 1, 'global');
+    return @boxes; });
+DefPrimitiveI('\lx@frontmatter@fallback', undef, sub {
+    my ($stomach) = @_;
+    my @boxes = ();
+    if (my $frontmatter_tks = LookupValue('@at@begin@maketitle')) {
+      push(@boxes, $stomach->digest(Tokens(@$frontmatter_tks)));
+      AssignValue('@at@begin@maketitle', undef, 'global'); }
+    return @boxes; });
 
 # Maintain a list of classes that apply to the document root.
 # This might involve global style options, like leqno.

--- a/lib/LaTeXML/Engine/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/LaTeX.pool.ltxml
@@ -1227,10 +1227,14 @@ DefPrimitive('\ltx@authors@multiline', sub {
 
 DefMacro('\@add@conversion@date', '\@add@frontmatter{ltx:date}[role=creation]{\today}');
 
+# In case \@maketitle defines these - we can't yet emulate that - so we can map them to \and:
+Let('\And', '\and');
+Let('\AND', '\and');
 # Doesn't produce anything (we're already inserting frontmatter),
 # But, it does make the various frontmatter macros into no-ops.
 DefMacroI('\maketitle', undef,
   '\lx@frontmatterhere'
+    . '\let\lx@frontmatter@fallback\relax'
     . '\@startsection@hook'
     . '\global\let\thanks\relax'
     . '\global\let\maketitle\relax'
@@ -1243,6 +1247,10 @@ DefMacroI('\maketitle', undef,
     . '\global\let\author\relax'
     . '\global\let\date\relax'
     . '\global\let\and\relax', locked => 1);
+# In case \maketitle isn't used in the document, let's check for it.
+AddToMacro(T_CS('\@startsection@hook'), T_CS('\lx@frontmatter@fallback'));
+# in cases such as titlepage, the document end is the last fallback.
+AtEndDocument(T_CS('\lx@frontmatter@fallback'));
 
 DefMacro('\@thanks', '\@empty');
 # make a throwaway optional argument available for OmniBus use
@@ -2291,7 +2299,7 @@ DefConstructor('\lx@equationgroup@subnumbering@begin',
     AssignValue(SAVED_EQUATION_NUMBER => LookupRegister('\c@equation'));
     $whatsit->setProperties(%eqn);
     ResetCounter('equation');
-    DefMacroI('\theequation',    undef, UnTeX($eqnum, 1) . '\alph{equation}');
+    DefMacroI('\theequation',    undef, UnTeX($eqnum,   1) . '\alph{equation}');
     DefMacroI('\theequation@ID', undef, UnTeX($eqn{id}, 1) . '.\@equation@ID'); });
 Tag('ltx:equationgroup', autoClose => 1);
 DefConstructor('\lx@equationgroup@subnumbering@end', sub {


### PR DESCRIPTION
Fixes #1929, as well as [ar5iv#174](https://github.com/dginev/ar5iv/issues/174)

A simple add-on for binding `\AND` also adresses the ~30 reports in arXiv resembling [html_feedback#1284](https://github.com/arXiv/html_feedback/issues/1284)

The PR is a spiritual successor to Tom's #1937. In this attempt, I tried to achieve the minimal goals of:
 - defer frontmatter digestion to `\maketitle` (accumulating the tokens until then)
 - mark certain frontmatter as replacable instead of extensible (to avoid duplicated entries, e.g. `\title`).
 - bind `\And`, `\AND` in the common LaTeX kernel to compensate for the limited `\@maketitle` emulation. I also realized emulating fully isn't actually a nice solution here, as they often get bound to `\end{table} ... \hfill ... \begin{table}` which isn't really useful in the latexml context. It is too low-level, we don't rely on `{table}` for the frontmatter XML.
  
What the PR does not attempt is coordinating any internal macros (such as `\@title`, `\@author`, `\@maketitle`, etc) with LaTeXML's frontmatter API. A more thorough approach may be available after the big kernel upgrade, but I wanted to have a simple alternative available, in case we want it.

I was surprise how quickly I got to a working state while only using the existing tricks in the codebase - the `at@begin@maketitle` accumulator is inspired by `at@begin@document`.