### PR TITLE
Preserve existing logs for archive output

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -860,6 +860,7 @@ t/91_latexmlc_api.t
 t/92_profiles.t
 t/93_formats.t
 t/931_epub.t
+t/932_zip.t
 t/94_runtimes.t
 t/95_complex_config.t
 t/96_fatal.t

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -182,8 +182,7 @@ my $destination = $opts->get('destination');
 # Always write log to a file, either specified via --log or 'latexml.log'
 # with the exception of *archive* outputs, where the log is in the ZIP
 my $whatsout   = $opts->get('whatsout');
-my $is_archive = $keep_log_file
-  || ($whatsout && ($whatsout =~ /^archive/));
+my $is_archive = $whatsout && ($whatsout =~ /^archive/);
 
 if ($log && !$is_archive) {
   chomp($log);

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -20,6 +20,7 @@ my $RealBin_safe;
 use FindBin;
 use File::Spec::Functions;
 use File::Which;
+use Storable qw(dclone);
 
 BEGIN {
   if ($FindBin::RealBin =~ /^([^\0]+)\z/) {    # Valid Unix path TODO: Windows, revisit regexp
@@ -103,21 +104,33 @@ if ($source eq '-') {
 # Use $jobname.latexml.log or just latexml.log for logging by default
 #
 # In the local conversion case, this can be delegated to LaTeXML.pm
-my $logfile = $opts->get('log');
+my $normalized_opts  = LaTeXML::Common::Config->new(%{ dclone($opts->options) });
+my $normalization_ok = eval {
+  $normalized_opts->check;
+  1;
+};
+my $whatsout   = $normalized_opts->get('whatsout');
+my $is_archive = $whatsout && ($whatsout =~ /^archive/);
+# Fail closed so an invalid configuration cannot remove a pre-existing log.
+my $preserve_existing_log = !$normalization_ok || $is_archive;
+my $logfile               = $opts->get('log');
 if (!$logfile) {
   if (!pathname_is_literaldata($source)) {
     my ($dir, $name, $ext) = pathname_split($source);
     if ($name) {
-      $logfile = pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); }
+      $logfile = $is_archive
+        ? pathname_make(name => $name, type => 'latexml.log')
+        : pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); }
     else {
       $logfile = 'latexml.log';
-  } }
+    } }
   else {
     $logfile = 'latexml.log'; }
   $opts->set('log', $logfile); }
 # A bit special: Since LaTeXML.pm will always try to append to the log file
-# make sure the file is new before we start.
-unlink($logfile) if (-f $logfile);
+# make sure the file is new before we start. Archive logs are buffered and
+# packaged, so they must not affect an external file with the same name.
+unlink($logfile) if (!$preserve_existing_log && (-f $logfile));
 
 #***************************************************************************
 # Prepare output variables:
@@ -167,9 +180,6 @@ my $destination = $opts->get('destination');
 
 # Always write log to a file, either specified via --log or 'latexml.log'
 # with the exception of *archive* outputs, where the log is in the ZIP
-my $whatsout   = $opts->get('whatsout');
-my $is_archive = $whatsout && ($whatsout =~ /^archive/);
-
 if ($log && !$is_archive) {
   chomp($log);
   # If we get a log payload in the response, likely from a latexmls call
@@ -186,7 +196,7 @@ if ($result) {
   if ($destination) {
     my $output_handle;
     open($output_handle, ">", $destination) or die("Fatal:I/O:forbidden Couldn't open output file " . $destination . ": $!");
-    if ($whatsout eq 'archive') {
+    if ($is_archive) {
       binmode($output_handle, ':raw');
     }
     print $output_handle $result;

--- a/bin/latexmlc
+++ b/bin/latexmlc
@@ -20,7 +20,6 @@ my $RealBin_safe;
 use FindBin;
 use File::Spec::Functions;
 use File::Which;
-use Storable qw(dclone);
 
 BEGIN {
   if ($FindBin::RealBin =~ /^([^\0]+)\z/) {    # Valid Unix path TODO: Windows, revisit regexp
@@ -104,21 +103,23 @@ if ($source eq '-') {
 # Use $jobname.latexml.log or just latexml.log for logging by default
 #
 # In the local conversion case, this can be delegated to LaTeXML.pm
-my $normalized_opts  = LaTeXML::Common::Config->new(%{ dclone($opts->options) });
-my $normalization_ok = eval {
-  $normalized_opts->check;
-  1;
-};
-my $whatsout   = $normalized_opts->get('whatsout');
-my $is_archive = $whatsout && ($whatsout =~ /^archive/);
-# Fail closed so an invalid configuration cannot remove a pre-existing log.
-my $preserve_existing_log = !$normalization_ok || $is_archive;
-my $logfile               = $opts->get('log');
+my $destination_path = $opts->get('destination') || '';
+my ($destination_type) = ($destination_path =~ /\.([^.]+)$/);
+my $format = $opts->defined('format')
+  ? $opts->get('format')
+  : ($destination_type || '');
+my $keep_log_file = 0;
+$keep_log_file = 1 if (($opts->get('whatsout') || '') =~ /^archive/);
+$keep_log_file = 1 if ($format =~ /^(?:epub|mobi|zip)$/i);
+$keep_log_file = 1
+  if (!$opts->defined('whatsout') && (($destination_type || '') eq 'zip'));
+
+my $logfile = $opts->get('log');
 if (!$logfile) {
   if (!pathname_is_literaldata($source)) {
     my ($dir, $name, $ext) = pathname_split($source);
     if ($name) {
-      $logfile = $is_archive
+      $logfile = $keep_log_file
         ? pathname_make(name => $name, type => 'latexml.log')
         : pathname_make(dir => pathname_cwd(), name => $name, type => 'latexml.log'); }
     else {
@@ -130,7 +131,7 @@ if (!$logfile) {
 # A bit special: Since LaTeXML.pm will always try to append to the log file
 # make sure the file is new before we start. Archive logs are buffered and
 # packaged, so they must not affect an external file with the same name.
-unlink($logfile) if (!$preserve_existing_log && (-f $logfile));
+unlink($logfile) if (!$keep_log_file && (-f $logfile));
 
 #***************************************************************************
 # Prepare output variables:
@@ -180,6 +181,10 @@ my $destination = $opts->get('destination');
 
 # Always write log to a file, either specified via --log or 'latexml.log'
 # with the exception of *archive* outputs, where the log is in the ZIP
+my $whatsout   = $opts->get('whatsout');
+my $is_archive = $keep_log_file
+  || ($whatsout && ($whatsout =~ /^archive/));
+
 if ($log && !$is_archive) {
   chomp($log);
   # If we get a log payload in the response, likely from a latexmls call

--- a/t/931_epub.t
+++ b/t/931_epub.t
@@ -9,6 +9,7 @@ use Test::More;
 use Config;
 use FindBin;
 
+use File::Basename qw(basename);
 use File::Temp qw(tempfile);
 use File::Spec::Functions qw(catfile);
 use Archive::Zip qw(:CONSTANTS :ERROR_CODES);
@@ -17,12 +18,22 @@ use IPC::Open3;
 my ($tmp_fh, $epub_filename) = tempfile('931_testXXXX', SUFFIX => '.epub');
 close $tmp_fh;
 
-my $log_filename = "931_test.log";
+my ($source_fh, $source_filename) = tempfile('931_sourceXXXX', SUFFIX => '.tex', DIR => '.', UNLINK => 0);
+print $source_fh "\\documentclass{article}\n\\begin{document}\ntest\n\\end{document}\n";
+close($source_fh);
+
+my $existing_log_content = "pre-existing external log\n";
+my $log_filename = basename($source_filename);
+$log_filename =~ s/\.tex$/.latexml.log/;
+open(my $log_fh, '>', $log_filename);
+print $log_fh $existing_log_content;
+close($log_fh);
+
 my $latexmlc = catfile($FindBin::Bin, '..', 'blib', 'script', 'latexmlc');
 
 my $path_to_perl = $Config{perlpath};
 my @invocation = $path_to_perl, map { ('-I', $_) } @INC;
-push(@invocation, $latexmlc, '--css=LaTeXML-epub.css', "--dest=$epub_filename", "--log=$log_filename", 'literal:test');
+push(@invocation, $latexmlc, '--css=LaTeXML-epub.css', "--dest=$epub_filename", $source_filename);
 
 my ($writer_discard, $reader_discard, $error_discard);
 my $pid = open3($writer_discard, $reader_discard, $error_discard, @invocation);
@@ -35,17 +46,92 @@ ok(!-z $epub_filename, 'epub file has content');
 
 my $zip_file = Archive::Zip->new();
 is($zip_file->read($epub_filename), AZ_OK, 'epub file successfully loads as Archive::Zip object');
-is($zip_file->numberOfMembers, 9, "correct number of files were present in final ePub");
-my $names = join(", ",sort($zip_file->memberNames));
-ok($names =~ /^META-INF\/, META-INF\/container\.xml, OPS\/, OPS\/931_test\.log, OPS\/931_test....\.xhtml, OPS\/LaTeXML-epub\.css, OPS\/LaTeXML\.css, OPS\/content\.opf, mimetype$/, "correct files were present in final ePub: $names");
+my $epub_document_name = basename($epub_filename);
+$epub_document_name =~ s/\.epub$/.xhtml/;
+my $log_member_name = basename($log_filename);
+my @expected_names = ('META-INF/', 'META-INF/container.xml', 'OPS/', "OPS/$log_member_name",
+  "OPS/$epub_document_name", 'OPS/LaTeXML-epub.css', 'OPS/LaTeXML.css', 'OPS/content.opf',
+  'OPS/ltx-article.css', 'mimetype');
+is($zip_file->numberOfMembers, scalar(@expected_names), "correct number of files were present in final ePub");
+my $names = join(", ", sort($zip_file->memberNames));
+is($names, join(", ", sort(@expected_names)), "correct files were present in final ePub");
 
-my $log_member = $zip_file->memberNamed("OPS/$log_filename");
+my $log_member = $zip_file->memberNamed("OPS/$log_member_name");
 ok($log_member, "log file was written to epub");
-my $log_content = $log_member->contents();
+my $log_content = $log_member ? $log_member->contents() : q{};
 ok($log_content =~ /No obvious problems/, 'epub conversion was error-free');
+unlike($log_content, qr/\Q$existing_log_content\E/, 'epub contains a fresh conversion log');
+
+ok(-f $log_filename, 'pre-existing external log was preserved');
+my $preserved_log_content;
+if (open(my $preserved_log, '<', $log_filename)) {
+  local $/;
+  $preserved_log_content = <$preserved_log>;
+  close($preserved_log);
+}
+is($preserved_log_content, $existing_log_content, 'pre-existing external log was not overwritten');
+
+my @invalid_invocation = $path_to_perl, map { ('-I', $_) } @INC;
+push(@invalid_invocation, $latexmlc, '--navigationtoc=bogus', "--dest=$epub_filename",
+  "--log=$log_filename", 'literal:test');
+my ($invalid_writer_discard, $invalid_reader_discard, $invalid_error_discard);
+my $invalid_pid = open3($invalid_writer_discard, $invalid_reader_discard, $invalid_error_discard, @invalid_invocation);
+{ local $/; <$invalid_reader_discard>; } # consume all output
+close($invalid_reader_discard);
+ok(waitpid($invalid_pid, 0), "invalid archive invocation completed: $!");
+ok(-f $log_filename, 'invalid archive invocation did not delete the pre-existing external log');
+my $log_content_after_invalid_invocation;
+if (open(my $log_after_invalid_invocation, '<', $log_filename)) {
+  local $/;
+  $log_content_after_invalid_invocation = <$log_after_invalid_invocation>;
+  close($log_after_invalid_invocation);
+}
+is($log_content_after_invalid_invocation, $existing_log_content,
+  'invalid archive invocation did not overwrite the pre-existing external log');
+
+my ($zip_fh, $zip_filename) = tempfile('931_testXXXX', SUFFIX => '.zip');
+close($zip_fh);
+my ($zip_log_fh, $zip_log_filename) = tempfile('931_testXXXX', SUFFIX => '.log', DIR => '.', UNLINK => 0);
+print $zip_log_fh $existing_log_content;
+close($zip_log_fh);
+
+my @zip_invocation = $path_to_perl, map { ('-I', $_) } @INC;
+push(@zip_invocation, $latexmlc, '--format=xml', "--dest=$zip_filename", "--log=$zip_log_filename", 'literal:test');
+my ($zip_writer_discard, $zip_reader_discard, $zip_error_discard);
+my $zip_pid = open3($zip_writer_discard, $zip_reader_discard, $zip_error_discard, @zip_invocation);
+{ local $/; <$zip_reader_discard>; } # consume all output
+close($zip_reader_discard);
+ok(waitpid($zip_pid, 0), "latexmlc invocation for explicit-format ZIP output: $!");
+
+my $generic_zip = Archive::Zip->new();
+is($generic_zip->read($zip_filename), AZ_OK, 'explicit-format ZIP successfully loads as Archive::Zip object');
+my $zip_log_member = $generic_zip->memberNamed(basename($zip_log_filename));
+ok($zip_log_member, 'log file was written to explicit-format ZIP');
+ok($zip_log_member->contents() =~ /No obvious problems/, 'explicit-format ZIP conversion was error-free');
+ok(-f $zip_log_filename, 'pre-existing external log was preserved for explicit-format ZIP');
+my $preserved_zip_log_content;
+if (open(my $preserved_zip_log, '<', $zip_log_filename)) {
+  local $/;
+  $preserved_zip_log_content = <$preserved_zip_log>;
+  close($preserved_zip_log);
+}
+is($preserved_zip_log_content, $existing_log_content,
+  'pre-existing external log was not overwritten for explicit-format ZIP');
 
 if (-f $epub_filename) {
   ok(unlink($epub_filename), "clean up generated epub file");
+}
+if (-f $log_filename) {
+  ok(unlink($log_filename), "clean up preserved log file");
+}
+if (-f $source_filename) {
+  ok(unlink($source_filename), "clean up source file");
+}
+if (-f $zip_filename) {
+  ok(unlink($zip_filename), "clean up generated ZIP file");
+}
+if (-f $zip_log_filename) {
+  ok(unlink($zip_log_filename), "clean up preserved ZIP log file");
 }
 
 done_testing();

--- a/t/931_epub.t
+++ b/t/931_epub.t
@@ -89,35 +89,6 @@ if (open(my $log_after_invalid_invocation, '<', $log_filename)) {
 is($log_content_after_invalid_invocation, $existing_log_content,
   'invalid archive invocation did not overwrite the pre-existing external log');
 
-my ($zip_fh, $zip_filename) = tempfile('931_testXXXX', SUFFIX => '.zip');
-close($zip_fh);
-my ($zip_log_fh, $zip_log_filename) = tempfile('931_testXXXX', SUFFIX => '.log', DIR => '.', UNLINK => 0);
-print $zip_log_fh $existing_log_content;
-close($zip_log_fh);
-
-my @zip_invocation = $path_to_perl, map { ('-I', $_) } @INC;
-push(@zip_invocation, $latexmlc, '--format=xml', "--dest=$zip_filename", "--log=$zip_log_filename", 'literal:test');
-my ($zip_writer_discard, $zip_reader_discard, $zip_error_discard);
-my $zip_pid = open3($zip_writer_discard, $zip_reader_discard, $zip_error_discard, @zip_invocation);
-{ local $/; <$zip_reader_discard>; } # consume all output
-close($zip_reader_discard);
-ok(waitpid($zip_pid, 0), "latexmlc invocation for explicit-format ZIP output: $!");
-
-my $generic_zip = Archive::Zip->new();
-is($generic_zip->read($zip_filename), AZ_OK, 'explicit-format ZIP successfully loads as Archive::Zip object');
-my $zip_log_member = $generic_zip->memberNamed(basename($zip_log_filename));
-ok($zip_log_member, 'log file was written to explicit-format ZIP');
-ok($zip_log_member->contents() =~ /No obvious problems/, 'explicit-format ZIP conversion was error-free');
-ok(-f $zip_log_filename, 'pre-existing external log was preserved for explicit-format ZIP');
-my $preserved_zip_log_content;
-if (open(my $preserved_zip_log, '<', $zip_log_filename)) {
-  local $/;
-  $preserved_zip_log_content = <$preserved_zip_log>;
-  close($preserved_zip_log);
-}
-is($preserved_zip_log_content, $existing_log_content,
-  'pre-existing external log was not overwritten for explicit-format ZIP');
-
 if (-f $epub_filename) {
   ok(unlink($epub_filename), "clean up generated epub file");
 }
@@ -126,12 +97,6 @@ if (-f $log_filename) {
 }
 if (-f $source_filename) {
   ok(unlink($source_filename), "clean up source file");
-}
-if (-f $zip_filename) {
-  ok(unlink($zip_filename), "clean up generated ZIP file");
-}
-if (-f $zip_log_filename) {
-  ok(unlink($zip_log_filename), "clean up preserved ZIP log file");
 }
 
 done_testing();

--- a/t/932_zip.t
+++ b/t/932_zip.t
@@ -1,0 +1,63 @@
+# -*- CPERL -*-
+#**********************************************************************
+# Test cases for ZIP generation integrity
+#**********************************************************************
+use strict;
+use warnings;
+
+use Test::More;
+use Config;
+use FindBin;
+
+use File::Basename qw(basename);
+use File::Temp qw(tempfile);
+use File::Spec::Functions qw(catfile);
+use Archive::Zip qw(:CONSTANTS :ERROR_CODES);
+use IPC::Open3;
+
+my ($zip_fh, $zip_filename) = tempfile('932_testXXXX', SUFFIX => '.zip');
+close($zip_fh);
+
+my $existing_log_content = "pre-existing external log\n";
+my ($log_fh, $log_filename) = tempfile('932_testXXXX', SUFFIX => '.log', DIR => '.', UNLINK => 0);
+print $log_fh $existing_log_content;
+close($log_fh);
+
+my $latexmlc = catfile($FindBin::Bin, '..', 'blib', 'script', 'latexmlc');
+my $path_to_perl = $Config{perlpath};
+my @invocation = $path_to_perl, map { ('-I', $_) } @INC;
+push(@invocation, $latexmlc, '--format=xml', "--dest=$zip_filename", "--log=$log_filename", 'literal:test');
+
+my ($writer_discard, $reader_discard, $error_discard);
+my $pid = open3($writer_discard, $reader_discard, $error_discard, @invocation);
+{ local $/; <$reader_discard>; } # consume all output
+close($reader_discard);
+ok(waitpid($pid, 0), "latexmlc invocation for explicit-format ZIP output: $!");
+
+my $zip_file = Archive::Zip->new();
+is($zip_file->read($zip_filename), AZ_OK, 'explicit-format ZIP successfully loads as Archive::Zip object');
+my $log_member = $zip_file->memberNamed(basename($log_filename));
+ok($log_member, 'log file was written to explicit-format ZIP');
+my $log_content = $log_member ? $log_member->contents() : q{};
+ok($log_content =~ /No obvious problems/, 'explicit-format ZIP conversion was error-free');
+ok(-f $log_filename, 'pre-existing external log was preserved for explicit-format ZIP');
+my $preserved_log_content;
+if (open(my $preserved_log, '<', $log_filename)) {
+  local $/;
+  $preserved_log_content = <$preserved_log>;
+  close($preserved_log);
+}
+is($preserved_log_content, $existing_log_content,
+  'pre-existing external log was not overwritten for explicit-format ZIP');
+
+if (-f $zip_filename) {
+  ok(unlink($zip_filename), "clean up generated ZIP file");
+}
+if (-f $log_filename) {
+  ok(unlink($log_filename), "clean up preserved ZIP log file");
+}
+
+done_testing();
+
+#**********************************************************************
+1;


### PR DESCRIPTION
Fixes #2836.

## Summary

- use a compact `$keep_log_file` flag to identify archive output before initializing the client log
- preserve pre-existing external log files for archive outputs
- keep default archive log names relative so a fresh conversion log is packaged inside EPUB/ZIP output
- keep EPUB regression coverage in `t/931_epub.t` and move the ZIP variant to `t/932_zip.t`

## Root cause

`latexmlc` unconditionally removed the selected log file before the output type had been normalized. Archive conversions buffer their log for packaging instead of writing that external file, so this could delete a pre-existing log without replacing it. The previous absolute default log path also prevented the fresh log from being added to the archive.

The preflight flag tracks the raw output-shape, format, and destination-extension signals that produce archive output. This keeps the live conversion configuration unchanged while preserving non-archive log handling.

## User impact

Running an EPUB, MOBI, or ZIP conversion no longer deletes or overwrites an existing external log with the same name. The archive still contains a fresh conversion log.

## Validation

- `prove -lv t/931_epub.t t/932_zip.t` (25 tests)
- related client, format, profile, runtime, configuration, fatal-path, and manifest tests (81 tests)
- `CI=true prove -lv t/97_manifest.t` (2 tests)
- `tools/latexmllint --precommit bin/latexmlc t/931_epub.t t/932_zip.t`
- `git diff --check`
