### PR TITLE
guard pgfNumber against double negation

### DIFF
--- a/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
+++ b/lib/LaTeXML/Package/pgfmath.code.tex.ltxml
@@ -108,6 +108,7 @@ DefMacro('\@@@show@pgfmatharg@{}', sub {
 DefParameterType('pgfNumber', sub {
     my ($gullet) = @_;
     my $pgf_number = ToString(Expand($gullet->readArg()));
+    $pgf_number =~ s/^\-\-//g;                  # drop leading double negation
     $pgf_number = "0" if $pgf_number eq '.';    # Apparently "." is a valid number!
     return $pgf_number; });
 
@@ -649,7 +650,7 @@ BEGIN {
 
   # Why can't I manage to import a few functions to be visible to the grammar actions?
   # NOTE Not yet done: quoted strings, extensible functions
-  $PGFMATHGrammarSpec = << 'EoGrammar';
+  $PGFMATHGrammarSpec = <<'EoGrammar';
 #  {BEGIN { use LaTeXML::Package::Pool; }}
 #  { use LaTeXML::Package::Pool; }
 #  { LaTeXML::Package::Pool->import(qw(pgfmath_apply)); }


### PR DESCRIPTION
Fixes #2696 

This may be a bit "too direct" in addressing the parameter symptom, as I have not dived to the full depths of how the `--0.5` was generated. What was clear from testing is that this is not coming from any of our perl binding code, neither is it directly interceptable in the usual `pgfmathparse` routine.

On the other hand, guarding a number parameter type for double negation seems both easy and uncontroversial. So possibly a reasonable patch?

Most importantly, the resulting SVG is quite impressively matching the PDF of the example.