### PR TITLE
newer hyperref.sty depends on etoolbox.sty

### DIFF
--- a/lib/LaTeXML/Package/hyperref.sty.ltxml
+++ b/lib/LaTeXML/Package/hyperref.sty.ltxml
@@ -17,7 +17,7 @@ use LaTeXML::Package;
 
 # Some of the requirements not yet applicable/supported in latexml
 RequirePackage('ltxcmds');
-#RequirePackage('iftex');
+RequirePackage('iftex');
 #RequirePackage('pdftexcmds');
 #RequirePackage('infwarerr');
 
@@ -41,6 +41,7 @@ RequirePackage('nameref');
 RequirePackage('url');
 RequirePackage('bitset');
 #RequirePackage('atbegshi');
+RequirePackage('etoolbox');
 
 # Can we load hyperref, to get all it's random sundry definitions?
 # No, too many weird extra packages loaded.
@@ -209,27 +210,27 @@ DefMacro('\hyperref', '\@ifnextchar[\hyperref@@ii\hyperref@@iv');
 # 2 argument form
 DefConstructor('\hyperref@@ii OptionalSemiverbatim {}',
   "<ltx:ref labelref='#label'>#2</ltx:ref>",
-  bounded    => 1,
+  bounded         => 1,
   enterHorizontal => 1,
-  properties => sub { (label => CleanLabel($_[1])); });
+  properties      => sub { (label => CleanLabel($_[1])); });
 # 4 argument form
 DefConstructor('\hyperref@@iv Semiverbatim Semiverbatim Semiverbatim Semiverbatim',
   "<ltx:ref href='#href'>#4</ltx:ref>",
   enterHorizontal => 1,
-  properties => sub {
+  properties      => sub {
     (href => ComposeURL(LookupValue('BASE_URL'), $_[1],
         CleanID(ToString($_[2]) . '.' . ToString($_[3])))); });
 
 DefConstructor('\htmlref Semiverbatim  Semiverbatim',
   "<ltx:ref labelref='#label'>#1</ltx:ref>",
   enterHorizontal => 1,
-  properties => sub { (label => CleanLabel($_[2])); });
+  properties      => sub { (label => CleanLabel($_[2])); });
 
 # \hyperlink{name}{text}
 DefConstructor('\hyperlink Semiverbatim {}',
   "<ltx:ref idref='#1'>#2</ltx:ref>",
   enterHorizontal => 1,
-  properties => sub { (id => CleanID($_[1])); });
+  properties      => sub { (id => CleanID($_[1])); });
 DefMacro('\hyper@@link{}{}{}', '\hyperlink{#2}{#3}');
 
 sub localized_anchor {
@@ -365,7 +366,7 @@ DefConstructor('\autoref OptionalMatch:* Semiverbatim',
   "<ltx:ref ?#1(class='ltx_refmacro_autoref ltx_nolink')(class='ltx_refmacro_autoref') " .
     "show='autoref' labelref='#label' _force_font='true'/>",
   enterHorizontal => 1,
-  properties => sub { (label => CleanLabel($_[2])); });
+  properties      => sub { (label => CleanLabel($_[2])); });
 
 DefMacro('\lx@autorefnum@@{}', sub {
     my ($gullet, $type) = @_;


### PR DESCRIPTION
This PR deeals with another awkward dependency pain. Newer hyperref depends on etoolbox, which was used in [arXiv:2512.16911v1](https://arxiv.org/html/2512.16911v1/__stdout.txt) , as reported in https://github.com/arXiv/html_feedback/issues/5763 .

So... just include the dependency even though we are not using it in perl?