### PR TITLE
Fix \label inside longtable not producing xml:id

### DIFF
--- a/lib/LaTeXML/Package/longtable.sty.ltxml
+++ b/lib/LaTeXML/Package/longtable.sty.ltxml
@@ -46,6 +46,9 @@ DefConstructor('\@@longtable [] Undigested DigestedBody',
   afterDigest  => sub {
     my ($stomach, $whatsit) = @_;
     $whatsit->setProperties(%{ LookupValue('LONGTABLE_PROPERTIES') || {} });
+    # Apply the stored \label to the table element.
+    if (my $label = LookupValue('LONGTABLE_LABEL')) {
+      $whatsit->setProperty(label => $label); }
     # Insert caption and toccaption, if any were encountered.
     if (my $captions = LookupValue('LONGTABLE_HEAD_CAPTIONS') || LookupValue('LONGTABLE_CAPTIONS')) {
       my ($toccaption, $caption) = @$captions;


### PR DESCRIPTION
## Summary

`\label{...}` inside a `longtable` environment does not produce a matching `xml:id` on the generated `<ltx:table>` element, causing cross-references (`\ref{...}`) to that label to become dangling.

**Root cause:** `\lx@longtable@label` (line 133) stores the label in `LONGTABLE_LABEL`, and `longtableBindings` (line 79) clears it on entry, but the `afterDigest` callback in `\@@longtable` never reads `LONGTABLE_LABEL` to set the `label` property on the whatsit. Since the constructor template uses `labels='#label'`, the property must be set for the `xml:id` to appear.

**Fix:** Add 3 lines to `afterDigest` to read `LONGTABLE_LABEL` and set it as the `label` property, matching how `LONGTABLE_PROPERTIES`, `LONGTABLE_CAPTIONS`, etc. are already handled.

## Minimal reproduction

```latex
\begin{longtable}{ll}
\caption{Example}\label{tab:example}\\
\hline
A & B \\
\end{longtable}

See Table~\ref{tab:example}.
```

Without the fix, the `\ref` produces `labelref="LABEL:tab:example"` in the intermediate XML but no element has a matching `xml:id`, so `latexmlpost` emits "Missing Target for Label: LABEL:tab:example".

## Test plan

- [x] Verified the fix resolves the dangling reference in our test document
- [x] Verified that regular `table` floats with `\label` are unaffected