### PR TITLE
protect p{} cell templates with an inner group

### DIFF
--- a/lib/LaTeXML/Engine/TeX_Tables.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Tables.pool.ltxml
@@ -68,8 +68,8 @@ DefColumnType('p{Dimension}', sub {
     $LaTeXML::BUILD_TEMPLATE->addColumn(
       before => Tokens(T_CS('\vtop'), T_BEGIN, T_CS('\hbox'),
         T_LETTER('t'), T_LETTER('o'), $_[1]->revert, T_CS('\relax'),
-        T_BEGIN),
-      after   => Tokens(T_END, T_END),
+        T_BEGIN,       T_BEGIN),
+      after   => Tokens(T_END, T_END, T_END),
       vattach => 'top',
       align   => 'justify',
     ); return; });
@@ -170,7 +170,7 @@ DefConstructor('\halign BoxSpecification',
   beforeConstruct => sub {
     my ($document) = @_;
     $document->maybeCloseElement('ltx:p'); },
-  afterDigest => sub {          # After spec, but before body!
+  afterDigest => sub {    # After spec, but before body!
     my ($stomach, $whatsit) = @_;
     $whatsit->setProperty(mode => 'internal_vertical');
     $stomach->beginMode('restricted_horizontal');
@@ -360,7 +360,7 @@ sub digestAlignmentColumn {
   my ($stomach, $alignment, $lastwascr) = @_;
   my $gullet = $stomach->getGullet;
   my $ismath = $STATE->lookupValue('IN_MATH');
-  my $mode = $STATE->lookupValue('MODE');
+  my $mode   = $STATE->lookupValue('MODE');
   local @LaTeXML::LIST = ();
   # Scan for leading \omit, skipping over (& saving) \hline.
   Debug("Halign $alignment: COLUMN starting scan ($mode)") if $LaTeXML::DEBUG{halign};
@@ -425,7 +425,7 @@ sub digestAlignmentColumn {
         push(@LaTeXML::LIST, $stomach->invokeToken($token));
         Debug("Halign $alignment: COLUMN " . Stringify($token) . " ==> " . Stringify(List(@LaTeXML::LIST)))
           if $LaTeXML::DEBUG{halign};
-  } } }
+      } } }
   return; }
 
 # This attempts to trim off the column template parts from contents of the full column,

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -51,13 +51,12 @@ sub lstPushValueLocally {
 our $EMPTY_CATTABLE = LaTeXML::Core::State->new(catcodes => 'none');
 
 # \leavevmode (or any primitive, really) to stop \halign from expanding too far.
-DefMacro('\lstinline', '\leavevmode\lx@lstinline');
+DefMacro('\lstinline', '\leavevmode\bgroup\lx@lstinline');
 DefMacro('\lx@lstinline OptionalKeyVals:LST', sub {
     my ($gullet, $keyvals) = @_;
-    $STATE->getStomach->bgroup;    # To localize activation
-    lstActivate($keyvals);         # But do BEFORE reading arg, since some options screw things up.
-                                   # get opening delim from gullet, before cattable swap,
-                                   # in case token was already peeked for the optional args!
+    lstActivate($keyvals);    # But do BEFORE reading arg, since some options screw things up.
+                              # get opening delim from gullet, before cattable swap,
+                              # in case token was already peeked for the optional args!
     my $init = $gullet->readToken;
     my $body = listingsReadRawString($gullet, (Equals($init, T_BEGIN) ? T_END : $init));
     return (
@@ -107,7 +106,7 @@ sub lstProcessInline {
 DefConstructor('\@listings@inline {}',
   "<ltx:text class='ltx_lstlisting' _noautoclose='1'>#1</ltx:text>",
   enterHorizontal => 1,
-  reversion => '\lstinline{#1}');
+  reversion       => '\lstinline{#1}');
 
 # Not a regular environment, since we're going to read the body verbatim!
 DefMacroI(T_CS('\begin{lstlisting}'), 'OptionalKeyVals:LST', sub {
@@ -249,7 +248,7 @@ DefConstructor('\@@listings {}',
     . "#tags"
     . "#1"
     . "</ltx:float>",
-  mode           => 'internal_vertical',
+  mode       => 'internal_vertical',
   properties => sub {
     my %props = RefStepID('lstlisting');
     return %props; },
@@ -1489,7 +1488,7 @@ DefConstructor('\@listingLiterate {}',
 DefConstructor('\@listingKeyword Semiverbatim {}',
   "?#class(<ltx:text class='ltx_lst_#class' _noautoclose='1'>#2</ltx:text>)(#2)",
   enterHorizontal => 1,
-  properties => { class => sub {
+  properties      => { class => sub {
       my $classname = ToString($_[1]);
       my $class     = $classname && LookupValue('LST_CLASSES')->{$classname};
       my $cssclass  = $class     && $$class{cssclass};


### PR DESCRIPTION
This came from a discovered regression on `arXiv:2310.06770v3` after raw interpretation was enabled.

I reduced it to a minimal example of a listing showing up inside a cell with a `p{}` template:

```tex
\documentclass{article}
\usepackage{listings}
\begin{document}
\begin{tabular}{p{\linewidth}}
A\begin{lstlisting}
  B
\end{lstlisting}
\end{tabular}
\end{document}
```

The errors produced have to do with TeX mode-matching, in particular the `\hbox` associated with `p{}` terminating the wrong mode at the end.

While fishing for more information I found that making a couple of groups more explicit avoids the error - was it simply a matter of not enough explicit groups? Probably not, as the article continues to encounter a few errors related to mode balancing. Flagging this with a draft PR for now, feedback welcome.

To download the arXiv source for testing:
https://arxiv.org/src/2310.06770v3