### PR TITLE
Reading from mouth

### DIFF
--- a/lib/LaTeXML/Core/Alignment.pm
+++ b/lib/LaTeXML/Core/Alignment.pm
@@ -914,7 +914,7 @@ sub ReadAlignmentTemplate {
 
 sub parseAlignmentTemplate {
   my ($spec) = @_;
-  return $STATE->getStomach->getGullet->readingFromMouth(LaTeXML::Core::Mouth->new("{" . $spec . "}"), sub {
+  return $STATE->getStomach->getGullet->readingFromMouth("{" . $spec . "}", sub {
       ReadAlignmentTemplate($_[0]); }); }
 
 sub MatrixTemplate {

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -101,17 +101,30 @@ sub flush {
   $$self{mouthstack} = [];
   return; }
 
-# Do something, while reading stuff from a specific Mouth.
+# Do something, while reading stuff from a specific source Mouth.
+# If $source is a string or Tokens, a Mouth will be created to process it.
 # This reads ONLY from that mouth (or any mouth openned by code in that source),
 # and the mouth should end up empty afterwards, and only be closed here.
 sub readingFromMouth {
-  my ($self, $mouth, $closure) = @_;
+  my ($self, $source, $closure) = @_;
+  my $mouth;
+  my $intokens;
+  my $sourcetype = ref $source;
+  if (! $sourcetype) {          # for a string, create Mouth to read its content
+    $mouth = LaTeXML::Core::Mouth->new($source); }
+  elsif ($sourcetype =~ /^LaTeXML::Core::Tokens?$/) { # Tokens will be unread into Mouth
+    $mouth = LaTeXML::Core::Mouth->new();
+    $intokens = $source; }
+  else {
+    $mouth = $source; }         # Hopefully is a Mouth.
   openMouth($self, $mouth, 1);    # only allow mouth to be explicitly closed here.
+  $self->unread($intokens) if $intokens; # Preload the mouth
   my ($result, @result);
   if (wantarray) {
     @result = &$closure($self); }
   else {
     $result = &$closure($self); }
+  $self->skipSpaces;            # Skip any remaining spaces on input.
   # $mouth must still be open, with (at worst) empty autoclosable mouths in front of it
   while (1) {
     if ($$self{mouth} eq $mouth) {
@@ -716,9 +729,8 @@ sub readArg {
     return readBalanced($self, $expanded, 0, 0); }
   else {
     if ($expanded) {
-      return $self->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
-          $self->unread(T_BEGIN, $token, T_END);
-          return $self->readBalanced($expanded, 0, 1); }); }
+      return $self->readingFromMouth(Tokens(T_BEGIN, $token, T_END), sub {
+         readBalanced($self, $expanded, 0, 1); } ); }
     else {
       return Tokens($token); } } }
 

--- a/lib/LaTeXML/Core/Parameters.pm
+++ b/lib/LaTeXML/Core/Parameters.pm
@@ -78,13 +78,9 @@ sub readArgumentsAndDigest {
 sub reparseArgument {
   my ($self, $gullet, $tokens) = @_;
   if (defined $tokens) {
-    return $gullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {    # start with empty mouth
+    return $gullet->readingFromMouth($tokens, sub {
         no warnings 'recursion';
-        my ($gulletx) = @_;
-        $gulletx->unread($tokens);                                         # but put back tokens to be read
-        my @values = $self->readArguments($gulletx);
-        $gulletx->skipSpaces;
-        return @values; }); }
+        $self->readArguments($gullet); }); }
   else {
     return (); } }
 

--- a/lib/LaTeXML/Core/Stomach.pm
+++ b/lib/LaTeXML/Core/Stomach.pm
@@ -127,9 +127,7 @@ sub digest {
   no warnings 'recursion';
   return unless defined $tokens;
   return
-    $$self{gullet}->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
-      my ($gullet) = @_;
-      $gullet->unread($tokens);
+    $$self{gullet}->readingFromMouth($tokens, sub {
       $STATE->clearPrefixes;    # prefixes shouldn't apply here.
       my $mode      = $STATE->lookupValue('MODE');
       my $ismath    = $STATE->lookupValue('IN_MATH');

--- a/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
+++ b/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
@@ -5552,8 +5552,7 @@ sub latexChangeCase {
   my ($gullet, $reqcase, $tokens) = @_;
   my $case = $reqcase;
   $case = 'upper' if $reqcase eq 'sentence' or $reqcase eq 'title';
-  return $gullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
-      $gullet->unread($tokens);
+  return $gullet->readingFromMouth($tokens, sub {
       my @toks   = ();
       my $inmath = 0;
       ## Read while expanding, but careful not to expand \dont_expand'd tokens!

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -951,18 +951,16 @@ sub Expand {
   my (@tokens) = @_;
   return () unless @tokens;
   my $gullet = $STATE->getStomach->getGullet;
-  return $gullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
-      $gullet->unread(T_BEGIN, @tokens, T_END);
-      return $gullet->readBalanced(2, 0, 1); }); }
+  return $gullet->readingFromMouth(Tokens(T_BEGIN, @tokens, T_END), sub {
+    $gullet->readBalanced(2, 0, 1); }); }
 
 # Return $tokens, partially expanded (defer protected, and results of \the)
 sub ExpandPartially {
   my (@tokens) = @_;
   return () unless @tokens;
   my $gullet = $STATE->getStomach->getGullet;
-  return $gullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
-      $gullet->unread(T_BEGIN, @tokens, T_END);
-      return $gullet->readBalanced(1, 0, 1); }); }
+  return $gullet->readingFromMouth(Tokens(T_BEGIN, @tokens, T_END), sub {
+    $gullet->readBalanced(1, 0, 1); }); }
 
 sub Invocation {
   my ($token, @args) = @_;
@@ -1372,10 +1370,8 @@ sub LookupDimension {
     if ($defn->isRegister) {    # Easy (and proper) case.
       return $defn->valueOf; }
     else {
-      $STATE->getStomach->getGullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub { # start with empty mouth
-          my ($gullet) = @_;
-          $gullet->unread($cs);    # but put back tokens to be read
-          return $gullet->readDimension; }); } }
+      return $STATE->getStomach->getGullet->readingFromMouth($cs, sub {
+        $_[0]->readDimension; }); } }
   else {
     Warn('expected', 'register', $STATE->getStomach,
       "The control sequence " . ToString($cs) . " is not a register"); }

--- a/lib/LaTeXML/Package/calc.sty.ltxml
+++ b/lib/LaTeXML/Package/calc.sty.ltxml
@@ -112,10 +112,8 @@ DefPrimitive('\settototalheight{Variable} HBoxContents', sub {
 # Here, type = Number, Glue
 
 sub readExpression {
-  my ($ogullet, $type, $tokens) = @_;
-  return $ogullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
-      my ($gullet) = @_;
-      $gullet->unread($tokens);    # Really so weird?
+  my ($gullet, $type, $tokens) = @_;
+  return $gullet->readingFromMouth($tokens, sub {
       my $term = readTerm($gullet, $type);
       while (my $op = $gullet->readKeyword('+', '-')) {
         my $term2 = readTerm($gullet, $type);
@@ -161,11 +159,9 @@ sub readValue {
   # Evaluate <Real> values
   elsif (Equals($peek, T_CS('\real'))) {
     my $arg = $gullet->readArg;
-    return $gullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
-        my ($igullet) = @_;
-        $igullet->unread($arg);    # Really so weird?
-                                   # Make a Float, but round it AS-IF it had been a fixpoint number
-        return Float(kround($igullet->readFloat()->valueOf * $UNITY) / $UNITY); }); }
+    return $gullet->readingFromMouth($arg, sub {
+      # Make a Float, but round it AS-IF it had been a fixpoint number
+      return Float(kround($gullet->readFloat()->valueOf * $UNITY) / $UNITY); }); }
   elsif (Equals($peek, T_CS('\ratio'))) {
     my $x    = readExpression($gullet, 'Glue', $gullet->readArg);
     my $y    = readExpression($gullet, 'Glue', $gullet->readArg);

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -1102,16 +1102,15 @@ DefKeyVal('LST', 'morefvcmdparams', '');
 DefMacro('\lst@@literate OptionalMatch:* Until:\end', sub {
     my ($gullet, $star, $patterns) = @_;
     # * means do not replace within strings, comments,...
-    $gullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
-        my ($igullet) = @_;
-        $igullet->unread($patterns);
+    $gullet->readingFromMouth($patterns, sub {
         while (1) {    # $patterns is repeated triples:
           my ($pattern, $replacement, $length)
-            = ($igullet->readArg, $igullet->readArg, $igullet->readArg);
+            = ($gullet->readArg, $gullet->readArg, $gullet->readArg);
           last unless defined $pattern;
           UnshiftValue(LST_LITERATE
               => [ToString($pattern), $replacement, ($star ? 1 : 0), $length]); } });
     return; });
+
 #======================================================================
 # 4.17 Language definitions
 #======================================================================

--- a/lib/LaTeXML/Package/multido.sty.ltxml
+++ b/lib/LaTeXML/Package/multido.sty.ltxml
@@ -56,10 +56,8 @@ DefMacro('\multidostop', '\multidocount=\multido@count');
 #   Number are fixed point (and print that way!)
 # concievably variables can be redefined in middle of loop?
 DefMacro('\multido@@initvars@@{}', sub {
-    my ($ogullet, $variables) = @_;
-    $ogullet->readingFromMouth(LaTeXML::Core::Mouth->new(), sub {
-        my ($gullet) = @_;
-        $gullet->unread($variables);
+    my ($gullet, $variables) = @_;
+    $gullet->readingFromMouth($variables, sub {
         my @inits = ();
         my @steps = ();
         $gullet->skipSpaces;


### PR DESCRIPTION
This is a somewhat overdue tweak of the API for `$gullet->readingFromMouth(...` that allows the source to be a string or `Tokens`, rather than only a `LaTeXML::Core::Mouth`. In those new cases, an appropriate `Mouth` is created as needed, simplifying the most common use cases.