### PR TITLE
Add directory on whatsin to the search paths

### DIFF
--- a/lib/LaTeXML/Common/Config.pm
+++ b/lib/LaTeXML/Common/Config.pm
@@ -220,6 +220,10 @@ sub read {
       $$opts{whatsin} = 'archive'; }
     elsif ($$opts{source} && ($$opts{source} =~ /\/$/)) {
       $$opts{whatsin} = 'directory'; } }
+  # If we are given a directory on input, add it to the searchpaths,
+  # as the actual tex source may be deeper within it (and will lose dir visibility)
+  if (($$opts{whatsin} || '') eq 'directory') {
+    push(@{ $$opts{paths} }, pathname_absolute($$opts{source})); }
   return $getOptions_success;
 }
 
@@ -420,7 +424,7 @@ sub _prepare_options {
       $$opts{whatsout} = 'archive';
     } else {
       $$opts{whatsout} = 'document';
-  } }
+    } }
   if ($$opts{format}) {
     # Lower-case for sanity's sake
     $$opts{format} = lc($$opts{format});


### PR DESCRIPTION
This was an oversight for a rare kind of input organization such as:
```
mydocument/00README.json
mydocument/main/main.tex
mydocument/sections/section-1.tex
mydocument/sections/section-2.tex
mydocument/figures/figure-1.png
...
```

With the invocation
```
latexmlc --whatsin=directory mydocument/
```

The `00README.json` will specify the path to the `main.tex` as the top-level file, and while the `sourcedirectory` was being correctly updated to `mydocument/` that wasn't actually added to the search paths. So when a conversion starts at `mydocument/main/main.tex`, an `\input{sections/section-1}` will no longer have visibility at the level above.

Simple fix, just add a directory input to the search paths -- in a way it is obviously correct.