### PR TITLE
booktabs: mark rows between \toprule and \midrule as table headers

### DIFF
--- a/lib/LaTeXML/Package/booktabs.sty.ltxml
+++ b/lib/LaTeXML/Package/booktabs.sty.ltxml
@@ -19,10 +19,17 @@ use LaTeXML::Package;
 # Except for the encodings of hline as t (normal) or T (thin)
 # there's currently no support for variable thickness.
 
-# \toprule[thickness]  doubled
-DefMacro('\toprule[Dimension]', '\hline\hline');
-# \midrule[thickness]
-DefMacro('\midrule[Dimension]', '\hline');
+# \toprule[thickness]  doubled; marks subsequent rows as header rows
+DefMacro('\toprule[Dimension]', sub {
+    if (my $alignment = LookupValue('Alignment')) {
+      $$alignment{in_tabular_head} = 1; }
+    return (T_CS('\hline'), T_CS('\hline')); });
+
+# \midrule[thickness]  ends the header region
+DefMacro('\midrule[Dimension]', sub {
+    if (my $alignment = LookupValue('Alignment')) {
+      $$alignment{in_tabular_head} = 0; }
+    return (T_CS('\hline')); });
 # \bottomrule[thickness] doubled
 DefMacro('\bottomrule[Dimension]', '\hline\hline');
 


### PR DESCRIPTION
## Summary

Tables using booktabs (`\toprule`, `\midrule`, `\bottomrule`) don't produce `<thead>`/`<tbody>` grouping in the output. All rows end up in `<tbody>`, so downstream converters (JATS, HTML) cannot distinguish header rows from data rows.

**Root cause:** The current `\toprule` and `\midrule` macros simply expand to `\hline` without setting the `in_tabular_head` flag on the Alignment.

**Fix:** Change `\toprule` and `\midrule` from simple macro expansions to DefMacro subs that set `$$alignment{in_tabular_head}` before returning the `\hline` tokens. `\toprule` enables the flag (marking subsequent rows as headers), `\midrule` disables it (ending the header region). This matches the universal booktabs convention where header rows appear between `\toprule` and `\midrule`.

## Minimal reproduction

```latex
\begin{tabular}{ll}
\toprule
Name & Value \\
\midrule
A & 1 \\
B & 2 \\
\bottomrule
\end{tabular}
```

**Before:** All rows in `<tbody>`, no `<thead>`.
**After:** "Name & Value" row in `<thead>`, data rows in `<tbody>`.

## Test plan

- [x] Verified correct `<thead>`/`<tbody>` output for booktabs tables in our JATS conversion pipeline
- [x] Verified that tables without booktabs are unaffected
- [x] Verified that `\bottomrule` behavior is unchanged (no header flag manipulation needed)