### PR TITLE
Make \par context-aware instead of retiming inPreamble (#2754, #2846)

### DIFF
--- a/lib/LaTeXML/Engine/TeX_Paragraph.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Paragraph.pool.ltxml
@@ -91,12 +91,18 @@ sub alignLine {
 # Remember; \par _closes_, not opens, paragraphs!
 # Generally, we want to close both an open ltx:p and ltx:para (if either are open).
 # But when executed "internally" (by $stomach->leaveHorizontal), only close ltx:p.
-# NOTE Also that the whole inPreamble bit is, I think, overused.
-# For example, \par should be a NOOP in vertical mode, and that would generally make it
-# ignored in the preamble. (if we can be sure we're tracking modes correctly).
+# \par is a NOOP only in the RAW preamble (before \begin{document}); everywhere else it
+# closes the paragraph being built.  This is the pragmatic reading of the old note here
+# ("\par should be a NOOP in vertical mode ... if we can be sure we're tracking modes
+# correctly"): we can NOT rely on mode (we stay vertical after a display equation, so a
+# mode test would drop the blank line between $$..$$ groups; and raw-preamble text is
+# horizontal, so mode can't tell it from an \AtBeginDocument \par), so we key on CONTEXT
+# — whether \begin{document} has opened the 'document' environment — instead (afterDigest).
+# This lets a blank line inside \AtBeginDocument split paragraphs while inPreamble is
+# still set (so \RequirePackage there stays legal), retiring the need for #2846.
 DefConstructorI('\lx@normal@par', undef, sub {
     my ($document, %props) = @_;
-    if ($props{inPreamble}) { }
+    if ($props{noop}) { }
     else {
       $document->maybeCloseElement('ltx:p');
       my $node  = $document->getElement;
@@ -124,8 +130,14 @@ DefConstructorI('\lx@normal@par', undef, sub {
     # When invoked by $stomach->leaveHorizontal: no reversion, don't close ltx:para
     $whatsit->setProperties(internal_par => 1, reversion=>Tokens())
         if $LaTeXML::INTERNAL_PAR;
-    if (LookupValue('inPreamble')) {
-      $whatsit->setProperty(inPreamble => 1); }
+    # \par is a NOOP only in the RAW preamble: inPreamble is set AND the 'document'
+    # environment is NOT yet on the stack (\begin{document} pushes it at its start, so
+    # it is present throughout the begindocument hooks and the body).  Everywhere else
+    # \par closes the paragraph being built (see the header note).  The stacked lookup
+    # only runs while inPreamble is set (&& short-circuits in the body).
+    if (LookupValue('inPreamble')
+      && !grep { $_ eq 'document' } $STATE->lookupStackedValues('current_environment')) {
+      $whatsit->setProperty(noop => 1); }
     else {
       # Check if flags were set by prior \par:
       if (my $c = LookupValue("next_para_class")) {

--- a/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
+++ b/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
@@ -325,9 +325,16 @@ DefConstructorI(T_CS('\begin{document}'), undef, sub {
 
     if (my $ops = LookupValue('@document@preamble@atend')) {
       push(@boxes, $stomach->digest(Tokens(@$ops))); }
-    AssignValue(inPreamble => 0);    # We're now leaving the preamble (!?)
     if (my $ops = LookupValue('@at@begin@document')) {
       push(@boxes, $stomach->digest(Tokens(@$ops))); }
+    AssignValue(inPreamble => 0);    # atbegin is still (sorta) preamble
+    # NOTE: inPreamble is cleared AFTER the begindocument hooks (reverting #2846), so
+    # \@onlypreamble commands (\RequirePackage/\usepackage) deferred to \AtBeginDocument
+    # stay legal (real latex.ltx disables \@preamblecmds only after the hook). #2754
+    # (a blank line in \AtBeginDocument must split paragraphs) is handled instead by
+    # \par being context-aware — a NOOP only in the raw preamble, active once
+    # current_environment 'document' is on the stack (set at \begin{document}'s start,
+    # above). See TeX_Paragraph.pool.ltxml \lx@normal@par.
     if (my $ops = LookupValue('@document@preamble@afterend')) {
       push(@boxes, $stomach->digest(Tokens(@$ops))); }
     $_[1]->setFont(LookupValue('font'));    # Start w/ whatever font was last selected.


### PR DESCRIPTION
Supersedes the earlier `inBeginDocumentHook` approach on this branch (force-pushed).

Fixes the `\RequirePackage`-in-`\AtBeginDocument` regression from #2846 while keeping #2754 fixed — **without** a second flag.

### The problem

#2846 moved *leaving the preamble* (`inPreamble => 0`) to **before** `@at@begin@document`, so that a blank line inside `\AtBeginDocument` breaks a paragraph (`\par` is a NOOP while `inPreamble`; #2754). But `inPreamble` **also** gates the `\@onlypreamble` guard, so this disabled the preamble-only commands too early: a `\RequirePackage`/`\usepackage` deferred to `\AtBeginDocument` now wrongly errors *"can only appear in the preamble"*.

```latex
\documentclass{article}
\AtBeginDocument{\RequirePackage{xcolor}}
\begin{document}
And {\color{red} red}.
\end{document}
```

Real-world witness: `inconsolata.sty` does `\AtBeginDocument{...\usepackage{upquote}}` → `upquote.sty`'s `\RequirePackage{textcomp}`.

### The fix

Stop routing `\par` through `inPreamble` at all:

1. **Revert #2846** — clear `inPreamble` **after** the begindocument hooks again (`latex.ltx` disables `\@preamblecmds` only after the hook), so a deferred `\RequirePackage`/`\usepackage` stays legal.
2. **Make `\lx@normal@par` context-aware** — a NOOP **only in the raw preamble**: `inPreamble` is set *and* `document` is not yet on the `current_environment` stack. `\begin{document}` pushes `document` at its start, so it is present throughout the begindocument hooks and the body.

So a blank line inside `\AtBeginDocument` still splits paragraphs (#2754), a deferred `\RequirePackage` stays legal, and a body-level `\RequirePackage` still errors.

### Why context, not "NOOP in vertical mode"?

This is the pragmatic reading of the existing note in `TeX_Paragraph.pool.ltxml` (*"`\par` should be a NOOP in vertical mode ... if we can be sure we're tracking modes correctly"*). We can't rely on mode: LaTeXML stays vertical after a display equation (a mode test would drop the blank line between `$$…$$` groups, and inside `\AtBeginDocument{\[x\]…}`), and raw-preamble text is horizontal — so mode can't tell it from a hook `\par`. **Context** — are we inside the `document` environment — is the stable signal. The check walks the `current_environment` *stack* (so a hook that opens a nested environment still counts as "in document") and only runs while `inPreamble` is set, so the hot body path short-circuits.

Fixes #2754. Follow-up to #2846.
