### PR TITLE
Ar xiv sandbox 2

### DIFF
--- a/lib/LaTeXML/Package/graphics.sty.ltxml
+++ b/lib/LaTeXML/Package/graphics.sty.ltxml
@@ -276,7 +276,7 @@ sub graphicS_options {
 sub graphicX_options {
   my ($starred, $kv) = @_;
   my @options = ();
-  my @kv      = $kv->getPairs;
+  my @kv      = ($kv ? $kv->getPairs : ());
   push(@options, 'clip=true') if $starred;
   #  my $keepaspect;
   my ($saw_w, $saw_h);


### PR DESCRIPTION
Next batch of arXiv sandbox test patches. The main one here is to better manage associating the generated xml elements with the digested boxes responsible for them. In particular, as boxes get accumulated, to avoid keeping them in the cache where they cannot be garbage collected; this was causing massive memory use in certain cases.