### PR TITLE
Robust on raw perl value instead of register value

### DIFF
--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -110,26 +110,26 @@ sub readingFromMouth {
   my $mouth;
   my $intokens;
   my $sourcetype = ref $source;
-  if (! $sourcetype) {          # for a string, create Mouth to read its content
+  if (!$sourcetype) {    # for a string, create Mouth to read its content
     $mouth = LaTeXML::Core::Mouth->new($source); }
-  elsif ($sourcetype =~ /^LaTeXML::Core::Tokens?$/) { # Tokens will be unread into Mouth
-    $mouth = LaTeXML::Core::Mouth->new();
+  elsif ($sourcetype =~ /^LaTeXML::Core::Tokens?$/) {    # Tokens will be unread into Mouth
+    $mouth    = LaTeXML::Core::Mouth->new();
     $intokens = $source; }
-  elsif (! $source->isa('LaTeXML::Core::Mouth')) {
-    Error('expected','Mouth', $self,
+  elsif (!$source->isa('LaTeXML::Core::Mouth')) {
+    Error('expected', 'Mouth', $self,
       "Input source was not a string, Tokens or Mouth: $source; ignoring it.");
     $mouth = LaTeXML::Core::Mouth->new(); }
   else {
     $mouth = $source; }
-  openMouth($self, $mouth, 1);    # only allow mouth to be explicitly closed here.
-  $self->unread($intokens) if $intokens; # Preload the mouth
+  openMouth($self, $mouth, 1);              # only allow mouth to be explicitly closed here.
+  $self->unread($intokens) if $intokens;    # Preload the mouth
   my ($result, @result);
   if (wantarray) {
     @result = &$closure($self); }
   else {
     $result = &$closure($self); }
-  $self->skipSpaces;            # Skip any remaining spaces on input.
-  # $mouth must still be open, with (at worst) empty autoclosable mouths in front of it
+  $self->skipSpaces;                        # Skip any remaining spaces on input.
+      # $mouth must still be open, with (at worst) empty autoclosable mouths in front of it
   while (1) {
     if ($$self{mouth} eq $mouth) {
       closeMouth($self, 1); last; }
@@ -186,10 +186,10 @@ sub showUnexpected {
   my ($self) = @_;
   my $message = "Input is empty";
   if (my $token = peekToken($self)) {
-    my @pb = @{ $$self{pushback} }[1..-1];
+    my @pb = @{ $$self{pushback} }[1 .. -1];
     $message = "Next token is " . Stringify($token)
       . " ( == " . Stringify($STATE->lookupMeaning($token)) . ")"
-        . (@pb ? " more: " . ToString(TokensI(@pb)) : ''); }
+      . (@pb ? " more: " . ToString(TokensI(@pb)) : ''); }
   return $message; }
 
 sub show_pushback {
@@ -328,7 +328,7 @@ sub readToken {
 # This might be needed in more places?
 sub peekToken {
   my ($self) = @_;
-  local $LaTeXML::ALIGN_STATE = 1000000; # Inhibit readToken from processing {}!!!
+  local $LaTeXML::ALIGN_STATE = 1000000;    # Inhibit readToken from processing {}!!!
   if (my $token = readToken($self)) {
     unshift(@{ $$self{pushback} }, $token);
     return $token; }
@@ -734,7 +734,7 @@ sub readArg {
   else {
     if ($expanded) {
       return $self->readingFromMouth(Tokens(T_BEGIN, $token, T_END), sub {
-         readBalanced($self, $expanded, 0, 1); } ); }
+          readBalanced($self, $expanded, 0, 1); }); }
     else {
       return Tokens($token); } } }
 
@@ -795,7 +795,14 @@ sub readRegisterValue {
     local $LaTeXML::CURRENT_TOKEN = $token;
     my $parms = $$defn{parameters};
     my $value = $defn->valueOf(($parms ? $parms->readArguments($self) : ()));
-    if ($type eq $rtype) {
+    if (!ref $value) {
+      Warn('malformed', 'register_value', $self,
+        "Register " . ToString($token) . " did not return a proper value, got " . Stringify($value));
+      if ($coercer) {
+        return &$coercer($sign * $value); }
+      else {
+        return Number($value); } }    # Default to Number fallback
+    elsif ($type eq $rtype) {
       return ($sign < 0 ? $value->negate : $value); }
     else {
       return &$coercer($sign * $value->valueOf); } }


### PR DESCRIPTION
This was encountered in `arXiv:2308.06254v1`, where a use of `\fam` was returning a perl `0` scalar value from `readRegisterValue`.

I think we should harden `readRegisterValue` to always return an object, catching these cases and defaulting them to what the coercing would do, or `Number` if nothing else is known.

With the change in the PR the article converts without a Fatal, instead emitting a warning:
```
Warning:malformed:register_value Register \fam did not return a proper value, got 0
```

That can also be made into an error if preferred. Encountered in an old issue when processed with the latest latexml worker, at https://github.com/arXiv/html_feedback/issues/22

Diff without whitespace lints at https://github.com/brucemiller/LaTeXML/pull/2693/files?w=1