### PR TITLE
Remove \@ifnext, use \@ifnextchar

### DIFF
--- a/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
+++ b/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
@@ -3167,7 +3167,7 @@ DefMacro('\caption',
 # First, check for trailing \label, move it into the caption as a standard position
 # NOTE: If one day we want to unlock \@caption, make sure to test against arXiv:cond-mat/0001395 for a passing build.
 DefMacro('\@caption{}[]{}',
-  '\@ifnext\label{\@caption@postlabel{#1}{#2}{#3}}{\@caption@{#1}{#2}{#3}}', locked => 1);
+  '\@ifnextchar\label{\@caption@postlabel{#1}{#2}{#3}}{\@caption@{#1}{#2}{#3}}', locked => 1);
 
 DefMacro('\@caption@postlabel{}{}{} SkipMatch:\label Semiverbatim',
   '\@caption@{#1}{#2}{#3\label{#4}}');
@@ -5640,7 +5640,6 @@ DefMacro('\@ifnextchar DefToken {}{}', sub {
     ((XEquals($token, (defined $next ? $next : T_END)) ? $if : $else)->unlist,
       (defined $next ? ($next) : ())); });
 Let('\kernel@ifnextchar', '\@ifnextchar');
-Let('\@ifnext',           '\@ifnextchar');    # ????
 
 # Hacky version matches multiple chars! but does NOT expand
 DefMacro('\@ifnext@n {} {}{}', sub {

--- a/lib/LaTeXML/Package/caption.sty.ltxml
+++ b/lib/LaTeXML/Package/caption.sty.ltxml
@@ -117,7 +117,7 @@ DefMacro('\maybe@@generic@caption', sub {
 # It isn't necessarily IN a figure or any float, so we'll wrap it in an otherwise empty one!
 DefMacro('\captionof', '\@ifstar{\@scaptionof}{\@captionof}');
 DefMacro('\@captionof{}[]{}',
-  '\@ifnext\label{\@captionof@postlabel{#1}{#2}{#3}}{\@captionof@{#1}{#2}{#3}}');
+  '\@ifnextchar\label{\@captionof@postlabel{#1}{#2}{#3}}{\@captionof@{#1}{#2}{#3}}');
 # Check for trailing \label!
 DefMacro('\@captionof@postlabel{}{}{} SkipMatch:\label Semiverbatim',
   '\@captionof@{#1}{#2}{#3\label{#4}}');


### PR DESCRIPTION
A misunderstanding a very long time ago had me mistakenly define `\@ifnext` as part of latex, proper. It doesn't belong there.

fixes #2810