### PR TITLE
Add graphicx load to grffile.sty.ltxml

### DIFF
--- a/lib/LaTeXML/Package/grffile.sty.ltxml
+++ b/lib/LaTeXML/Package/grffile.sty.ltxml
@@ -18,6 +18,8 @@ use LaTeXML::Package;
 # The main use of grffile.sty is to allow for filenames with spaces in \includegraphics
 # LaTeXML can already handle that natively.
 
+RequirePackage('graphicx');
+
 # Documentation: http://bay.uchicago.edu/tex-archive/macros/latex/contrib/oberdiek/grffile.pdf
 
 DefMacro('\grffilesetup{}', '');


### PR DESCRIPTION
This was the underlying cause in https://github.com/arXiv/html_feedback/issues/4370

Simply, [grffile.sty](https://ctan.org/tex-archive/macros/latex/contrib/grffile?lang=en) directly loads graphicx nowadays.

Tested with arXiv:2507.07693v1