### PR TITLE
expl syntax in siunitx options

### DIFF
--- a/lib/LaTeXML/Package/siunitx.sty.ltxml
+++ b/lib/LaTeXML/Package/siunitx.sty.ltxml
@@ -1564,12 +1564,12 @@ RawTeX(<<'EoTeX');
   number-unit-product = \,      ,
   product-units       = repeat,
 
-  list-final-separator = { ~ and ~ } ,
-  list-pair-separator  = { ~ and ~ } ,
-  list-separator       = { , ~ }     ,
+  list-final-separator = { and } ,
+  list-pair-separator  = { and } ,
+  list-separator       = {, }    ,
   list-units           = repeat,
 
-  range-phrase = { ~ to ~ },
+  range-phrase = { to },
   range-units  = repeat,
 
   table-unit-alignment = center,

--- a/t/complex/si.xml
+++ b/t/complex/si.xml
@@ -90,11 +90,11 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
               </XMApp>
               <XMWrap>
                 <XMTok color="#0000FF" meaning="1" role="NUMBER" xml:id="p1.m4.1">1</XMTok>
-                <XMText role="PUNCT"><text color="#0000FF"> ,   </text></XMText>
+                <XMText role="PUNCT"><text color="#0000FF">, </text></XMText>
                 <XMTok color="#0000FF" meaning="2" role="NUMBER" xml:id="p1.m4.2">2</XMTok>
-                <XMText role="PUNCT"><text color="#0000FF"> ,   </text></XMText>
+                <XMText role="PUNCT"><text color="#0000FF">, </text></XMText>
                 <XMTok color="#0000FF" meaning="3" role="NUMBER" xml:id="p1.m4.3">3</XMTok>
-                <XMText role="PUNCT"><text color="#0000FF">   and   </text></XMText>
+                <XMText role="PUNCT"><text color="#0000FF"> and </text></XMText>
                 <XMTok color="#0000FF" meaning="4" role="NUMBER" xml:id="p1.m4.4">4</XMTok>
               </XMWrap>
             </XMDual>
@@ -2261,9 +2261,9 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                   </XMApp>
                   <XMWrap>
                     <XMTok meaning="0.1" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m1.1">0.1</XMTok>
-                    <XMText role="PUNCT"> ,   </XMText>
+                    <XMText role="PUNCT">, </XMText>
                     <XMTok meaning="0.2" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m1.2">0.2</XMTok>
-                    <XMText role="PUNCT">   and   </XMText>
+                    <XMText role="PUNCT"> and </XMText>
                     <XMTok meaning="0.3" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m1.3">0.3</XMTok>
                   </XMWrap>
                 </XMDual>
@@ -2279,9 +2279,9 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                   </XMApp>
                   <XMWrap>
                     <XMTok color="#0000FF" meaning="0.1" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m2.1">0.1</XMTok>
-                    <XMText role="PUNCT"><text color="#0000FF"> ,   </text></XMText>
+                    <XMText role="PUNCT"><text color="#0000FF">, </text></XMText>
                     <XMTok color="#0000FF" meaning="0.2" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m2.2">0.2</XMTok>
-                    <XMText role="PUNCT"><text color="#0000FF">   and   </text></XMText>
+                    <XMText role="PUNCT"><text color="#0000FF"> and </text></XMText>
                     <XMTok color="#0000FF" meaning="0.3" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m2.3">0.3</XMTok>
                   </XMWrap>
                 </XMDual>
@@ -2299,7 +2299,7 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                     <XMTok meaning="0.1" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m3.1">0.1</XMTok>
                     <XMText role="PUNCT">; </XMText>
                     <XMTok meaning="0.2" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m3.2">0.2</XMTok>
-                    <XMText role="PUNCT">   and   </XMText>
+                    <XMText role="PUNCT"> and </XMText>
                     <XMTok meaning="0.3" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m3.3">0.3</XMTok>
                   </XMWrap>
                 </XMDual>
@@ -2315,7 +2315,7 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                   </XMApp>
                   <XMWrap>
                     <XMTok meaning="0.1" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m4.1">0.1</XMTok>
-                    <XMText role="PUNCT"> ,   </XMText>
+                    <XMText role="PUNCT">, </XMText>
                     <XMTok meaning="0.2" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m4.2">0.2</XMTok>
                     <XMText role="PUNCT">, </XMText>
                     <XMTok meaning="0.3" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m4.3">0.3</XMTok>
@@ -2350,7 +2350,7 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                   </XMApp>
                   <XMWrap>
                     <XMTok meaning="0.1" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m6.1">0.1</XMTok>
-                    <XMText role="PUNCT">   and   </XMText>
+                    <XMText role="PUNCT"> and </XMText>
                     <XMTok meaning="0.2" role="NUMBER" xml:id="S1.SS6.SSS1.p1.m6.2">0.2</XMTok>
                   </XMWrap>
                 </XMDual>
@@ -2392,7 +2392,7 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                 </XMApp>
                 <XMWrap>
                   <XMTok meaning="5" role="NUMBER" xml:id="S1.SS7.p1.m1.1">5</XMTok>
-                  <XMText role="PUNCT">   to   </XMText>
+                  <XMText role="PUNCT"> to </XMText>
                   <XMTok meaning="100" role="NUMBER" xml:id="S1.SS7.p1.m1.2">100</XMTok>
                 </XMWrap>
               </XMDual>
@@ -6645,19 +6645,19 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                       <XMTok meaning="2" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m1.1.1">2</XMTok>
                       <XMTok class="ltx_unit" meaning="tesla" role="ID" xml:id="S2.SS2.SSS5.p1.m1.1.3">T</XMTok>
                     </XMApp>
-                    <XMText role="PUNCT"> ,   </XMText>
+                    <XMText role="PUNCT">, </XMText>
                     <XMApp xml:id="S2.SS2.SSS5.p1.m1.2">
                       <XMText meaning="times" role="MULOP" xml:id="S2.SS2.SSS5.p1.m1.2.2"> </XMText>
                       <XMTok meaning="4" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m1.2.1">4</XMTok>
                       <XMTok class="ltx_unit" meaning="tesla" role="ID" xml:id="S2.SS2.SSS5.p1.m1.2.3">T</XMTok>
                     </XMApp>
-                    <XMText role="PUNCT"> ,   </XMText>
+                    <XMText role="PUNCT">, </XMText>
                     <XMApp xml:id="S2.SS2.SSS5.p1.m1.3">
                       <XMText meaning="times" role="MULOP" xml:id="S2.SS2.SSS5.p1.m1.3.2"> </XMText>
                       <XMTok meaning="6" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m1.3.1">6</XMTok>
                       <XMTok class="ltx_unit" meaning="tesla" role="ID" xml:id="S2.SS2.SSS5.p1.m1.3.3">T</XMTok>
                     </XMApp>
-                    <XMText role="PUNCT">   and   </XMText>
+                    <XMText role="PUNCT"> and </XMText>
                     <XMApp xml:id="S2.SS2.SSS5.p1.m1.4">
                       <XMText meaning="times" role="MULOP" xml:id="S2.SS2.SSS5.p1.m1.4.2"> </XMText>
                       <XMTok meaning="8" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m1.4.1">8</XMTok>
@@ -6681,11 +6681,11 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                     <XMWrap>
                       <XMText role="OPEN">(</XMText>
                       <XMTok meaning="2" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m2.1.1">2</XMTok>
-                      <XMText role="PUNCT"> ,   </XMText>
+                      <XMText role="PUNCT">, </XMText>
                       <XMTok meaning="4" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m2.1.2">4</XMTok>
-                      <XMText role="PUNCT"> ,   </XMText>
+                      <XMText role="PUNCT">, </XMText>
                       <XMTok meaning="6" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m2.1.3">6</XMTok>
-                      <XMText role="PUNCT">   and   </XMText>
+                      <XMText role="PUNCT"> and </XMText>
                       <XMTok meaning="8" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m2.1.4">8</XMTok>
                       <XMText role="CLOSE">)</XMText>
                     </XMWrap>
@@ -6709,19 +6709,19 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                       <XMTok meaning="2" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m3.1.1">2</XMTok>
                       <XMTok class="ltx_unit" meaning="tesla" role="ID" xml:id="S2.SS2.SSS5.p1.m3.1.3">T</XMTok>
                     </XMApp>
-                    <XMText role="PUNCT"> ,   </XMText>
+                    <XMText role="PUNCT">, </XMText>
                     <XMApp xml:id="S2.SS2.SSS5.p1.m3.2">
                       <XMText meaning="times" role="MULOP" xml:id="S2.SS2.SSS5.p1.m3.2.2"> </XMText>
                       <XMTok meaning="4" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m3.2.1">4</XMTok>
                       <XMTok class="ltx_unit" meaning="tesla" role="ID" xml:id="S2.SS2.SSS5.p1.m3.2.3">T</XMTok>
                     </XMApp>
-                    <XMText role="PUNCT"> ,   </XMText>
+                    <XMText role="PUNCT">, </XMText>
                     <XMApp xml:id="S2.SS2.SSS5.p1.m3.3">
                       <XMText meaning="times" role="MULOP" xml:id="S2.SS2.SSS5.p1.m3.3.2"> </XMText>
                       <XMTok meaning="6" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m3.3.1">6</XMTok>
                       <XMTok class="ltx_unit" meaning="tesla" role="ID" xml:id="S2.SS2.SSS5.p1.m3.3.3">T</XMTok>
                     </XMApp>
-                    <XMText role="PUNCT">   and   </XMText>
+                    <XMText role="PUNCT"> and </XMText>
                     <XMApp xml:id="S2.SS2.SSS5.p1.m3.4">
                       <XMText meaning="times" role="MULOP" xml:id="S2.SS2.SSS5.p1.m3.4.2"> </XMText>
                       <XMTok meaning="8" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m3.4.1">8</XMTok>
@@ -6744,11 +6744,11 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                     </XMApp>
                     <XMWrap>
                       <XMTok meaning="2" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m4.1.1">2</XMTok>
-                      <XMText role="PUNCT"> ,   </XMText>
+                      <XMText role="PUNCT">, </XMText>
                       <XMTok meaning="4" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m4.1.2">4</XMTok>
-                      <XMText role="PUNCT"> ,   </XMText>
+                      <XMText role="PUNCT">, </XMText>
                       <XMTok meaning="6" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m4.1.3">6</XMTok>
-                      <XMText role="PUNCT">   and   </XMText>
+                      <XMText role="PUNCT"> and </XMText>
                       <XMTok meaning="8" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m4.1.4">8</XMTok>
                     </XMWrap>
                   </XMDual>
@@ -6769,7 +6769,7 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                       <XMTok meaning="2" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m5.1.1">2</XMTok>
                       <XMTok class="ltx_unit" meaning="degreeCelsius" name="SIUnitSymbolCelsius" role="ID" xml:id="S2.SS2.SSS5.p1.m5.1.3">°C</XMTok>
                     </XMApp>
-                    <XMText role="PUNCT">   to   </XMText>
+                    <XMText role="PUNCT"> to </XMText>
                     <XMApp xml:id="S2.SS2.SSS5.p1.m5.2">
                       <XMText meaning="times" role="MULOP" xml:id="S2.SS2.SSS5.p1.m5.2.2"> </XMText>
                       <XMTok meaning="4" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m5.2.1">4</XMTok>
@@ -6791,7 +6791,7 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                     <XMWrap>
                       <XMText role="OPEN">(</XMText>
                       <XMTok meaning="2" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m6.1.1">2</XMTok>
-                      <XMText role="PUNCT">   to   </XMText>
+                      <XMText role="PUNCT"> to </XMText>
                       <XMTok meaning="4" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m6.1.2">4</XMTok>
                       <XMText role="CLOSE">)</XMText>
                     </XMWrap>
@@ -6813,7 +6813,7 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                       <XMTok meaning="2" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m7.1.1">2</XMTok>
                       <XMTok class="ltx_unit" meaning="degreeCelsius" name="SIUnitSymbolCelsius" role="ID" xml:id="S2.SS2.SSS5.p1.m7.1.3">°C</XMTok>
                     </XMApp>
-                    <XMText role="PUNCT">   to   </XMText>
+                    <XMText role="PUNCT"> to </XMText>
                     <XMApp xml:id="S2.SS2.SSS5.p1.m7.2">
                       <XMText meaning="times" role="MULOP" xml:id="S2.SS2.SSS5.p1.m7.2.2"> </XMText>
                       <XMTok meaning="4" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m7.2.1">4</XMTok>
@@ -6834,7 +6834,7 @@ Some text <break/><Math mode="inline" tex="4\text{\,}\mathrm{m}\text{\,}{\mathrm
                     </XMApp>
                     <XMWrap>
                       <XMTok meaning="2" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m8.1.1">2</XMTok>
-                      <XMText role="PUNCT">   to   </XMText>
+                      <XMText role="PUNCT"> to </XMText>
                       <XMTok meaning="4" role="NUMBER" xml:id="S2.SS2.SSS5.p1.m8.1.2">4</XMTok>
                     </XMWrap>
                   </XMDual>


### PR DESCRIPTION
siunitx options are entered in expl syntax.  This matters for a few of the options.  (Note that in the xml, a number of the deletions are non-breaking spaces.)  This is the slight adjustment I mentioned in #1734.

We also cannot just make all of the options inside `\ExplSyntaxOn` and `\ExplSyntaxOff` because there are a few `_` that need to become subscripts.