### PR TITLE
index columns starting by 1 in Locator

### DIFF
--- a/lib/LaTeXML/Common/Locator.pm
+++ b/lib/LaTeXML/Common/Locator.pm
@@ -146,7 +146,7 @@ case of an anonymous string. C<$fromLine> and C<$fromCol> should be integers
 containing the line and column numbers of the start of the range in the source
 file, or undef if unknown. C<$toLine> and C<$toCol> should be the integers
 containing the line and column numbers of the end of the range, or undef 
-if a point is being referred to. 
+if a point is being referred to. Lines and columns should be 1-indexed.
 
 =item C<< $locator = LaTeXML::Common::Locator->newRange($from, $to); >>
 

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -196,7 +196,7 @@ sub getLocator {
   else {
     $fromLine = $toLine;
     $fromCol  = $toCol; }
-  return LaTeXML::Common::Locator->new($$self{source}, $fromLine, $fromCol, $toLine, $toCol); }
+  return LaTeXML::Common::Locator->new($$self{source}, $fromLine, $fromCol + 1, $toLine, $toCol + 1); }
 
 sub getSource {
   my ($self) = @_;

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -2738,7 +2738,7 @@ sub LoadFormat {
     && FindFile($format . '_dump', type => 'pool', notex => 1,
       installation_subdir => 'Engine')) {    # dump of $format?
     LoadPool($format . '_bootstrap', noerror => 1);
-    local $LaTeXML::LOCATOR = LaTeXML::Common::Locator->new($format, 0, 0, 0, 0);
+    local $LaTeXML::LOCATOR = LaTeXML::Common::Locator->new($format, 1, 1, 1, 1);
     $success = LoadPool($format . '_dump');
     LoadPool($format . '_constructs', noerror => 1); }
   elsif (FindFile($format . '_base', type => 'pool', notex => 1,


### PR DESCRIPTION
Fix #2669 and document [what I think should be] the intended behaviour, i.e. that lines and columns should be one-indexed, in three lines.

From a simple grep, all the other locators (BibTeX and Binding) use line numbers only, and they consistently start at one.