### PR TITLE
Fix typo: \plpaarsep -> \plparsep

### DIFF
--- a/lib/LaTeXML/Package/paralist.sty.ltxml
+++ b/lib/LaTeXML/Package/paralist.sty.ltxml
@@ -68,7 +68,7 @@ ProcessOptions();
 DefRegister('\pltopsep'    => Dimension(0));
 DefRegister('\plpartopsep' => Dimension(0));
 DefRegister('\plitemsep'   => Dimension(0));
-DefRegister('\plpaarsep'   => Dimension(0));
+DefRegister('\plparsep'    => Dimension(0));
 
 DefMacro('\setdefaultleftmargin{}{}{}{}{}{}', '');    # Ignore?
 #======================================================================


### PR DESCRIPTION
Fix for a typo in in paralist.sty.ltxml (\plpaarsep instead of \plparsep).
