### PR TITLE
add lang attribute to top-level <html> in ePub

### DIFF
--- a/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-epub3.xsl
@@ -38,6 +38,14 @@
     <xsl:apply-templates select="." mode="doctype"/>
     <xsl:element name="html" namespace="{$html_ns}">
       <xsl:apply-templates select="." mode="begin"/>
+      <xsl:choose>
+        <xsl:when test="*/@xml:lang">
+          <xsl:apply-templates select="*/@xml:lang" mode="copy-attribute"/>
+        </xsl:when>
+        <xsl:otherwise><!-- the default language is English -->
+          <xsl:attribute name="lang">en</xsl:attribute>
+        </xsl:otherwise>
+      </xsl:choose>
       <xsl:apply-templates select="." mode="head"/>
       <xsl:apply-templates select="." mode="body"/>
       <xsl:apply-templates select="." mode="end"/>


### PR DESCRIPTION
Fixes #2661

I believe this was a simple oversight. I carried over the identical rule from `LaTeXML-webpage-xhtml.xsl`