### PR TITLE
Use 'math', not 'inline_math'

### DIFF
--- a/lib/LaTeXML/Core/Box.pm
+++ b/lib/LaTeXML/Core/Box.pm
@@ -107,9 +107,9 @@ sub toString {
 
 # Methods for overloaded operators
 my %mode_abbrev = (
-  vertical    => 'V',  internal_vertical     => 'iV',
-  horizontal  => 'H',  restricted_horizontal => 'rH',
-  inline_math => 'iM', display_math          => 'dM');
+  vertical   => 'V', internal_vertical     => 'iV',
+  horizontal => 'H', restricted_horizontal => 'rH',
+  math       => 'M', display_math          => 'dM');
 
 sub _stringify {
   my ($self) = @_;

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -385,7 +385,7 @@ sub endgroup {
 #     This is a bound mode set by \hbox.
 #     It is the default mode for digesting Whatsit arguments, although they
 #     may be absorbed into paragraphs where line-breaks occur.
-#  inline_math : math within a horizontal mode. A bound mode.
+#  math : math within a horizontal mode. A bound mode.
 #  display_math : math within a vertical mode. A bound mode.
 #     Should be illegal in restricted_horizontal mode;
 #     Should leaveHorizontal if in horizontal mode.
@@ -396,7 +396,8 @@ our %bindable_mode = (
     restricted_horizontal => 'restricted_horizontal',
     vertical              => 'internal_vertical',
     internal_vertical     => 'internal_vertical',
-    inline_math           => 'inline_math',
+    math                  => 'math',
+    inline_math           => 'math',
     display_math          => 'display_math');
 
 # Switch to horizontal mode, w/o stacking the mode
@@ -441,7 +442,7 @@ sub repackHorizontal {
   while(@LaTeXML::LIST
         && ($item = $LaTeXML::LIST[-1])
         && (($mode = ($item->getProperty('mode')||'horizontal'))
-            =~ /^(?:horizontal|restricted_horizontal|inline_math)$/)) {
+            =~ /^(?:horizontal|restricted_horizontal|math)$/)) {
     # if ONLY horizontal mode spaces, we can prune them; it just makes an empty ltx:p
     $keep = 1 if ($mode ne 'horizontal') || ! $item->getProperty('isSpace');
     unshift(@para,pop(@LaTeXML::LIST)); }

--- a/lib/LaTeXML/Engine/TeX_Logic.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Logic.pool.ltxml
@@ -120,7 +120,7 @@ DefConditionalI('\ifvmode', undef, sub {
 DefConditionalI('\ifhmode', undef, sub {
   LookupValue('MODE') =~ /horizontal$/; });
 DefConditionalI('\ifinner', undef, sub {
-  LookupValue('MODE') =~ /^(?:restricted_horizontal|internal_vertical|inline_math)$/; });
+  LookupValue('MODE') =~ /^(?:restricted_horizontal|internal_vertical|math)$/; });
 DefConditionalI('\ifmmode', undef, sub {
   LookupValue('MODE') =~ /math$/; });
 

--- a/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
@@ -59,7 +59,7 @@ DefPrimitiveI('\lx@dollar@default', undef, sub {
           "Missing \$ closing display math.",
           "Ignoring; expect to be in wrong math/text mode.");
         $op = undef; } }
-    elsif ($mode eq 'inline_math') {
+    elsif ($mode eq 'math') {
       $op = '\\lx@end@inline@math'; }
     # Only check for 2nd $ when within a vertical mode
     elsif (($bound =~ /vertical$/) && ($gullet->ifNext(T_MATH))) {
@@ -148,12 +148,12 @@ DefConstructorI('\lx@begin@inline@math', undef,
   reversion    => Tokens(T_MATH),
   beforeDigest => sub {
     $_[0]->enterHorizontal;
-    $_[0]->beginMode('inline_math'); },
-  properties  => { mode => 'inline_math' },
+    $_[0]->beginMode('math'); },
+  properties  => { mode => 'math' },
   captureBody => 1);
 DefConstructorI('\\lx@end@inline@math', undef, "",
   reversion    => Tokens(T_MATH),
-  beforeDigest => sub { $_[0]->endMode('inline_math'); });
+  beforeDigest => sub { $_[0]->endMode('math'); });
 
 #======================================================================
 # Add the TeX code from the object that created this node,

--- a/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
+++ b/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
@@ -1957,7 +1957,7 @@ DefEnvironment('{math}',
     . "#body"
     . "</ltx:XMath>"
     . "</ltx:Math>",
-  mode => 'inline_math');
+  mode => 'math');
 
 Let('\curr@math@size', '\@empty');
 

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -3581,7 +3581,7 @@ DefPrimitive options are
 
 See L</"Common Options">.
 
-=item C<mode=E<gt> ('restricted_horizontal' | 'internal_vertical' | 'display_math' | 'inline_math')>
+=item C<mode=E<gt> ('restricted_horizontal' | 'internal_vertical' | 'display_math' | 'math')>
 
 Binds to this mode during digestion, with grouping.
 

--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -890,7 +890,7 @@ DefConstructor('\boxed@text{}',
     . "#1"
     . "</ltx:XMath>"
     . "</ltx:Math>",
-  mode         => 'inline_math', bounded => 1,
+  mode         => 'math', bounded => 1,
   beforeDigest => sub {
     Let("\\\\", '\lx@newline'); },
   alias => '\boxed');

--- a/lib/LaTeXML/Package/revtex3_support.sty.ltxml
+++ b/lib/LaTeXML/Package/revtex3_support.sty.ltxml
@@ -46,7 +46,7 @@ DefMacro('\endmathletters', '\lx@equationgroup@subnumbering@end');
 #======================================================================
 # Revtex perversely defines {equation} (roughly) to be a block $\displaymath ...$,
 # rather than $$...$$ ! Thus you can use $ within it to switch BACK to text!!!
-# we could do similar (eg. with mode=>'inline_math'), but we'd end up with alternating
+# we could do similar (eg. with mode=>'math'), but we'd end up with alternating
 # ltx:Math & text to be re-combined(?) rather than XMText within.
 # So, let's get tricky with rebinding $ to a magic decoding ring to decipher
 # when a $ means to Start or End either math or embedded text.


### PR DESCRIPTION
Use `math`, as Knuth does, to name the mode, rather than `inline_math`, avoiding confusion and weirdness. Should have been part of the earlier mode PR, but better late than never.