### PR TITLE
add a sample owners file for easier PR reviewer tagging

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# For full documentation see
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These will be the default "owners" for everything in
+# the repo. Unless a later match takes precedence,
+# both will be requested for review when someone opens a pull request.
+
+* @brucemiller @dginev


### PR DESCRIPTION
This is a cosmetic github PR, which will automatically assign me and Bruce as reviewers to any incoming pull requests. But maybe just as conveniently - will assign each other on our own PRs.

Here is a link to the [github documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) as well as a sample file as used by the much larger tensorflow project [here](https://github.com/tensorflow/tensorflow/blob/master/CODEOWNERS).

We could make this more refined if we wished, and any more specific paths would override the star rule.