### PR TITLE
Resync listings test for change to underline

### DIFF
--- a/t/alignment/listing.xml
+++ b/t/alignment/listing.xml
@@ -2177,9 +2177,9 @@ and with messed up braces <text class="ltx_lst_numbers_left ltx_lstlisting"><tex
             <tag>1</tag>
             <tag role="refnum">1</tag>
             <tag role="typerefnum">line 1</tag>
-          </tags><text class="ltx_lst_keyword"><text font="bold" framed="underline">foo</text></text><text class="ltx_lst_space"> </text><indexmark>
+          </tags><text class="ltx_lst_keyword ltx_underline" font="bold">foo</text><text class="ltx_lst_space"> </text><indexmark>
             <indexphrase key="bar"><text font="typewriter">bar</text></indexphrase>
-          </indexmark><text class="ltx_lst_keyword"><text font="bold" framed="underline">bar</text></text><text class="ltx_lst_space"> </text><indexmark>
+          </indexmark><text class="ltx_lst_keyword ltx_underline" font="bold">bar</text><text class="ltx_lst_space"> </text><indexmark>
             <indexphrase key="baz"><text font="typewriter">baz</text></indexphrase>
           </indexmark><text class="ltx_lst_identifier">baz</text><text class="ltx_lst_space"> </text><indexmark>
             <indexphrase key="bing"><text font="typewriter">bing</text></indexphrase>


### PR DESCRIPTION
This PR resyncs the listings test case from #2817 to match the treatment of merged #2798; the latter started a move to consider underline as its own thing and not a "frame".