### PR TITLE
allow unbalanced \read and \readline to succeed

### DIFF
--- a/lib/LaTeXML/Engine/TeX_FileIO.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_FileIO.pool.ltxml
@@ -29,10 +29,10 @@ Let('\@currname', '\lx@empty');
 Let('\@currext',  '\lx@empty');
 
 DefMacro('\lx@pushfilename',
-    '\xdef\@currnamestack{{\@currname}{\@currext}{\the\catcode`\@}\@currnamestack}');
+  '\xdef\@currnamestack{{\@currname}{\@currext}{\the\catcode`\@}\@currnamestack}');
 DefMacro('\lx@popfilename', '\expandafter\lx@p@pfilename\@currnamestack\@nil');
 DefMacro('\lx@p@pfilename {}{}{} Until:\@nil',
-   '\gdef\@currname{#1}%
+  '\gdef\@currname{#1}%
     \gdef\@currext{#2}%
     \catcode`\@#3\relax
     \gdef\@currnamestack{#4}');
@@ -80,13 +80,14 @@ DefPrimitive('\read Number SkipKeyword:to SkipSpaces Token', sub {
       AssignValue(PRESERVE_NEWLINES => 2);    # Special EOL/EOF treatment for \read
       AssignValue(INCLUDE_COMMENTS  => 0);
       my @tokens = ();
-      my ($t, $level) = (undef, 0);
+      my ($t, $level, $skip) = (undef, 0, undef);
       while ($t = $mouth->readToken) {
         my $cc = $t->getCatcode;
-        push(@tokens, $t) unless $cc == CC_MARKER;    # End of line marker
-        $level++ if $cc == CC_BEGIN;
-        $level-- if $cc == CC_END;
-        last     if !$level && $mouth->isEOL; }
+        $level++  if $cc == CC_BEGIN;
+        $level--  if $cc == CC_END;
+        $skip = 1 if $level < 0;
+        push(@tokens, $t) unless $skip || ($cc == CC_MARKER);    # End of line marker
+        last if ($skip || !$level) && $mouth->isEOL; }
       $stomach->egroup;
       DefMacroI($token, undef, Tokens(@tokens), nopackParameters => 1); }
     return; });


### PR DESCRIPTION
Fixes #2429 . But it also merits further review and discussion.

Explanation of the diagnostics and possible choices in the details:

<details>

I first reduced the failing greek babel load to a minimal TeX equivalent:
```tex
\begin{filecontents}{test.ini}
sigma.final.3.0 = { ()"()[σΣ] } }
\end{filecontents}
\documentclass{article}
\begin{document}
\makeatletter

\newread\stream
\openin\stream=test.ini
\loop
    \if T\ifeof\stream F\fi T\relax % Trick, because inside \loop
    \read\stream to \aline
    \message{\meaning\aline}
\repeat
done.
\end{document}
```

Note that the `sigma.final.3.0` line has an actual error, and has been checked in with it in the texlive distribution - there is one more closing brace on that line than needed, making it unbalanced.

Next, I checked what TeX does exactly during that `\read`, and two of the relevant snippets appear to be:
<img width="600" height="323" alt="Screenshot From 2025-09-06 21-25-25" src="https://github.com/user-attachments/assets/b63687c9-e1c7-40f9-bcd5-b78eae849b5c" />

This implies that whatever the inner read_toks read does, it gets directly assigned to the CS. And within read_toks we get to the rule:
<img width="1116" height="610" alt="Screenshot From 2025-09-06 21-52-38" src="https://github.com/user-attachments/assets/b38c6b28-e247-4ff8-ad51-fc0a346fea77" />

Note the comment: `unmatched ‘}’ aborts the line`

Faced with that, I checked a couple of variants, and indeed TeX drops everything upto the end of the line when an unbalanced `}` is encountered. So the question is how best to implement that behavior - I am not quite sure I have the answer.

</details>

---

As a first attempt, I did one of the more obvious conservative changes:
 - Introduce a new option `allowUnbalanced` which permits an expansion to be unbalanced, by emitting an Error instead of a Fatal (or should this be even an Info?) and trimming down to the balanced portion of the tokens. Note that pdflatex is completely quiet when it does this trim.
 - Implements the option by adding `Tokens::toBalanced` and using it when necessary in `Expansion::new`.

One could also do all of this specifically inside the DefPrimitive code for `\read`, but the flag seems more reusable for `\readline`, which appears rather similar?

I think this is useful enough to share already, but definitely in need of discussion.