### PR TITLE
[CI] update actions/checkout to v6

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,7 +48,7 @@ jobs:
             allow_failure: true
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Print Program Versions
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,7 @@ jobs:
           #   allow_failure: true
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       # ====================
       # Setup Perl


### PR DESCRIPTION
We were getting CI warnings that `actions/checkout@v2` is about to be phased out in September 2026, so updating to the current version.