### PR TITLE
add etoolbox dependency to microtype

### DIFF
--- a/lib/LaTeXML/Package/microtype.sty.ltxml
+++ b/lib/LaTeXML/Package/microtype.sty.ltxml
@@ -24,6 +24,9 @@ use LaTeXML::Package;
 # Wouldn't it be nice!!
 # We'll just ignore this all for now...
 
+# etoolbox is sometimes used as implied, see arXiv:2507.04590v1
+RequirePackage('etoolbox');
+
 DefMacro('\microtypesetup{}',                            '');
 DefMacro('\DeclareMicrotypeSet OptionalMatch:* []{}{}',  '');
 DefMacro('\UseMicrotypeSet[]{}',                         '');


### PR DESCRIPTION
This is minor, but corrects a recent report from [arXiv/html_feedback#4418](https://github.com/arXiv/html_feedback/issues/4418).

etoolbox.sty is sometimes expected courtesy of microtype.sty loading it, and the failure mode can be a bit too harsh. In the report, the author used a toggle-based conditional, which led to most of the article getting "eaten" in the if branch that wasn't visited.

This PR simply adds the RequirePackage, following the raw sty.