### PR TITLE
[arXiv] `bibconfig` option for latexml.sty

### DIFF
--- a/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
+++ b/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
@@ -3957,8 +3957,11 @@ DefMacro('\lx@ifusebbl{}{}{}', sub {
 
     my $bbl_path     = FindFile($jobname, type => 'bbl');
     my $missing_bibs = '';
-    my $bib_config   = LookupValue("BIBTEX_CONFIG") || '';
-    if ($bib_config eq 'BBL_ONLY' or ($bbl_path and $bib_config eq 'BBL_FIRST')) {
+    my $bib_config   = LookupValue("BIB_CONFIG") || ['bib', 'bbl'];
+    if ((ref $bib_config ne 'ARRAY') || scalar(@$bib_config) == 0) {
+      Info('missing', 'bib_config', $gullet, "BIB_CONFIG was empty, ignoring bibliography phase.");
+      return; }
+    if ($$bib_config[0] eq 'bbl') {
       if (not $bbl_path) {
         Info('expected', "bbl", $_[0], "Couldn't find bbl file, bibliography may be empty.");
         return Tokens(); }

--- a/lib/LaTeXML/Package/latexml.sty.ltxml
+++ b/lib/LaTeXML/Package/latexml.sty.ltxml
@@ -51,9 +51,12 @@ DeclareOption('noguesstabularheaders', sub { AssignValue(GUESS_TABULAR_HEADERS =
 
 # 'nobibtex' intended to be used for arXiv-like build harnesses, where there
 # is explicit instruction to only use ".bbl" and that bibtex will not be ran.
-DeclareOption('bibtex',   sub { AssignValue('BIBTEX_CONFIG' => 'BIBTEX',    'global'); });
-DeclareOption('nobibtex', sub { AssignValue('BIBTEX_CONFIG' => 'BBL_ONLY',  'global'); });
-DeclareOption('usebbl',   sub { AssignValue('BIBTEX_CONFIG' => 'BBL_FIRST', 'global'); });
+DeclareOption('bibtex',   sub { AssignValue('BIB_CONFIG' => ['bib', 'bbl'], 'global'); });
+DeclareOption('nobibtex', sub { AssignValue('BIB_CONFIG' => ['bbl'],        'global'); });
+
+DefKeyVal('LTXML', 'bibconfig', 'Semiverbatim', '', code => sub {
+    AssignValue('BIB_CONFIG' => [split(',', ToString($_[1]))], 'global');
+    return; });
 
 # Lexeme serialization for math formulas
 DeclareOption('mathlexemes', sub { AssignValue('LEXEMATIZE_MATH' => 1, 'global'); });


### PR DESCRIPTION
As of yesterday, arXiv submissions now process `.bib` files. To stay backwards compatible, this is done without any additional configuration markup, but via convention. Namely:

- if a `.bbl` is present in the submission, use that file
- if a `.bbl` is not present, and the appropriate `.bib` files are present, run the appropriate bibtex/biber build steps.

In LaTeXML, we had emulated the previous convention (always use `.bbl`, never run bibtex) via adding a `nobibtex` option to latexml.sty.

~~I have extended that a bit, by also adding a `usebbl` option (name suggestions welcome!), which will follow the new arXiv convention.~~

After a round of feedback, I have added a `bblconfig` option which takes a flexible value which can reorder the biblioraphy processors. The usual expectede uses are:
 - `--preload=[bibconfig={bib,bbl}]latexml.sty`
 - `--preload=[bibconfig={bbl,bib}]latexml.sty`
 - `--preload=[bibconfig={bbl}]latexml.sty`
 - `--preload=[bibconfig={bib}]latexml.sty`

Allowing to enable/disable bbl and bib processing, as well as to prefer one over the other.

With this, the arXiv/ar5iv configuration for latexml will migrate from `--preload=[nobibtex]latexml.sty` to `--preload=[bibconfig={bbl,bib}]latexml.sty`.

As latexml already had existing support for the bibtex processing, this PR is *only* a configuration adapter. 