### PR TITLE
Resolve typo on llncs (converting macros to more correct registers)

### DIFF
--- a/lib/LaTeXML/Package/llncs.cls.ltxml
+++ b/lib/LaTeXML/Package/llncs.cls.ltxml
@@ -80,7 +80,7 @@ DefRegister('\authorrunning' => Tokens());
 DefRegister('\tocauthor'     => Tokens());    # Box!
 DefRegister('\titrun'        => Tokens());    # Box!
 DefRegister('\titlerunning'  => Tokens());
-DefRegister('\toctitle{}'    => Tokens());
+DefRegister('\toctitle'      => Tokens());
 
 DefRegister('\tocchpnum'         => Dimension(0));
 DefRegister('\tocsecnum'         => Dimension('15pt'));


### PR DESCRIPTION
Fix a typo.

Closes #2253