### PR TITLE
Typos

### DIFF
--- a/lib/LaTeXML/MathParser.pm
+++ b/lib/LaTeXML/MathParser.pm
@@ -350,6 +350,9 @@ sub parse_rec {
           $attr{font} = $font->specialize($content); } }
       else {
         delete $attr{_font}; }
+      # Don't copy _box (as string!) from $node if $result already has _box recorded.
+      if (exists $attr{_box} && p_getAttribute($result,'_box')) {
+        delete $attr{_box}; }
       foreach my $key (keys %attr) {
         next unless ($key =~ /^_/) || $document->canHaveAttribute($rtag, $key);
         my $value = $attr{$key};

--- a/lib/LaTeXML/Package/amscd.sty.ltxml
+++ b/lib/LaTeXML/Package/amscd.sty.ltxml
@@ -114,15 +114,15 @@ DefMacro('\leftrightarrowfill@ {}', '\lx@amscd@leftrightarrow');
 
 # These are stretchy, widenned version; should be \minCDarrowsidth or \minaw@ wide
 DefPrimitive('\lx@amscd@leftarrow', sub {
-    Box("\x{2190}", undef, undef, '\leftarrow',
+    Box("\x{2190}", undef, undef, T_CS('\leftarrow'),
       role => 'ARROW', stretchy => 'true', meaning => 'leftarrow',
       class=>'ltx_horizontally_stretchy',  width => Dimension('30pt')); });
 DefPrimitive('\lx@amscd@rightarrow', sub {
-    Box("\x{2192}", undef, undef, '\rightarrow',
+    Box("\x{2192}", undef, undef, T_CS('\rightarrow'),
       role => 'ARROW', stretchy => 'true', meaning => 'rightarrow',
       class=>'ltx_horizontally_stretchy',  width => Dimension('30pt')); });
 DefPrimitive('\lx@amscd@leftrightarrow', sub {
-    Box("\x{2194}", undef, undef, '\leftrightarrow',
+    Box("\x{2194}", undef, undef, T_CS('\leftrightarrow'),
       role => 'ARROW', stretchy => 'true', meaning => 'leftrightarrow',
       class=>'ltx_horizontally_stretchy',  width => Dimension('30pt')); });
 DefPrimitive('\lx@amscd@equals', sub {


### PR DESCRIPTION
This PR fixes a couple of minor issues that turned up: (1) The MathParser could mindlessly try to set the internal `_box` attribute (recording the Box responsible for an XML node) to the id of the box, rather than the actual box.  (2) Boxes record their reversion which should be Tokens, not a string.