### PR TITLE
Foreign object tuning

### DIFF
--- a/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
@@ -407,12 +407,14 @@ Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
     # Reminder: TeX/LaTeXML think origin is left & baseline
     # svg foreignObject content will draw down from the top
     if ($whatsit) {
+      my $svg = $document->findnode('ancestor::svg:svg', $node);
       my ($w, $h, $d) = $whatsit->getSize;
       my $H = $h->add($d);
       my $W = $w;
       my $x = Dimension(0);
-      my $y = $h;
-      my $f = $whatsit->getFont;
+      my $f = ($svg && $document->getNodeFont($svg)) || $whatsit->getFont;
+      # Heuristic: Browsers seem set on creating at least a lineheight box, so adjust
+      my $y = $h->larger(Dimension($f->getSize . 'pt'));
       Debug("SVG:foreignObject " . $w->pxValue . ' x ' . $h->pxValue . ' x ' . $d->pxValue . "; "
           . " => H=" . $H->pxValue . " @ y=" . $y->pxValue
           . " for Whatsit=" . ToString($whatsit)) if $LaTeXML::DEBUG{svg_verbose};
@@ -422,12 +424,14 @@ Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
       # Set top of FO height above current, as if baseline will line up w/outside
       $node->setAttribute(transform => 'matrix(1 0 0 -1 ' . $x->pxValue . ' ' . $y->pxValue . ')');
       $node->setAttribute(overflow  => 'visible');
+      # Reset the font size, so not affected by any svg scaling.
+      my $style = '';
       # Store expected size for experimentation Temporary?
-      $document->setAttribute($node,
-        style => '--ltx-fo-width:' . $w->emValue(undef, $f) . 'em;'
-          . '--ltx-fo-height:' . $h->emValue(undef, $f) . 'em;'
-          . '--ltx-fo-depth:' . $d->emValue(undef, $f) . 'em;'
-          . 'font-size:' . $f->getSize . 'pt;');
+      $style .= '--ltx-fo-width:' . $w->toAttribute . ';'
+        . '--ltx-fo-height:' . $h->toAttribute . ';'
+        . '--ltx-fo-depth:' . $d->toAttribute . ';';
+      $style .= 'font-size:' . $f->getSize . 'pt;';
+      $document->setAttribute($node, style => $style) if $style;
 } });
 
 sub isVAttached {

--- a/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Box.pool.ltxml
@@ -413,8 +413,10 @@ Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
       my $W = $w;
       my $x = Dimension(0);
       my $f = ($svg && $document->getNodeFont($svg)) || $whatsit->getFont;
+      my $y = $h;
       # Heuristic: Browsers seem set on creating at least a lineheight box, so adjust
-      my $y = $h->larger(Dimension($f->getSize . 'pt'));
+      my $vhack = $h->subtract(Dimension($f->getSize . 'pt'));
+      $vhack = Dimension(0) if $vhack->valueOf > 0;
       Debug("SVG:foreignObject " . $w->pxValue . ' x ' . $h->pxValue . ' x ' . $d->pxValue . "; "
           . " => H=" . $H->pxValue . " @ y=" . $y->pxValue
           . " for Whatsit=" . ToString($whatsit)) if $LaTeXML::DEBUG{svg_verbose};
@@ -430,7 +432,9 @@ Tag('svg:foreignObject', autoOpen => 1, autoClose => 1,
       $style .= '--ltx-fo-width:' . $w->toAttribute . ';'
         . '--ltx-fo-height:' . $h->toAttribute . ';'
         . '--ltx-fo-depth:' . $d->toAttribute . ';';
-      $style .= 'font-size:' . $f->getSize . 'pt;';
+      # Reset font-size to parent svg's, so not affected by svg scaling.
+      $style .= 'font-size:' . $f->getSize . 'pt;'
+        . '--ltx-fo-vhack:' . $vhack->emValue(2, $f) . 'em;';
       $document->setAttribute($node, style => $style) if $style;
 } });
 

--- a/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
+++ b/lib/LaTeXML/Engine/TeX_Math.pool.ltxml
@@ -303,7 +303,7 @@ sub cleanup_XMText {
             $document->replaceNode($m, map { $_->childNodes } $m->childNodes); }
           else {                                           # Otherwise, wrap whatever it is in an XMText
             $document->wrapNodes('ltx:XMText', $m); }
-        } } }
+    } } }
     # And now we don't need the XMText any more.
     foreach my $attr ($textnode->attributes) {    # Copy the child's attributes (should Merge!!)
       $table->setAttribute($attr->nodeName => $attr->getValue); }
@@ -426,7 +426,7 @@ sub scriptHandler {
     my $c = (($op eq 'SUPERSCRIPT') ? '^' : '_');
     Error('unexpected', $c, $stomach, "Script $c can only appear in math mode");
     return Box($c, undef, undef, (($op eq 'SUPERSCRIPT') ? T_SUPER : T_SUB));
-  } }
+} }
 
 DefPrimitiveI(T_SUPER, undef, sub { scriptHandler($_[0], 'SUPERSCRIPT'); });
 DefPrimitiveI(T_SUB,   undef, sub { scriptHandler($_[0], 'SUBSCRIPT'); });
@@ -547,7 +547,7 @@ DefRewrite(xpath => 'descendant::ltx:Math[child::ltx:XMath[child::ltx:XMApp[' .
             elsif ($role eq 'FLOATSUBSCRIPT') {
               $document->insertElement('ltx:sub', $text);
               return; }
-          } } } }
+    } } } }
     # should never happen, but just in case:
     Info("rewrite", "footnotemark", "Failed to find floating node in: " . $math->toString(1));
     $document->getNode->appendChild($math);
@@ -822,7 +822,7 @@ sub augmentDelimiterProperties {
       if (exists $$entry{char}) {                    # replace the char content!
         if (my $char = $$entry{char}) {
           $delim->firstChild->setData($char); } }
-    } }
+  } }
   return; }
 
 # Useful for afterConstruct of delimiter sizing macros (eg. \bigl)
@@ -1058,10 +1058,22 @@ sub adjustMathStyle_internal {
 
 sub fracSizer {
   my ($numerator, $denominator) = @_;
-  my $w = $numerator->getWidth->larger($denominator->getWidth);
-  my $d = $denominator->getTotalHeight->multiply(0.5);
-  my $h = $numerator->getTotalHeight->add($d);
-  return ($w, $h, $d); }
+  my $nfont     = $numerator   && $numerator->getFont;
+  my $dfont     = $denominator && $denominator->getFont;
+  my $style     = $nfont       && $nfont->getMathstyle || 'text';
+  my $isdisplay = ($style eq 'display');
+  my $syfont    = 'cmsy' . ($nfont && $nfont->getSize || 10);
+  my ($wnum, $hnum, $dnum) = map { $_->valueOf } $numerator->getSize;
+  my ($wden, $hden, $dden) = map { $_->valueOf } $denominator->getSize;
+  my ($wnom, $hnom, $dnom) = map { $_->valueOf } $nfont->getNominalSize;
+  my $th      = Dimension('0.4pt')->valueOf;
+  my $xheight = getFontDimen($syfont, 5);
+  my $maxis   = $xheight / 2 + $th;
+  my $pad     = ($isdisplay ? 3.5 : 1.5) * $th;
+  my $h       = $pad + max($dnum, $dnom) + $hnum + $maxis;
+  my $d       = $pad + max($hden, $hnom) + $dden - $maxis;
+  my $w       = max($wnum, $wden) + Dimension('2.4pt')->valueOf;    # should be what?
+  return (Dimension($w), Dimension($h), Dimension($d)); }
 
 # \lx@generalized@over{reversion}{keyvals}{top}{bottom}
 # keyvals: role,meaning, left,right, thickness

--- a/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
+++ b/lib/LaTeXML/Engine/latex_constructs.pool.ltxml
@@ -1234,6 +1234,7 @@ sub applyAligningContext {
       setAlignOrClass($document, $child, $align, $class) if $child->nodeType == XML_ELEMENT_NODE; } }
   return; }
 
+DefConstructorI('\lx@maybe@aligning@context', undef, \&setupAligningContext);
 DefConstructorI('\centering', undef, \&setupAligningContext,
   beforeDigest => sub { UnshiftValue(beforeAfterGroup => T_CS('\@add@centering')); });
 DefConstructorI('\raggedright', undef, \&setupAligningContext,
@@ -4788,7 +4789,13 @@ DefEnvironment('{minipage}[] OptionalUndigested [] {Dimension}', sub {
     AssignRegister('\textwidth'   => $width);
     AssignRegister('\columnwidth' => $width);
     $whatsit->setProperties(width => $width, vattach => $vattach);
-    Let('\\\\', '\lx@newline'); },
+    Let('\\\\', '\lx@newline');
+    Digest('\lx@maybe@aligning@context'); },    # So we can be centered.
+  beforeDigestEnd => sub {                      # Detect sneaky way of centering
+    if (LookupDimension('\leftskip')->getStretch->valueOf
+      && LookupDimension('\rightskip')->getStretch->valueOf) {
+      return Digest('\@add@centering'); }
+    return; },
   afterDigestBody => sub {
     my ($stomach, $whatsit) = @_;
     $whatsit->getBody->setProperty(vattach => $whatsit->getProperty('vattach')); },

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -491,6 +491,9 @@ span.ltx_framed       { display:inline-block; text-indent:0; } /* avoid padding/
 .ltx_svg_fog foreignObject  { margin:0; padding:0; overflow:visible; }
 .ltx_svg_fog foreignObject > p { margin:0; padding:0; display:block; }
 
+/* Temporary(?) hack until text-box-trim is supported */
+.ltx_foreignobject_content { translate: 0 var(--ltx-fo-vhack); }
+
 /*======================================================================
  Low-level Basics */
 /* Note that LaTeX(ML)'s font model doesn't map quite exactly to CSS's */
@@ -587,6 +590,7 @@ cite                 { font-style: normal; }
   .ltx_foreignobject_content {
     color: var(--fn-fg-color-to-dark-mode, white);
   }
+
   /* We eventually want to cover the full range of possible attributes where color
       customization is expected in latexml's HTML format. This will be easier once
       CSS @function becomes widely available in browsers.

--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -479,26 +479,9 @@ span.ltx_framed       { display:inline-block; text-indent:0; } /* avoid padding/
 /*======================================================================
  SVG (pgf/tikz & xy) basics
  */
-/* Heuristically adjust for content uncentered within line-box */
-foreignObject {
-    translate: 0 0.1em;
-    --ltx-fo-width: 100%; }
-/* Use flex to vertically center foreignObject,
-   to accommodate potentially tall line-box */
-.ltx_foreignobject_container {
-    display:flex;
-    align-items:center;
-    height:100%;
-    width:var(--ltx-fo-width);
-}
 /* Also horizontally for single math, since Chrome adds a lot of left/right spacing. */
 .ltx_foreignobject_container:has( > .ltx_foreignobject_content > math:only-child) {
     justify-content:center;
-}
-/* If multiple children, give more space to avoid unexpected line breaks
-   due to font differences. */
-.ltx_foreignobject_container:has( > .ltx_foreignobject_content > :not(:only-child)) {
-    width:calc(1.1 * var(--ltx-fo-width));
 }
 /* line height 0 just for this layer, to keep the line-box compact */
 .ltx_foreignobject_content {

--- a/t/graphics/xytest.xml
+++ b/t/graphics/xytest.xml
@@ -11,14 +11,14 @@
       <svg:svg height="2.75em" overflow="visible" style="vertical-align:-4.73px" version="1.1" viewBox="-6.62 4.73 81.86 38.1" width="5.92em">
         <svg:g transform="matrix(1 0 0 -1 -6.62 38.1) translate(-6.62,0)">
           <svg:g transform="translate(6.62,0) translate(0,-4.73)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.38"><Math mode="inline" tex="\textstyle{A}" text="A" xml:id="p1.pic1.m1">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.38"><Math mode="inline" tex="\textstyle{A}" text="A" xml:id="p1.pic1.m1">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">A</XMTok>
                 </XMath>
               </Math></svg:foreignObject>
           </svg:g>
           <svg:g transform="translate(68.99,0) translate(0,23.62) translate(4.15,0) translate(0,-4.73)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:8.1pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="p1.pic1.m2">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:8.1pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="p1.pic1.m2">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">B</XMTok>
                 </XMath>
@@ -37,14 +37,14 @@
       <svg:svg height="7.55em" overflow="visible" style="vertical-align:-94.32px" version="1.1" viewBox="9.63 94.32 161.23 104.47" width="11.65em">
         <svg:g transform="matrix(1 0 0 -1 9.63 104.47) translate(9.63,0)">
           <svg:g transform="translate(-9.63,0) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.9pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.96"><Math mode="inline" tex="\textstyle{U\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces}" text="U" xml:id="p2.pic1.m1">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.9pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.96"><Math mode="inline" tex="\textstyle{U\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces}" text="U" xml:id="p2.pic1.m1">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">U</XMTok>
                 </XMath>
               </Math></svg:foreignObject>
           </svg:g>
           <svg:g transform="translate(14.38,0) translate(0,-54.38) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:4.3pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="5.96"><Math mode="inline" tex="\scriptstyle{y}" text="y" xml:id="p2.pic1.m2">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:4.3pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;--ltx-fo-vhack:-0.7em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.96"><Math mode="inline" tex="\scriptstyle{y}" text="y" xml:id="p2.pic1.m2">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">y</XMTok>
                 </XMath>
@@ -63,7 +63,7 @@
           <svg:path d="M 9.63 -5.94 L 53.77 -33.21" fill="none" stroke="#000000"/>
           <svg:path d="M 53.74 -33.19 L 53.77 -33.21" fill="none" stroke="#000000"/>
           <svg:g transform="translate(67.97,0) translate(0,-7.5) translate(4.15,0) translate(0,-2.09)">
-            <svg:foreignObject height="4.17" overflow="visible" style="--ltx-fo-width:4.5pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="6.27"><Math mode="inline" tex="\scriptstyle{x}" text="x" xml:id="p2.pic1.m3">
+            <svg:foreignObject height="4.17" overflow="visible" style="--ltx-fo-width:4.5pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.7em;" transform="matrix(1 0 0 -1 0 4.17)" width="6.27"><Math mode="inline" tex="\scriptstyle{x}" text="x" xml:id="p2.pic1.m3">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">x</XMTok>
                 </XMath>
@@ -75,7 +75,7 @@
           </svg:g>
           <svg:path d="M 9.61 -0.87 C 52.38 -5.35 92.76 -17.6 130.75 -37.63" fill="none" stroke="#000000"/>
           <svg:g transform="translate(42.84,0) translate(0,-43.36) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="11.53" overflow="visible" style="--ltx-fo-width:33.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:1.5pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="46.4"><Math mode="inline" tex="\textstyle{X\times_{Z}Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X * _ Z Y" xml:id="p2.pic1.m5">
+            <svg:foreignObject height="11.53" overflow="visible" style="--ltx-fo-width:33.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:1.5pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="46.4"><Math mode="inline" tex="\textstyle{X\times_{Z}Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X * _ Z Y" xml:id="p2.pic1.m5">
                 <XMath>
                   <XMApp>
                     <XMApp role="MULOP">
@@ -91,7 +91,7 @@
           </svg:g>
           <svg:path class="droprule" d="M 69.91 -53.04 L 70.47 -53.04" fill="none" stroke="#000000"/>
           <svg:g transform="translate(70.19,0) translate(0,-65.03) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:3.9pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="5.42"><Math mode="inline" tex="\scriptstyle{q}" text="q" xml:id="p2.pic1.m6">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:3.9pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;--ltx-fo-vhack:-0.7em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.42"><Math mode="inline" tex="\scriptstyle{q}" text="q" xml:id="p2.pic1.m6">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">q</XMTok>
                 </XMath>
@@ -105,7 +105,7 @@
           <svg:path class="droprule" d="M 69.91 -76.56 L 70.47 -76.56" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 97.54 -43.63 L 97.54 -43.08" fill="none" stroke="#000000"/>
           <svg:g transform="translate(98.68,0) translate(0,-50.53) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:4.1pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="5.7"><Math mode="inline" tex="\scriptstyle{p}" text="p" xml:id="p2.pic1.m7">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:4.1pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;--ltx-fo-vhack:-0.7em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.7"><Math mode="inline" tex="\scriptstyle{p}" text="p" xml:id="p2.pic1.m7">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">p</XMTok>
                 </XMath>
@@ -118,7 +118,7 @@
           <svg:path class="droprule" d="M 97.54 -43.63 L 130.75 -43.08" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 130.75 -43.63 L 130.75 -43.08" fill="none" stroke="#000000"/>
           <svg:g transform="translate(130.75,0) translate(0,-43.36) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:9.1pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="12.55"><Math mode="inline" tex="\textstyle{X\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X" xml:id="p2.pic1.m8">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:9.1pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="12.55"><Math mode="inline" tex="\textstyle{X\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X" xml:id="p2.pic1.m8">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">X</XMTok>
                 </XMath>
@@ -126,7 +126,7 @@
           </svg:g>
           <svg:path class="droprule" d="M 140.9 -50.97 L 141.46 -50.97" fill="none" stroke="#000000"/>
           <svg:g transform="translate(126.4,0) translate(0,-65.03) translate(4.15,0) translate(0,-2.42)">
-            <svg:foreignObject height="8.61" overflow="visible" style="--ltx-fo-width:4.7pt;--ltx-fo-height:4.9pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="6.48"><Math mode="inline" tex="\scriptstyle{f}" text="f" xml:id="p2.pic1.m9">
+            <svg:foreignObject height="8.61" overflow="visible" style="--ltx-fo-width:4.7pt;--ltx-fo-height:4.9pt;--ltx-fo-depth:1.4pt;font-size:10pt;--ltx-fo-vhack:-0.51em;" transform="matrix(1 0 0 -1 0 6.73)" width="6.48"><Math mode="inline" tex="\scriptstyle{f}" text="f" xml:id="p2.pic1.m9">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">f</XMTok>
                 </XMath>
@@ -139,7 +139,7 @@
           <svg:path class="droprule" d="M 140.9 -76.56 L 141.46 -50.97" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 140.9 -76.56 L 141.46 -76.56" fill="none" stroke="#000000"/>
           <svg:g transform="translate(60.49,0) translate(0,-86.71) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:8.0pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="11.11"><Math mode="inline" tex="\textstyle{Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="Y" xml:id="p2.pic1.m11">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:8.0pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="11.11"><Math mode="inline" tex="\textstyle{Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="Y" xml:id="p2.pic1.m11">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">Y</XMTok>
                 </XMath>
@@ -147,7 +147,7 @@
           </svg:g>
           <svg:path class="droprule" d="M 79.9 -86.99 L 79.9 -86.44" fill="none" stroke="#000000"/>
           <svg:g transform="translate(98.66,0) translate(0,-79.53) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:4.2pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="5.75"><Math mode="inline" tex="\scriptstyle{g}" text="g" xml:id="p2.pic1.m12">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:4.2pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;--ltx-fo-vhack:-0.7em;" transform="matrix(1 0 0 -1 0 4.17)" width="5.75"><Math mode="inline" tex="\scriptstyle{g}" text="g" xml:id="p2.pic1.m12">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">g</XMTok>
                 </XMath>
@@ -160,7 +160,7 @@
           <svg:path class="droprule" d="M 79.9 -86.99 L 131.81 -86.44" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 131.81 -86.99 L 131.81 -86.44" fill="none" stroke="#000000"/>
           <svg:g transform="translate(131.81,0) translate(0,-86.71) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.44"><Math mode="inline" tex="\textstyle{Z}" text="Z" xml:id="p2.pic1.m13">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.44"><Math mode="inline" tex="\textstyle{Z}" text="Z" xml:id="p2.pic1.m13">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">Z</XMTok>
                 </XMath>
@@ -182,7 +182,7 @@
                 <svg:svg height="4.48em" overflow="visible" style="vertical-align:-51.91px" version="1.1" viewBox="9.59 51.91 73.11 62.06" width="5.28em">
                   <svg:g transform="matrix(1 0 0 -1 9.59 62.06) translate(0,3.46) translate(9.59,0)">
                     <svg:g transform="translate(-9.34,0) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.38"><Math mode="inline" tex="\textstyle{A\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="A" xml:id="S0.Ex1.m1.pic1.m1">
+                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.38"><Math mode="inline" tex="\textstyle{A\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="A" xml:id="S0.Ex1.m1.pic1.m1">
                           <XMath>
                             <XMTok font="italic" role="UNKNOWN">A</XMTok>
                           </XMath>
@@ -210,21 +210,21 @@
                     <svg:path d="M 9.13 -7.61 L 42.8 -35.68" fill="none" stroke="#000000"/>
                     <svg:path d="M 42.79 -35.61 L 42.8 -35.68" fill="none" stroke="#000000"/>
                     <svg:g transform="translate(43.41,0) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:8.1pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="S0.Ex1.m1.pic1.m2">
+                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:8.1pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="S0.Ex1.m1.pic1.m2">
                           <XMath>
                             <XMTok font="italic" role="UNKNOWN">B</XMTok>
                           </XMath>
                         </Math></svg:foreignObject>
                     </svg:g>
                     <svg:g transform="translate(-9.59,0) translate(0,-44.3) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.9pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.88"><Math mode="inline" tex="\textstyle{C}" text="C" xml:id="S0.Ex1.m1.pic1.m3">
+                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.9pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.32em;" transform="matrix(1 0 0 -1 0 9.46)" width="10.88"><Math mode="inline" tex="\textstyle{C}" text="C" xml:id="S0.Ex1.m1.pic1.m3">
                           <XMath>
                             <XMTok font="italic" role="UNKNOWN">C</XMTok>
                           </XMath>
                         </Math></svg:foreignObject>
                     </svg:g>
                     <svg:g transform="translate(42.8,0) translate(0,-44.3) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="11.35" overflow="visible" style="--ltx-fo-width:9.0pt;--ltx-fo-height:8.2pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="12.42"><text class="ltx_markedasmath" fontsize="120%">D</text></svg:foreignObject>
+                      <svg:foreignObject height="11.35" overflow="visible" style="--ltx-fo-width:9.0pt;--ltx-fo-height:8.2pt;--ltx-fo-depth:0.0pt;font-size:10pt;--ltx-fo-vhack:-0.18em;" transform="matrix(1 0 0 -1 0 11.35)" width="12.42"><text class="ltx_markedasmath" fontsize="120%">D</text></svg:foreignObject>
                     </svg:g>
                   </svg:g>
                 </svg:svg>
@@ -253,7 +253,7 @@
                       <svg:path d="M 23.87 -5.36 C 24.91 -7.61 24.91 -8.99 25.94 -11.24" fill="none" stroke="#000000"/>
                       <svg:path d="M 25.94 -11.24 C 26.98 -13.49 29.06 -16.6 33.21 -16.6" fill="none" stroke="#000000"/>
                       <svg:g transform="translate(21.45,0) translate(0,-8.3)">
-                        <svg:foreignObject height="6.92" overflow="visible" style="--ltx-fo-width:5.0pt;--ltx-fo-height:2.5pt;--ltx-fo-depth:2.5pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="6.92"><text class="ltx_markedasmath" fontsize="70%" width="5.0pt"> </text></svg:foreignObject>
+                        <svg:foreignObject height="6.92" overflow="visible" style="--ltx-fo-width:5.0pt;--ltx-fo-height:2.5pt;--ltx-fo-depth:2.5pt;font-size:10pt;--ltx-fo-vhack:-0.75em;" transform="matrix(1 0 0 -1 0 3.46)" width="6.92"><text class="ltx_markedasmath" fontsize="70%" width="5.0pt"> </text></svg:foreignObject>
                       </svg:g>
                       <svg:path d="M 16.6 -16.6 C 20.44 -16.6 22.51 -13.94 23.62 -11.76" fill="none" stroke="#000000"/>
                       <svg:path d="M 26.2 -4.84 C 27.31 -2.66 29.37 0 33.21 0" fill="none" stroke="#000000"/>

--- a/t/graphics/xytest.xml
+++ b/t/graphics/xytest.xml
@@ -11,14 +11,14 @@
       <svg:svg height="2.75em" overflow="visible" style="vertical-align:-4.73px" version="1.1" viewBox="-6.62 4.73 81.86 38.1" width="5.92em">
         <svg:g transform="matrix(1 0 0 -1 -6.62 38.1) translate(-6.62,0)">
           <svg:g transform="translate(6.62,0) translate(0,-4.73)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.75em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="10.38"><Math mode="inline" tex="\textstyle{A}" text="A" xml:id="p1.pic1.m1">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.38"><Math mode="inline" tex="\textstyle{A}" text="A" xml:id="p1.pic1.m1">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">A</XMTok>
                 </XMath>
               </Math></svg:foreignObject>
           </svg:g>
           <svg:g transform="translate(68.99,0) translate(0,23.62) translate(4.15,0) translate(0,-4.73)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.81em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="p1.pic1.m2">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:8.1pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="p1.pic1.m2">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">B</XMTok>
                 </XMath>
@@ -37,14 +37,14 @@
       <svg:svg height="7.55em" overflow="visible" style="vertical-align:-94.32px" version="1.1" viewBox="9.63 94.32 161.23 104.47" width="11.65em">
         <svg:g transform="matrix(1 0 0 -1 9.63 104.47) translate(9.63,0)">
           <svg:g transform="translate(-9.63,0) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.79em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="10.96"><Math mode="inline" tex="\textstyle{U\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces}" text="U" xml:id="p2.pic1.m1">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.9pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.96"><Math mode="inline" tex="\textstyle{U\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces}" text="U" xml:id="p2.pic1.m1">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">U</XMTok>
                 </XMath>
               </Math></svg:foreignObject>
           </svg:g>
           <svg:g transform="translate(14.38,0) translate(0,-54.38) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:0.43em;--ltx-fo-height:0.3em;--ltx-fo-depth:0.14em;font-size:10pt;" transform="matrix(1 0 0 -1 0 4.17)" width="5.96"><Math mode="inline" tex="\scriptstyle{y}" text="y" xml:id="p2.pic1.m2">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:4.3pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="5.96"><Math mode="inline" tex="\scriptstyle{y}" text="y" xml:id="p2.pic1.m2">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">y</XMTok>
                 </XMath>
@@ -63,7 +63,7 @@
           <svg:path d="M 9.63 -5.94 L 53.77 -33.21" fill="none" stroke="#000000"/>
           <svg:path d="M 53.74 -33.19 L 53.77 -33.21" fill="none" stroke="#000000"/>
           <svg:g transform="translate(67.97,0) translate(0,-7.5) translate(4.15,0) translate(0,-2.09)">
-            <svg:foreignObject height="4.17" overflow="visible" style="--ltx-fo-width:0.45em;--ltx-fo-height:0.3em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 4.17)" width="6.27"><Math mode="inline" tex="\scriptstyle{x}" text="x" xml:id="p2.pic1.m3">
+            <svg:foreignObject height="4.17" overflow="visible" style="--ltx-fo-width:4.5pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="6.27"><Math mode="inline" tex="\scriptstyle{x}" text="x" xml:id="p2.pic1.m3">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">x</XMTok>
                 </XMath>
@@ -75,7 +75,7 @@
           </svg:g>
           <svg:path d="M 9.61 -0.87 C 52.38 -5.35 92.76 -17.6 130.75 -37.63" fill="none" stroke="#000000"/>
           <svg:g transform="translate(42.84,0) translate(0,-43.36) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="11.53" overflow="visible" style="--ltx-fo-width:3.35em;--ltx-fo-height:0.68em;--ltx-fo-depth:0.15em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="46.4"><Math mode="inline" tex="\textstyle{X\times_{Z}Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X * _ Z Y" xml:id="p2.pic1.m5">
+            <svg:foreignObject height="11.53" overflow="visible" style="--ltx-fo-width:33.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:1.5pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="46.4"><Math mode="inline" tex="\textstyle{X\times_{Z}Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X * _ Z Y" xml:id="p2.pic1.m5">
                 <XMath>
                   <XMApp>
                     <XMApp role="MULOP">
@@ -91,7 +91,7 @@
           </svg:g>
           <svg:path class="droprule" d="M 69.91 -53.04 L 70.47 -53.04" fill="none" stroke="#000000"/>
           <svg:g transform="translate(70.19,0) translate(0,-65.03) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:0.39em;--ltx-fo-height:0.3em;--ltx-fo-depth:0.14em;font-size:10pt;" transform="matrix(1 0 0 -1 0 4.17)" width="5.42"><Math mode="inline" tex="\scriptstyle{q}" text="q" xml:id="p2.pic1.m6">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:3.9pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="5.42"><Math mode="inline" tex="\scriptstyle{q}" text="q" xml:id="p2.pic1.m6">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">q</XMTok>
                 </XMath>
@@ -105,7 +105,7 @@
           <svg:path class="droprule" d="M 69.91 -76.56 L 70.47 -76.56" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 97.54 -43.63 L 97.54 -43.08" fill="none" stroke="#000000"/>
           <svg:g transform="translate(98.68,0) translate(0,-50.53) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:0.41em;--ltx-fo-height:0.3em;--ltx-fo-depth:0.14em;font-size:10pt;" transform="matrix(1 0 0 -1 0 4.17)" width="5.7"><Math mode="inline" tex="\scriptstyle{p}" text="p" xml:id="p2.pic1.m7">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:4.1pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="5.7"><Math mode="inline" tex="\scriptstyle{p}" text="p" xml:id="p2.pic1.m7">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">p</XMTok>
                 </XMath>
@@ -118,7 +118,7 @@
           <svg:path class="droprule" d="M 97.54 -43.63 L 130.75 -43.08" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 130.75 -43.63 L 130.75 -43.08" fill="none" stroke="#000000"/>
           <svg:g transform="translate(130.75,0) translate(0,-43.36) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.91em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="12.55"><Math mode="inline" tex="\textstyle{X\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X" xml:id="p2.pic1.m8">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:9.1pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="12.55"><Math mode="inline" tex="\textstyle{X\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="X" xml:id="p2.pic1.m8">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">X</XMTok>
                 </XMath>
@@ -126,7 +126,7 @@
           </svg:g>
           <svg:path class="droprule" d="M 140.9 -50.97 L 141.46 -50.97" fill="none" stroke="#000000"/>
           <svg:g transform="translate(126.4,0) translate(0,-65.03) translate(4.15,0) translate(0,-2.42)">
-            <svg:foreignObject height="8.61" overflow="visible" style="--ltx-fo-width:0.47em;--ltx-fo-height:0.49em;--ltx-fo-depth:0.14em;font-size:10pt;" transform="matrix(1 0 0 -1 0 6.73)" width="6.48"><Math mode="inline" tex="\scriptstyle{f}" text="f" xml:id="p2.pic1.m9">
+            <svg:foreignObject height="8.61" overflow="visible" style="--ltx-fo-width:4.7pt;--ltx-fo-height:4.9pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="6.48"><Math mode="inline" tex="\scriptstyle{f}" text="f" xml:id="p2.pic1.m9">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">f</XMTok>
                 </XMath>
@@ -139,7 +139,7 @@
           <svg:path class="droprule" d="M 140.9 -76.56 L 141.46 -50.97" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 140.9 -76.56 L 141.46 -76.56" fill="none" stroke="#000000"/>
           <svg:g transform="translate(60.49,0) translate(0,-86.71) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.8em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="11.11"><Math mode="inline" tex="\textstyle{Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="Y" xml:id="p2.pic1.m11">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:8.0pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="11.11"><Math mode="inline" tex="\textstyle{Y\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="Y" xml:id="p2.pic1.m11">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">Y</XMTok>
                 </XMath>
@@ -147,7 +147,7 @@
           </svg:g>
           <svg:path class="droprule" d="M 79.9 -86.99 L 79.9 -86.44" fill="none" stroke="#000000"/>
           <svg:g transform="translate(98.66,0) translate(0,-79.53) translate(4.15,0) translate(0,-1.14)">
-            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:0.42em;--ltx-fo-height:0.3em;--ltx-fo-depth:0.14em;font-size:10pt;" transform="matrix(1 0 0 -1 0 4.17)" width="5.75"><Math mode="inline" tex="\scriptstyle{g}" text="g" xml:id="p2.pic1.m12">
+            <svg:foreignObject height="6.05" overflow="visible" style="--ltx-fo-width:4.2pt;--ltx-fo-height:3.0pt;--ltx-fo-depth:1.4pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="5.75"><Math mode="inline" tex="\scriptstyle{g}" text="g" xml:id="p2.pic1.m12">
                 <XMath>
                   <XMTok font="italic" fontsize="70%" role="UNKNOWN">g</XMTok>
                 </XMath>
@@ -160,7 +160,7 @@
           <svg:path class="droprule" d="M 79.9 -86.99 L 131.81 -86.44" fill="none" stroke="#000000"/>
           <svg:path class="droprule" d="M 131.81 -86.99 L 131.81 -86.44" fill="none" stroke="#000000"/>
           <svg:g transform="translate(131.81,0) translate(0,-86.71) translate(4.15,0) translate(0,-3.46)">
-            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.75em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="10.44"><Math mode="inline" tex="\textstyle{Z}" text="Z" xml:id="p2.pic1.m13">
+            <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.44"><Math mode="inline" tex="\textstyle{Z}" text="Z" xml:id="p2.pic1.m13">
                 <XMath>
                   <XMTok font="italic" role="UNKNOWN">Z</XMTok>
                 </XMath>
@@ -182,7 +182,7 @@
                 <svg:svg height="4.48em" overflow="visible" style="vertical-align:-51.91px" version="1.1" viewBox="9.59 51.91 73.11 62.06" width="5.28em">
                   <svg:g transform="matrix(1 0 0 -1 9.59 62.06) translate(0,3.46) translate(9.59,0)">
                     <svg:g transform="translate(-9.34,0) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.75em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="10.38"><Math mode="inline" tex="\textstyle{A\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="A" xml:id="S0.Ex1.m1.pic1.m1">
+                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.5pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.38"><Math mode="inline" tex="\textstyle{A\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces%&#10;\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces\ignorespaces}" text="A" xml:id="S0.Ex1.m1.pic1.m1">
                           <XMath>
                             <XMTok font="italic" role="UNKNOWN">A</XMTok>
                           </XMath>
@@ -210,21 +210,21 @@
                     <svg:path d="M 9.13 -7.61 L 42.8 -35.68" fill="none" stroke="#000000"/>
                     <svg:path d="M 42.79 -35.61 L 42.8 -35.68" fill="none" stroke="#000000"/>
                     <svg:g transform="translate(43.41,0) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.81em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="S0.Ex1.m1.pic1.m2">
+                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:8.1pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="11.19"><Math mode="inline" tex="\textstyle{B}" text="B" xml:id="S0.Ex1.m1.pic1.m2">
                           <XMath>
                             <XMTok font="italic" role="UNKNOWN">B</XMTok>
                           </XMath>
                         </Math></svg:foreignObject>
                     </svg:g>
                     <svg:g transform="translate(-9.59,0) translate(0,-44.3) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:0.79em;--ltx-fo-height:0.68em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 9.46)" width="10.88"><Math mode="inline" tex="\textstyle{C}" text="C" xml:id="S0.Ex1.m1.pic1.m3">
+                      <svg:foreignObject height="9.46" overflow="visible" style="--ltx-fo-width:7.9pt;--ltx-fo-height:6.8pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="10.88"><Math mode="inline" tex="\textstyle{C}" text="C" xml:id="S0.Ex1.m1.pic1.m3">
                           <XMath>
                             <XMTok font="italic" role="UNKNOWN">C</XMTok>
                           </XMath>
                         </Math></svg:foreignObject>
                     </svg:g>
                     <svg:g transform="translate(42.8,0) translate(0,-44.3) translate(4.15,0) translate(0,-3.46)">
-                      <svg:foreignObject height="11.35" overflow="visible" style="--ltx-fo-width:0.9em;--ltx-fo-height:0.82em;--ltx-fo-depth:0em;font-size:10pt;" transform="matrix(1 0 0 -1 0 11.35)" width="12.42"><text class="ltx_markedasmath" fontsize="120%">D</text></svg:foreignObject>
+                      <svg:foreignObject height="11.35" overflow="visible" style="--ltx-fo-width:9.0pt;--ltx-fo-height:8.2pt;--ltx-fo-depth:0.0pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="12.42"><text class="ltx_markedasmath" fontsize="120%">D</text></svg:foreignObject>
                     </svg:g>
                   </svg:g>
                 </svg:svg>
@@ -253,7 +253,7 @@
                       <svg:path d="M 23.87 -5.36 C 24.91 -7.61 24.91 -8.99 25.94 -11.24" fill="none" stroke="#000000"/>
                       <svg:path d="M 25.94 -11.24 C 26.98 -13.49 29.06 -16.6 33.21 -16.6" fill="none" stroke="#000000"/>
                       <svg:g transform="translate(21.45,0) translate(0,-8.3)">
-                        <svg:foreignObject height="6.92" overflow="visible" style="--ltx-fo-width:0.63em;--ltx-fo-height:0.31em;--ltx-fo-depth:0.31em;font-size:7pt;" transform="matrix(1 0 0 -1 0 3.46)" width="6.92"><text class="ltx_markedasmath" fontsize="70%" width="5.0pt"> </text></svg:foreignObject>
+                        <svg:foreignObject height="6.92" overflow="visible" style="--ltx-fo-width:5.0pt;--ltx-fo-height:2.5pt;--ltx-fo-depth:2.5pt;font-size:10pt;" transform="matrix(1 0 0 -1 0 13.84)" width="6.92"><text class="ltx_markedasmath" fontsize="70%" width="5.0pt"> </text></svg:foreignObject>
                       </svg:g>
                       <svg:path d="M 16.6 -16.6 C 20.44 -16.6 22.51 -13.94 23.62 -11.76" fill="none" stroke="#000000"/>
                       <svg:path d="M 26.2 -4.84 C 27.31 -2.66 29.37 0 33.21 0" fill="none" stroke="#000000"/>


### PR DESCRIPTION
This PR improves svg foreignObject sizing & positioning.

Since text & graphical items within an svg must be scaled together to preserve the relationship, but we don't know what font size will be used in the browser, we must set the svg size in font-relative units. This was done in a previous PR. But since this introduces an unknown scaling seen by the foreignObject (and in case the svg itself has a stray scaling), we must reset the font size on the foreignObject. (Contrary to what some on the web assert, the svg scaling *does* affect the font size). However, we  should reset it to the font-size used on the parent svg, not the font within the object (% sizes will accumulate!).

I also improved sizing of fractions, and recognized a tricky way that tikz does centering in minipage.

I've removed the use of `--ltx-fo-*` variables from `LaTeXML.css`, since they were used for heuristic tweaks that caused as many problems as they solved, and in fact made it harder to solve the problems correctly. Really, CSS should be used for styling, not for fixing bugs.  I've put the variables back to pts instead of ems, but I'd really prefer to remove them.


fixes #2695