### PR TITLE
guard ill-formed input in DecodeColor

### DIFF
--- a/lib/LaTeXML/Package/xcolor.sty.ltxml
+++ b/lib/LaTeXML/Package/xcolor.sty.ltxml
@@ -329,6 +329,10 @@ sub DecodeColor {
       $color = ($postfix && ($postfix =~ /!!\[(\d+)\]/)    # Note "out-of-order" effect!
         ? indexColorSeries($name, $1)
         : LookupXColor($name));
+      if (!$color) {
+        Error('misdefined', 'color', $STATE->getStomach,
+          "could not resolve <color> name in '$expression'");
+        return Black; }
       if (my $blend = LookupValue('color_blend')) {        # Combine any stored blend with the mix_expr.
         $mix_expr .= $blend; }
       if ($mix_expr) {


### PR DESCRIPTION
A patch for the regressed [arXiv issue 5016](https://github.com/arXiv/html_feedback/issues/5016), at [arXiv:2410.12896v1](https://arxiv.org/src/2410.12896v1).

A valiant effor of latexml interpreting `forest.sty` raw hits a Fatal error:
```
Fatal:misdefined:LaTeXML::Package::Pool::DecodeColor Can't call method 'mix' on an undefined value
```

That is subotpimal, as completing the run with an error is much more useful (and was possible before raw interpretation got enabled). With this PR we instead flag an Error:
```
Error:misdefined:color could not resolve <color> name in '0!15' at sample-manuscript.tex; line 643 col 0
```

And produce a healthy HTML document. Just an intermediate step until `forest.sty` can be fully managed. Ready for review.