### PR TITLE
Set dark-mode css colors on body, not :root

### DIFF
--- a/lib/LaTeXML/resources/CSS/LaTeXML.css
+++ b/lib/LaTeXML/resources/CSS/LaTeXML.css
@@ -596,10 +596,11 @@ cite                 { font-style: normal; }
   }
 }
 @media (prefers-color-scheme: dark) {
-  :root {
+  body {
     background-color: black;
     color: white;
   }
+
   /* The :root rule does not appear to propagate color: into SVG foreignObject */
   .ltx_foreignobject_content {
     color: var(--fn-fg-color-to-dark-mode, white);


### PR DESCRIPTION
A tiny cleanup; it's probably best to restrict  `:root` to setting variables, rather than properties, since it has high specificity and makes it more awkward to tune.