### PR TITLE
extract first rather than last image of multipage images

### DIFF
--- a/lib/LaTeXML/Util/Image.pm
+++ b/lib/LaTeXML/Util/Image.pm
@@ -448,6 +448,8 @@ sub image_read {
   if (!$source) {
     Error('imageprocessing', 'read', undef, "No image source given"); return; }
   return unless $source;
+  # read first page by default
+  $source .= '[0]';
   my $image = image_object();
   # Just in case this is pdf, set this option; ImageMagick defaults to MediaBox (Wrong!!!)
   image_internalop($image, 'Set',  option => 'pdf:use-cropbox=true') or return;


### PR DESCRIPTION
Fix #2639.

(Appending `[N]` to the file name is the documented way of selecting a particular frame, and it starts from 0, see https://imagemagick.org/Magick++/Image++.html.)