### PR TITLE
Simplify perlcritic configuration (to work with stock ubuntu install)

### DIFF
--- a/tools/latexml.perlcritic
+++ b/tools/latexml.perlcritic
@@ -32,6 +32,8 @@ severity=3
 exclude = Bangs
 #exclude = Bangs CodeLayout::RequireUseUTF8 Documentation::RequirePODUseEncodingUTF8
 
+exclude =  Miscellanea::ProhibitUnrestrictedNoCritic  CodeLayout::RequireUseUTF8  Documentation::RequirePODUseEncodingUTF8  ErrorHandling::RequireUseOfExceptions  ValuesAndExpressions::ProhibitFiletest_f  InputOutput::ProhibitInteractiveTest  Compatibility::ProhibitThreeArgumentOpen  ValuesAndExpressions::ProhibitAccessOfPrivateData  ValuesAndExpressions::ProhibitCommaSeparatedStatements
+
 [LaTeXML::RequireDoubleSigils]
 
 #======================================================================
@@ -99,9 +101,9 @@ severity=1
 severity=4
 # was 3; portability mess
 
-[CodeLayout::ProhibitHashBarewords]
-severity=1
-# was 3; oh c'mon!?!?
+# [CodeLayout::ProhibitHashBarewords]
+# severity=1
+# # was 3; oh c'mon!?!?
 
 [ControlStructures::ProhibitCascadingIfElse]
 severity=2
@@ -148,25 +150,25 @@ severity=2
 #======================================================================
 # Try out Perl::Critic::StricterSubs
 
-[Modules::RequireExplicitInclusion]
-#severity=4
-severity=1
+# [Modules::RequireExplicitInclusion]
+# #severity=4
+# severity=1
 
-# This sounds wonderful, but doesn't actually track the imports
-# implicitly imported by a plain "use Module;"
-[Subroutines::ProhibitCallsToUndeclaredSubs]
-#severity=4
-severity=1
+# # This sounds wonderful, but doesn't actually track the imports
+# # implicitly imported by a plain "use Module;"
+# [Subroutines::ProhibitCallsToUndeclaredSubs]
+# #severity=4
+# severity=1
 
-[Subroutines::ProhibitCallsToUnexportedSubs]
-#severity=4
-severity=1
+# [Subroutines::ProhibitCallsToUnexportedSubs]
+# #severity=4
+# severity=1
 
-[Subroutines::ProhibitExportingUndeclaredSubs]
-severity=4
+# [Subroutines::ProhibitExportingUndeclaredSubs]
+# severity=4
 
-[Subroutines::ProhibitQualifiedSubDeclarations]
-severity=4
+# [Subroutines::ProhibitQualifiedSubDeclarations]
+# severity=4
 
 #======================================================================
 # [Probably will want to]
@@ -190,33 +192,33 @@ severity=4
 # severity=1
 # # was 2; possibly useful, but not yet...
 
-#======================================================================
-# DISABLE some policies that we may want to revisit in the future
+# #======================================================================
+# # DISABLE some policies that we may want to revisit in the future
 
-# What's the point of using "## no critic" if you just get different complaints?
-[-Miscellanea::ProhibitUnrestrictedNoCritic]
+# # What's the point of using "## no critic" if you just get different complaints?
+# [-Miscellanea::ProhibitUnrestrictedNoCritic]
 
-# Exclude (for now) the suggestion to "use utf8" (and also in POD)
-# [probably would prefer that the sources remain pure ASCII]
-[-CodeLayout::RequireUseUTF8]
-[-Documentation::RequirePODUseEncodingUTF8]
+# # Exclude (for now) the suggestion to "use utf8" (and also in POD)
+# # [probably would prefer that the sources remain pure ASCII]
+# [-CodeLayout::RequireUseUTF8]
+# [-Documentation::RequirePODUseEncodingUTF8]
 
-# Does Perl even have a (decent) Exception system? (maybe it does now)
-[-ErrorHandling::RequireUseOfExceptions]
+# # Does Perl even have a (decent) Exception system? (maybe it does now)
+# [-ErrorHandling::RequireUseOfExceptions]
 
-# Why is -f so bad?
-[-ValuesAndExpressions::ProhibitFiletest_f]
-[-InputOutput::ProhibitInteractiveTest]
+# # Why is -f so bad?
+# [-ValuesAndExpressions::ProhibitFiletest_f]
+# [-InputOutput::ProhibitInteractiveTest]
 
-# I really don't need compatibility with Perl 5.6 or 5.8!!!
-#[-Compatibility::ProhibitColonsInBarewordHashKeys]
-[-Compatibility::ProhibitThreeArgumentOpen]
+# # I really don't need compatibility with Perl 5.6 or 5.8!!!
+# #[-Compatibility::ProhibitColonsInBarewordHashKeys]
+# [-Compatibility::ProhibitThreeArgumentOpen]
 
-# I don't necessarily disagree with this policy,
-# but it seems to be itself buggy; it complains about $_->[0], eg.
-[-ValuesAndExpressions::ProhibitAccessOfPrivateData]
-# Ditto, seems buggy
-[-ValuesAndExpressions::ProhibitCommaSeparatedStatements]
+# # I don't necessarily disagree with this policy,
+# # but it seems to be itself buggy; it complains about $_->[0], eg.
+# [-ValuesAndExpressions::ProhibitAccessOfPrivateData]
+# # Ditto, seems buggy
+# [-ValuesAndExpressions::ProhibitCommaSeparatedStatements]
 #======================================================================
 
 


### PR DESCRIPTION
As it says... It still seems to check the basics/important stuff.