### PR TITLE
Add dirtytalk binding

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -486,6 +486,7 @@ lib/LaTeXML/Package/dcolumn.sty.ltxml
 lib/LaTeXML/Package/deluxetable.sty.ltxml
 lib/LaTeXML/Package/diagbox.sty.ltxml
 lib/LaTeXML/Package/ding.fontmap.ltxml
+lib/LaTeXML/Package/dirtytalk.sty.ltxml
 lib/LaTeXML/Package/doi.sty.ltxml
 lib/LaTeXML/Package/doublespace.sty.ltxml
 lib/LaTeXML/Package/dsfont.sty.ltxml
@@ -1724,6 +1725,8 @@ t/structure/crazybib.xml
 t/structure/csquotes.pdf
 t/structure/csquotes.tex
 t/structure/csquotes.xml
+t/structure/dirtytalk.tex
+t/structure/dirtytalk.xml
 t/structure/book.pdf
 t/structure/book.tex
 t/structure/book.xml

--- a/MANIFEST
+++ b/MANIFEST
@@ -1725,6 +1725,7 @@ t/structure/crazybib.xml
 t/structure/csquotes.pdf
 t/structure/csquotes.tex
 t/structure/csquotes.xml
+t/structure/dirtytalk.pdf
 t/structure/dirtytalk.tex
 t/structure/dirtytalk.xml
 t/structure/book.pdf

--- a/lib/LaTeXML/Package/dirtytalk.sty.ltxml
+++ b/lib/LaTeXML/Package/dirtytalk.sty.ltxml
@@ -1,0 +1,54 @@
+# -*- mode: Perl -*-
+# /=====================================================================\ #
+# |  dirtytalk                                                          | #
+# | Implementation for LaTeXML                                          | #
+# |=====================================================================| #
+# | Part of LaTeXML:                                                    | #
+# |  Public domain software, produced as part of work done by the       | #
+# |  United States Government & not subject to copyright in the US.     | #
+# \=====================================================================/ #
+package LaTeXML::Package::Pool;
+use strict;
+use warnings;
+use LaTeXML::Package;
+
+sub setDirtytalkSymbol {
+  my ($cs, $tokens) = @_;
+  return if IsEmpty($tokens);
+  DefMacroI($cs, undef, $tokens);
+  return;
+}
+
+DefMacro('\\dirtytalk@lqq', '\\textquotedblleft');
+DefMacro('\\dirtytalk@rqq', '\\textquotedblright');
+DefMacro('\\dirtytalk@lq',  '\\textquoteleft');
+DefMacro('\\dirtytalk@rq',  '\\textquoteright');
+
+DefKeyVal('dirtytalk', 'left',     'UndigestedKey', '', code => sub { setDirtytalkSymbol('\\dirtytalk@lqq', $_[1]); });
+DefKeyVal('dirtytalk', 'right',    'UndigestedKey', '', code => sub { setDirtytalkSymbol('\\dirtytalk@rqq', $_[1]); });
+DefKeyVal('dirtytalk', 'leftsub',  'UndigestedKey', '', code => sub { setDirtytalkSymbol('\\dirtytalk@lq',  $_[1]); });
+DefKeyVal('dirtytalk', 'rightsub', 'UndigestedKey', '', code => sub { setDirtytalkSymbol('\\dirtytalk@rq',  $_[1]); });
+
+ProcessOptions(inorder => 1, keysets => ['dirtytalk']);
+
+RawTeX(<<'EoTeX');
+\newcounter{dirtytalk@qdepth}
+\newcommand{\dirtytalk@lsymb}{%
+  \ifnum\value{dirtytalk@qdepth}>1
+    \dirtytalk@lq
+  \else
+    \dirtytalk@lqq
+  \fi}
+\newcommand{\dirtytalk@rsymb}{%
+  \ifnum\value{dirtytalk@qdepth}>1
+    \dirtytalk@rq
+  \else
+    \dirtytalk@rqq
+  \fi}
+\providecommand{\say}[1]{%
+  \addtocounter{dirtytalk@qdepth}{1}%
+  \dirtytalk@lsymb #1\dirtytalk@rsymb%
+  \addtocounter{dirtytalk@qdepth}{-1}}
+EoTeX
+
+1;

--- a/t/structure/dirtytalk.pdf
+++ b/t/structure/dirtytalk.pdf
@@ -1,0 +1,39 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Length 189 >>
+stream
+BT /F2 14 Tf 72 720 Td (1 Dirtytalk quotations) Tj ET
+BT /F1 10 Tf 72 672 Td (A plain \223outer quote\224.) Tj ET
+BT /F1 10 Tf 72 648 Td (A nested \223outer \221inner\222 quote\224.) Tj ET
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000257 00000 n 
+0000000354 00000 n 
+0000000456 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+695
+%%EOF

--- a/t/structure/dirtytalk.tex
+++ b/t/structure/dirtytalk.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+\usepackage{dirtytalk}
+
+\begin{document}
+\section{Dirtytalk quotations}
+
+A plain \say{outer quote}.
+
+A nested \say{outer \say{inner} quote}.
+
+\end{document}

--- a/t/structure/dirtytalk.xml
+++ b/t/structure/dirtytalk.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?latexml class="article"?>
+<?latexml package="dirtytalk"?>
+<?latexml RelaxNGSchema="LaTeXML"?>
+<document xmlns="http://dlmf.nist.gov/LaTeXML">
+  <resource src="LaTeXML.css" type="text/css"/>
+  <resource src="ltx-article.css" type="text/css"/>
+  <section inlist="toc" xml:id="S1">
+    <tags>
+      <tag>1</tag>
+      <tag role="refnum">1</tag>
+      <tag role="typerefnum">§1</tag>
+    </tags>
+    <title><tag close=" ">1</tag>Dirtytalk quotations</title>
+    <para xml:id="S1.p1">
+      <p>A plain “outer quote”.</p>
+    </para>
+    <para xml:id="S1.p2">
+      <p>A nested “outer ‘inner’ quote”.</p>
+    </para>
+  </section>
+</document>


### PR DESCRIPTION
Summary

Adds a LaTeXML binding for the `dirtytalk` package, covering the common `\say{...}` command and nested quotation behavior.

- Defines `dirtytalk.sty.ltxml` with default outer/inner quotation marks.
- Handles package options for custom `left`, `right`, `leftsub`, and `rightsub` quote symbols.
- Adds a focused structure test for plain and nested `\say{...}` usage.
- Updates `MANIFEST` for the new binding and fixtures.

Validation
- `git diff --check`
- `CI=true perl t/97_manifest.t`
- Syntax/load check of `dirtytalk.sty.ltxml`

Full `t/50_structure.t` was not run locally because this environment is missing LaTeXML's Perl dependency chain, starting with `Text::Unidecode`.