### PR TITLE
Bump \fmtversion to 2021/06/01 to satisfy memoir class requirements

### DIFF
--- a/lib/LaTeXML/Engine/latex_base.pool.ltxml
+++ b/lib/LaTeXML/Engine/latex_base.pool.ltxml
@@ -253,7 +253,7 @@ EOTeX
 # C.3.1 Making Sentences
 #======================================================================
 DefMacroI('\fmtname',    undef, 'LaTeX2e');
-DefMacroI('\fmtversion', undef, '2018/12/01');
+DefMacroI('\fmtversion', undef, '2021/06/01');
 
 #======================================================================
 # C.3.2 Making Paragraphs


### PR DESCRIPTION
This PR updates the hard-coded LaTeX format date in
`lib/LaTeXML/Engine/latex_base.pool.ltxml`:

  - DefMacroI('\fmtversion', undef, '2018/12/01');
  + DefMacroI('\fmtversion', undef, '2021/06/01');

Rationale:
- The `memoir` class (and some other modern packages) require at least LaTeX format `2021/06/01`.
- With the previous value (`2018/12/01`), LaTeXML fails immediately with:

    Class memoir Error: Your LaTeX release is too old.
    The memoir class requires at LaTeX format from at least 2021/06/01 onwards.

- After applying this patch locally, I was able to successfully process documents using `memoir` with LaTeXML.

This should unblock users of `memoir` and other classes that check `\fmtversion`.

**Notes:**
While running make test, I observed 3 failing subtests in t/81_babel.t.
However, the same failures occur when testing against the current master branch, so they appear unrelated to this change.