### PR TITLE
[WiP] Institute frontmatter

### DIFF
--- a/lib/LaTeXML/Engine/AmSTeX.pool.ltxml
+++ b/lib/LaTeXML/Engine/AmSTeX.pool.ltxml
@@ -136,7 +136,7 @@ DefMacro('\title Until:\endtitle', '\@add@frontmatter{ltx:title}{#1}');
 DefConstructor('\@personname{}', "<ltx:personname>#1</ltx:personname>",
   mode => 'restricted_horizontal');
 DefMacro('\author Until:\endauthor', '\@add@frontmatter{ltx:creator}[role=author]{\@personname{#1}}');
-DefConstructor('\@institute{}', "<ltx:contact role='institute'>#1</ltx:contact>", bounded => 1);
+DefConstructor('\@institute{}', "<ltx:contact role='affiliation'>#1</ltx:contact>", bounded => 1);
 DefMacro('\thanks Until:\endthanks',     '\@add@to@frontmatter{ltx:creator}{\@institute{#1}}');
 DefMacro('\abstract Until:\endabstract', '\@add@frontmatter{ltx:abstract}{#1}');
 

--- a/lib/LaTeXML/Engine/Base_Utility.pool.ltxml
+++ b/lib/LaTeXML/Engine/Base_Utility.pool.ltxml
@@ -299,7 +299,10 @@ DefConstructor('\lx@frontmatterhere', sub { insertFrontMatter($_[0]); },
     my ($stomach) = @_;
     my @boxes = ();
     if (my $frontmatter_tks = LookupValue('@at@begin@maketitle')) {
+      Let('\@add@to@frontmatter@save','\@add@to@frontmatter');
+      Let('\@add@to@frontmatter','\@add@to@frontmatter@now');
       push(@boxes, $stomach->digest(Tokens(@$frontmatter_tks)));
+      Let('\@add@to@frontmatter','\@add@to@frontmatter@save');
       AssignValue('@at@begin@maketitle', undef, 'global'); }
     AssignValue(frontmatter_deferred => 1, 'global');
     return @boxes; });

--- a/lib/LaTeXML/Package/aa_support.sty.ltxml
+++ b/lib/LaTeXML/Package/aa_support.sty.ltxml
@@ -26,7 +26,7 @@ use LaTeXML::Package;
 foreach my $option (qw(10pt 11pt 12pt twoside onecolumn twocolumn
   draft final referee
   leqno fleqn longauth rnote
-  oldversion
+  oldversion utf8 hideoverfull
   runningheads
   envcountreset envcountsect
   structabstract traditabstract

--- a/lib/LaTeXML/Package/inst_support.sty.ltxml
+++ b/lib/LaTeXML/Package/inst_support.sty.ltxml
@@ -37,22 +37,23 @@ use LaTeXML::Package;
 # Our implementation strategy is similar, but we split the \institution into several
 # ltx:note's. We check to see if there is an ltx:creator with a footnote mark
 # with the same mark number, and copy the institute information into that creator element
-# as an ltx:contact(with @role='institute').
+# as an ltx:contact(with @role='affiliation').
 
 # add optinal argument for OmniBus use
 DefMacro('\author[]{}', sub {
     map { (T_CS('\lx@author'), T_BEGIN, @$_, T_END) } SplitTokens($_[2], T_CS('\and'), T_OTHER(',')); });
 
-DefMacro('\@institutemark{}', '\lx@contact{institutemark}{#1}');
-
 # \inst typically appears INSIDE \author, so @add@to@frontmatter doesn't sync them
-DefConstructor('\@@@inst{}',
-  "^<ltx:contact role='institutemark' _mark='#1'>#1</ltx:contact>"
+# This adds ltx:contact(s) to the ltx:creator; arg is marks to connect to \institute
+DefConstructor('\lx@add@creator@marks@@{}',
+  "^<ltx:contact role='affiliationmark' _mark='#1'>#1</ltx:contact>"
     . "<ltx:contact role='emailmark' _mark='#1'>#1</ltx:contact>");
-DefMacro('\@inst{}', '\@add@to@frontmatter{ltx:creator}{\@@@inst{#1}}');
-DefMacro('\inst{}', sub {
-    map { (T_CS('\@inst'), T_BEGIN, @$_, T_END) } SplitTokens($_[1], T_OTHER(',')); });
-
+DefMacro('\lx@add@creator@marks@{}',
+  '\@add@to@frontmatter{ltx:creator}{\lx@add@creator@marks@@{#1}}');
+DefMacro('\lx@add@creator@marks{}', sub {
+    map { (T_CS('\lx@add@creator@marks@'), T_BEGIN, @$_, T_END) }
+      SplitTokens($_[1], T_OTHER(',')); });
+Let('\inst',    '\lx@add@creator@marks');
 Let('\at',      '\and');    # Actually this is different than \and, but...
 Let('\iand',    '\and');
 Let('\nand',    '\and');
@@ -78,44 +79,64 @@ DefConstructor('\@in@inst@email{}',
 
 # This creates the note for each institute.
 DefConstructor('\@add@institute {}',
-  "<ltx:note role='institutetext' mark='#mark'>#1</ltx:note>",
+  "<ltx:note role='affiliationtext' mark='#mark' xml:id='#id'>#1</ltx:note>",
   bounded    => 1, beforeDigest => sub { AssignValue(inPreamble => 0); },
-  properties => sub { (mark => ToString(Expand(T_CS('\theinst')))); });
+  properties => sub {
+    my $mark = ToString(Expand(T_CS('\theinst')));
+    # Need an xmlm:id, so ltx:note can accept \label
+    (mark => $mark, id => "inst$mark"); });
 
-# Reconnecting the institute to the appropriate author:
+# Reconnecting the institute, email to the appropriate author:
 # [Handling is similar to reconnecting footnotemark & footnotetext]
-Tag('ltx:note', afterClose => \&relocateInstitute);
+# This can't work until AFTER both authors AND institute have been absorbed!
+Tag('ltx:document', afterClose => sub {
+  map { relocateInstitute($_[0], $_); } $_[0]->findnodes(".//ltx:note[\@role]"); });
 
 sub relocateInstitute {
-  my ($document, $instnode) = @_;
-  if (($instnode->getAttribute('role') || '') eq 'institutetext') {
-    if (my $mark = $instnode->getAttribute('mark')) {
-      # Find authors with same mark.
-      my @authors;
-      if (@authors = $document->findnodes(".//ltx:contact[\@role='institutemark'][\@_mark='$mark']")) {
-        foreach my $author (@authors) {
-          $document->appendClone($author, $instnode->childNodes);
-          $author->setAttribute(role => 'institute');
-          $author->removeAttribute('_mark'); }
-        $instnode->parentNode->removeChild($instnode); }
-      # Not sure if this is right; find authors WITHOUT a contact mark.
-      elsif (@authors = $document->findnodes(".//ltx:creator[not(descendant::ltx:contact[\@role='institutemark'])]")) {
-        foreach my $author (@authors) {
-          $document->appendTree($author, ['ltx:contact', { role => 'institute' }, $instnode->childNodes]);
-          $instnode->parentNode->removeChild($instnode); } }
-  } }
+  my ($document, $instnode, $nopurge) = @_;
+  my $role  = $instnode->getAttribute('role') || '';
+  my $mark  = $instnode->getAttribute('mark') || '';
+  my $label = $instnode->getAttribute('labels') || '';
+  my $match = join(' or ', ($mark ? "(\@_mark='$mark')" : ()),
+                   ($label ? "(ltx:ref[\@labelref='$label'])" : ()));
+  # Perversely, can have the email note embedded within the affiliation note!
+  if(my $embedded = ($role eq 'affiliationtext')
+     && $document->findnode("ltx:note[\@role='email']", $instnode)) {
+    $embedded->setAttribute(mark => $mark);
+    $embedded->setAttribute(labels => $label);
+    relocateInstitute($document, $embedded, 1); }
+
+  if ($role eq 'affiliationtext') {
+    # Find authors with same mark or containing ltx:ref@label.
+    if (my @contacts = ($mark || $label)
+        && $document->findnodes(".//ltx:contact[\@role='affiliationmark'][$match]")) {
+      foreach my $contact (@contacts) {
+        map { $contact->removeChild($_); } $contact->childNodes;
+        $document->appendClone($contact, $instnode->childNodes);
+        $contact->setAttribute(role => 'affiliation');
+        $contact->removeAttribute('_mark'); }
+      $instnode->parentNode->removeChild($instnode); }
+    # Not sure if this is right; find authors WITHOUT a contact mark.
+    elsif (my @authors = $document->findnodes(".//ltx:creator[not(descendant::ltx:contact[\@role='affiliationmark'])]")) {
+      foreach my $author (@authors) {
+        $document->appendTree($author, ['ltx:contact', { role => 'affiliation' }, $instnode->childNodes]);
+        $instnode->parentNode->removeChild($instnode); } }
+  }
   # Or relocate email
-  if (($instnode->getAttribute('role') || '') eq 'email') {
-    if (my $mark = $instnode->getAttribute('mark')) {
-      # Find authors with same mark.
-      my @authors;
-      if (@authors = $document->findnodes(".//ltx:contact[\@role='emailmark'][\@_mark='$mark']")) {
-        foreach my $author (@authors) {
-          $document->appendClone($author, $instnode->childNodes);
-          $author->setAttribute(role => 'email');
-          $author->removeAttribute('_mark'); }
-        $instnode->parentNode->removeChild($instnode); }
-  } }
+  if ($role eq 'email') {
+    if (my @contacts = ($mark || $label)
+        && $document->findnodes(".//ltx:contact[\@role='emailmark'][$match]")) {
+      foreach my $contact (@contacts) {
+        map { $contact->removeChild($_); } $contact->childNodes;
+        $document->appendClone($contact, $instnode->childNodes);
+        $contact->setAttribute(role => 'email');
+        $contact->removeAttribute('_mark'); }
+      $instnode->parentNode->removeChild($instnode); }
+  }
+  # Any remaining ltx:contact that have the mark or label can be removed
+  if((! $nopurge) && ($mark || $label)){
+    map { $_->parentNode->removeChild($_); }
+      $document->findnodes(".//ltx:contact[$match]"); }
   return; }
 
 1;

--- a/lib/LaTeXML/Package/jheppub.sty.ltxml
+++ b/lib/LaTeXML/Package/jheppub.sty.ltxml
@@ -29,19 +29,40 @@ RequirePackage('epsfig');
 RequirePackage('graphicx');
 RequirePackage('inst_support');
 # \author[]{}
+# Add an author (repeated), and add ltx:contact stubs to be filled in
+# by inst_support for affiliation & email
+# optional arg is a mark identifying which affliation belongs
 DefMacro('\author[]{}',
-  '\ifx.#1.\else\@institutemark{#1}\fi'
-    . '\def\@author{#2}\lx@author{#2}', locked => 1);
+  '\def\@author{#2}\lx@author{#2}'
+  . '\ifx.#1.\else\lx@add@creator@marks{#1}\fi'
+  . '\@add@to@frontmatter{ltx:creator}{\lx@jhep@emailstub}', locked => 1);
 
+# Define the affiliation; optional arg is the mark connecting to author
 DefConstructor('\affiliation[]{}',
-  "<ltx:note role='institutetext' mark='#1'>#2</ltx:note>",
+  "<ltx:note role='affiliationtext' mark='#1'>#2</ltx:note>",
   bounded => 1, beforeDigest => sub { AssignValue(inPreamble => 0); });
 
 # \note{} appears inside author?
 Let('\note', '\footnote');
 
-DefConstructor('\@@@email{}', "^ <ltx:contact role='email'>#1</ltx:contact>");
-DefMacro('\emailAdd Semiverbatim', '\@add@to@frontmatter{ltx:creator}{\@@@email{#1}}');
+NewCounter('\lx@jhep@nauthor');
+NewCounter('\lx@jhep@nemail');
+DefConstructor('\lx@jhep@emailstub',
+  "<ltx:contact role='emailmark' _mark='#mark'></ltx:contact>",
+  properties => sub {
+    StepCounter('\lx@jhep@nauthor');
+    ( mark => 'email' . ToString(CounterValue('\lx@jhep@nauthor')) ); });
+
+# \emailAdd{email}, repeated, after \author(s),
+# adds email address to each author in sequence
+# use ltx:note, rather than ltx:contact; inst_support moves these to the right place.
+DefConstructor('\lx@jhep@email{}',
+  "^ <ltx:note role='email' mark='#mark'>#1</ltx:note>",
+  properties => sub {
+    StepCounter('\lx@jhep@nemail');
+    ( mark => 'email' . ToString(CounterValue('\lx@jhep@nemail')) ); });
+DefMacro('\emailAdd Semiverbatim',
+  '\@add@to@frontmatter{ltx:creator}{\lx@jhep@email{#1}}');
 
 DefMacro('\keywordname', '\textbf{Keywords}');
 DefMacro('\keywords{}',  '\@add@frontmatter{ltx:keywords}[name={\keywordname}]{#1}');

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -74,11 +74,13 @@ a.ltx_LaTeXML_logo { text-decoration: none; }
 .ltx_authors_1line .ltx_author_after { display:inline;}
 .ltx_authors_1line .ltx_author_notes { display:inline-block; }
 .ltx_authors_1line .ltx_author_notes:before { content:"*"; color:blue;}
-.ltx_authors_1line .ltx_author_notes span { display:none; }
-.ltx_authors_1line .ltx_author_notes:hover span {
+.ltx_authors_1line .ltx_author_notes .ltx_author_notes_content { display:none; }
+.ltx_authors_1line .ltx_author_notes:hover .ltx_author_notes_content {
     display:block; position:absolute; z-index:10;
     background:white; text-align:left;
     border: 1px solid black; border-radius: 0 5px 5px 5px; box-shadow: 5px 5px 10px gray; }
+.ltx_authors_1line .ltx_author_notes:hover .ltx_author_notes_content .ltx_contact {
+    display:block; }
 
 /* add class=ltx_authors_multiline to get authors & affliations on separate lines*/
 .ltx_authors_multiline .ltx_creator,

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-jats.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-jats.xsl
@@ -207,7 +207,7 @@
     </address>
   </xsl:template>
 
-  <xsl:template match="ltx:note[@role='institutetext']"/>
+  <xsl:template match="ltx:note[@role='affiliationtext']"/>
 
   <xsl:template match="ltx:personname">
     <name>

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-structure-xhtml.xsl
@@ -554,9 +554,12 @@
       <xsl:if test="ltx:contact">
         <xsl:element name="span" namespace="{$html_ns}">
           <xsl:attribute name="class">ltx_author_notes</xsl:attribute>
-          <xsl:apply-templates select="ltx:contact">
-            <xsl:with-param name="context" select="$innercontext"/>
-          </xsl:apply-templates>
+          <xsl:element name="span" namespace="{$html_ns}">
+            <xsl:attribute name="class">ltx_author_notes_content</xsl:attribute>
+            <xsl:apply-templates select="ltx:contact">
+              <xsl:with-param name="context" select="$innercontext"/>
+            </xsl:apply-templates>
+          </xsl:element>
         </xsl:element>
       </xsl:if>
       <xsl:apply-templates select="." mode="end">

--- a/lib/LaTeXML/resources/XSLT/LaTeXML-tei.xsl
+++ b/lib/LaTeXML/resources/XSLT/LaTeXML-tei.xsl
@@ -207,7 +207,7 @@
     <xsl:apply-templates/>
   </xsl:template>
 
-  <xsl:template match="ltx:note[@role='institutetext']"/>
+  <xsl:template match="ltx:note[@role='affiliationtext']"/>
 
   <xsl:template match="ltx:note[@role='thanks']">
     <p>


### PR DESCRIPTION
This PR improves the machinery of `inst_support` which caused it to fail to attach affiliations & email to the appropriate author, resulting in awkwardly placed rows of apparent footnotes containing the info. It also handles a peculiar technique where authors use `\ref` and `\label` to associate the items, rather than the usual `\inst` with numbers.

This PR is still a draft, as further refinement to `Engine/Base_Utility` is needed to control how the digestion of frontmatter is deferred.