### PR TITLE
tabular vertical align

### DIFF
--- a/lib/LaTeXML/Engine/TeX_Tables.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Tables.pool.ltxml
@@ -68,9 +68,8 @@ DefColumnType('r', sub {
 # BUT @{} might add other contents to the cell!  So, we need an inline-block
 DefColumnType('p{Dimension}', sub {
     $LaTeXML::BUILD_TEMPLATE->addColumn(
-      before  => Tokens(T_CS('\lx@tabular@p'), T_LETTER('t'), T_BEGIN, $_[1]->revert, T_END, T_BEGIN),
-      after   => Tokens(T_END),
-      vattach => 'top',
+      before => Tokens(T_CS('\lx@tabular@p'), T_LETTER('t'), T_BEGIN, $_[1]->revert, T_END, T_BEGIN),
+      after  => Tokens(T_END)
     ); return; });
 # Make sure the content sees the desired width as \hsize
 DefMacro('\lx@tabular@p{}{}', '\hsize=#2\relax\lx@tabular@p@{#1}{#2}');

--- a/lib/LaTeXML/Package/array.sty.ltxml
+++ b/lib/LaTeXML/Package/array.sty.ltxml
@@ -27,15 +27,13 @@ DefColumnType('<{}', sub { $LaTeXML::BUILD_TEMPLATE->addAfterColumn($_[1]->unlis
 # m{} and b{} are like p{}, but vertical alignment is middle or bottom
 DefColumnType('m{Dimension}', sub {
     $LaTeXML::BUILD_TEMPLATE->addColumn(
-      before  => Tokens(T_CS('\lx@tabular@p'), T_LETTER('m'), T_BEGIN, $_[1]->revert, T_END, T_BEGIN),
-      after   => Tokens(T_END),
-      vattach => 'middle',
+      before => Tokens(T_CS('\lx@tabular@p'), T_LETTER('m'), T_BEGIN, $_[1]->revert, T_END, T_BEGIN),
+      after  => Tokens(T_END)
     ); return; });
 DefColumnType('b{Dimension}', sub {
     $LaTeXML::BUILD_TEMPLATE->addColumn(
-      before  => Tokens(T_CS('\lx@tabular@p'), T_LETTER('b'), T_BEGIN, $_[1]->revert, T_END, T_BEGIN),
-      after   => Tokens(T_END),
-      vattach => 'bottom',
+      before => Tokens(T_CS('\lx@tabular@p'), T_LETTER('b'), T_BEGIN, $_[1]->revert, T_END, T_BEGIN),
+      after  => Tokens(T_END)
     ); return; });
 
 # Like @{}, but should NOT suppress intercolumn space

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -210,6 +210,9 @@ a.ltx_LaTeXML_logo { text-decoration: none; }
 .ltx_align_justify  { text-align:justify; }
 .ltx_align_top      { vertical-align:top; }
 .ltx_align_bottom   { vertical-align:bottom; }
+@supports (baseline-source: first) {
+  .ltx_align_top    { vertical-align:baseline; baseline-source:first; }
+  .ltx_align_bottom { vertical-align:baseline; baseline-source:last; } }
 .ltx_align_middle   { vertical-align:middle; }
 .ltx_align_baseline { vertical-align:baseline; }
 
@@ -243,7 +246,7 @@ a.ltx_LaTeXML_logo { text-decoration: none; }
 /* equations in aligned mode (aligning tags, etc as well as equations) */
 .ltx_eqn_table { display:table; width:100%; border-collapse:collapse; }
 .ltx_eqn_row   { display:table-row; }
-.ltx_eqn_cell  { display:table-cell; width:auto; }
+.ltx_eqn_cell  { display:table-cell; width:auto; vertical-align:middle; }
 
 /* Padding between column pairs in ams align */
 table.ltx_eqn_align tr.ltx_equation td.ltx_align_left + td.ltx_align_right,
@@ -276,7 +279,10 @@ li.ltx_item > .ltx_tag {
     display:inline-block; margin-left:-1.5em; min-width:1.5em;
     text-align:right; }
 .ltx_item .ltx_tag + .ltx_para {
-    display:inline-block; vertical-align:top;}
+    display:inline-block; vertical-align:top; }
+@supports (baseline-source: first) {
+  .ltx_item .ltx_tag + .ltx_para {
+    vertical-align:baseline; baseline-source:first; } }
 .ltx_item .ltx_tag + .ltx_para .ltx_p  {
     display:inline; }
 .ltx_item > .ltx_para > .ltx_p:first-child {
@@ -396,7 +402,7 @@ span.ltx_rowspan { position:absolute; top:0; bottom:0; }
 .ltx_tbody   { display:table-row-group; }
 .ltx_tr      { display:table-row; }
 .ltx_td,
-.ltx_th      { display:table-cell; }
+.ltx_th      { display:table-cell; vertical-align:baseline; }
 
 .ltx_tabular .ltx_td,
 .ltx_tabular .ltx_th { padding:0.1em 0.5em; }

--- a/t/alignment/array.xml
+++ b/t/alignment/array.xml
@@ -19,24 +19,24 @@
       <tabular vattach="middle">
         <tbody>
           <tr>
-            <td align="left" border="l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="l r t"><inline-block vattach="top" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="left" border="r t" vattach="middle"><inline-block vattach="middle" width="72.3pt">
+            <td align="left" border="r t"><inline-block vattach="middle" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="left" border="r t" vattach="bottom"><inline-block vattach="bottom" width="72.3pt">
+            <td align="left" border="r t"><inline-block vattach="bottom" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
           </tr>
           <tr>
-            <td align="left" border="b l r t" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="b l r t"><inline-block vattach="top" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="left" border="b r t" vattach="middle"><inline-block vattach="middle" width="72.3pt">
+            <td align="left" border="b r t"><inline-block vattach="middle" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
-            <td align="left" border="b r t" vattach="bottom"><inline-block vattach="bottom" width="72.3pt">
+            <td align="left" border="b r t"><inline-block vattach="bottom" width="72.3pt">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit</p>
               </inline-block></td>
           </tr>

--- a/t/alignment/cells.xml
+++ b/t/alignment/cells.xml
@@ -69,7 +69,7 @@
         <tr>
           <td align="center" border="l r t"><tabular vattach="middle">
               <tr>
-                <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <td align="left" class="ltx_nopad_r"><inline-block vattach="top" width="85.4pt">
                     <p>Cell long text with predefined width</p>
                   </inline-block></td>
               </tr>
@@ -79,7 +79,7 @@
         <tr>
           <td align="center" border="b l r t"><tabular vattach="middle">
               <tr>
-                <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="85.4pt">
+                <td align="left" class="ltx_nopad_r"><inline-block vattach="top" width="85.4pt">
                     <p>Cell long…</p>
                   </inline-block></td>
               </tr>
@@ -148,12 +148,12 @@
                   <td align="center" class="ltx_nopad_r" thead="column row"><inline-block angle="90" depth="0.0pt" height="96.1pt" innerdepth="9.5pt" innerheight="14.5pt" innerwidth="96.1pt" width="24.0pt" xtranslate="-36.0pt" ytranslate="-36.0pt">
                       <p><text color="#FF0000" font="bold"><tabular rowsep="-1.7pt" vattach="middle">
                             <tr>
-                              <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="90.1pt">
+                              <td align="left" class="ltx_nopad_r"><inline-block vattach="top" width="90.1pt">
                                   <p>Second multilined</p>
                                 </inline-block></td>
                             </tr>
                             <tr>
-                              <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="90.1pt">
+                              <td align="left" class="ltx_nopad_r"><inline-block vattach="top" width="90.1pt">
                                   <p>column head</p>
                                 </inline-block></td>
                             </tr>
@@ -298,7 +298,7 @@
           <tr>
             <td align="left" border="l r t"><tabular vattach="middle">
                 <tr>
-                  <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="142.3pt">
+                  <td align="left" class="ltx_nopad_r"><inline-block vattach="top" width="142.3pt">
                       <p>Cell …</p>
                     </inline-block></td>
                 </tr>
@@ -308,7 +308,7 @@
           <tr>
             <td align="left" border="b l r t"><tabular vattach="middle">
                 <tr>
-                  <td align="left" class="ltx_nopad_r" vattach="top"><inline-block vattach="top" width="142.3pt">
+                  <td align="left" class="ltx_nopad_r"><inline-block vattach="top" width="142.3pt">
                       <p>Cell …</p>
                     </inline-block></td>
                 </tr>

--- a/t/alignment/colortbls.xml
+++ b/t/alignment/colortbls.xml
@@ -82,23 +82,23 @@ p{3cm}}"?>
       <tabular>
         <thead>
           <tr>
-            <td align="center" backgroundcolor="#00FFFF" colspan="3" thead="column" vattach="top"><text backgroundcolor="#00FFFF" font="bold" fontsize="120%">A long table example</text></td>
+            <td align="center" backgroundcolor="#00FFFF" colspan="3" thead="column"><text backgroundcolor="#00FFFF" font="bold" fontsize="120%">A long table example</text></td>
           </tr>
           <tr>
-            <td align="center" backgroundcolor="#FF00FF" colspan="2" thead="column" vattach="top"><text backgroundcolor="#FF00FF" color="#FFFFFF">First two columns</text></td>
+            <td align="center" backgroundcolor="#FF00FF" colspan="2" thead="column"><text backgroundcolor="#FF00FF" color="#FFFFFF">First two columns</text></td>
             <td align="center" backgroundcolor="#FF00FF" thead="column"><text backgroundcolor="#FF00FF" color="#FFFFFF">Third column</text></td>
           </tr>
           <tr>
-            <td align="center" backgroundcolor="#FF00FF" colspan="2" thead="column" vattach="top"><text backgroundcolor="#FF00FF" color="#FFFFFF">p-type</text></td>
+            <td align="center" backgroundcolor="#FF00FF" colspan="2" thead="column"><text backgroundcolor="#FF00FF" color="#FFFFFF">p-type</text></td>
             <td align="center" backgroundcolor="#FF00FF" thead="column"><text backgroundcolor="#FF00FF" color="#FFFFFF">D-type (<text font="sansserif">dcolumn</text>)</text></td>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">P-column</text></p>
               </inline-block></td>
-            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">and another one</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}12\cdot 34" text="12.34" xml:id="S2.T1.m1">
@@ -117,10 +117,10 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">Some long text in the first column</text></p>
               </inline-block></td>
-            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 2" text="1.2" xml:id="S2.T1.m3">
@@ -130,10 +130,10 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">and some long text in the second column</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m4">
@@ -152,10 +152,10 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m6">
@@ -165,11 +165,11 @@ p{3cm}}"?>
               </Math></td>
           </tr>
           <tr>
-            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">Note that the coloured rules in all columns stretch to accomodate
 large entries in one column.</text></p>
               </inline-block></td>
-            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}1\cdot 345" text="1.345" xml:id="S2.T1.m7">
@@ -179,10 +179,10 @@ large entries in one column.</text></p>
               </Math></td>
           </tr>
           <tr>
-            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}100" text="100" xml:id="S2.T1.m8">
@@ -192,10 +192,10 @@ large entries in one column.</text></p>
               </Math></td>
           </tr>
           <tr>
-            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">Depending on your driver you may get unsightly gaps or lines
 where the ‘screens’ used to produce different shapes interact
 badly. You may want to cause adjacent panels of the same colour by
@@ -209,10 +209,10 @@ or by adding some negative space (in a ”“noalign” between rows.</text></p>
               </Math></td>
           </tr>
           <tr>
-            <td align="left" backgroundcolor="#FF0000" vattach="top"><inline-block vattach="top" width="56.9pt">
+            <td align="left" backgroundcolor="#FF0000"><inline-block vattach="top" width="56.9pt">
                 <p class="ltx_align_left"><text backgroundcolor="#FF0000" color="#FFFFFF">aaa</text></p>
               </inline-block></td>
-            <td align="left" backgroundcolor="#0000FF" vattach="top"><inline-block vattach="top" width="85.4pt">
+            <td align="left" backgroundcolor="#0000FF"><inline-block vattach="top" width="85.4pt">
                 <p class="ltx_align_left"><text backgroundcolor="#0000FF" color="#FFFF00">bbb</text></p>
               </inline-block></td>
             <td align="char:⋅" backgroundcolor="#FFFF00"><Math mode="inline" tex="\pagecolor{yellow}45\cdot 3" text="45.3" xml:id="S2.T1.m10">
@@ -224,7 +224,7 @@ or by adding some negative space (in a ”“noalign” between rows.</text></p>
         </tbody>
         <tfoot>
           <tr>
-            <td align="center" backgroundcolor="#00FFFF" colspan="3" thead="column" vattach="top"><text backgroundcolor="#00FFFF" font="bold" fontsize="120%">The End</text></td>
+            <td align="center" backgroundcolor="#00FFFF" colspan="3" thead="column"><text backgroundcolor="#00FFFF" font="bold" fontsize="120%">The End</text></td>
           </tr>
         </tfoot>
       </tabular>

--- a/t/alignment/tabular.xml
+++ b/t/alignment/tabular.xml
@@ -13,7 +13,7 @@
         <tr>
           <td border="l rr tt" thead="column row"/>
           <td align="center" border="r tt" colspan="2" thead="column">Price</td>
-          <td align="left" border="r tt" thead="column" vattach="top"/>
+          <td align="left" border="r tt" thead="column"/>
         </tr>
         <tr>
           <td align="center" border="l rr" thead="column row">Year</td>
@@ -27,7 +27,7 @@
           <td align="right" border="l rr t" thead="row">1971</td>
           <td align="right" border="t" class="ltx_nopad_r">97–</td>
           <td align="left" border="r t" class="ltx_nopad_l">245</td>
-          <td align="left" border="r t" vattach="top"><inline-block vattach="top" width="90.3pt">
+          <td align="left" border="r t"><inline-block vattach="top" width="90.3pt">
               <p>Bad year.</p>
             </inline-block></td>
         </tr>
@@ -35,7 +35,7 @@
           <td align="right" border="l rr t" thead="row">72</td>
           <td align="right" border="t" class="ltx_nopad_r">245–</td>
           <td align="left" border="r t" class="ltx_nopad_l">245</td>
-          <td align="left" border="r t" vattach="top"><inline-block vattach="top" width="90.3pt">
+          <td align="left" border="r t"><inline-block vattach="top" width="90.3pt">
               <p>Light trading due to a heavy winter.</p>
             </inline-block></td>
         </tr>
@@ -43,7 +43,7 @@
           <td align="right" border="b l rr t" thead="row">73</td>
           <td align="right" border="b t" class="ltx_nopad_r">245–</td>
           <td align="left" border="b r t" class="ltx_nopad_l">2001</td>
-          <td align="left" border="b r t" vattach="top"><inline-block vattach="top" width="90.3pt">
+          <td align="left" border="b r t"><inline-block vattach="top" width="90.3pt">
               <p>No gnus was very good gnus this year.</p>
             </inline-block></td>
         </tr>
@@ -77,24 +77,24 @@
     <tabular vattach="middle">
       <tbody>
         <tr>
-          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r">1  <inline-block vattach="top" width="30.0pt">
               <p>a</p>
             </inline-block>2</td>
-          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r"><inline-block vattach="top" width="30.0pt">
               <p>b</p>
             </inline-block>3</td>
-          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r"><inline-block vattach="top" width="30.0pt">
               <p>c</p>
             </inline-block>4</td>
         </tr>
         <tr>
-          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top">1  <inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r">1  <inline-block vattach="top" width="30.0pt">
               <p>a a a a a a a a a a</p>
             </inline-block>2</td>
-          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r"><inline-block vattach="top" width="30.0pt">
               <p>b</p>
             </inline-block>3</td>
-          <td align="left" class="ltx_nopad_l ltx_nopad_r" vattach="top"><inline-block vattach="top" width="30.0pt">
+          <td align="left" class="ltx_nopad_l ltx_nopad_r"><inline-block vattach="top" width="30.0pt">
               <p>c</p>
             </inline-block>4</td>
         </tr>

--- a/t/graphics/graphrot.xml
+++ b/t/graphics/graphrot.xml
@@ -413,11 +413,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td align="left" border="t" thead="column">Pottery</td>
             <td align="left" border="t" thead="column">Flint</td>
             <td align="left" border="t" thead="column">Animal</td>
-            <td align="left" border="t" thead="column" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="t" thead="column"><inline-block vattach="top" width="72.3pt">
                 <p>Stone</p>
               </inline-block></td>
             <td align="left" border="t" thead="column">Other</td>
-            <td align="left" border="r t" thead="column" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r t" thead="column"><inline-block vattach="top" width="72.3pt">
                 <p>C14 Dates</p>
               </inline-block></td>
           </tr>
@@ -430,9 +430,9 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td thead="column"/>
             <td thead="column"/>
             <td align="left" thead="column">Bones</td>
-            <td align="left" thead="column" vattach="top"/>
+            <td align="left" thead="column"/>
             <td thead="column"/>
-            <td align="left" border="r" thead="column" vattach="top"/>
+            <td align="left" border="r" thead="column"/>
           </tr>
         </thead>
         <tbody>
@@ -445,13 +445,13 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td border="t"/>
             <td border="t"/>
             <td border="t"/>
-            <td align="left" border="t" vattach="top"/>
+            <td align="left" border="t"/>
             <td border="t"/>
-            <td align="left" border="r t" vattach="top"/>
+            <td align="left" border="r t"/>
           </tr>
           <tr>
             <td align="left" border="l" colspan="10"><text font="bold">Grooved Ware</text></td>
-            <td align="left" border="r" vattach="top"/>
+            <td align="left" border="r"/>
           </tr>
           <tr>
             <td align="left" border="l">784</td>
@@ -470,13 +470,13 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>8</td>
-            <td align="left" vattach="top"/>
+            <td align="left"/>
             <td align="left"><Math mode="inline" tex="\times" text="*" xml:id="S2.T5.m3">
                 <XMath>
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>2 bone</td>
-            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r"><inline-block vattach="top" width="72.3pt">
                 <p>2150<Math mode="inline" tex="\pm" text="plus-or-minus" xml:id="S2.T5.m4">
                     <XMath>
                       <XMTok meaning="plus-or-minus" name="pm" role="ADDOP">±</XMTok>
@@ -501,11 +501,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>21</td>
-            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left"><inline-block vattach="top" width="72.3pt">
                 <p>Hammerstone</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>
@@ -526,11 +526,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>57*</td>
-            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r"><inline-block vattach="top" width="72.3pt">
                 <p>1990 <Math mode="inline" tex="\pm" text="plus-or-minus" xml:id="S2.T5.m9">
                     <XMath>
                       <XMTok meaning="plus-or-minus" name="pm" role="ADDOP">±</XMTok>
@@ -559,11 +559,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                   <XMTok meaning="times" role="MULOP">×</XMTok>
                 </XMath>
               </Math>8</td>
-            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
             <td align="left">Fired clay</td>
-            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>
@@ -576,13 +576,13 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td/>
             <td/>
             <td/>
-            <td align="left" vattach="top"/>
+            <td align="left"/>
             <td/>
-            <td align="left" border="r" vattach="top"/>
+            <td align="left" border="r"/>
           </tr>
           <tr>
             <td align="left" border="l" colspan="10"><text font="bold">Beaker</text></td>
-            <td align="left" border="r" vattach="top"/>
+            <td align="left" border="r"/>
           </tr>
           <tr>
             <td align="left" border="l">552</td>
@@ -593,11 +593,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
             <td align="left">P7–14</td>
             <td align="left">—</td>
             <td align="left">—</td>
-            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>
@@ -614,11 +614,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                 </XMath>
               </Math>12</td>
             <td align="left">—</td>
-            <td align="left" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left"><inline-block vattach="top" width="72.3pt">
                 <p>Quartzite-lump</p>
               </inline-block></td>
             <td align="left">—</td>
-            <td align="left" border="r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="r"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>
@@ -635,11 +635,11 @@ the whales Save the whale Save the <ref class="ltx_href" href="http://dlmf.nist.
                 </XMath>
               </Math>3</td>
             <td align="left" border="b">—</td>
-            <td align="left" border="b" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="b"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
             <td align="left" border="b">—</td>
-            <td align="left" border="b r" vattach="top"><inline-block vattach="top" width="72.3pt">
+            <td align="left" border="b r"><inline-block vattach="top" width="72.3pt">
                 <p>—</p>
               </inline-block></td>
           </tr>


### PR DESCRIPTION
Fix #2732 plus *more side effects* (hopefully all good).

The three notable changes are:
- Columns `p`, `m`, `b` don't get `vattach` anymore. This is a no-brainer: the `vattach` is already on the `inline-block` for those column types (in fact, you had already fixed the core issue, the only remaining problem was the extra `@vattach`).
- The top/bottom vertical alignments now opt into using `baseline-source`, which behaves like TeX; this also produces better alignment between tags and text in lists. This should be low risk. I am only worried by MathML, because some CSS stops working there.
- **All** table cells default to `vertical-align:baseline` instead of `middle`. This is dangerous! I had to revert the change in *equation* cells, because tags are pretty much hard-coded to `ltx_align_middle`. I believe that all other `<table>`s are generated from `tabular`, `\halign`, and other TeX constructs for which the baseline alignment is correct, so *in theory* this is all fine.

I checked that the result works in all three main browsers (Chrome, Safari, Firefox). Firefox does not implement `baseline-source`, so it falls back to the less precise `vertical-align:top`.

Note: while the CSS spec says authors should prefer the shorthand `vertical-align: first baseline`, Chrome only supports the longhand `baseline-source`. That's why I used `@supports`.