### PR TITLE
fbox: add padding only to framed boxes generated by \fbox, \framebox

### DIFF
--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -896,12 +896,14 @@ DefConstructor('\boxed@math{}',
   alias => '\boxed');
 
 DefConstructor('\boxed@text{}',
-  "<ltx:Math mode='display' framed='rectangle'>"
+  "<ltx:Math mode='display' framed='rectangle' framecolor='#framecolor' cssstyle='#cssstyle'>"
     . "<ltx:XMath>"
     . "#1"
     . "</ltx:XMath>"
     . "</ltx:Math>",
   mode         => 'math', bounded => 1,
+  properties => sub {
+    framedProperties(margin => '\fboxsep'); },
   beforeDigest => sub {
     Let("\\\\", '\lx@newline'); },
   alias => '\boxed');

--- a/lib/LaTeXML/Package/color.sty.ltxml
+++ b/lib/LaTeXML/Package/color.sty.ltxml
@@ -106,9 +106,11 @@ DefMacro('\colorbox[]{}{}', '\hbox{\ifx.#1.\pagecolor{#2}\else\pagecolor[#1]{#2}
 
 #\fcolorbox{name}{text} or \fcolorbox[model]{spec}{text}
 DefConstructor('\fcolorbox[]{}{} Undigested',
-  "<ltx:text framed='rectangle' framecolor='#framecolor'"
+  "<ltx:text framed='rectangle' framecolor='#framecolor' cssstyle='#cssstyle'"
     . " _noautoclose='1'>#text</ltx:text>",
   mode        => 'internal_vertical',
+  properties  => sub {
+    framedProperties(margin => '\fboxsep'); },
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
     my ($model, $fspec, $bspec, $text) = $whatsit->getArgs;

--- a/lib/LaTeXML/Package/listings.sty.ltxml
+++ b/lib/LaTeXML/Package/listings.sty.ltxml
@@ -258,8 +258,11 @@ DefConstructor('\@@listings {}',
   beforeDigest => sub { beforeFloat('lstlisting'); },
   afterDigest  => sub { afterFloat($_[1]); });
 
+our %frames = (none => undef, leftline => 'left', topline => 'top', bottomline => 'bottom',
+  lines => 'topbottom', single => 'rectangle', shadowbox => 'rectangle');
+
 DefConstructor('\@@listings@block {} {} {}',
-"<ltx:listing class='ltx_lstlisting' data='#data' datamimetype='#datamimetype' dataencoding='#dataencoding' dataname='#3'>#2</ltx:listing>",
+"<ltx:listing class='ltx_lstlisting' data='#data' datamimetype='#datamimetype' dataencoding='#dataencoding' dataname='#3' cssstyle='#cssstyle' framed='#framed' framecolor='#framecolor'>#2</ltx:listing>",
   mode        => 'internal_vertical',
   afterDigest => sub {
     my ($stomach, $whatsit) = @_;
@@ -270,7 +273,19 @@ DefConstructor('\@@listings@block {} {} {}',
       $listings_data = encode('UTF-8', $listings_data);
     }
     my $data = encode_base64($listings_data, '');    # NO linebreaking!
-    $whatsit->setProperties(data => $data, datamimetype => 'text/plain', dataencoding => 'base64'); });
+    $whatsit->setProperties(data => $data, datamimetype => 'text/plain', dataencoding => 'base64');
+    my $frame = ToString(LookupValue('LST@frame'));
+    if ($frame ne 'none') {
+      my $border = $frames{$frame};
+      if (!defined $border) {
+        $border = join(' ',
+          $frame =~ m/t/i ? ('top')    : (),
+          $frame =~ m/b/i ? ('bottom') : (),
+          $frame =~ m/l/i ? ('left')   : (),
+          $frame =~ m/r/i ? ('right')  : ());
+      }
+      $whatsit->setProperties(framedProperties(frame => $border, margin => LookupValue('LST@framesep'))); }
+    return; });
 
 DefMacro('\lst@HRefStepCounter{}', '');
 
@@ -498,8 +513,8 @@ sub lstSetClassStyle {
       $props{class} = $stylestring; }            # add indirect to class.
     else {
       delete $$classes{$class}{class};
-      $props{begin} = Tokens($style, T_BEGIN);   # Otherwise, presumably TeX
-      $props{end} = T_END; } }
+      $props{begin} = Tokens($style, T_BEGIN);    # Otherwise, presumably TeX
+      $props{end}   = T_END; } }
   if ($class =~ /^(\w+?)s?$/) {
     $props{cssclass} = $1; }
   map { $$classes{$class}{$_} = $props{$_} } keys %props;
@@ -920,17 +935,7 @@ DefKeyVal('LST', 'breakautoindent', '', 'true');
 # 4.11 Frames
 #======================================================================
 # Mosly ignorable, but some could be used
-DefKeyVal('LST', 'frame', ''); # none | leftline | topline | bottomline | lines | single | shadowbox
-our %frames = (none => undef, leftline => 'left', topline => 'top', bottomline => 'bottom',
-  lines => 'topbottom', single => 'rectangle', shadowbox => 'rectangle');
-DefPrimitive('\lst@@frame Until:\end', sub {
-    my $name = ToString(Digest($_[1]));
-    AssignValue(LISTINGS_FRAME => $frames{$name});
-    lstPushValueLocally(LISTINGS_PREAMBLE => T_CS('\lst@@@set@frame')); });
-
-DefConstructor('\lst@@@set@frame', "^framed='#frame'",
-  properties => {
-    frame => sub { LookupValue('LISTINGS_INLINE') ? undef : LookupValue('LISTINGS_FRAME'); } });
+DefKeyVal('LST', 'frame', ''); # none | leftline | topline | bottomline | lines | single | shadowbox, see %frames
 
 DefKeyVal('LST', 'framearound',        '');            # t|f * 4
 DefKeyVal('LST', 'framesep',           'Dimension');

--- a/lib/LaTeXML/Package/xcolor.sty.ltxml
+++ b/lib/LaTeXML/Package/xcolor.sty.ltxml
@@ -876,9 +876,11 @@ DefPrimitive('\rrshift Variable', sub {
 
 #\fcolorbox{name}{text} or \fcolorbox[model]{spec}{text}
 DefConstructor('\fcolorbox[]{}{} Undigested',
-  "<ltx:text framed='rectangle' framecolor='#framecolor'"
+  "<ltx:text framed='rectangle' framecolor='#framecolor' cssstyle='#cssstyle'"
     . " _noautoclose='1'>#text</ltx:text>",
   enterHorizontal => 1, mode => 'internal_vertical', sizer => '#text',
+  properties => sub {
+    framedProperties(margin => '\fboxsep'); },
   afterDigest     => sub {
     my ($stomach, $whatsit) = @_;
     my ($model, $fspec, $bspec, $text) = $whatsit->getArgs;

--- a/t/alignment/listing.xml
+++ b/t/alignment/listing.xml
@@ -374,7 +374,7 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
     </tags>
     <title><tag close=" ">7</tag>Framing and such</title>
     <para xml:id="S7.p1">
-      <listing backgroundcolor="#FF5EFF" class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain" framecolor="#FF0000" framed="rectangle">
+      <listing backgroundcolor="#FF5EFF" class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" cssstyle="padding:3.0pt" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain" framecolor="#FF0000" framed="rectangle">
         <listingline xml:id="lstnumberx39"><tags>
             <tag>1</tag>
             <tag role="refnum">1</tag>
@@ -420,7 +420,7 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             <tag role="typerefnum">line 4</tag>
           </tags><text class="ltx_lst_keyword" font="bold">end</text>;</listingline>
       </listing>
-      <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain" framed="rectangle">
+      <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" cssstyle="padding:3.0pt" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain" framecolor="#000000" framed="rectangle">
         <listingline xml:id="lstnumberx47"><tags>
             <tag>1</tag>
             <tag role="refnum">1</tag>
@@ -444,7 +444,7 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       </listing>
     </para>
     <para xml:id="S7.p3">
-      <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain" framed="topbottom">
+      <listing class="ltx_lst_language_Pascal ltx_lst_numbers_left ltx_lstlisting" cssstyle="padding:3.0pt" data="Zm9yIGk6PW1heGludCB0byAwIGRvCmJlZ2luCiAgeyBkbyBub3RoaW5nIH0KZW5kOw==" dataencoding="base64" datamimetype="text/plain" framecolor="#000000" framed="topbottom">
         <listingline xml:id="lstnumberx51"><tags>
             <tag>1</tag>
             <tag role="refnum">1</tag>
@@ -475,7 +475,7 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
       </tags>
       <toccaption><tag close=" ">2</tag>A C language listing</toccaption>
       <caption><tag close=": ">Listing 2</tag>A C language listing</caption>
-      <listing backgroundcolor="#E6E6E6" class="ltx_lst_language_C ltx_lst_numbers_left ltx_lstlisting" data="I2RlZmluZSBFWEFNUExFIHdoaWNod2hhdAp4ID0gImZvbyI7CmJyZWFrOw==" dataencoding="base64" datamimetype="text/plain" framed="topbottom">
+      <listing backgroundcolor="#E6E6E6" class="ltx_lst_language_C ltx_lst_numbers_left ltx_lstlisting" cssstyle="padding:3.0pt" data="I2RlZmluZSBFWEFNUExFIHdoaWNod2hhdAp4ID0gImZvbyI7CmJyZWFrOw==" dataencoding="base64" datamimetype="text/plain" framecolor="#000000" framed="topbottom">
         <listingline xml:id="lstnumberx55"><tags>
             <tag>1</tag>
             <tag role="refnum">1</tag>

--- a/t/graphics/colors.xml
+++ b/t/graphics/colors.xml
@@ -105,10 +105,10 @@ vs. <text color="#E6E6E6">Light</text></p>
       <p>vs. <text backgroundcolor="#808080" color="#E6E6E6">Light within Gray</text></p>
     </para>
     <para xml:id="S5.p3">
-      <p><text backgroundcolor="#FF0000" color="#00FF00" framecolor="#0000FF" framed="rectangle">Green in Red surrounded by Blue</text></p>
+      <p><text backgroundcolor="#FF0000" color="#00FF00" cssstyle="padding:3.0pt" framecolor="#0000FF" framed="rectangle">Green in Red surrounded by Blue</text></p>
     </para>
     <para xml:id="S5.p4">
-      <p><text backgroundcolor="#00FFFF" color="#FFFF00" framecolor="#FF00FF" framed="rectangle">Yellow in Cyan surrounded by Magenta</text></p>
+      <p><text backgroundcolor="#00FFFF" color="#FFFF00" cssstyle="padding:3.0pt" framecolor="#FF00FF" framed="rectangle">Yellow in Cyan surrounded by Magenta</text></p>
     </para>
   </section>
   <section inlist="toc" xml:id="S6">
@@ -152,9 +152,9 @@ vs. <text color="#E6E6E6">Light</text></p>
           <XMath>
             <XMApp>
               <XMTok meaning="plus" role="ADDOP">+</XMTok>
-              <XMText backgroundcolor="#0000FF" framecolor="#00FF00" framed="rectangle"><text color="#FF0000">R</text></XMText>
-              <XMText backgroundcolor="#FF0000" framecolor="#0000FF" framed="rectangle"><text color="#00FF00">G</text></XMText>
-              <XMText backgroundcolor="#00FF00" framecolor="#FF0000" framed="rectangle"><text color="#0000FF">B</text></XMText>
+              <XMText backgroundcolor="#0000FF" cssstyle="padding:3.0pt" framecolor="#00FF00" framed="rectangle"><text color="#FF0000">R</text></XMText>
+              <XMText backgroundcolor="#FF0000" cssstyle="padding:3.0pt" framecolor="#0000FF" framed="rectangle"><text color="#00FF00">G</text></XMText>
+              <XMText backgroundcolor="#00FF00" cssstyle="padding:3.0pt" framecolor="#FF0000" framed="rectangle"><text color="#0000FF">B</text></XMText>
             </XMApp>
           </XMath>
         </Math>

--- a/t/graphics/xcolors.xml
+++ b/t/graphics/xcolors.xml
@@ -221,10 +221,10 @@ No blend: <text width="20.0pt"><rule color="#FF0000" height="6.5pt" width="20.0p
       <p>vs. <text backgroundcolor="#808080" color="#E6E6E6">Light within Gray</text></p>
     </para>
     <para xml:id="S7.p3">
-      <p><text backgroundcolor="#FF0000" color="#00FF00" framecolor="#0000FF" framed="rectangle">Green in Red surrounded by Blue</text></p>
+      <p><text backgroundcolor="#FF0000" color="#00FF00" cssstyle="padding:3.0pt" framecolor="#0000FF" framed="rectangle">Green in Red surrounded by Blue</text></p>
     </para>
     <para xml:id="S7.p4">
-      <p><text backgroundcolor="#00FFFF" color="#FFFF00" framecolor="#FF00FF" framed="rectangle">Yellow in Cyan surrounded by Magenta</text></p>
+      <p><text backgroundcolor="#00FFFF" color="#FFFF00" cssstyle="padding:3.0pt" framecolor="#FF00FF" framed="rectangle">Yellow in Cyan surrounded by Magenta</text></p>
     </para>
     <rule color="#FFFFFF" depth="4.3pt" framecolor="#FF8000" framed="rectangle" height="8.6pt" width="100.0pt"/>
   </section>

--- a/t/math/sampler.xml
+++ b/t/math/sampler.xml
@@ -199,7 +199,7 @@ attributes <text font="typewriter">@mathvariant</text>, <text font="typewriter">
                 <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
                 <XMTok color="#00FF00" font="italic" role="UNKNOWN" xml:id="S1.E4.m1.3">X</XMTok>
                 <XMTok role="PUNCT" rpadding="20.0pt">,</XMTok>
-                <XMText backgroundcolor="#FF0000" framecolor="#0000FF" framed="rectangle" xml:id="S1.E4.m1.4"><text color="#00FF00">X</text></XMText>
+                <XMText backgroundcolor="#FF0000" cssstyle="padding:3.0pt" framecolor="#0000FF" framed="rectangle" xml:id="S1.E4.m1.4"><text color="#00FF00">X</text></XMText>
               </XMWrap>
             </XMDual>
           </XMath>


### PR DESCRIPTION
Apply `padding:3pt` only to boxes generated by `\fbox` and `\framebox`, or more precisely the ones that respect `\fboxsep`. That includes a few other boxes I have found by grepping for `framed`.

This resolves issues like `\textul`, `\underbar` gaining padding that they should not have.

While I was there, I have added support for `\fboxsep` where it was missing in amsmath, color, xcolor. amsmath now also uses the current color as frame color.