### PR TITLE
make listings line numbers not selectable

### DIFF
--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -322,11 +322,13 @@ dl.ltx_description dl.ltx_description dd { margin-left:3em; }
 .ltx_listingline { white-space:nowrap; min-height:1em; }
 .ltx_lst_space { white-space: pre; }
 .ltx_lst_numbers_left .ltx_listingline .ltx_tag {
+    user-select: none;
     background-color:transparent;
     margin-left:-3em; width:2.5em;
     position:absolute;
     text-align:right; }
 .ltx_lst_numbers_right .ltx_listingline .ltx_tag {
+    user-select: none;
     background-color:transparent;
     width:2.5em;
     position:absolute; right:3em;


### PR DESCRIPTION
Alleviate an issue related to #2629: currently, if you select code in a listing across multiple lines, you also grab some of the line numbers. Making numbers not selectable seems more sensible.