### PR TITLE
avoid breakable mode in tcolorbox

### DIFF
--- a/lib/LaTeXML/Package/tcolorbox.sty.ltxml
+++ b/lib/LaTeXML/Package/tcolorbox.sty.ltxml
@@ -17,6 +17,8 @@ use LaTeXML::Package;
 
 # used in tcbbreakable.code.tex assuming it was defined? so:
 DefRegister('\doublecol@number' => Number(0));
+# Ensure only unbreakable mode is possible
+DefMacro('\tcb@init@breakable', '\tcb@init@unbreakable', locked => 1);
 
 RequirePackage('expl3');
 RequirePackage('xparse');


### PR DESCRIPTION
Fixes the example reported in https://github.com/brucemiller/LaTeXML/issues/2506#issuecomment-2922287738

I am not sure if there is a general+clean approach to veto-ing the load of a tcolorbox module, but I found a reliable low-level approach. That is, to ensure the initialization code for breakable never runs, by mapping it to the usual unbreakable case.

What I think can be reasoned through is that since latexml is not interested in the breaking aspects imposed by pages, avoiding that module entirely is concpetually more correct than loading its boilerplate code fully.

With this in place, I can focus on a couple of sizing questions, now that the conversion reliably produces HTML+SVG again.