### PR TITLE
use correct number of columns in \hdotsfor

### DIFF
--- a/lib/LaTeXML/Package/amsmath.sty.ltxml
+++ b/lib/LaTeXML/Package/amsmath.sty.ltxml
@@ -841,8 +841,11 @@ DefMacroI('\DOTSI', undef, Tokens());
 DefMacroI('\DOTSX', undef, Tokens());
 Let('\hdots', '\lx@ldots');
 
-DefMacro('\hdotsfor Number', sub {
-    (map { T_CS('\hdots') } 1 .. $_[1]->valueOf); });
+# The optional argument determines the visual space between the dots, currently ignored
+DefMacro('\hdotsfor[]{Number}', sub {
+    my $cols = $_[2]->valueOf;
+    $cols = 1 if $cols < 1;
+    (map { T_CS('\hdots'), T_ALIGN } 1 .. $cols - 1), T_CS('\hdots'); });
 
 # The basic idea is simple enough (in TeX world);
 # Peek to see what follows (\futurelet) and if mathbin or mathrel, use cdots.


### PR DESCRIPTION
`\hdotsfor{N}` creates dots spanning `N` columns within a matrix. LaTeXML does not.

This is a simple fix that creates all the columns required, with some dots in each. It also fixes the prototype (it was wrong!).

The ideal implementation would create a multicolumn cell with an inline-block with dotted border... or something of that sort. That's beyond the scope of this PR though. I just want the matrices to be semantically correct.

Fixes #2839.