### PR TITLE
Added bindings for causets (TikZ extension).

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -460,6 +460,7 @@ lib/LaTeXML/Package/calrsfs.sty.ltxml
 lib/LaTeXML/Package/cancel.sty.ltxml
 lib/LaTeXML/Package/caption.sty.ltxml
 lib/LaTeXML/Package/cases.sty.ltxml
+lib/LaTeXML/Package/causets.sty.ltxml
 lib/LaTeXML/Package/ccfonts.sty.ltxml
 lib/LaTeXML/Package/chancery.sty.ltxml
 lib/LaTeXML/Package/chapterbib.sty.ltxml

--- a/lib/LaTeXML/Package/causets.sty.ltxml
+++ b/lib/LaTeXML/Package/causets.sty.ltxml
@@ -18,8 +18,6 @@ use warnings;
 use LaTeXML::Package;
 
 #=========================================================================#
-RequirePackage('tikz');
-RequirePackage('pgf');
 InputDefinitions('causets', type => 'sty', noltxml => 1);
 #=========================================================================#
 

--- a/lib/LaTeXML/Package/causets.sty.ltxml
+++ b/lib/LaTeXML/Package/causets.sty.ltxml
@@ -1,0 +1,26 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  causets                                                            | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# |---------------------------------------------------------------------| #
+# | Initially implemented by Christoph Minz                             | #
+# |---------------------------------------------------------------------| #
+# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
+# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
+# \=========================================================ooo==U==ooo=/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+#=========================================================================#
+RequirePackage('tikz');
+RequirePackage('pgf');
+InputDefinitions('causets', type => 'sty', noltxml => 1);
+#=========================================================================#
+
+1;


### PR DESCRIPTION
The bindings only contains the standard code for a TikZ extension.

To test it, use the files in the package repository at https://github.com/c-minz/LaTeX-causets (the pdf and html outputs are also included there). My environment:
- `pdflatex ...` to create the corresponding pdf files (on Linux, Kubuntu 24.04)
  pdfTeX 3.141592653-2.6-1.40.28 (TeX Live 2025)
  (including causets v1.5)
- `bin/latexmlc --strict ...` to create corresponding html files

The main test file runs without issues:
[test_causets.tex](https://github.com/c-minz/LaTeX-causets/blob/main/test_causets.tex)

The example files show some warning (coming from other packages), but run also without issues otherwise:
[causets_example1.tex](https://github.com/c-minz/LaTeX-causets/blob/main/causets_example1.tex)
[causets_example2.tex](https://github.com/c-minz/LaTeX-causets/blob/main/causets_example2.tex)