### PR TITLE
bindings for pgfkeys, pgfmath, pgfrcs

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -664,10 +664,13 @@ lib/LaTeXML/Package/pdftexcmds.sty.ltxml
 lib/LaTeXML/Package/pgf.sty.ltxml
 lib/LaTeXML/Package/pgfcircutils.tex.ltxml
 lib/LaTeXML/Package/pgfkeys.code.tex.ltxml
+lib/LaTeXML/Package/pgfkeys.sty.ltxml
 lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+lib/LaTeXML/Package/pgfmath.sty.ltxml
 lib/LaTeXML/Package/pgfmathcalc.code.tex.ltxml
 lib/LaTeXML/Package/pgfplots.sty.ltxml
 lib/LaTeXML/Package/pgfplotstable.sty.ltxml
+lib/LaTeXML/Package/pgfrcs.sty.ltxml
 lib/LaTeXML/Package/pgfsys-latexml.def.ltxml
 lib/LaTeXML/Package/pgfutil-common.tex.ltxml
 lib/LaTeXML/Package/physics.sty.ltxml

--- a/lib/LaTeXML/Package/pgfkeys.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfkeys.sty.ltxml
@@ -1,0 +1,20 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  pgfkeys.sty                                                        | #
+# | Implementation for LaTeXML                                          | #
+# |---------------------------------------------------------------------| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+InputDefinitions('pgfkeys.code', type => 'tex');
+
+1;

--- a/lib/LaTeXML/Package/pgfmath.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.sty.ltxml
@@ -1,0 +1,23 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  pgfmath.sty                                                        | #
+# | Implementation for LaTeXML                                          | #
+# |---------------------------------------------------------------------| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+RequirePackage('pgfrcs');
+RequirePackage('pgfkeys');
+
+InputDefinitions('pgfmath.code', type => 'tex');
+
+1;

--- a/lib/LaTeXML/Package/pgfrcs.sty.ltxml
+++ b/lib/LaTeXML/Package/pgfrcs.sty.ltxml
@@ -1,0 +1,22 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  pgfrcs.sty                                                         | #
+# | Implementation for LaTeXML                                          | #
+# |---------------------------------------------------------------------| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+InputDefinitions('pgfutil-common', type => 'tex');
+InputDefinitions('pgfutil-latex',  type => 'def');
+InputDefinitions('pgfrcs.code',    type => 'tex');
+
+1;


### PR DESCRIPTION
These are simple top-level bindings for the already supported pgf internals in question.

Recently spotted this in the [arXiv:2508.00812 log](https://arxiv.org/html/2508.00812/__stdout.txt).

A simple test snippet is:
```tex
\documentclass{article}
\usepackage{pgfmath}
\begin{document}
\pgfmathapproxequalto{0.15}{0.1499999999}\pgfmathresult

\pgfmathapproxequalto{0.15}{0.144}\pgfmathresult
\end{document}
```