### PR TITLE
\href and math mode

### DIFF
--- a/lib/LaTeXML/Post/MathML.pm
+++ b/lib/LaTeXML/Post/MathML.pm
@@ -572,6 +572,14 @@ sub pmml_maybe_resize {
       my $s     = $$attr{style};
       my $style = 'border-color: ' . $color;
       $$attr{style} = ($s ? $s . '; ' . $style : $style); } }
+
+  # Preserve href attribute for links in math mode
+  if (ref $result && $result->[0] =~ /^m:/) {
+    my $href = $node->getAttribute('href');
+    my $attr = $$result[1];
+    $$attr{href} = $href if $href;
+  }
+
   return $result; }
 
 sub filter_row {

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -241,8 +241,7 @@ table.ltx_eqn_eqnarray tr.ltx_eqn_lefteqn + tr td.ltx_align_right { min-width:2e
 li.ltx_item > .ltx_tag {
     display:inline-block; margin-left:-1.5em; min-width:1.5em;
     text-align:right; }
-.ltx_item .ltx_tag + .ltx_para {
-    display:inline-block; vertical-align:top;}
+.ltx_item .ltx_tag + .ltx_para,
 .ltx_item .ltx_tag + .ltx_para .ltx_p  {
     display:inline; }
 .ltx_item > .ltx_para > .ltx_p:first-child {


### PR DESCRIPTION
This pull request fixes the behaviour of the `\href` command while in math mode, and of math passed as an argument to `\href`.
- The LaTeX code ```$\href{#}{x = y}$``` did not produce any link. The href attribute was present in the XML file, but not in the HTML. This is fixed by changing the pmml_maybe_resize subroutine in the postprocessor.
- The LaTeX code ```\item foo \href{#}{$x = y$}``` (inside an itemize environment) was producing a link, but a linebreak was present between `foo` and the link. This is fixed by changing the css.