### PR TITLE
updated dependencies for aastex63

### DIFF
--- a/lib/LaTeXML/Package/aas_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aas_support.sty.ltxml
@@ -34,6 +34,8 @@ RequirePackage('xcolor');
 RequirePackage('hyperref');
 RequirePackage('array');
 RequirePackage('lineno');
+RequirePackage('amssymb');
+RequirePackage('epsf');
 RequirePackage('ulem');
 #======================================================================
 # 2.1.3 Editorial Information
@@ -132,7 +134,7 @@ DefConstructor('\altaffiltext{}{}',
 DefMacro('\software{}',      '\@add@frontmatter{ltx:note}[role=software]{#1}');
 DefMacro('\submitjournal{}', '\@add@frontmatter{ltx:note}[role=journal]{#1}');
 # Alas \doi is not frontmatter.
-DefConstructor('\doi{}',             '<ltx:ref href="https:/doi.org/#1">#1</ltx:ref>',
+DefConstructor('\doi{}', '<ltx:ref href="https:/doi.org/#1">#1</ltx:ref>',
   enterHorizontal => 1);
 DefConstructor('\@@@collaborator{}', "<ltx:note role='collaborator'>#1</ltx:note>");
 DefMacro('\collaboration{}{}', '\@add@to@frontmatter{ltx:creator}{\@@@collaborator{#2}}');
@@ -493,7 +495,7 @@ DefConstructor('\aas@@fstack Undigested {}',
     . "<ltx:XMWrap>#2</ltx:XMWrap>"
     . "</ltx:XMApp>",
   properties => { scriptpos => sub { "mid" . $_[0]->getScriptLevel; } },
-  font => { shape => 'upright' }, bounded => 1, reversion => '#1', sizer=>'#2');
+  font       => { shape     => 'upright' }, bounded => 1, reversion => '#1', sizer => '#2');
 DefMacro('\aas@fstack{}', '\ensuremath{\aas@@fstack{#1}}');
 
 DefMacro('\fd',    '\ensuremath{\@fd}');
@@ -565,14 +567,14 @@ RequirePackage('url');
 DefConstructor('\anchor Semiverbatim Semiverbatim',
   "<ltx:ref href='#href'>#2</ltx:ref>",
   enterHorizontal => 1,
-  properties => sub { (href => ComposeURL(LookupValue('BASE_URL'), $_[1])); });
+  properties      => sub { (href => ComposeURL(LookupValue('BASE_URL'), $_[1])); });
 
 # This should be in effect only after frontmatter
 # \email{address}
 DefConstructor('\@@email Semiverbatim',
   "<ltx:ref href='#href'>#1</ltx:ref>",
   enterHorizontal => 1,
-  properties => sub { (href => CleanURL("mailto:" . ToString($_[1]))); });
+  properties      => sub { (href => CleanURL("mailto:" . ToString($_[1]))); });
 
 # RequirePackage('verbatim');
 

--- a/lib/LaTeXML/Package/aastex.cls.ltxml
+++ b/lib/LaTeXML/Package/aastex.cls.ltxml
@@ -33,14 +33,15 @@ foreach my $option (qw(10pt 11pt 12pt
 DeclareOption('eqsecnum', sub { Digest(Tokenize('\AtEndOfClass{\eqsecnum}')); });
 
 # revtex4 option from emulateapj.cls loads revtex4.cls
-DeclareOption('revtex4', sub { LoadClass('revtex4'); return; });
+# Nowadays a no-op.
+DeclareOption('revtex4', sub { return; });
 
 DeclareOption(undef, sub {
     PassOptions('article', 'cls', ToString(Expand(T_CS('\CurrentOption')))); });
 
 ProcessOptions();
 
-LoadClass('article');
+LoadClass('revtex4');
 RequirePackage('aas_support');
 
 # #======================================================================


### PR DESCRIPTION
This was the cause behind the report in https://github.com/arXiv/html_feedback/issues/817

Namely, [aastex63.cls](https://journals.aas.org/wp-content/uploads/2021/02/aastex631.cls) now always depends on revtex4, (which allowed for `\text` use).
I also spotted two extra packages getting loaded which I added to aas_support.

Tested with the arXiv:2311.00744v2 article in question, resolves the reported problem.