### PR TITLE
[Idea] introduce color variables for inline style attributes

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-common.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-common.xsl
@@ -610,15 +610,15 @@
     <xsl:if test="@yoffset">
       <xsl:value-of select="concat('position:relative; bottom:',@yoffset,';')"/>
     </xsl:if>
-    <xsl:if test="@color"><xsl:value-of select="concat('color:',@color,';')"/></xsl:if>
+    <xsl:if test="@color">
+      <xsl:value-of select="concat('color:',@color,';--inline-color:',@color,';')"/>
+    </xsl:if>
     <xsl:if test="@backgroundcolor">
-      <xsl:value-of select="concat('background-color:',@backgroundcolor,';')"/>
+      <xsl:value-of select="concat('background-color:',@backgroundcolor,';--inline-bg-color:',@backgroundcolor,';')"/>
     </xsl:if>
     <xsl:if test="@opacity"><xsl:value-of select="concat('opacity:',@opacity,';')"/></xsl:if>
     <xsl:if test="@framecolor">
-      <xsl:value-of select="'border-color: '"/>
-      <xsl:value-of select="@framecolor"/>
-      <xsl:value-of select="';'"/>
+      <xsl:value-of select="concat('border-color: ',@framecolor,';--inline-border-color: ',@framecolor,';')"/>
     </xsl:if>
     <xsl:if test="@cssstyle"><xsl:value-of select="concat(@cssstyle,';')"/></xsl:if>
   </xsl:template>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-inline-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-inline-xhtml.xsl
@@ -199,9 +199,10 @@
     <xsl:choose>
       <xsl:when test="@color">
         <xsl:value-of select="concat('background:',@color,';display:inline-block;')"/>
+        <xsl:value-of select="concat('--inline-bg-color:',@color,';')"/>
       </xsl:when>
       <!-- Note: width doesn't affect an inline element, but we don't want to be a block -->
-      <xsl:otherwise>background:black;display:inline-block;</xsl:otherwise>
+      <xsl:otherwise>background:black;display:inline-block;--inline-bg-color:black;</xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 


### PR DESCRIPTION
This manages to avoid a CSS limitation where a `color:` remapping can not use the `currentColor`, for the case of latexml's inline style attributes.

The idea is to employ dark mode rules such as:

```css
[data-theme="dark"] [style*="--inline-color:"] {
    color: oklch(from var(--inline-color) calc(0.8237 - l) c h) !important;
}
[data-theme="dark"] [style*="--inline-bg-color:"] {
    background-color: oklch(from var(--inline-bg-color) calc(0.8237 - l) c h) !important;
}
```

Which can generically cover a broad range of unknown colors used by authors (such as the 24,500 colors used in ar5iv today).