### PR TITLE
rename --fo_* CSS variables to --ltx-fo-* for consistency with color variables

### DIFF
--- a/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
@@ -382,9 +382,9 @@ Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
       $node->setAttribute(overflow  => 'visible');
       # Store expected size for experimentation Temporary?
       $document->setAttribute($node,
-        style=>'--fo_width :' . $w->emValue(undef,$f).'em;'
-              .'--fo_height:' . $h->emValue(undef,$f).'em;'
-              .'--fo_depth :' . $d->emValue(undef,$f).'em;');
+        style=>'--ltx-fo-width:'  . $w->emValue(undef,$f).'em;'
+              .'--ltx-fo-height:' . $h->emValue(undef,$f).'em;'
+              .'--ltx-fo-depth:'  . $d->emValue(undef,$f).'em;');
  } });
 
 sub isVAttached {

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -442,14 +442,14 @@ span.ltx_framed       { display:inline-block; text-indent:0; } /* avoid padding/
 /* Heuristically adjust for content uncentered within line-box */
 foreignObject {
     translate: 0 0.1em;
-    --fo_width: 100%; }
+    --ltx-fo-width: 100%; }
 /* Use flex to vertically center foreignObject,
    to accommodate potentially tall line-box */
 .ltx_foreignobject_container {
     display:flex;
     align-items:center;
     height:100%;
-    width:var(--fo_width);
+    width:var(--ltx-fo-width);
 }
 /* Also horizontally for single math, since Chrome adds a lot of left/right spacing. */
 .ltx_foreignobject_container:has( > .ltx_foreignobject_content > math:only-child) {
@@ -458,7 +458,7 @@ foreignObject {
 /* If multiple children, give more space to avoid unexpected line breaks
    due to font differences. */
 .ltx_foreignobject_container:has( > .ltx_foreignobject_content > :not(:only-child)) {
-    width:calc(1.1 * var(--fo_width));
+    width:calc(1.1 * var(--ltx-fo-width));
 }
 /* line height 0 just for this layer, to keep the line-box compact */
 .ltx_foreignobject_content {

--- a/t/graphics/xytest.xml
+++ b/t/graphics/xytest.xml
@@ -11,14 +11,14 @@
       <svg:svg height="38.1" overflow="visible" style="vertical-align:-4.73px" version="1.1" viewBox="-6.62 4.73 81.86 38.1" width="81.86">
         <svg:g transform="matrix(1 0 0 -1 -6.62 38.1) translate(-6.62,0)">
           <svg:g transform="translate(6.62,0) translate(0,-4.73)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--fo_width :0.75em;--fo_height:0.68em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.38"><Math mode="inline" tex="\textstyle{A}" text="A" xml:id="p1.pic1.m1">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.75em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.38"><Math mode="inline" tex="\textstyle{A}" text="A" xml:id="p1.pic1.m1">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">A</XMTok>
                 </XMath>
               </Math></svg:foreignObject>
           </svg:g>
           <svg:g transform="translate(68.99,0) translate(0,23.62) translate(4.15,0) translate(0,-4.73)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--fo_width :0.81em;--fo_height:0.68em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 9.46)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="p1.pic1.m2">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.81em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 9.46)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="p1.pic1.m2">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">B</XMTok>
                 </XMath>
@@ -37,14 +37,14 @@
       <svg:svg height="104.47" overflow="visible" style="vertical-align:-94.32px" version="1.1" viewBox="9.63 94.32 161.23 104.47" width="161.23">
         <svg:g transform="matrix(1 0 0 -1 9.63 104.47) translate(9.63,0)">
           <svg:g transform="translate(-9.63,0) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--fo_width :0.79em;--fo_height:0.68em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.96"><Math mode="inline" tex="\textstyle{U\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces}" text="U" xml:id="p2.pic1.m1">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.79em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.96"><Math mode="inline" tex="\textstyle{U\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces}" text="U" xml:id="p2.pic1.m1">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">U</XMTok>
                 </XMath>
               </Math></svg:foreignObject>
           </svg:g>
           <svg:g transform="translate(14.38,0) translate(0,-54.38) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--fo_width :0.43em;--fo_height:0.3em;--fo_depth :0.14em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.96"><Math mode="inline" tex="\scriptstyle{y}" text="y" xml:id="p2.pic1.m2">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:0.43em;--ltx-fo-height:0.3em;--ltx-fo-depth:0.14em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.96"><Math mode="inline" tex="\scriptstyle{y}" text="y" xml:id="p2.pic1.m2">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">y</XMTok>
                 </XMath>
@@ -63,7 +63,7 @@
           <svg:path d="M 9.63 -5.94 L 53.77 -33.21" fill="none" stroke="#000000"/>
           <svg:path d="M 53.74 -33.19 L 53.77 -33.21" fill="none" stroke="#000000"/>
           <svg:g transform="translate(67.97,0) translate(0,-7.5) translate(4.15,0) translate(0,-2.09)">
-            <svg:foreignObject height="4.17" overflow="visible" style="--fo_width :0.45em;--fo_height:0.3em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 4.17)" width="6.27"><Math mode="inline" tex="\scriptstyle{x}" text="x" xml:id="p2.pic1.m3">
+            <svg:foreignObject height="4.17" overflow="visible" style="--ltx-fo-width:0.45em;--ltx-fo-height:0.3em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 4.17)" width="6.27"><Math mode="inline" tex="\scriptstyle{x}" text="x" xml:id="p2.pic1.m3">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">x</XMTok>
                 </XMath>
@@ -75,7 +75,7 @@
           </svg:g>
           <svg:path d="M 9.61 -0.87 C 52.38 -5.35 92.76 -17.6 130.75 -37.63" fill="none" stroke="#000000"/>
           <svg:g transform="translate(42.84,0) translate(0,-43.36) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="11.53" overflow="visible" style="--fo_width :3.35em;--fo_height:0.68em;--fo_depth :0.15em;" transform="matrix(1 0 0 -1 0 9.46)" width="46.4"><Math mode="inline" tex="\textstyle{X\times_{Z}Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X * _ Z Y" xml:id="p2.pic1.m5">
+            <svg:foreignObject height="11.53" overflow="visible" style="--ltx-fo-width:3.35em;--ltx-fo-height:0.68em;--ltx-fo-depth:0.15em;" transform="matrix(1 0 0 -1 0 9.46)" width="46.4"><Math mode="inline" tex="\textstyle{X\times_{Z}Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X * _ Z Y" xml:id="p2.pic1.m5">
                 <XMath>
                   <XMApp>
                     <XMApp role="MULOP">
@@ -91,7 +91,7 @@
           </svg:g>
           <svg:path class="droprule" d="M 69.91 -53.04 L 70.47 -53.04" fill="none" stroke="#000000"/>
           <svg:g transform="translate(70.19,0) translate(0,-65.03) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--fo_width :0.39em;--fo_height:0.3em;--fo_depth :0.14em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.42"><Math mode="inline" tex="\scriptstyle{q}" text="q" xml:id="p2.pic1.m6">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:0.39em;--ltx-fo-height:0.3em;--ltx-fo-depth:0.14em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.42"><Math mode="inline" tex="\scriptstyle{q}" text="q" xml:id="p2.pic1.m6">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">q</XMTok>
                 </XMath>
@@ -105,7 +105,7 @@
           <svg:path class="droprule" d="M 69.91 -76.56 L 70.47 -76.56" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 97.54 -43.63 L 97.54 -43.08" fill="none" stroke="#000000"/>
           <svg:g transform="translate(98.68,0) translate(0,-50.53) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--fo_width :0.41em;--fo_height:0.3em;--fo_depth :0.14em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.7"><Math mode="inline" tex="\scriptstyle{p}" text="p" xml:id="p2.pic1.m7">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:0.41em;--ltx-fo-height:0.3em;--ltx-fo-depth:0.14em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.7"><Math mode="inline" tex="\scriptstyle{p}" text="p" xml:id="p2.pic1.m7">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">p</XMTok>
                 </XMath>
@@ -118,7 +118,7 @@
           <svg:path class="droprule" d="M 97.54 -43.63 L 130.75 -43.08" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 130.75 -43.63 L 130.75 -43.08" fill="none" stroke="#000000"/>
           <svg:g transform="translate(130.75,0) translate(0,-43.36) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--fo_width :0.91em;--fo_height:0.68em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 9.46)" width="12.55"><Math mode="inline" tex="\textstyle{X\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X" xml:id="p2.pic1.m8">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.91em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 9.46)" width="12.55"><Math mode="inline" tex="\textstyle{X\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X" xml:id="p2.pic1.m8">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">X</XMTok>
                 </XMath>
@@ -126,7 +126,7 @@
           </svg:g>
           <svg:path class="droprule" d="M 140.9 -50.97 L 141.46 -50.97" fill="none" stroke="#000000"/>
           <svg:g transform="translate(126.4,0) translate(0,-65.03) translate(4.15,0) translate(0,-2.42)">
-            <svg:foreignObject height="8.61" overflow="visible" style="--fo_width :0.47em;--fo_height:0.49em;--fo_depth :0.14em;" transform="matrix(1 0 0 -1 0 6.73)" width="6.48"><Math mode="inline" tex="\scriptstyle{f}" text="f" xml:id="p2.pic1.m9">
+            <svg:foreignObject height="8.61" overflow="visible" style="--ltx-fo-width:0.47em;--ltx-fo-height:0.49em;--ltx-fo-depth:0.14em;" transform="matrix(1 0 0 -1 0 6.73)" width="6.48"><Math mode="inline" tex="\scriptstyle{f}" text="f" xml:id="p2.pic1.m9">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">f</XMTok>
                 </XMath>
@@ -139,7 +139,7 @@
           <svg:path class="droprule" d="M 140.9 -76.56 L 141.46 -50.97" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 140.9 -76.56 L 141.46 -76.56" fill="none" stroke="#000000"/>
           <svg:g transform="translate(60.49,0) translate(0,-86.71) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--fo_width :0.8em;--fo_height:0.68em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 9.46)" width="11.11"><Math mode="inline" tex="\textstyle{Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="Y" xml:id="p2.pic1.m11">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.8em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 9.46)" width="11.11"><Math mode="inline" tex="\textstyle{Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="Y" xml:id="p2.pic1.m11">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">Y</XMTok>
                 </XMath>
@@ -147,7 +147,7 @@
           </svg:g>
           <svg:path class="droprule" d="M 79.9 -86.99 L 79.9 -86.44" fill="none" stroke="#000000"/>
           <svg:g transform="translate(98.66,0) translate(0,-79.53) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--fo_width :0.42em;--fo_height:0.3em;--fo_depth :0.14em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.75"><Math mode="inline" tex="\scriptstyle{g}" text="g" xml:id="p2.pic1.m12">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:0.42em;--ltx-fo-height:0.3em;--ltx-fo-depth:0.14em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.75"><Math mode="inline" tex="\scriptstyle{g}" text="g" xml:id="p2.pic1.m12">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">g</XMTok>
                 </XMath>
@@ -160,7 +160,7 @@
           <svg:path class="droprule" d="M 79.9 -86.99 L 131.81 -86.44" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 131.81 -86.99 L 131.81 -86.44" fill="none" stroke="#000000"/>
           <svg:g transform="translate(131.81,0) translate(0,-86.71) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--fo_width :0.75em;--fo_height:0.68em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.44"><Math mode="inline" tex="\textstyle{Z}" text="Z" xml:id="p2.pic1.m13">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.75em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.44"><Math mode="inline" tex="\textstyle{Z}" text="Z" xml:id="p2.pic1.m13">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">Z</XMTok>
                 </XMath>
@@ -182,7 +182,7 @@
                 <svg:svg height="62.06" overflow="visible" style="vertical-align:-51.91px" version="1.1" viewBox="9.59 51.91 73.11 62.06" width="73.11">
                   <svg:g transform="matrix(1 0 0 -1 9.59 62.06) translate(0,3.46) translate(9.59,0)">
                     <svg:g transform="translate(-9.34,0) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="9.46" overflow="visible" style="--fo_width :0.75em;--fo_height:0.68em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.38"><Math mode="inline" tex="\textstyle{A\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="A" xml:id="S0.Ex1.m1.pic1.m1">
+                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.75em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.38"><Math mode="inline" tex="\textstyle{A\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="A" xml:id="S0.Ex1.m1.pic1.m1">
                           <XMath>
                             <XMTok font="italic" role="UNKNOWN">A</XMTok>
                           </XMath>
@@ -210,21 +210,21 @@
                     <svg:path d="M 9.13 -7.61 L 42.8 -35.68" fill="none" stroke="#000000"/>
                     <svg:path d="M 42.79 -35.61 L 42.8 -35.68" fill="none" stroke="#000000"/>
                     <svg:g transform="translate(43.41,0) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="9.46" overflow="visible" style="--fo_width :0.81em;--fo_height:0.68em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 9.46)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="S0.Ex1.m1.pic1.m2">
+                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.81em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 9.46)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="S0.Ex1.m1.pic1.m2">
                           <XMath>
                             <XMTok font="italic" role="UNKNOWN">B</XMTok>
                           </XMath>
                         </Math></svg:foreignObject>
                     </svg:g>
                     <svg:g transform="translate(-9.59,0) translate(0,-44.3) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="9.46" overflow="visible" style="--fo_width :0.79em;--fo_height:0.68em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.88"><Math mode="inline" tex="\textstyle{C}" text="C" xml:id="S0.Ex1.m1.pic1.m3">
+                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.79em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.88"><Math mode="inline" tex="\textstyle{C}" text="C" xml:id="S0.Ex1.m1.pic1.m3">
                           <XMath>
                             <XMTok font="italic" role="UNKNOWN">C</XMTok>
                           </XMath>
                         </Math></svg:foreignObject>
                     </svg:g>
                     <svg:g transform="translate(42.8,0) translate(0,-44.3) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="11.35" overflow="visible" style="--fo_width :0.9em;--fo_height:0.82em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 11.35)" width="12.42"><text class="ltx_markedasmath" fontsize="120%">D</text></svg:foreignObject>
+                      <svg:foreignObject height="11.35" overflow="visible" style="--ltx-fo-width:0.9em;--ltx-fo-height:0.82em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 11.35)" width="12.42"><text class="ltx_markedasmath" fontsize="120%">D</text></svg:foreignObject>
                     </svg:g>
                   </svg:g>
                 </svg:svg>
@@ -253,7 +253,7 @@
                       <svg:path d="M 23.87 -5.36 C 24.91 -7.61 24.91 -8.99 25.94 -11.24" fill="none" stroke="#000000"/>
                       <svg:path d="M 25.94 -11.24 C 26.98 -13.49 29.06 -16.6 33.21 -16.6" fill="none" stroke="#000000"/>
                       <svg:g transform="translate(21.45,0) translate(0,-8.3)">
-                        <svg:foreignObject height="6.92" overflow="visible" style="--fo_width :0.63em;--fo_height:0.31em;--fo_depth :0.31em;" transform="matrix(1 0 0 -1 0 3.46)" width="6.92"><text class="ltx_markedasmath" fontsize="70%" width="5.0pt"> </text></svg:foreignObject>
+                        <svg:foreignObject height="6.92" overflow="visible" style="--ltx-fo-width:0.63em;--ltx-fo-height:0.31em;--ltx-fo-depth:0.31em;" transform="matrix(1 0 0 -1 0 3.46)" width="6.92"><text class="ltx_markedasmath" fontsize="70%" width="5.0pt"> </text></svg:foreignObject>
                       </svg:g>
                       <svg:path d="M 16.6 -16.6 C 20.44 -16.6 22.51 -13.94 23.62 -11.76" fill="none" stroke="#000000"/>
                       <svg:path d="M 26.2 -4.84 C 27.31 -2.66 29.37 0 33.21 0" fill="none" stroke="#000000"/>

--- a/t/tikz/various_colors.xml
+++ b/t/tikz/various_colors.xml
@@ -516,12 +516,12 @@
               <svg:path d="M 1.97 1.97 L 1.97 267.66 L 598.03 267.66 L 598.03 1.97 Z" style="stroke:none"/>
             </svg:g>
             <svg:g fill-opacity="1.0" transform="matrix(1.0 0.0 0.0 1.0 21.65 276.26)">
-              <svg:foreignObject color="#FFFFFF" height="156.01" overflow="visible" style="--fo_width :40.23em;--fo_height:11.08em;--fo_depth :0.19em;" transform="matrix(1 0 0 -1 0 153.32)" width="556.69"><inline-block class="ltx_minipage" vattach="bottom" width="40.23em">
+              <svg:foreignObject color="#FFFFFF" height="156.01" overflow="visible" style="--ltx-fo-width:40.23em;--ltx-fo-height:11.08em;--ltx-fo-depth:0.19em;" transform="matrix(1 0 0 -1 0 153.32)" width="556.69"><inline-block class="ltx_minipage" vattach="bottom" width="40.23em">
                   <p><text font="bold">Table C.5</text>: Prompt to Choose Representative Landmarks for Each Cluster</p>
                 </inline-block></svg:foreignObject>
             </svg:g>
             <svg:g fill-opacity="1.0" transform="matrix(1.0 0.0 0.0 1.0 21.65 13.78)">
-              <svg:foreignObject height="242.07" overflow="visible" style="--fo_width :40.23em;--fo_height:17.49em;--fo_depth :0em;" transform="matrix(1 0 0 -1 0 242.07)" width="556.69"><inline-block class="ltx_minipage" vattach="bottom" width="40.23em">
+              <svg:foreignObject height="242.07" overflow="visible" style="--ltx-fo-width:40.23em;--ltx-fo-height:17.49em;--ltx-fo-depth:0em;" transform="matrix(1 0 0 -1 0 242.07)" width="556.69"><inline-block class="ltx_minipage" vattach="bottom" width="40.23em">
                   <p>You have been provided with a set of similar documents, each indexed by a number. Your task is to identify the most representative example from this cluster of documents. Please carefully analyze the given documents and select one document that best captures the common essence and characteristics of the samples. The selection should emphasize the representativeness and relevance of the chosen sample to the category, so that it can serve as a reference for labeling the entire cluster.</p>
                   <p>Documents in the cluster:</p>
                   <p>1-. {Document 1}……</p>


### PR DESCRIPTION
Since you opted for the convention `--ltx-fg-color` for color variables, I have renamed the foreign object variables in the same way. (I plan to rely on those variables once 0.9 is out!)