### PR TITLE
add missing refactor for textunderscore

### DIFF
--- a/lib/LaTeXML/Package/underscore.sty.ltxml
+++ b/lib/LaTeXML/Package/underscore.sty.ltxml
@@ -17,7 +17,7 @@ use LaTeXML::Package;
 
 #======================================================================
 # Don't really need to change \_, but do need to make _ work in text!
-DefMacroI(T_ACTIVE('_'),   undef, '\ifmmode\sb\lx@text@underscore\fi');
+DefMacroI(T_ACTIVE('_'), undef, '\ifmmode\sb\else\textunderscore\fi');
 AtBeginDocument('\catcode`_\active');
 #======================================================================
 1;


### PR DESCRIPTION
Fixes #2702 

The internal macro name was refactored away at some point, originally here:

https://github.com/brucemiller/LaTeXML/blob/2be9933ade1094cd2d5d185f52f06c2bd5d113b3/lib/LaTeXML/Package/TeX.pool.ltxml#L6374

Testing on the simple snippet from the issue shows `\textunderscore` doing the job just fine.

